### PR TITLE
nameparser fix

### DIFF
--- a/sickbeard/name_parser/parser.py
+++ b/sickbeard/name_parser/parser.py
@@ -37,7 +37,7 @@ class NameParser(object):
     NORMAL_REGEX = 1
     ANIME_REGEX = 2
 
-    def __init__(self, file_name=True, showObj=None, tryIndexers=False, naming_pattern=False):
+    def __init__(self, file_name=True, showObj=None, tryIndexers=False, naming_pattern=False, parse_method = None):
 
         self.file_name = file_name
         self.showObj = showObj
@@ -45,9 +45,9 @@ class NameParser(object):
 
         self.naming_pattern = naming_pattern
 
-        if self.showObj and not self.showObj.is_anime:
+        if (self.showObj and not self.showObj.is_anime) or parse_method == 'normal':
             self._compile_regexes(self.NORMAL_REGEX)
-        elif self.showObj and self.showObj.is_anime:
+        elif (self.showObj and self.showObj.is_anime) or parse_method == 'anime':
             self._compile_regexes(self.ANIME_REGEX)
         else:
             self._compile_regexes(self.ALL_REGEX)

--- a/sickbeard/providers/generic.py
+++ b/sickbeard/providers/generic.py
@@ -364,12 +364,7 @@ class GenericProvider(object):
 
             # parse the file name
             try:
-                if show.is_anime:
-                    method = 'anime'
-                else:
-                    method = 'normal'
-                    
-                myParser = NameParser(parse_method=method)
+                myParser = NameParser(parse_method=('normal', 'anime')[show.is_anime])
                 parse_result = myParser.parse(title)
             except InvalidNameException:
                 logger.log(u"Unable to parse the filename " + title + " into a valid episode", logger.DEBUG)

--- a/sickbeard/providers/generic.py
+++ b/sickbeard/providers/generic.py
@@ -364,7 +364,12 @@ class GenericProvider(object):
 
             # parse the file name
             try:
-                myParser = NameParser(False)
+                if show.is_anime:
+                    method = 'anime'
+                else:
+                    method = 'normal'
+                    
+                myParser = NameParser(parse_method=method)
                 parse_result = myParser.parse(title)
             except InvalidNameException:
                 logger.log(u"Unable to parse the filename " + title + " into a valid episode", logger.DEBUG)


### PR DESCRIPTION
PLEASE, DON'T MERGE UNTIL YOU CAN TEST IT (It can cause a real chaos)

This code avoid to use ALL_REGEX when we know type of show to parse,
because some shows are being parsed incorrectly (anime shows being
parsed as normal shows and vice versa). This problem will affect later
to scoring system, giving invalid results.

SR matching works as follows:
- Firstly, SR has a show object with episode searched
- Secondly, for each result obtained from each provider, SR tries to
  construct an object of type show
- If SR has succes building the object, SR compare it with original show
  object. If they are equal gives it as valid result.

For that reason we never should send the original show object to
NameParser method (we learned it by hard way...)

This modification allow us to tell NameParser what type of show we're
parsing from findSearchResults method (generic.py) without affect others
calls to this method (there are several calls to NameParser method...)

Please be careful with this, I'm pretty sure that it's working fine but
would be great if somebody else could test it.

@miigotu @duramato @fernandog could you take a look?
