### PR TITLE
add more explicit dependencies so it builds better from clean node install

### DIFF
--- a/.build/bower.json
+++ b/.build/bower.json
@@ -25,5 +25,8 @@
     "jquery-confirm": "~2.5.2",
     "bootstrap-formhelpers": "~2.3.0",
     "isotope": "~2.2.2"
+  },
+  "resolutions": {
+    "bootstrap": "~3.3.5"
   }
 }

--- a/.build/package.json
+++ b/.build/package.json
@@ -2,9 +2,10 @@
   "name": "sickrage",
   "version": "4.0.72",
   "private": true,
-  "dependencies": {
+  "devDependencies": {
     "grunt": "^0.4.5",
     "grunt-bower-concat": "^0.5.0",
+    "grunt-cli": "^0.1.13",
     "grunt-contrib-cssmin": "^0.14.0",
     "grunt-contrib-jshint": "^0.11.3",
     "grunt-contrib-uglify": "^0.9.2"


### PR DESCRIPTION
- use devDependencies instead of dependencies since bower is handling the actual dependencies
- add grunt-cli for if you don't have it installed globally
- be more explicit on our bootstrap version so bower doesn't prompt which one to choose
