### PR TITLE
add some unit tests for exceptions helper

### DIFF
--- a/tests/exceptions_helper_tests.py
+++ b/tests/exceptions_helper_tests.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+
+import sys, os.path
+sys.path.insert(1, os.path.abspath(os.path.join(os.path.dirname(__file__), '../lib')))
+sys.path.insert(1, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+import unittest
+
+import test_lib as test
+from sickrage.helper.exceptions import ex
+
+class ExceptionsHelperTestCase(unittest.TestCase):
+
+    def test_none_returns_empty(self):
+        self.assertEqual(ex(None), u'')
+
+    def test_empty_args_returns_empty(self):
+        self.assertEqual(ex(Exception()), u'')
+
+    def test_args_of_none_returns_empty(self):
+        self.assertEqual(ex(Exception(None, None)), u'')
+
+    def test_Exception_returns_args_string(self):
+        self.assertEqual(ex(Exception('hi')), 'hi')
+
+# TODO why doesn't this work?
+#    def test_Exception_returns_args_ustring(self):
+#        self.assertEqual(ex(Exception('\xc3\xa4h')), u'äh')
+
+    def test_Exception_returns_concatenated_args_strings(self):
+        self.assertEqual(ex(Exception('lots', 'of', 'strings')), 'lots : of : strings')
+
+    def test_Exception_returns_stringified_args(self):
+        self.assertEqual(ex(Exception(303)), 'error 303')
+
+if __name__ == '__main__':
+    if len(sys.argv) > 1:
+        suite = unittest.TestLoader().loadTestsFromName('exceptions_helper_tests.ExceptionsHelperTestCase.test_' + sys.argv[1])
+        unittest.TextTestRunner(verbosity=2).run(suite)
+    else:
+        suite = unittest.TestLoader().loadTestsFromTestCase(ExceptionsHelperTestCase)
+        unittest.TextTestRunner(verbosity=2).run(suite)


### PR DESCRIPTION
Well that was rather annoying. I also hit this issue: https://github.com/SiCKRAGETV/sickrage-issues/issues/2358 and could not figure out what was happening. So I started writing unit tests for this class, until I realized the problem happened earlier. Here's how we can recreate it:

```
class Dummy():
    def __str__(self):
        return DummyException()

class DummyException(Exception):
    pass
```

...

```
    def test_bad_string_issue_2358(self):
        try:
            o = Dummy()
            print 'Error : %s' % o
        except TypeError as e:
            self.assertEqual(ex(e), u'lala')
```

I figured we can keep the unit tests instead of throwing them away... Next step is to figure out which string interpolation in helpers.py is getting the object with the broken **str** method. Sigh...
