### PR TITLE
Fix backlog searches for episodes in season 0

### DIFF
--- a/sickbeard/searchBacklog.py
+++ b/sickbeard/searchBacklog.py
@@ -144,7 +144,7 @@ class BacklogSearcher:
         logger.log(u"Seeing if we need anything from {show_name}".format(show_name=show.name), logger.DEBUG)
 
         myDB = db.DBConnection()
-        sqlResults = myDB.select("SELECT status, season, episode FROM tv_episodes WHERE season > 0 AND airdate > ? AND showid = ?",
+        sqlResults = myDB.select("SELECT status, season, episode FROM tv_episodes WHERE airdate > ? AND showid = ?",
                 [fromDate.toordinal(), show.indexerid])
 
         # check through the list of statuses to see if we want any


### PR DESCRIPTION
As far as I can tell, this is a bug in that if you have an episode in season 0 that is in your backlog, it will never be processed by Sickrage without this change.

I looked through the code and cannot see why this sqlite search was restricted to season 1 and above.   My best guess is that this routine/method was written before "season 0" was used by Sickrage.   Perhaps someone that's been around would know better.

Anyway, I had been wondering for a while while my season 0 stuff wasn't being processed during the backlog searches ...and now I know why! :)
