### PR TITLE
Save multiple plex servers

### DIFF
--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -4694,7 +4694,7 @@ class ConfigNotifications(Config):
         sickbeard.PLEX_NOTIFY_ONSUBTITLEDOWNLOAD = config.checkbox_to_value(plex_notify_onsubtitledownload)
         sickbeard.PLEX_UPDATE_LIBRARY = config.checkbox_to_value(plex_update_library)
         sickbeard.PLEX_HOST = config.clean_hosts(plex_host)
-        sickbeard.PLEX_SERVER_HOST = config.clean_host(plex_server_host)
+        sickbeard.PLEX_SERVER_HOST = config.clean_hosts(plex_server_host)
         sickbeard.PLEX_SERVER_TOKEN = config.clean_host(plex_server_token)
         sickbeard.PLEX_USERNAME = plex_username
         sickbeard.PLEX_PASSWORD = plex_password


### PR DESCRIPTION
Multiple plex servers can be provided in the web UI and the test also uses them. But due to the bug only one server would get saved.
