### PR TITLE
Move some variables to sickrage module

### DIFF
--- a/sickbeard/common.py
+++ b/sickbeard/common.py
@@ -54,24 +54,16 @@ if SPOOF_USER_AGENT:
     shuffle(user_agents)
     USER_AGENT = user_agents[0]
 
-mediaExtensions = ['avi', 'mkv', 'mpg', 'mpeg', 'wmv',
-                   'ogm', 'mp4', 'iso', 'img', 'divx',
-                   'm2ts', 'm4v', 'ts', 'flv', 'f4v',
-                   'mov', 'rmvb', 'vob', 'dvr-ms', 'wtv',
-                   'ogv', '3gp', 'webm', 'tp']
-
-subtitleExtensions = ['srt', 'sub', 'ass', 'idx', 'ssa']
-
 cpu_presets = {'HIGH': 5,
                'NORMAL': 2,
                'LOW': 1
               }
 
-### Other constants
+# Other constants
 MULTI_EP_RESULT = -1
 SEASON_RESULT = -2
 
-### Notification Types
+# Notification Types
 NOTIFY_SNATCH = 1
 NOTIFY_DOWNLOAD = 2
 NOTIFY_SUBTITLE_DOWNLOAD = 3
@@ -85,7 +77,7 @@ notifyStrings[NOTIFY_SUBTITLE_DOWNLOAD] = "Subtitle Download Finished"
 notifyStrings[NOTIFY_GIT_UPDATE] = "SickRage Updated"
 notifyStrings[NOTIFY_GIT_UPDATE_TEXT] = "SickRage Updated To Commit#: "
 
-### Episode statuses
+# Episode statuses
 UNKNOWN = -1  # should never happen
 UNAIRED = 1  # episodes that haven't aired yet
 SNATCHED = 2  # qualified with quality
@@ -572,6 +564,7 @@ statusStrings = StatusStrings(
      }
 )
 
+
 # pylint: disable=R0903
 class Overview(object):
     UNAIRED = UNAIRED  # 1
@@ -589,11 +582,6 @@ class Overview(object):
                        GOOD: "good",
                        UNAIRED: "unaired",
                        SNATCHED: "snatched"}
-
-
-# Get our xml namespaces correct for lxml
-XML_NSMAP = {'xsi': 'http://www.w3.org/2001/XMLSchema-instance',
-             'xsd': 'http://www.w3.org/2001/XMLSchema'}
 
 countryList = {'Australia': 'AU',
                'Canada': 'CA',

--- a/sickbeard/helpers.py
+++ b/sickbeard/helpers.py
@@ -51,12 +51,11 @@ from socket import timeout as SocketTimeout
 
 from sickbeard import logger, classes
 from sickbeard.common import USER_AGENT
-from sickbeard.common import mediaExtensions
-from sickbeard.common import subtitleExtensions
 from sickbeard import db
 from sickbeard.notifiers.synoindex import notifier as synoindex_notifier
 from sickbeard import clients
 from sickbeard.subtitles import isValidLanguage
+from sickrage.helper.common import media_extensions, subtitle_extensions
 from sickrage.helper.encoding import ek
 from sickrage.helper.exceptions import ex, MultipleShowObjectsException
 from cachecontrol import CacheControl, caches
@@ -105,7 +104,7 @@ def remove_extension(name):
     if name and "." in name:
         # pylint: disable=W0612
         base_name, sep, extension = name.rpartition('.')  # @UnusedVariable
-        if base_name and extension.lower() in ['nzb', 'torrent'] + mediaExtensions:
+        if base_name and extension.lower() in ['nzb', 'torrent'] + media_extensions:
             name = base_name
 
     return name
@@ -244,7 +243,7 @@ def isMediaFile(filename):
     if re.search('extras?$', sepFile[0], re.I):
         return False
 
-    if sepFile[2].lower() in mediaExtensions:
+    if sepFile[2].lower() in media_extensions:
         return True
     else:
         return False
@@ -649,7 +648,7 @@ def rename_ep_file(cur_path, new_path, old_path_length=0):
         cur_file_ext = cur_path[old_path_length:]
         cur_file_name = cur_path[:old_path_length]
 
-    if cur_file_ext[1:] in subtitleExtensions:
+    if cur_file_ext[1:] in subtitle_extensions:
         # Extract subtitle language from filename
         sublang = os.path.splitext(cur_file_name)[1][1:]
 

--- a/sickbeard/postProcessor.py
+++ b/sickbeard/postProcessor.py
@@ -36,6 +36,7 @@ from sickbeard import notifiers
 from sickbeard import show_name_helpers
 from sickbeard import failed_history
 from sickbeard.name_parser.parser import NameParser, InvalidNameException, InvalidShowException
+from sickrage.helper.common import subtitle_extensions
 from sickrage.helper.encoding import ek
 from sickrage.helper.exceptions import EpisodeNotFoundException, EpisodePostProcessingFailedException, ex
 from sickrage.helper.exceptions import ShowDirectoryNotFoundException
@@ -197,7 +198,7 @@ class PostProcessor(object):
                 file_extension = filefound.rpartition('.')[2]
                 is_subtitle = None
 
-                if file_extension in common.subtitleExtensions:
+                if file_extension in subtitle_extensions:
                     is_subtitle = True
 
                 if not base_name_only:
@@ -222,7 +223,7 @@ class PostProcessor(object):
                 continue
 
             # only list it if the only non-shared part is the extension or if it is a subtitle
-            if subtitles_only and not associated_file_path[len(associated_file_path) - 3:] in common.subtitleExtensions:
+            if subtitles_only and not associated_file_path[len(associated_file_path) - 3:] in subtitle_extensions:
                 continue
 
             # Exclude .rar files from associated list
@@ -232,7 +233,7 @@ class PostProcessor(object):
             # Add the extensions that the user doesn't allow to the 'extensions_to_delete' list
             if sickbeard.MOVE_ASSOCIATED_FILES and sickbeard.ALLOWED_EXTENSIONS:
                 allowed_extensions = sickbeard.ALLOWED_EXTENSIONS.split(",")
-                if not associated_file_path[-3:] in allowed_extensions and not associated_file_path[-3:] in common.subtitleExtensions:
+                if not associated_file_path[-3:] in allowed_extensions and not associated_file_path[-3:] in subtitle_extensions:
                     if ek(os.path.isfile, associated_file_path):
                         extensions_to_delete.append(associated_file_path)
 
@@ -335,7 +336,7 @@ class PostProcessor(object):
             cur_extension = cur_file_path[old_base_name_length + 1:]
 
             # check if file have subtitles language
-            if os.path.splitext(cur_extension)[1][1:] in common.subtitleExtensions:
+            if os.path.splitext(cur_extension)[1][1:] in subtitle_extensions:
                 cur_lang = os.path.splitext(cur_extension)[0]
                 if cur_lang:
                     cur_lang = cur_lang.lower()
@@ -354,7 +355,7 @@ class PostProcessor(object):
             else:
                 new_file_name = helpers.replaceExtension(cur_file_name, cur_extension)
 
-            if sickbeard.SUBTITLES_DIR and cur_extension[-3:] in common.subtitleExtensions:
+            if sickbeard.SUBTITLES_DIR and cur_extension[-3:] in subtitle_extensions:
                 subs_new_path = ek(os.path.join, new_path, sickbeard.SUBTITLES_DIR)
                 dir_exists = helpers.makeDir(subs_new_path)
                 if not dir_exists:

--- a/sickbeard/processTV.py
+++ b/sickbeard/processTV.py
@@ -28,7 +28,8 @@ from sickbeard import logger
 from sickbeard.name_parser.parser import NameParser, InvalidNameException, InvalidShowException
 from sickbeard import common
 from sickbeard import failedProcessor
-from sickrage.helper.encoding import ek, ss
+from sickrage.helper.common import subtitle_extensions
+from sickrage.helper.encoding import ek
 from sickrage.helper.exceptions import EpisodePostProcessingFailedException, ex, FailedPostProcessingFailedException
 
 from unrar2 import RarFile
@@ -547,15 +548,15 @@ def process_media(processPath, videoFiles, nzbName, process_method, force, is_pr
 
         try:
             processor = postProcessor.PostProcessor(cur_video_file_path, nzbName, process_method, is_priority)
-            # This feature prevents PP for files that do not have subtitle associated with the video file        
+            # This feature prevents PP for files that do not have subtitle associated with the video file
             if sickbeard.POSTPONE_IF_NO_SUBS:
                 associatedFiles = processor.list_associated_files(cur_video_file_path, subtitles_only=True)
-                if not [associatedFile for associatedFile in associatedFiles if associatedFile[-3:] in common.subtitleExtensions]:
+                if not [associatedFile for associatedFile in associatedFiles if associatedFile[-3:] in subtitle_extensions]:
                     result.output += logHelper(u"No subtitles associated. Postponing the post-process of this file: %s" % cur_video_file, logger.DEBUG)
                     continue
                 else:
-                    result.output += logHelper(u"Found subtitles associated. Continuing the post-process of this file: %s" % cur_video_file) 
-        
+                    result.output += logHelper(u"Found subtitles associated. Continuing the post-process of this file: %s" % cur_video_file)
+
             result.result = processor.process()
             process_fail_message = ""
         except EpisodePostProcessingFailedException, e:

--- a/sickrage/helper/common.py
+++ b/sickrage/helper/common.py
@@ -18,4 +18,9 @@
 
 dateFormat = '%Y-%m-%d'
 dateTimeFormat = '%Y-%m-%d %H:%M:%S'
+media_extensions = [
+    '3gp', 'avi', 'divx', 'dvr-ms', 'f4v', 'flv', 'img', 'iso', 'm2ts', 'm4v', 'mkv', 'mov', 'mp4', 'mpeg', 'mpg',
+    'ogm', 'ogv', 'rmvb', 'tp', 'ts', 'vob', 'webm', 'wmv', 'wtv',
+]
+subtitle_extensions = ['ass', 'idx', 'srt', 'ssa', 'sub']
 timeFormat = '%A %I:%M %p'


### PR DESCRIPTION
Move `mediaExtensions` and `subtitleExtensions` from `sickbeard.common` to `sickrage.helper.common`.
`XML_NSMAP` was not used anywhere, so I removed it.
