### PR TITLE
Update test_libs.py for PEPs, Lint, and docstrings

### DIFF
--- a/tests/pp_tests.py
+++ b/tests/pp_tests.py
@@ -35,20 +35,20 @@ from sickbeard.name_cache import addNameToCache
 class PPInitTests(unittest.TestCase):
 
     def setUp(self):
-        self.pp = PostProcessor(test.FILEPATH)
+        self.pp = PostProcessor(test.FILE_PATH)
 
     def test_init_file_name(self):
         self.assertEqual(self.pp.file_name, test.FILENAME)
 
     def test_init_folder_name(self):
-        self.assertEqual(self.pp.folder_name, test.SHOWNAME)
+        self.assertEqual(self.pp.folder_name, test.SHOW_NAME)
 
 class PPBasicTests(test.SickbeardTestDBCase):
 
     def test_process(self):
         show = TVShow(1,3)
-        show.name = test.SHOWNAME
-        show.location = test.SHOWDIR
+        show.name = test.SHOW_NAME
+        show.location = test.SHOW_DIR
         show.saveToDB()
 
         sickbeard.showList = [show]
@@ -59,7 +59,7 @@ class PPBasicTests(test.SickbeardTestDBCase):
         addNameToCache('show name', 3)
         sickbeard.PROCESS_METHOD = 'move'
 
-        pp = PostProcessor(test.FILEPATH)
+        pp = PostProcessor(test.FILE_PATH)
         self.assertTrue(pp.process())
 
 

--- a/tests/test_lib.py
+++ b/tests/test_lib.py
@@ -1,5 +1,6 @@
 # coding=UTF-8
 # Author: Dennis Lutter <lad1337@gmail.com>
+
 # URL: http://code.google.com/p/sickbeard/
 #
 # This file is part of SickRage.
@@ -17,58 +18,93 @@
 # You should have received a copy of the GNU General Public License
 # along with SickRage.  If not, see <http://www.gnu.org/licenses/>.
 
+# pylint: disable=C0301
+# Line too long
 
-import sys, os.path
+"""
+Create a test database for testing.
+
+Methods:
+    create_test_log_folder
+    create_test_cache_folder
+    setup_test_db
+    teardown_test_db
+    setup_test_episode_file
+    teardown_test_episode_file
+    setup_test_show_dir
+    teardown_test_show_dir
+
+Classes:
+    SickbeardTestDBCase
+    TestDBConnection
+    TestCacheDBConnection
+"""
+
+import sys
+import os.path
+import unittest
+import shutil
+
 sys.path.insert(1, os.path.abspath(os.path.join(os.path.dirname(__file__), '../lib')))
 sys.path.insert(1, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
-import unittest
+# pylint: disable=F0401
+# Unable to import
+import shutil_custom
 
-from configobj import ConfigObj
 import sickbeard
-
 from sickbeard import db, providers
 from sickbeard.databases import mainDB
 from sickbeard.databases import cache_db, failed_db
 from sickbeard.tv import TVEpisode
 
-import shutil
-import shutil_custom
+# pylint: disable=F0401
+# Unable to import
+from configobj import ConfigObj
+
 
 shutil.copyfile = shutil_custom.copyfile_custom
 
-#=================
-# test globals
-#=================
-TESTDIR = os.path.abspath(os.path.dirname(__file__))
-TESTDBNAME = "sickbeard.db"
-TESTCACHEDBNAME = "cache.db"
-TESTFAILEDDBNAME = "failed.db"
+# =================
+#  test globals
+# =================
+TEST_DIR = os.path.abspath(os.path.dirname(__file__))
+TEST_DB_NAME = "sickbeard.db"
+TEST_CACHE_DB_NAME = "cache.db"
+TEST_FAILED_DB_NAME = "failed.db"
 
-SHOWNAME = u"show name"
+SHOW_NAME = u"show name"
 SEASON = 4
 EPISODE = 2
 FILENAME = u"show name - s0" + str(SEASON) + "e0" + str(EPISODE) + ".mkv"
-FILEDIR = os.path.join(TESTDIR, SHOWNAME)
-FILEPATH = os.path.join(FILEDIR, FILENAME)
-SHOWDIR = os.path.join(TESTDIR, SHOWNAME + " final")
+FILE_DIR = os.path.join(TEST_DIR, SHOW_NAME)
+FILE_PATH = os.path.join(FILE_DIR, FILENAME)
+SHOW_DIR = os.path.join(TEST_DIR, SHOW_NAME + " final")
 
-#=================
-# prepare env functions
-#=================
-def createTestLogFolder():
+
+# =================
+#  prepare env functions
+# =================
+def create_test_log_folder():
+    """
+    Create a log folder for test logs.
+    """
     if not os.path.isdir(sickbeard.LOG_DIR):
         os.mkdir(sickbeard.LOG_DIR)
 
-def createTestCacheFolder():
+
+def create_test_cache_folder():
+    """
+    Create a cache folder for caching tests.
+    """
     if not os.path.isdir(sickbeard.CACHE_DIR):
         os.mkdir(sickbeard.CACHE_DIR)
 
-# call env functions at appropriate time during sickbeard var setup
+# call env functions at appropriate time during SickBeard var setup
 
-#=================
-# sickbeard globals
-#=================
+# =================
+#  SickBeard globals
+# =================
 sickbeard.SYS_ENCODING = 'UTF-8'
 
 sickbeard.showList = []
@@ -85,168 +121,226 @@ sickbeard.PROVIDER_ORDER = ["sick_beard_index"]
 sickbeard.newznabProviderList = providers.getNewznabProviderList("'Sick Beard Index|http://lolo.sickbeard.com/|0|5030,5040|0|eponly|0|0|0!!!NZBs.org|https://nzbs.org/||5030,5040,5060,5070,5090|0|eponly|0|0|0!!!Usenet-Crawler|https://www.usenet-crawler.com/||5030,5040,5060|0|eponly|0|0|0'")
 sickbeard.providerList = providers.makeProviderList()
 
-sickbeard.PROG_DIR = os.path.abspath(os.path.join(TESTDIR, '..'))
-sickbeard.DATA_DIR = TESTDIR
+sickbeard.PROG_DIR = os.path.abspath(os.path.join(TEST_DIR, '..'))
+sickbeard.DATA_DIR = TEST_DIR
 sickbeard.CONFIG_FILE = os.path.join(sickbeard.DATA_DIR, "config.ini")
 sickbeard.CFG = ConfigObj(sickbeard.CONFIG_FILE)
 
-sickbeard.BRANCG = sickbeard.config.check_setting_str(sickbeard.CFG, 'General', 'branch', '')
+sickbeard.BRANCH = sickbeard.config.check_setting_str(sickbeard.CFG, 'General', 'branch', '')
 sickbeard.CUR_COMMIT_HASH = sickbeard.config.check_setting_str(sickbeard.CFG, 'General', 'cur_commit_hash', '')
 sickbeard.GIT_USERNAME = sickbeard.config.check_setting_str(sickbeard.CFG, 'General', 'git_username', '')
 sickbeard.GIT_PASSWORD = sickbeard.config.check_setting_str(sickbeard.CFG, 'General', 'git_password', '', censor_log=True)
 
-sickbeard.LOG_DIR = os.path.join(TESTDIR, 'Logs')
+sickbeard.LOG_DIR = os.path.join(TEST_DIR, 'Logs')
 sickbeard.logger.logFile = os.path.join(sickbeard.LOG_DIR, 'test_sickbeard.log')
-createTestLogFolder()
+create_test_log_folder()
 
-sickbeard.CACHE_DIR = os.path.join(TESTDIR, 'cache')
-createTestCacheFolder()
+sickbeard.CACHE_DIR = os.path.join(TEST_DIR, 'cache')
+create_test_cache_folder()
 
+# pylint: disable=E1103
+# Has no member
 sickbeard.logger.initLogging(False, True)
 
-#=================
-# dummy functions
-#=================
-def _dummy_saveConfig():
+
+# =================
+#  dummy functions
+# =================
+def _dummy_save_config():
+    """
+    Override the SickBeard save_config which gets called during a db upgrade.
+
+    :return: True
+    """
     return True
 
-# this overrides the sickbeard save_config which gets called during a db upgrade
+# this overrides the SickBeard save_config which gets called during a db upgrade
 # this might be considered a hack
-mainDB.sickbeard.save_config = _dummy_saveConfig
+mainDB.sickbeard.save_config = _dummy_save_config
 
 
-# the real one tries to contact tvdb just stop it from getting more info on the ep
-def _fake_specifyEP(self, season, episode):
+# pylint: disable=W0613
+# Unused arguments
+def _fake_specify_ep(self, season, episode):
+    """
+    Override contact to TVDB indexer.
+
+    :param self:
+    :param season: Season to search for  ...not used
+    :param episode: Episode to search for  ...not used
+    """
     pass
 
-TVEpisode.specifyEpisode = _fake_specifyEP
+# the real one tries to contact TVDB just stop it from getting more info on the ep
+TVEpisode.specifyEpisode = _fake_specify_ep
 
-#=================
-# test classes
-#=================
+
+# =================
+#  test classes
+# =================
 class SickbeardTestDBCase(unittest.TestCase):
+    """
+    Superclass for testing the database.
+
+    Methods:
+        setUp
+        tearDown
+    """
     def setUp(self):
         sickbeard.showList = []
-        setUp_test_db()
-        setUp_test_episode_file()
-        setUp_test_show_dir()
+        setup_test_db()
+        setup_test_episode_file()
+        setup_test_show_dir()
 
     def tearDown(self):
         sickbeard.showList = []
-        tearDown_test_db()
-        tearDown_test_episode_file()
-        tearDown_test_show_dir()
+        teardown_test_db()
+        teardown_test_episode_file()
+        teardown_test_show_dir()
+
 
 class TestDBConnection(db.DBConnection, object):
+    """
+    Test connecting to the database.
+    """
+    def __init__(self, db_file_name=TEST_DB_NAME):
+        db_file_name = os.path.join(TEST_DIR, db_file_name)
+        super(TestDBConnection, self).__init__(db_file_name)
 
-    def __init__(self, dbFileName=TESTDBNAME):
-        dbFileName = os.path.join(TESTDIR, dbFileName)
-        super(TestDBConnection, self).__init__(dbFileName)
 
 class TestCacheDBConnection(TestDBConnection, object):
-    def __init__(self, providerName):
-        db.DBConnection.__init__(self, os.path.join(TESTDIR, TESTCACHEDBNAME))
+    """
+    Test connecting to the cache database.
+    """
+    def __init__(self, provider_name):
+        # pylint: disable=W0233
+        # Init method from non-direct base class
+        db.DBConnection.__init__(self, os.path.join(TEST_DIR, TEST_CACHE_DB_NAME))
 
         # Create the table if it's not already there
         try:
-            if not self.hasTable(providerName):
-                sql = "CREATE TABLE [" + providerName + "] (name TEXT, season NUMERIC, episodes TEXT, indexerid NUMERIC, url TEXT, time NUMERIC, quality TEXT, release_group TEXT)"
+            if not self.hasTable(provider_name):
+                sql = "CREATE TABLE [" + provider_name + "] (name TEXT, season NUMERIC, episodes TEXT, indexerid NUMERIC, url TEXT, time NUMERIC, quality TEXT, release_group TEXT)"
                 self.connection.execute(sql)
                 self.connection.commit()
-        except Exception, e:
-            if str(e) != "table [" + providerName + "] already exists":
+        # pylint: disable=W0703
+        # Catching too general exception
+        except Exception as error:
+            if str(error) != "table [" + provider_name + "] already exists":
                 raise
 
             # add version column to table if missing
-            if not self.hasColumn(providerName, 'version'):
-                self.addColumn(providerName, 'version', "NUMERIC", "-1")
+            if not self.hasColumn(provider_name, 'version'):
+                self.addColumn(provider_name, 'version', "NUMERIC", "-1")
 
         # Create the table if it's not already there
         try:
             sql = "CREATE TABLE lastUpdate (provider TEXT, time NUMERIC);"
             self.connection.execute(sql)
             self.connection.commit()
-        except Exception, e:
-            if str(e) != "table lastUpdate already exists":
+        # pylint: disable=W0703
+        # Catching too general exception
+        except Exception as error:
+            if str(error) != "table lastUpdate already exists":
                 raise
 
 # this will override the normal db connection
 sickbeard.db.DBConnection = TestDBConnection
 sickbeard.tvcache.CacheDBConnection = TestCacheDBConnection
 
-#=================
-# test functions
-#=================
-def setUp_test_db():
-    """upgrades the db to the latest version
+
+# =================
+#  test functions
+# =================
+def setup_test_db():
     """
+    Set up the test databases.
+    """
+    # Upgrade the db to the latest version.
     # upgrading the db
     db.upgradeDatabase(db.DBConnection(), mainDB.InitialSchema)
 
     # fix up any db problems
     db.sanityCheckDatabase(db.DBConnection(), mainDB.MainSanityCheck)
 
-    # and for cachedb too
+    # and for cache.db too
     db.upgradeDatabase(db.DBConnection("cache.db"), cache_db.InitialSchema)
 
-    # and for faileddb too
+    # and for failed.db too
     db.upgradeDatabase(db.DBConnection("failed.db"), failed_db.InitialSchema)
 
 
-def tearDown_test_db():
+def teardown_test_db():
+    """
+    Tear down the test database.
+    """
     from sickbeard.db import db_cons
     for connection in db_cons:
         db_cons[connection].commit()
-#        db_cons[connection].close()
+    #     db_cons[connection].close()
+    #
+    # for current_db in [ TEST_DB_NAME, TEST_CACHE_DB_NAME, TEST_FAILED_DB_NAME ]:
+    #    file_name = os.path.join(TEST_DIR, current_db)
+    #    if os.path.exists(file_name):
+    #        try:
+    #            os.remove(file_name)
+    #        except Exception as e:
+    #            print 'ERROR: Failed to remove ' + file_name
+    #            print exception(e)
 
-#    for current_db in [ TESTDBNAME, TESTCACHEDBNAME, TESTFAILEDDBNAME ]:
-#        file_name = os.path.join(TESTDIR, current_db)
-#        if os.path.exists(file_name):
-#            try:
-#                os.remove(file_name)
-#            except Exception as e:
-#                print 'ERROR: Failed to remove ' + file_name
-#                print exception(e)
 
-
-def setUp_test_episode_file():
-    if not os.path.exists(FILEDIR):
-        os.makedirs(FILEDIR)
+def setup_test_episode_file():
+    """
+    Create a test episode directory with a test episode in it.
+    """
+    if not os.path.exists(FILE_DIR):
+        os.makedirs(FILE_DIR)
 
     try:
-        with open(FILEPATH, 'wb') as f:
-            f.write("foo bar")
-            f.flush()
+        with open(FILE_PATH, 'wb') as ep_file:
+            ep_file.write("foo bar")
+            ep_file.flush()
+    # pylint: disable=W0703
+    # Catching too general exception
     except Exception:
         print "Unable to set up test episode"
         raise
 
 
-def tearDown_test_episode_file():
-    if os.path.exists(FILEDIR):
-        shutil.rmtree(FILEDIR)
+def teardown_test_episode_file():
+    """
+    Remove the test episode.
+    """
+    if os.path.exists(FILE_DIR):
+        shutil.rmtree(FILE_DIR)
 
 
-def setUp_test_show_dir():
-    if not os.path.exists(SHOWDIR):
-        os.makedirs(SHOWDIR)
+def setup_test_show_dir():
+    """
+    Create a test show directory.
+    """
+    if not os.path.exists(SHOW_DIR):
+        os.makedirs(SHOW_DIR)
 
 
-def tearDown_test_show_dir():
-    if os.path.exists(SHOWDIR):
-        shutil.rmtree(SHOWDIR)
+def teardown_test_show_dir():
+    """
+    Remove the test show.
+    """
+    if os.path.exists(SHOW_DIR):
+        shutil.rmtree(SHOW_DIR)
 
 
 if __name__ == '__main__':
     print "=================="
-    print "Dont call this directly"
+    print "Don't call this directly"
     print "=================="
     print "you might want to call"
 
-    dirList = os.listdir(TESTDIR)
-    for fname in dirList:
-        if (fname.find("_test") > 0) and (fname.find("pyc") < 0):
-            print "- " + fname
+    DIR_LIST = os.listdir(TEST_DIR)
+    for filename in DIR_LIST:
+        if (filename.find("_test") > 0) and (filename.find("pyc") < 0):
+            print "- " + filename
 
     print "=================="
     print "or just call all_tests.py"


### PR DESCRIPTION
Pylint 10/10 after adding pylint disables: C0301,  E1103, F0401, W0233, W0613, W0703
PEP 0008: Refactor variables and functions (also affects pp_tests.py)
PEP 0008: Move imports to top of file
PEP 0008: Whitespace, indentation, and spelling
PEP 0257: Add docstrings
