### PR TITLE
The authentication validation method should return false on error.

### DIFF
--- a/sickbeard/providers/titansoftv.py
+++ b/sickbeard/providers/titansoftv.py
@@ -51,6 +51,7 @@ class TitansOfTVProvider(generic.TorrentProvider):
 
         if 'error' in data:
             logger.log(u"Invalid api key. Check your settings", logger.WARNING)
+            return False
 
         return True
 


### PR DESCRIPTION
This is a small bug; however, the method that checks to make sure that the api key is set properly should return False so that the rest of the routine doesn't try to process.

It appears that other provider files have the "return False" properly in this method -- so, it was probably just an oversight/typo here.
