### PR TITLE
Move more functions to sickrage.helper.common and add more tests

### DIFF
--- a/gui/slick/views/displayShow.mako
+++ b/gui/slick/views/displayShow.mako
@@ -10,6 +10,7 @@
     from sickbeard.common import SKIPPED, WANTED, UNAIRED, ARCHIVED, IGNORED, FAILED
     from sickbeard.common import Quality, qualityPresets, statusStrings, Overview
     from sickbeard.helpers import anon_url
+    from sickrage.helper.common import pretty_file_size
 %>
 <%block name="scripts">
 <script type="text/javascript" src="${srRoot}/js/lib/jquery.bookmarkscroll.js?${sbPID}"></script>
@@ -201,7 +202,7 @@
                     </tr>
                 % endif
 
-                <tr><td class="showLegend">Size:</td><td>${sickbeard.helpers.pretty_filesize(sickbeard.helpers.get_size(showLoc[0]))}</td></tr>
+                <tr><td class="showLegend">Size:</td><td>${pretty_file_size(sickbeard.helpers.get_size(showLoc[0]))}</td></tr>
 
                 </table>
 
@@ -469,8 +470,7 @@
             <td class="col-name">${epLoc}</td>
             <td class="col-ep">
                 % if epResult["file_size"]:
-                    <% file_size = sickbeard.helpers.pretty_filesize(epResult["file_size"]) %>
-                    ${file_size}
+                    ${pretty_file_size(epResult["file_size"])}
                 % endif
             </td>
             <td class="col-airdate">

--- a/gui/slick/views/home.mako
+++ b/gui/slick/views/home.mako
@@ -4,6 +4,7 @@
     import calendar
     from sickbeard import sbdatetime
     from sickbeard import network_timezones
+    from sickrage.helper.common import pretty_file_size
     import re
 %>
 <%block name="metas">
@@ -393,7 +394,7 @@
         </td>
 
         ## <% show_size = sickbeard.helpers.get_size(curShow._location) %>
-        ## <td align="center" data-show-size="${show_size}">${sickbeard.helpers.pretty_filesize(show_size)}</td>
+        ## <td align="center" data-show-size="${show_size}">${pretty_file_size(show_size)}</td>
 
         <td align="center">
             <% paused = int(curShow.paused) == 0 and curShow.status == 'Continuing' %>

--- a/gui/slick/views/layouts/main.mako
+++ b/gui/slick/views/layouts/main.mako
@@ -3,6 +3,7 @@
     import re
     import sickbeard
     from sickbeard import network_timezones
+    from sickrage.helper.common import pretty_file_size
     from sickrage.show.Show import Show
     from time import time
 
@@ -301,7 +302,7 @@
 
                 <div>
                     % if has_resource_module:
-                    Memory used: <span class="footerhighlight">${sickbeard.helpers.pretty_filesize(resource.getrusage(resource.RUSAGE_SELF).ru_maxrss)}</span> |
+                    Memory used: <span class="footerhighlight">${pretty_file_size(resource.getrusage(resource.RUSAGE_SELF).ru_maxrss)}</span> |
                     % endif
                     Load time: <span class="footerhighlight">${"%.4f" % (time() - sbStartTime)}s</span> / Mako: <span class="footerhighlight">${"%.4f" % (time() - makoStartTime)}s</span> |
                     Branch: <span class="footerhighlight">${sickbeard.BRANCH}</span> |

--- a/sickbeard/helpers.py
+++ b/sickbeard/helpers.py
@@ -53,7 +53,7 @@ from sickbeard.common import USER_AGENT
 from sickbeard import db
 from sickbeard.notifiers.synoindex import notifier as synoindex_notifier
 from sickbeard import clients
-from sickrage.helper.common import media_extensions, subtitle_extensions
+from sickrage.helper.common import media_extensions, pretty_file_size, subtitle_extensions
 from sickrage.helper.encoding import ek
 from sickrage.helper.exceptions import ex, MultipleShowObjectsException
 from cachecontrol import CacheControl, caches
@@ -159,17 +159,6 @@ def remove_non_release_groups(name):
             _name = re.sub(r'(?i)' + remove_string, '', _name)
 
     return _name
-
-
-def notTorNZBFile(filename):
-    """
-    Returns true if filename is not a NZB nor Torrent file
-
-    :param filename: Filename to check
-    :return: True if filename is not a NZB nor Torrent
-    """
-
-    return not (filename.endswith(".torrent") or filename.endswith(".nzb"))
 
 
 def isSyncFile(filename):
@@ -1721,18 +1710,6 @@ def generateApiKey():
     return m.hexdigest()
 
 
-def pretty_filesize(file_bytes):
-    """Return humanly formatted sizes from bytes"""
-    for mod in ['B', 'KB', 'MB', 'GB', 'TB', 'PB']:
-        if file_bytes < 1024.00:
-            return "%3.2f %s" % (file_bytes, mod)
-        file_bytes /= 1024.00
-
-if __name__ == '__main__':
-    import doctest
-    doctest.testmod()
-
-
 def remove_article(text=''):
     """Remove the english articles from a text string"""
 
@@ -1805,7 +1782,7 @@ def verify_freespace(src, dest, oldfile=None):
         return True
     else:
         logger.log(u"Not enough free space: Needed: %s bytes ( %s ), found: %s bytes ( %s )"
-                   % (neededspace, pretty_filesize(neededspace), diskfree, pretty_filesize(diskfree)), logger.WARNING)
+                   % (neededspace, pretty_file_size(neededspace), diskfree, pretty_file_size(diskfree)), logger.WARNING)
         return False
 
 
@@ -1876,9 +1853,9 @@ def getDiskSpaceUsage(diskPath=None):
         if platform.system() == 'Windows':
             free_bytes = ctypes.c_ulonglong(0)
             ctypes.windll.kernel32.GetDiskFreeSpaceExW(ctypes.c_wchar_p(diskPath), None, None, ctypes.pointer(free_bytes))
-            return pretty_filesize(free_bytes.value)
+            return pretty_file_size(free_bytes.value)
         else:
             st = os.statvfs(diskPath)
-            return pretty_filesize(st.f_bavail * st.f_frsize)
+            return pretty_file_size(st.f_bavail * st.f_frsize)
     else:
         return False

--- a/sickbeard/processTV.py
+++ b/sickbeard/processTV.py
@@ -28,7 +28,7 @@ from sickbeard import logger
 from sickbeard.name_parser.parser import NameParser, InvalidNameException, InvalidShowException
 from sickbeard import common
 from sickbeard import failedProcessor
-from sickrage.helper.common import subtitle_extensions
+from sickrage.helper.common import is_torrent_or_nzb_file, subtitle_extensions
 from sickrage.helper.encoding import ek
 from sickrage.helper.exceptions import EpisodePostProcessingFailedException, ex, FailedPostProcessingFailedException
 
@@ -176,7 +176,7 @@ def processDir(dirName, nzbName=None, process_method=None, force=False, is_prior
 
     path, dirs, files = get_path_dir_files(dirName, nzbName, proc_type)
 
-    files = [x for x in files if helpers.notTorNZBFile(x)]
+    files = [x for x in files if not is_torrent_or_nzb_file(x)]
     SyncFiles = [x for x in files if helpers.isSyncFile(x)]
 
     # Don't post process if files are still being synced and option is activated

--- a/sickbeard/webapi.py
+++ b/sickbeard/webapi.py
@@ -31,7 +31,7 @@ import datetime
 import traceback
 
 import sickbeard
-from sickrage.helper.common import dateFormat, dateTimeFormat, timeFormat
+from sickrage.helper.common import dateFormat, dateTimeFormat, pretty_file_size, timeFormat
 from sickrage.helper.encoding import ek
 from sickrage.helper.exceptions import CantUpdateShowException, ex, ShowDirectoryNotFoundException
 from sickrage.helper.quality import get_quality_string
@@ -755,7 +755,7 @@ class CMD_Episode(ApiCall):
         status, quality = Quality.splitCompositeStatus(int(episode["status"]))
         episode["status"] = _get_status_strings(status)
         episode["quality"] = get_quality_string(quality)
-        episode["file_size_human"] = helpers.pretty_filesize(episode["file_size"])
+        episode["file_size_human"] = pretty_file_size(episode["file_size"])
 
         return _responds(RESULT_SUCCESS, episode)
 

--- a/sickrage/helper/common.py
+++ b/sickrage/helper/common.py
@@ -26,6 +26,43 @@ subtitle_extensions = ['ass', 'idx', 'srt', 'ssa', 'sub']
 timeFormat = '%A %I:%M %p'
 
 
+def is_torrent_or_nzb_file(filename):
+    """
+    Check if the provided ``filename`` if a NZB file or a torrent file, based on its extension.
+    :param filename: The filename to check
+    :return: ``True`` if the ``filename`` is a NZB file or a torrent file, ``False`` otherwise
+    """
+
+    if filename is None:
+        return False
+
+    return filename.endswith('.nzb') or filename.endswith('.torrent')
+
+
+def pretty_file_size(size):
+    """
+    Return a human readable representation of the provided ``size``.
+    :param size: The size to convert
+    :return: The converted size
+    """
+
+    if isinstance(size, str) and size.isdigit():
+        size = float(size)
+
+    if not isinstance(size, (int, long, float)):
+        return ''
+
+    remaining_size = size
+
+    for unit in ['B', 'KB', 'MB', 'GB', 'TB', 'PB']:
+        if remaining_size < 1024.:
+            return '%3.2f %s' % (remaining_size, unit)
+
+        remaining_size /= 1024.
+
+    return size
+
+
 def remove_extension(filename):
     """
     Remove the extension of the provided ``filename``.

--- a/tests/sickrage_tests/helper/common_tests.py
+++ b/tests/sickrage_tests/helper/common_tests.py
@@ -24,10 +24,64 @@ import sys
 sys.path.insert(1, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../../lib')))
 sys.path.insert(1, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../..')))
 
-from sickrage.helper.common import remove_extension, replace_extension
+from sickrage.helper.common import is_torrent_or_nzb_file, pretty_file_size, remove_extension, replace_extension
 
 
 class CommonTests(TestCase):
+    def test_is_torrent_or_nzb_file(self):
+        tests = {
+            None: False,
+            '': False,
+            u'': False,
+            'filename': False,
+            u'filename': False,
+            '.nzb': True,
+            u'.nzb': True,
+            'file.nzb': True,
+            u'file.nzb': True,
+            'file.nzb.part': False,
+            u'file.nzb.part': False,
+            '.torrent': True,
+            u'.torrent': True,
+            'file.torrent': True,
+            u'file.torrent': True,
+            'file.torrent.part': False,
+            u'file.torrent.part': False,
+        }
+
+        for (filename, result) in tests.iteritems():
+            self.assertEqual(is_torrent_or_nzb_file(filename), result)
+
+    def test_pretty_file_size(self):
+        tests = {
+            None: '',
+            '': '',
+            u'': '',
+            '1024': '1.00 KB',
+            u'1024': '1.00 KB',
+            '1024.5': '',
+            u'1024.5': '',
+            -42.5: '-42.50 B',
+            -42: '-42.00 B',
+            0: '0.00 B',
+            25: '25.00 B',
+            25.5: '25.50 B',
+            2 ** 10: '1.00 KB',
+            50 * 2 ** 10 + 25: '50.02 KB',
+            2 ** 20: '1.00 MB',
+            100 * 2 ** 20 + 50 * 2 ** 10 + 25: '100.05 MB',
+            2 ** 30: '1.00 GB',
+            200 * 2 ** 30 + 100 * 2 ** 20 + 50 * 2 ** 10 + 25: '200.10 GB',
+            2 ** 40: '1.00 TB',
+            400 * 2 ** 40 + 200 * 2 ** 30 + 100 * 2 ** 20 + 50 * 2 ** 10 + 25: '400.20 TB',
+            2 ** 50: '1.00 PB',
+            800 * 2 ** 50 + 400 * 2 ** 40 + 200 * 2 ** 30 + 100 * 2 ** 20 + 50 * 2 ** 10 + 25: '800.39 PB',
+            2 ** 60: 2 ** 60,
+        }
+
+        for (size, result) in tests.iteritems():
+            self.assertEqual(pretty_file_size(size), result)
+
     def test_remove_extension(self):
         tests = {
             None: None,


### PR DESCRIPTION
Move `notTorNZBFile` (as `is_torrent_or_nzb_file`) and `pretty_filesize` (as `pretty_file_size`) to `sickrage.helper.common`.

The behavior of `pretty_file_size` changed a bit:
- If the provided size if too big, it returns the provided size (instead of `None` in the current implementation)
- The type of the parameter is checked. So a string containing a float is not parsed and returns an empty string. If the string contains an int, it works fine
