### PR TITLE
Fix/clean file browser CSS

### DIFF
--- a/gui/slick/css/browser.css
+++ b/gui/slick/css/browser.css
@@ -3,6 +3,10 @@
     overflow-y: auto;
 }
 
+#fileBrowserDialog h2 {
+    font-size: 20px;
+}
+
 #fileBrowserDialog ul {
     margin: 0;
     padding: 0;
@@ -20,7 +24,7 @@
 }
 
 #fileBrowserDialog ul li a:hover {
-    color: #09A2FF;
+    color: #00f;
     background: none;
 }
 
@@ -29,8 +33,6 @@
     float: left;
 }
 
-
-/* jQuery-UI autocomplete overrides to make it look more like the old autocomplete */
 .ui-autocomplete {
     max-height: 180px;
     overflow-y: auto;
@@ -38,22 +40,4 @@
     overflow-x: hidden;
     /* add padding to account for vertical scrollbar */
     padding-right: 20px;
-}
-
-* html .ui-autocomplete {
-    height: 180px;
-}
-
-.ui-menu .ui-menu-item {
-    background-color: #eeeeee;
-}
-
-.ui-menu .ui-menu-item-alternate{
-    background-color: #ffffff;
-}
-
-.ui-menu a.ui-state-hover{
-    background: none;
-    background-color: #0A246A;
-    color: #ffffff;
 }

--- a/gui/slick/css/style.css
+++ b/gui/slick/css/style.css
@@ -189,6 +189,15 @@ inc_top.mako
     background: #eceadf url("../css/lib/images/ui-bg_fine-grain_10_eceadf_60x60.png") 50% 50% repeat !important;
 }
 
+/* restore 1.8.x resize handle on dialog button pane */
+.ui-dialog .ui-resizable-se {
+    width: 14px;
+    height: 14px;
+    right: 3px;
+    bottom: 3px;
+    background-position: -80px -224px;
+}
+
 .ui-accordion-content,
 .ui-tabs-panel {
     background: #ededed !important;
@@ -2638,50 +2647,6 @@ input sizing (for config pages)
 .input350 {
     width: 350px;
     margin-top: -4px;
-}
-
-/* =======================================================================
-browser.css overrides
-========================================================================== */
-
-#fileBrowserDialog {
-    overflow-y: auto;
-}
-
-#fileBrowserDialog ul li a:hover {
-    color: #00f;
-    background: none;
-}
-
-#fileBrowserDialog h2 {
-    font-size: 20px;
-}
-
-.ui-autocomplete {
-    max-height: 180px;
-    overflow-x: hidden;
-    overflow-y: auto;
-}
-
-/* IE6 hack since it doesn't support max-height */
-* html .ui-autocomplete {
-    height: 180px;
-    padding-right: 20px;
-}
-
-.ui-autocomplete .ui-menu-item .ui-state-focus {
-    color: #fff;
-    background: none;
-    background-color: #0a246a;
-}
-
-/* restore 1.8.x resize handle on dialog button pane */
-.ui-dialog .ui-resizable-se {
-    width: 14px;
-    height: 14px;
-    right: 3px;
-    bottom: 3px;
-    background-position: -80px -224px;
 }
 
 /* =======================================================================

--- a/gui/slick/js/browser.js
+++ b/gui/slick/js/browser.js
@@ -60,7 +60,7 @@
             fileBrowserDialog = $('<div id="fileBrowserDialog" style="display:hidden"></div>').appendTo('body').dialog({
                 dialogClass: 'browserDialog',
                 title:       options.title,
-                position:    ['center', 40],
+                position:    { my: 'center top', at: 'center top+60', of: window },
                 minWidth:    Math.min($(document).width() - 80, 650),
                 height:      Math.min($(document).height() - 80, $(window).height() - 80),
                 maxHeight:   Math.min($(document).height() - 80, $(window).height() - 80),
@@ -129,7 +129,6 @@
                 },
                 open: function (event, ui) {
                     $(".ui-autocomplete li.ui-menu-item a").removeClass("ui-corner-all");
-                    $(".ui-autocomplete li.ui-menu-item:odd a").addClass("ui-menu-item-alternate");
                 }
             })
                 .data("ui-autocomplete")._renderItem = function (ul, item) {


### PR DESCRIPTION
This centers the file browser dialog and removes some
duplicate/unnecessary CSS.
