### PR TITLE
Add custom_url option for kat and tpb, set them like "http://kat.cr" …

### DIFF
--- a/gui/slick/views/config_providers.mako
+++ b/gui/slick/views/config_providers.mako
@@ -76,10 +76,14 @@ $('#config-components').tabs();
                                     continue
 
                                 curName = curProvider.getID()
+                                if hasattr(curProvider, 'custom_url'):
+                                    curURL = curProvider.custom_url or curProvider.url
+                                else:
+                                    curURL = curProvider.url
                             %>
                             <li class="ui-state-default ${('nzb-provider', 'torrent-provider')[bool(curProvider.providerType == "torrent")]}" id="${curName}">
                                 <input type="checkbox" id="enable_${curName}" class="provider_enabler" ${('', 'checked="checked"')[curProvider.isEnabled() is True]}/>
-                                <a href="${anon_url(curProvider.url)}" class="imgLink" rel="noreferrer" onclick="window.open(this.href, '_blank'); return false;"><img src="${srRoot}/images/providers/${curProvider.imageName()}" alt="${curProvider.name}" title="${curProvider.name}" width="16" height="16" style="vertical-align:middle;"/></a>
+                                <a href="${anon_url(curURL)}" class="imgLink" rel="noreferrer" onclick="window.open(this.href, '_blank'); return false;"><img src="${srRoot}/images/providers/${curProvider.imageName()}" alt="${curProvider.name}" title="${curProvider.name}" width="16" height="16" style="vertical-align:middle;"/></a>
                                 <span style="vertical-align:middle;">${curProvider.name}</span>
                                 ${('*', '')[bool(curProvider.supportsBacklog)]}
                                 <span class="ui-icon ui-icon-arrowthick-2-n-s pull-right" style="vertical-align:middle;"></span>
@@ -313,7 +317,7 @@ $('#config-components').tabs();
                             <label>
                                 <span class="component-title">&nbsp;</span>
                                 <span class="component-desc">
-                                    <p>The URL should include the protocol and port (if applicable).  Examples:  http://192.168.1.4/ or http://localhost:3000/</p>
+                                    <p>The URL should include the protocol (and port if applicable).  Examples:  http://192.168.1.4/ or http://localhost:3000/</p>
                                 </span>
                             </label>
                         </div>

--- a/sickbeard/config.py
+++ b/sickbeard/config.py
@@ -595,7 +595,8 @@ def check_setting_str(config, cfg_name, item_name, def_val, silent=True, censor_
             config[cfg_name][item_name] = helpers.encrypt(my_val, encryption_version)
 
     if censor_log or (cfg_name, item_name) in logger.censoredItems.iteritems():
-        logger.censoredItems[cfg_name, item_name] = my_val
+        if not item_name.endswith('custom_url'):
+            logger.censoredItems[cfg_name, item_name] = my_val
 
     if not silent:
         logger.log(item_name + " -> " + my_val, logger.DEBUG)

--- a/sickbeard/providers/kat.py
+++ b/sickbeard/providers/kat.py
@@ -18,8 +18,8 @@
 # along with SickRage.  If not, see <http://www.gnu.org/licenses/>.
 
 
+import posixpath  # Must use posixpath
 import traceback
-
 from urllib import urlencode
 from bs4 import BeautifulSoup
 
@@ -43,13 +43,14 @@ class KATProvider(generic.TorrentProvider):
         self.minseed = None
         self.minleech = None
 
-
         self.urls = {
-            'base_url': 'https://kickass.unblocked.pe/',
-            'search': 'https://kickass.unblocked.pe/%s/',
+            'base_url': 'https://kat.cr/',
+            'search': 'https://kat.cr/%s/',
         }
 
         self.url = self.urls['base_url']
+        self.custom_url = None
+
         self.headers.update({'User-Agent': USER_AGENT})
 
         self.search_params = {
@@ -61,7 +62,6 @@ class KATProvider(generic.TorrentProvider):
         }
 
         self.cache = KATCache(self)
-
 
     def _doSearch(self, search_strings, search_mode='eponly', epcount=0, age=0, epObj=None):
         results = []
@@ -84,11 +84,13 @@ class KATProvider(generic.TorrentProvider):
                 url_fmt_string = 'usearch' if mode != 'RSS' else search_string
                 try:
                     searchURL = self.urls['search'] % url_fmt_string + '?' + urlencode(self.search_params)
+                    if self.custom_url:
+                        searchURL = posixpath.join(self.custom_url, searchURL.split(self.url)[1].lstrip('/')) # Must use posixpath
+
                     logger.log(u"Search URL: %s" % searchURL, logger.DEBUG)
                     data = self.getURL(searchURL)
-                    # data = self.getURL(self.urls[('search', 'rss')[mode is 'RSS']], params=self.search_params)
                     if not data:
-                        logger.log(u"No data returned from provider", logger.DEBUG)
+                        logger.log(u'URL did not return data, maybe try a custom url, or a different one', logger.DEBUG)
                         continue
 
                     if not data.startswith('<?xml'):

--- a/sickbeard/providers/thepiratebay.py
+++ b/sickbeard/providers/thepiratebay.py
@@ -18,8 +18,8 @@
 
 
 import re
+import posixpath # Must use posixpath
 from urllib import urlencode
-
 from sickbeard import logger
 from sickbeard import tvcache
 from sickbeard.providers import generic
@@ -42,12 +42,14 @@ class ThePirateBayProvider(generic.TorrentProvider):
         self.cache = ThePirateBayCache(self)
 
         self.urls = {
-            'base_url': 'https://pirateproxy.pl/',
-            'search': 'https://pirateproxy.pl/s/',
-            'rss': 'https://pirateproxy.pl/tv/latest'
+            'base_url': 'https://thepiratebay.gd/',
+            'search': 'https://thepiratebay.gd/s/',
+            'rss': 'https://thepiratebay.gd/tv/latest'
         }
 
         self.url = self.urls['base_url']
+        self.custom_url = None
+
         self.headers.update({'User-Agent': USER_AGENT})
 
         """
@@ -79,10 +81,13 @@ class ThePirateBayProvider(generic.TorrentProvider):
                     logger.log(u"Search string: " + search_string, logger.DEBUG)
 
                 searchURL = self.urls[('search', 'rss')[mode is 'RSS']] + '?' + urlencode(self.search_params)
+                if self.custom_url:
+                    searchURL = posixpath.join(self.custom_url, searchURL.split(self.url)[1].lstrip('/')) # Must use posixpath
+
                 logger.log(u"Search URL: %s" % searchURL, logger.DEBUG)
                 data = self.getURL(searchURL)
-                # data = self.getURL(self.urls[('search', 'rss')[mode is 'RSS']], params=self.search_params)
                 if not data:
+                    logger.log(u'URL did not return data, maybe try a custom url, or a different one', logger.DEBUG)
                     continue
 
                 matches = re.compile(self.re_title_url, re.DOTALL).finditer(data)


### PR DESCRIPTION
Use the official urls by default, can type in a mirror url in the "Custom url" field of the provider's setting if the official one is blocked for you.

Fixes https://github.com/SickRage/sickrage-issues/issues/7

This is the initial step towards having a list that autoselects the best mirror.

This does not mask the custom url from logs (intentionally) and also updates the href url you are taken to when clicking on the provider icon.
