### PR TITLE
Convert to new style class with explicit object subclassing

### DIFF
--- a/sickbeard/notifiers/boxcar2.py
+++ b/sickbeard/notifiers/boxcar2.py
@@ -1,3 +1,5 @@
+# coding=utf-8
+
 # Author: Rafael Silva <rpluto@gmail.com>
 # Author: Marvin Pinto <me@marvinp.ca>
 # Author: Dennis Lutter <lad1337@gmail.com>
@@ -18,7 +20,8 @@
 # You should have received a copy of the GNU General Public License
 # along with SickRage.  If not, see <http://www.gnu.org/licenses/>.
 
-import urllib, urllib2
+import urllib
+import urllib2
 
 import sickbeard
 
@@ -29,7 +32,7 @@ from sickrage.helper.exceptions import ex
 API_URL = "https://new.boxcar.io/api/notifications"
 
 
-class Boxcar2Notifier:
+class Boxcar2Notifier(object):
     def test_notify(self, accesstoken, title="SickRage : Test"):
         return self._sendBoxcar2("This is a test notification from SickRage", title, accesstoken)
 
@@ -59,7 +62,7 @@ class Boxcar2Notifier:
         # send the request to boxcar2
         try:
             req = urllib2.Request(curUrl)
-            handle = urllib2.urlopen(req, data,timeout=60)
+            handle = urllib2.urlopen(req, data, timeout=60)
             handle.close()
 
         except Exception as e:
@@ -87,7 +90,6 @@ class Boxcar2Notifier:
         if sickbeard.BOXCAR2_NOTIFY_ONSNATCH:
             self._notifyBoxcar2(title, ep_name)
 
-
     def notify_download(self, ep_name, title=notifyStrings[NOTIFY_DOWNLOAD]):
         if sickbeard.BOXCAR2_NOTIFY_ONDOWNLOAD:
             self._notifyBoxcar2(title, ep_name)
@@ -96,10 +98,10 @@ class Boxcar2Notifier:
         if sickbeard.BOXCAR2_NOTIFY_ONSUBTITLEDOWNLOAD:
             self._notifyBoxcar2(title, ep_name + ": " + lang)
 
-    def notify_git_update(self, new_version = "??"):
+    def notify_git_update(self, new_version="??"):
         if sickbeard.USE_BOXCAR2:
-            update_text=notifyStrings[NOTIFY_GIT_UPDATE_TEXT]
-            title=notifyStrings[NOTIFY_GIT_UPDATE]
+            update_text = notifyStrings[NOTIFY_GIT_UPDATE_TEXT]
+            title = notifyStrings[NOTIFY_GIT_UPDATE]
             self._notifyBoxcar2(title, update_text + new_version)
 
     def _notifyBoxcar2(self, title, message, accesstoken=None):


### PR DESCRIPTION
PEP 8: Fix multiple imports on one line

PEP 8: Fix white space, blank lines, and indentation

PEP 263: Add encoding declaration

Replaces #25
