### PR TITLE
Add custom_url property to torrent providers

### DIFF
--- a/gui/slick/views/config_providers.mako
+++ b/gui/slick/views/config_providers.mako
@@ -301,6 +301,24 @@ $('#config-components').tabs();
 
                     % for curTorrentProvider in [curProvider for curProvider in sickbeard.providers.sortedProviderList() if curProvider.providerType == GenericProvider.TORRENT]:
                     <div class="providerDiv" id="${curTorrentProvider.getID()}Div">
+
+                        % if hasattr(curTorrentProvider, 'custom_url'):
+                        <div class="field-pair">
+                            <label for="${curTorrentProvider.getID()}_custom_url">
+                                <span class="component-title">Custom URL:</span>
+                                <span class="component-desc">
+                                    <input type="text" name="${curTorrentProvider.getID()}_custom_url" id="${curTorrentProvider.getID()}_custom_url" value="${curTorrentProvider.custom_url}" class="form-control input-sm input350" />
+                                </span>
+                            </label>
+                            <label>
+                                <span class="component-title">&nbsp;</span>
+                                <span class="component-desc">
+                                    <p>The URL should include the protocol and port (if applicable).  Examples:  http://192.168.1.4/ or http://localhost:3000/</p>
+                                </span>
+                            </label>
+                        </div>
+                        % endif
+
                         % if hasattr(curTorrentProvider, 'api_key'):
                         <div class="field-pair">
                             <label for="${curTorrentProvider.getID()}_api_key">

--- a/sickbeard/__init__.py
+++ b/sickbeard/__init__.py
@@ -1228,6 +1228,9 @@ def initialize(consoleLogging=True):
                                    curProvider.providerType == GenericProvider.TORRENT]:
             curTorrentProvider.enabled = bool(check_setting_int(CFG, curTorrentProvider.getID().upper(),
                                                                 curTorrentProvider.getID(), 0))
+            if hasattr(curTorrentProvider, 'custom_url'):
+                curTorrentProvider.custom_url = check_setting_str(CFG, curTorrentProvider.getID().upper(),
+                                                                curTorrentProvider.getID() + '_custom_url', '', censor_log=True)                                           
             if hasattr(curTorrentProvider, 'api_key'):
                 curTorrentProvider.api_key = check_setting_str(CFG, curTorrentProvider.getID().upper(),
                                                                curTorrentProvider.getID() + '_api_key', '', censor_log=True)
@@ -1789,6 +1792,9 @@ def save_config():
                                curProvider.providerType == GenericProvider.TORRENT]:
         new_config[curTorrentProvider.getID().upper()] = {}
         new_config[curTorrentProvider.getID().upper()][curTorrentProvider.getID()] = int(curTorrentProvider.enabled)
+        if hasattr(curTorrentProvider, 'custom_url'):
+            new_config[curTorrentProvider.getID().upper()][
+                curTorrentProvider.getID() + '_custom_url'] = curTorrentProvider.custom_url
         if hasattr(curTorrentProvider, 'digest'):
             new_config[curTorrentProvider.getID().upper()][
                 curTorrentProvider.getID() + '_digest'] = curTorrentProvider.digest

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -4470,6 +4470,12 @@ class ConfigProviders(Config):
         for curTorrentProvider in [curProvider for curProvider in sickbeard.providers.sortedProviderList() if
                                    curProvider.providerType == sickbeard.GenericProvider.TORRENT]:
 
+            if hasattr(curTorrentProvider, 'custom_url'):
+                try:
+                    curTorrentProvider.custom_url = str(kwargs[curTorrentProvider.getID() + '_custom_url']).strip()
+                except Exception:
+                    curTorrentProvider.custom_url = None
+
             if hasattr(curTorrentProvider, 'minseed'):
                 try:
                     curTorrentProvider.minseed = int(str(kwargs[curTorrentProvider.getID() + '_minseed']).strip())


### PR DESCRIPTION
This commit will add a "custom_url" property for torrent provider modules.

Although the configuration page will provide examples as to the appropriate format for the URL provided (protocol://IP[:port]/), it will be the responsibility of the module to ensure that the URL is valid.
