### PR TITLE
Add autocapitalize="off" to all inputs.

### DIFF
--- a/gui/slick/views/apiBuilder.mako
+++ b/gui/slick/views/apiBuilder.mako
@@ -85,10 +85,10 @@
         <div class="collapse navbar-collapse" id="nav-collapsed">
             <div class="btn-group navbar-btn" data-toggle="buttons">
                 <label class="btn btn-primary">
-                    <input autocomplete="off" id="option-profile" type="checkbox" /> Profile
+                    <input autocomplete="off" id="option-profile" type="checkbox"  autocapitalize="off" /> Profile
                 </label>
                 <label class="btn btn-primary">
-                    <input autocomplete="off" id="option-jsonp" type="checkbox" /> JSONP
+                    <input autocomplete="off" id="option-jsonp" type="checkbox"  autocapitalize="off" /> JSONP
                 </label>
             </div>
 
@@ -103,7 +103,7 @@
 
             <form class="navbar-form navbar-right">
                 <div class="form-group">
-                    <input autocomplete="off" class="form-control" id="command-search" placeholder="Command name" type="search"/>
+                    <input autocomplete="off" class="form-control" id="command-search" placeholder="Command name" type="search" autocapitalize="off" />
                 </div>
             </form>
         </div>
@@ -271,10 +271,10 @@ var episodes = ${episodes};
         </select>
     % elif type == 'int':
         % if parameter not in ('episode', 'season'):
-        <input class="form-control" name="${parameter}" placeholder="${parameter}" type="number" data-command="${command}" />
+        <input class="form-control" name="${parameter}" placeholder="${parameter}" type="number" data-command="${command}"  autocapitalize="off" />
         % endif
     % elif type == 'string':
-        <input class="form-control" name="${parameter}" placeholder="${parameter}" type="text" data-command="${command}" />
+        <input class="form-control" name="${parameter}" placeholder="${parameter}" type="text" data-command="${command}"  autocapitalize="off" />
     % endif
 % endfor
 </div>

--- a/gui/slick/views/config_anime.mako
+++ b/gui/slick/views/config_anime.mako
@@ -27,7 +27,7 @@
 
                     <fieldset class="component-group-list">
                         <div class="field-pair">
-                            <input type="checkbox" class="enabler" name="use_anidb" id="use_anidb" ${('', 'checked="checked"')[bool(sickbeard.USE_ANIDB)]} />
+                            <input type="checkbox" class="enabler" name="use_anidb" id="use_anidb" ${('', 'checked="checked"')[bool(sickbeard.USE_ANIDB)]}  autocapitalize="off" />
                             <label for="use_notifo">
                                 <span class="component-title">Enable</span>
                                 <span class="component-desc">Should SickRage use data from AniDB?</span>
@@ -38,7 +38,7 @@
                             <div class="field-pair">
                                 <label class="nocheck">
                                     <span class="component-title">AniDB Username</span>
-                                    <input type="text" name="anidb_username" id="anidb_username" value="${sickbeard.ANIDB_USERNAME}" class="form-control input-sm input350" />
+                                    <input type="text" name="anidb_username" id="anidb_username" value="${sickbeard.ANIDB_USERNAME}" class="form-control input-sm input350"  autocapitalize="off" />
                                 </label>
                                 <label class="nocheck">
                                     <span class="component-title">&nbsp;</span>
@@ -49,7 +49,7 @@
                             <div class="field-pair">
                                 <label class="nocheck">
                                     <span class="component-title">AniDB Password</span>
-                                    <input type="password" name="anidb_password" id="anidb_password" value="${sickbeard.ANIDB_PASSWORD}" class="form-control input-sm input350" />
+                                    <input type="password" name="anidb_password" id="anidb_password" value="${sickbeard.ANIDB_PASSWORD}" class="form-control input-sm input350"  autocapitalize="off" />
                                 </label>
                                 <label class="nocheck">
                                     <span class="component-title">&nbsp;</span>
@@ -57,14 +57,14 @@
                                 </label>
                             </div>
                             <div class="field-pair">
-                                <input type="checkbox" name="anidb_use_mylist" id="anidb_use_mylist" ${('', 'checked="checked"')[bool(sickbeard.ANIDB_USE_MYLIST)]}/>
+                                <input type="checkbox" name="anidb_use_mylist" id="anidb_use_mylist" ${('', 'checked="checked"')[bool(sickbeard.ANIDB_USE_MYLIST)]} autocapitalize="off" />
                                 <label>
                                     <span class="component-title">AniDB MyList</span>
                                     <span class="component-desc">Do you want to add the PostProcessed Episodes to the MyList ?</span>
                                 </label>
                             </div>
                         </div>
-                        <input type="submit" class="btn config_submitter" value="Save Changes" />
+                        <input type="submit" class="btn config_submitter" value="Save Changes"  autocapitalize="off" />
                     </fieldset>
 
                 </div><!-- /component-group //-->
@@ -76,17 +76,17 @@
                     </div>
                     <fieldset class="component-group-list">
                         <div class="field-pair">
-                            <input type="checkbox" class="enabler" name="split_home" id="split_home" ${('', 'checked="checked"')[bool(sickbeard.ANIME_SPLIT_HOME)]}/>
+                            <input type="checkbox" class="enabler" name="split_home" id="split_home" ${('', 'checked="checked"')[bool(sickbeard.ANIME_SPLIT_HOME)]} autocapitalize="off" />
                             <label for="use_notifo">
                                 <span class="component-title">Split show lists</span>
                                 <span class="component-desc">Separate anime and normal shows in groups</span>
                             </label>
                         </div>
-                        <input type="submit" class="btn config_submitter" value="Save Changes" />
+                        <input type="submit" class="btn config_submitter" value="Save Changes"  autocapitalize="off" />
                    </fieldset>
                 </div><!-- /component-group //-->
 
-                <br><input type="submit" class="btn config_submitter" value="Save Changes" /><br>
+                <br><input type="submit" class="btn config_submitter" value="Save Changes"  autocapitalize="off" /><br>
 
             </div><!-- /config-components //-->
 

--- a/gui/slick/views/config_backuprestore.mako
+++ b/gui/slick/views/config_backuprestore.mako
@@ -43,8 +43,8 @@
 
                             <br><br>
 
-                            <input type="text" name="backupDir" id="backupDir" class="form-control input-sm input350" />
-                            <input class="btn btn-inline" type="button" value="Backup" id="Backup" />
+                            <input type="text" name="backupDir" id="backupDir" class="form-control input-sm input350"  autocapitalize="off" />
+                            <input class="btn btn-inline" type="button" value="Backup" id="Backup"  autocapitalize="off" />
 
                             <br>
 
@@ -66,8 +66,8 @@
 
                             <br><br>
 
-                            <input type="text" name="backupFile" id="backupFile" class="form-control input-sm input350" />
-                            <input class="btn btn-inline" type="button" value="Restore" id="Restore" />
+                            <input type="text" name="backupFile" id="backupFile" class="form-control input-sm input350"  autocapitalize="off" />
+                            <input class="btn btn-inline" type="button" value="Restore" id="Restore"  autocapitalize="off" />
 
                             <br>
 

--- a/gui/slick/views/config_general.mako
+++ b/gui/slick/views/config_general.mako
@@ -62,7 +62,7 @@
                             <label for="launch_browser">
                                 <span class="component-title">Launch browser</span>
                                 <span class="component-desc">
-                                    <input type="checkbox" name="launch_browser" id="launch_browser" ${('', 'checked="checked"')[bool(sickbeard.LAUNCH_BROWSER)]}/>
+                                    <input type="checkbox" name="launch_browser" id="launch_browser" ${('', 'checked="checked"')[bool(sickbeard.LAUNCH_BROWSER)]} autocapitalize="off" />
                                     <p>open the SickRage home page on startup</p>
                                 </span>
                             </label>
@@ -86,7 +86,7 @@
                             <label for="showupdate_hour">
                                 <span class="component-title">When to update shows</span>
                                 <span class="component-desc">
-                                    <input type="text" name="showupdate_hour" id="showupdate_hour" value="${sickbeard.SHOWUPDATE_HOUR}" class="form-control input-sm input75" />
+                                    <input type="text" name="showupdate_hour" id="showupdate_hour" value="${sickbeard.SHOWUPDATE_HOUR}" class="form-control input-sm input75"  autocapitalize="off" />
                                     <p>with information such as next air dates, show ended, etc. Use 15 for 3pm, 4 for 4am etc. Anything over 23 or under 0 will be set to 0 (12am)</p>
                                 </span>
                             </label>
@@ -96,11 +96,11 @@
                             <span class="component-title">Send to trash for actions</span>
                             <span class="component-desc">
                                 <label for="trash_remove_show" class="nextline-block">
-                                    <input type="checkbox" name="trash_remove_show" id="trash_remove_show" ${('', 'checked="checked"')[bool(sickbeard.TRASH_REMOVE_SHOW)]}/>
+                                    <input type="checkbox" name="trash_remove_show" id="trash_remove_show" ${('', 'checked="checked"')[bool(sickbeard.TRASH_REMOVE_SHOW)]} autocapitalize="off" />
                                     <p>when using show "Remove" and delete files</p>
                                 </label>
                                 <label for="trash_rotate_logs" class="nextline-block">
-                                    <input type="checkbox" name="trash_rotate_logs" id="trash_rotate_logs" ${('', 'checked="checked"')[bool(sickbeard.TRASH_ROTATE_LOGS)]}/>
+                                    <input type="checkbox" name="trash_rotate_logs" id="trash_rotate_logs" ${('', 'checked="checked"')[bool(sickbeard.TRASH_ROTATE_LOGS)]} autocapitalize="off" />
                                     <p>on scheduled deletes of the oldest log files</p>
                                 </label>
                                 <div class="clear-left"><p>selected actions use trash (recycle bin) instead of the default permanent delete</p></div>
@@ -111,7 +111,7 @@
                             <label for="log_dir">
                                 <span class="component-title">Log file folder location</span>
                                 <span class="component-desc">
-                                    <input type="text" name="log_dir" id="log_dir" value="${sickbeard.ACTUAL_LOG_DIR}" class="form-control input-sm input350" />
+                                    <input type="text" name="log_dir" id="log_dir" value="${sickbeard.ACTUAL_LOG_DIR}" class="form-control input-sm input350"  autocapitalize="off" />
                                 </span>
                             </label>
                         </div>
@@ -120,7 +120,7 @@
                             <label for="log_nr">
                                 <span class="component-title">Number of Log files saved</span>
                                 <span class="component-desc">
-                                    <input type="text" name="log_nr" id="log_nr" value="${sickbeard.LOG_NR}" class="form-control input-sm input75" />
+                                    <input type="text" name="log_nr" id="log_nr" value="${sickbeard.LOG_NR}" class="form-control input-sm input75"  autocapitalize="off" />
                                     <p>number of log files saved when rotating logs (default: 5) (REQUIRES RESTART)</p>
                                 </span>
                             </label>
@@ -130,7 +130,7 @@
                             <label for="log_size">
                                 <span class="component-title">Size of Log files saved</span>
                                 <span class="component-desc">
-                                    <input type="text" name="log_size" id="log_size" value="${sickbeard.LOG_SIZE}" class="form-control input-sm input75" />
+                                    <input type="text" name="log_size" id="log_size" value="${sickbeard.LOG_SIZE}" class="form-control input-sm input75"  autocapitalize="off" />
                                     <p>maximum size of a log file saved (default: 1048576 (1MB)) (REQUIRES RESTART)</p>
                                 </span>
                             </label>
@@ -155,7 +155,7 @@
                             <label for="indexer_timeout">
                                 <span class="component-title">Timeout show indexer at</span>
                                 <span class="component-desc">
-                                    <input type="text" name="indexer_timeout" id="indexer_timeout" value="${sickbeard.INDEXER_TIMEOUT}" class="form-control input-sm input75" />
+                                    <input type="text" name="indexer_timeout" id="indexer_timeout" value="${sickbeard.INDEXER_TIMEOUT}" class="form-control input-sm input75"  autocapitalize="off" />
                                     <p>seconds of inactivity when finding new shows (default:10)</p>
                                 </span>
                             </label>
@@ -171,7 +171,7 @@
                             </label>
                         </div>
 
-                        <input type="submit" class="btn config_submitter" value="Save Changes" />
+                        <input type="submit" class="btn config_submitter" value="Save Changes"  autocapitalize="off" />
                     </fieldset>
                 </div>
                 <div class="component-group">
@@ -186,7 +186,7 @@
                             <label for="version_notify">
                                 <span class="component-title">Check software updates</span>
                                 <span class="component-desc">
-                                    <input type="checkbox" name="version_notify" id="version_notify" ${('', 'checked="checked"')[bool(sickbeard.VERSION_NOTIFY)]}/>
+                                    <input type="checkbox" name="version_notify" id="version_notify" ${('', 'checked="checked"')[bool(sickbeard.VERSION_NOTIFY)]} autocapitalize="off" />
                                     <p>and display notifications when updates are available.
                                     Checks are run on startup and at the frequency set below*</p>
                                 </span>
@@ -197,7 +197,7 @@
                             <label for="auto_update">
                                 <span class="component-title">Automatically update</span>
                                 <span class="component-desc">
-                                    <input type="checkbox" name="auto_update" id="auto_update" ${('', 'checked="checked"')[bool(sickbeard.AUTO_UPDATE)]}/>
+                                    <input type="checkbox" name="auto_update" id="auto_update" ${('', 'checked="checked"')[bool(sickbeard.AUTO_UPDATE)]} autocapitalize="off" />
                                     <p>fetch and install software updates.
                                     Updates are run on startup and in the background at the frequency set below*</p>
                                 </span>
@@ -208,7 +208,7 @@
                             <label>
                                 <span class="component-title">Check the server every*</span>
                                 <span class="component-desc">
-                                    <input type="text" name="update_frequency" id="update_frequency" value="${sickbeard.UPDATE_FREQUENCY}" class="form-control input-sm input75" />
+                                    <input type="text" name="update_frequency" id="update_frequency" value="${sickbeard.UPDATE_FREQUENCY}" class="form-control input-sm input75"  autocapitalize="off" />
                                     <p>hours for software updates (default:12)</p>
                                 </span>
                             </label>
@@ -218,13 +218,13 @@
                             <label for="notify_on_update">
                                 <span class="component-title">Notify on software update</span>
                                 <span class="component-desc">
-                                    <input type="checkbox" name="notify_on_update" id="notify_on_update" ${('', 'checked="checked"')[bool(sickbeard.NOTIFY_ON_UPDATE)]}/>
+                                    <input type="checkbox" name="notify_on_update" id="notify_on_update" ${('', 'checked="checked"')[bool(sickbeard.NOTIFY_ON_UPDATE)]} autocapitalize="off" />
                                     <p>send a message to all enabled notifiers when SickRage has been updated</p>
                                 </span>
                             </label>
                         </div>
 
-                        <input type="submit" class="btn config_submitter" value="Save Changes" />
+                        <input type="submit" class="btn config_submitter" value="Save Changes"  autocapitalize="off" />
                     </fieldset>
 
                 </div>
@@ -266,7 +266,7 @@
                             <label for="sort_article">
                                 <span class="component-title">Sort with "The", "A", "An"</span>
                                 <span class="component-desc">
-                                    <input type="checkbox" name="sort_article" id="sort_article" ${('', 'checked="checked"')[bool(sickbeard.SORT_ARTICLE)]}/>
+                                    <input type="checkbox" name="sort_article" id="sort_article" ${('', 'checked="checked"')[bool(sickbeard.SORT_ARTICLE)]} autocapitalize="off" />
                                     <p>include articles ("The", "A", "An") when sorting show lists</p>
                                 </span>
                             </label>
@@ -275,7 +275,7 @@
                             <label for="coming_eps_missed_range">
                                 <span class="component-title">Missed episodes range</span>
                                 <span class="component-desc">
-                                    <input type="number" step="1" min="7" name="coming_eps_missed_range" id="coming_eps_missed_range" value="${sickbeard.COMING_EPS_MISSED_RANGE}" class="form-control input-sm input75" />
+                                    <input type="number" step="1" min="7" name="coming_eps_missed_range" id="coming_eps_missed_range" value="${sickbeard.COMING_EPS_MISSED_RANGE}" class="form-control input-sm input75"  autocapitalize="off" />
                                     <p>Set the range in days of the missed episodes in the Schedule page</p>
                                 </span>
                             </label>
@@ -284,7 +284,7 @@
                             <label for="fuzzy_dating">
                                 <span class="component-title">Display fuzzy dates</span>
                                 <span class="component-desc">
-                                    <input type="checkbox" name="fuzzy_dating" id="fuzzy_dating" class="viewIf datePresets" ${('', 'checked="checked"')[bool(sickbeard.FUZZY_DATING)]}/>
+                                    <input type="checkbox" name="fuzzy_dating" id="fuzzy_dating" class="viewIf datePresets" ${('', 'checked="checked"')[bool(sickbeard.FUZZY_DATING)]} autocapitalize="off" />
                                     <p>move absolute dates into tooltips and display e.g. "Last Thu", "On Tue"</p>
                                 </span>
                             </label>
@@ -293,7 +293,7 @@
                             <label for="trim_zero">
                                 <span class="component-title">Trim zero padding</span>
                                 <span class="component-desc">
-                                    <input type="checkbox" name="trim_zero" id="trim_zero" ${('', 'checked="checked"')[bool(sickbeard.TRIM_ZERO)]}/>
+                                    <input type="checkbox" name="trim_zero" id="trim_zero" ${('', 'checked="checked"')[bool(sickbeard.TRIM_ZERO)]} autocapitalize="off" />
                                     <p>remove the leading number "0" shown on hour of day, and date of month</p>
                                 </span>
                             </label>
@@ -336,10 +336,10 @@
                             <span class="component-title">Timezone:</span>
                             <span class="component-desc">
                                 <label for="local" class="space-right">
-                                    <input type="radio" name="timezone_display" id="local" value="local" ${('', 'checked="checked"')[sickbeard.TIMEZONE_DISPLAY == "local"]} />Local
+                                    <input type="radio" name="timezone_display" id="local" value="local" ${('', 'checked="checked"')[sickbeard.TIMEZONE_DISPLAY == "local"]}  autocapitalize="off" />Local
                                 </label>
                                 <label for="network">
-                                    <input type="radio" name="timezone_display" id="network" value="network" ${('', 'checked="checked"')[sickbeard.TIMEZONE_DISPLAY == "network"]} />Network
+                                    <input type="radio" name="timezone_display" id="network" value="network" ${('', 'checked="checked"')[sickbeard.TIMEZONE_DISPLAY == "network"]}  autocapitalize="off" />Network
                                 </label>
                                 <div class="clear-left">
                                 <p>display dates and times in either your timezone or the shows network timezone</p>
@@ -353,7 +353,7 @@
                         <div class="field-pair">
                             <label for="download_url">
                                 <span class="component-title">Download url</span>
-                                <input type="text" name="download_url" id="download_url" value="${sickbeard.DOWNLOAD_URL}" size="35" />
+                                <input type="text" name="download_url" id="download_url" value="${sickbeard.DOWNLOAD_URL}" size="35"  autocapitalize="off" />
                             </label>
                             <label>
                                 <span class="component-title">&nbsp;</span>
@@ -362,7 +362,7 @@
                         </div>
 
 
-                        <input type="submit" class="btn config_submitter" value="Save Changes" />
+                        <input type="submit" class="btn config_submitter" value="Save Changes"  autocapitalize="off" />
 
                     </fieldset>
 
@@ -382,7 +382,7 @@
                             <label for="api_key">
                                 <span class="component-title">API key</span>
                                 <span class="component-desc">
-                                    <input type="text" name="api_key" id="api_key" value="${sickbeard.API_KEY}" class="form-control input-sm input300" readonly="readonly" />
+                                    <input type="text" name="api_key" id="api_key" value="${sickbeard.API_KEY}" class="form-control input-sm input300" readonly="readonly"  autocapitalize="off" />
                                     <input class="btn btn-inline" type="button" id="generate_new_apikey" value="Generate">
                                     <div class="clear-left">
                                         <p>used to give 3rd party programs limited access to SickRage</p>
@@ -396,7 +396,7 @@
                             <label for="web_log">
                                 <span class="component-title">HTTP logs</span>
                                 <span class="component-desc">
-                                    <input type="checkbox" name="web_log" id="web_log" ${('', 'checked="checked"')[bool(sickbeard.WEB_LOG)]}/>
+                                    <input type="checkbox" name="web_log" id="web_log" ${('', 'checked="checked"')[bool(sickbeard.WEB_LOG)]} autocapitalize="off" />
                                     <p>enable logs from the internal Tornado web server</p>
                                 </span>
                             </label>
@@ -406,7 +406,7 @@
                             <label for="web_username">
                                 <span class="component-title">HTTP username</span>
                                 <span class="component-desc">
-                                    <input type="text" name="web_username" id="web_username" value="${sickbeard.WEB_USERNAME}" class="form-control input-sm input300" />
+                                    <input type="text" name="web_username" id="web_username" value="${sickbeard.WEB_USERNAME}" class="form-control input-sm input300"  autocapitalize="off" />
                                     <p>set blank for no login</p>
                                 </span>
                             </label>
@@ -416,7 +416,7 @@
                             <label for="web_password">
                                 <span class="component-title">HTTP password</span>
                                 <span class="component-desc">
-                                    <input type="password" name="web_password" id="web_password" value="${sickbeard.WEB_PASSWORD}" class="form-control input-sm input300" />
+                                    <input type="password" name="web_password" id="web_password" value="${sickbeard.WEB_PASSWORD}" class="form-control input-sm input300"  autocapitalize="off" />
                                     <p>blank = no authentication</span>
                             </label>
                         </div>
@@ -425,7 +425,7 @@
                             <label for="web_port">
                                 <span class="component-title">HTTP port</span>
                                 <span class="component-desc">
-                                    <input type="text" name="web_port" id="web_port" value="${sickbeard.WEB_PORT}" class="form-control input-sm input100" />
+                                    <input type="text" name="web_port" id="web_port" value="${sickbeard.WEB_PORT}" class="form-control input-sm input100"  autocapitalize="off" />
                                     <p>web port to browse and access SickRage (default:8081)</p>
                                 </span>
                             </label>
@@ -435,7 +435,7 @@
                             <label for="web_ipv6">
                                 <span class="component-title">Listen on IPv6</span>
                                 <span class="component-desc">
-                                    <input type="checkbox" name="web_ipv6" id="web_ipv6" ${('', 'checked="checked"')[bool(sickbeard.WEB_IPV6)]}/>
+                                    <input type="checkbox" name="web_ipv6" id="web_ipv6" ${('', 'checked="checked"')[bool(sickbeard.WEB_IPV6)]} autocapitalize="off" />
                                     <p>attempt binding to any available IPv6 address</p>
                                 </span>
                             </label>
@@ -445,7 +445,7 @@
                             <label for="enable_https">
                                 <span class="component-title">Enable HTTPS</span>
                                 <span class="component-desc">
-                                    <input type="checkbox" name="enable_https" class="enabler" id="enable_https" ${('', 'checked="checked"')[bool(sickbeard.ENABLE_HTTPS)]}/>
+                                    <input type="checkbox" name="enable_https" class="enabler" id="enable_https" ${('', 'checked="checked"')[bool(sickbeard.ENABLE_HTTPS)]} autocapitalize="off" />
                                     <p>enable access to the web interface using a HTTPS address</p>
                                 </span>
                             </label>
@@ -455,7 +455,7 @@
                                 <label for="https_cert">
                                     <span class="component-title">HTTPS certificate</span>
                                     <span class="component-desc">
-                                        <input type="text" name="https_cert" id="https_cert" value="${sickbeard.HTTPS_CERT}" class="form-control input-sm input300" />
+                                        <input type="text" name="https_cert" id="https_cert" value="${sickbeard.HTTPS_CERT}" class="form-control input-sm input300"  autocapitalize="off" />
                                         <div class="clear-left"><p>file name or path to HTTPS certificate</p></div>
                                     </span>
                                 </label>
@@ -464,7 +464,7 @@
                                 <label for="https_key">
                                     <span class="component-title">HTTPS key</span>
                                     <span class="component-desc">
-                                        <input type="text" name="https_key" id="https_key" value="${sickbeard.HTTPS_KEY}" class="form-control input-sm input300" />
+                                        <input type="text" name="https_key" id="https_key" value="${sickbeard.HTTPS_KEY}" class="form-control input-sm input300"  autocapitalize="off" />
                                         <div class="clear-left"><p>file name or path to HTTPS key</p></div>
                                     </span>
                                 </label>
@@ -475,13 +475,13 @@
                             <label for="handle_reverse_proxy">
                                 <span class="component-title">Reverse proxy headers</span>
                                 <span class="component-desc">
-                                    <input type="checkbox" name="handle_reverse_proxy" id="handle_reverse_proxy" ${('', 'checked="checked"')[bool(sickbeard.HANDLE_REVERSE_PROXY)]}/>
+                                    <input type="checkbox" name="handle_reverse_proxy" id="handle_reverse_proxy" ${('', 'checked="checked"')[bool(sickbeard.HANDLE_REVERSE_PROXY)]} autocapitalize="off" />
                                     <p>accept the following reverse proxy headers (advanced)...<br>(X-Forwarded-For, X-Forwarded-Host, and X-Forwarded-Proto)</p>
                                 </span>
                             </label>
                         </div>
 
-                        <input type="submit" class="btn config_submitter" value="Save Changes" />
+                        <input type="submit" class="btn config_submitter" value="Save Changes"  autocapitalize="off" />
 
                     </fieldset>
 
@@ -517,7 +517,7 @@
                             <label>
                                 <span class="component-title">Anonymous redirect</span>
                                 <span class="component-desc">
-                                    <input type="text" name="anon_redirect" value="${sickbeard.ANON_REDIRECT}" class="form-control input-sm input300" />
+                                    <input type="text" name="anon_redirect" value="${sickbeard.ANON_REDIRECT}" class="form-control input-sm input300"  autocapitalize="off" />
                                     <div class="clear-left"><p>backlink protection via anonymizer service, must end in "?"</p></div>
                                 </span>
                             </label>
@@ -527,7 +527,7 @@
                             <label for="debug">
                                 <span class="component-title">Enable debug</span>
                                 <span class="component-desc">
-                                    <input type="checkbox" name="debug" id="debug" ${('', 'checked="checked"')[bool(sickbeard.DEBUG)]}/>
+                                    <input type="checkbox" name="debug" id="debug" ${('', 'checked="checked"')[bool(sickbeard.DEBUG)]} autocapitalize="off" />
                                     <p>Enable debug logs<p>
                                 </span>
                             </label>
@@ -537,7 +537,7 @@
                             <label for="ssl_verify">
                                 <span class="component-title">Verify SSL Certs</span>
                                     <span class="component-desc">
-                                        <input type="checkbox" name="ssl_verify" id="ssl_verify" ${('', 'checked="checked"')[bool(sickbeard.SSL_VERIFY)]}/>
+                                        <input type="checkbox" name="ssl_verify" id="ssl_verify" ${('', 'checked="checked"')[bool(sickbeard.SSL_VERIFY)]} autocapitalize="off" />
                                         <p>Verify SSL Certificates (Disable this for broken SSL installs (Like QNAP))<p>
                                     </span>
                             </label>
@@ -547,7 +547,7 @@
                             <label for="no_restart">
                                 <span class="component-title">No Restart</span>
                                 <span class="component-desc">
-                                    <input type="checkbox" name="no_restart" id="no_restart" ${('', 'checked="checked"')[bool(sickbeard.NO_RESTART)]}/>
+                                    <input type="checkbox" name="no_restart" id="no_restart" ${('', 'checked="checked"')[bool(sickbeard.NO_RESTART)]} autocapitalize="off" />
                                     <p>Only shutdown when restarting SR.
                                     Only select this when you have external software restarting SR automatically when it stops (like FireDaemon)</p>
                                 </span>
@@ -559,7 +559,7 @@
                             <label for="encryption_version">
                                 <span class="component-title">Encrypt passwords</span>
                                 <span class="component-desc">
-                                    <input type="checkbox" name="encryption_version" id="encryption_version" ${('', 'checked="checked"')[bool(sickbeard.ENCRYPTION_VERSION)]}/>
+                                    <input type="checkbox" name="encryption_version" id="encryption_version" ${('', 'checked="checked"')[bool(sickbeard.ENCRYPTION_VERSION)]} autocapitalize="off" />
                                     <p>in the <code>config.ini</code> file.
                                     <b>Warning:</b> Passwords must only contain <a target="_blank" href="${anon_url('http://en.wikipedia.org/wiki/ASCII#ASCII_printable_characters')}">ASCII characters</a></p>
                                 </span>
@@ -570,7 +570,7 @@
                             <label for="calendar_unprotected">
                                 <span class="component-title">Unprotected calendar</span>
                                 <span class="component-desc">
-                                    <input type="checkbox" name="calendar_unprotected" id="calendar_unprotected" ${('', 'checked="checked"')[bool(sickbeard.CALENDAR_UNPROTECTED)]}/>
+                                    <input type="checkbox" name="calendar_unprotected" id="calendar_unprotected" ${('', 'checked="checked"')[bool(sickbeard.CALENDAR_UNPROTECTED)]} autocapitalize="off" />
                                     <p>allow subscribing to the calendar without user and password.
                                     Some services like Google Calendar only work this way</p>
                                 </span>
@@ -582,7 +582,7 @@
                             <label for="calendar_icons">
                                 <span class="component-title">Google Calendar Icons</span>
                                 <span class="component-desc">
-                                    <input type="checkbox" name="calendar_icons" id="calendar_icons" ${('', 'checked="checked"')[bool(sickbeard.CALENDAR_ICONS)]}/>
+                                    <input type="checkbox" name="calendar_icons" id="calendar_icons" ${('', 'checked="checked"')[bool(sickbeard.CALENDAR_ICONS)]} autocapitalize="off" />
                                     <p>show an icon next to exported calendar events in Google Calendar.</p>
                                 </span>
 
@@ -593,7 +593,7 @@
                             <label>
                                 <span class="component-title">Proxy host</span>
                                 <span class="component-desc">
-                                    <input type="text" name="proxy_setting" value="${sickbeard.PROXY_SETTING}" class="form-control input-sm input300" />
+                                    <input type="text" name="proxy_setting" value="${sickbeard.PROXY_SETTING}" class="form-control input-sm input300"  autocapitalize="off" />
                                     <div class="clear-left"><p>blank to disable or proxy to use when connecting to providers</p></div>
                             </label>
                         </div>
@@ -602,7 +602,7 @@
                             <label for="proxy_indexers">
                                 <span class="component-title">Use proxy for indexers</span>
                                 <span class="component-desc">
-                                    <input type="checkbox" name="proxy_indexers" id="proxy_indexers" ${('', 'checked="checked"')[bool(sickbeard.PROXY_INDEXERS)]}/>
+                                    <input type="checkbox" name="proxy_indexers" id="proxy_indexers" ${('', 'checked="checked"')[bool(sickbeard.PROXY_INDEXERS)]} autocapitalize="off" />
                                     <p>use proxy host for connecting to indexers (thetvdb)</p>
                                 </span>
                             </label>
@@ -612,7 +612,7 @@
                             <label for="skip_removed_files">
                                 <span class="component-title">Skip Remove Detection</span>
                                 <span class="component-desc">
-                                <input type="checkbox" name="skip_removed_files" id="skip_removed_files" ${('', 'checked="checked"')[bool(sickbeard.SKIP_REMOVED_FILES)]}/>
+                                <input type="checkbox" name="skip_removed_files" id="skip_removed_files" ${('', 'checked="checked"')[bool(sickbeard.SKIP_REMOVED_FILES)]} autocapitalize="off" />
                                 <p>Skip detection of removed files. If disabled the episode will be set to the default deleted status</p>
                                  </span>
                                 <div class="clear-left">
@@ -636,7 +636,7 @@
                                             <option value="${defStatus}" ${('', 'selected="selected"')[sickbeard.EP_DEFAULT_DELETED_STATUS == defStatus]}>${statusStrings[defStatus]}</option>
                                         % endfor
                                         </select>
-                                        <input type="hidden" name="ep_default_deleted_status" value="${sickbeard.EP_DEFAULT_DELETED_STATUS}" />
+                                        <input type="hidden" name="ep_default_deleted_status" value="${sickbeard.EP_DEFAULT_DELETED_STATUS}"  autocapitalize="off" />
 % endif
                                     <span>Define the status to be set for media file that has been deleted.</span>
                                     <div class="clear-left">
@@ -647,7 +647,7 @@
                             </label>
                         </div>
 
-                        <input type="submit" class="btn config_submitter" value="Save Changes" />
+                        <input type="submit" class="btn config_submitter" value="Save Changes"  autocapitalize="off" />
                     </fieldset>
                 </div>
 
@@ -695,7 +695,7 @@
                             <label for="git_username">
                                 <span class="component-title">GitHub username</span>
                                 <span class="component-desc">
-                                    <input type="text" name="git_username" id="git_username" value="${sickbeard.GIT_USERNAME}" class="form-control input-sm input300" />
+                                    <input type="text" name="git_username" id="git_username" value="${sickbeard.GIT_USERNAME}" class="form-control input-sm input300"  autocapitalize="off" />
                                     <div class="clear-left"><p>*** (REQUIRED FOR SUBMITTING ISSUES) ***</p></div>
                                 </span>
                             </label>
@@ -705,7 +705,7 @@
                             <label for="git_password">
                                 <span class="component-title">GitHub password</span>
                                 <span class="component-desc">
-                                    <input type="password" name="git_password" id="git_password" value="${sickbeard.GIT_PASSWORD}" class="form-control input-sm input300" />
+                                    <input type="password" name="git_password" id="git_password" value="${sickbeard.GIT_PASSWORD}" class="form-control input-sm input300"  autocapitalize="off" />
                                     <div class="clear-left"><p>*** (REQUIRED FOR SUBMITTING ISSUES) ***</p></div>
                                 </span>
                             </label>
@@ -715,7 +715,7 @@
                             <label for="git_remote">
                                 <span class="component-title">GitHub remote for branch</span>
                                 <span class="component-desc">
-                                    <input type="text" name="git_remote" id="git_remote" value="${sickbeard.GIT_REMOTE}" class="form-control input-sm input300" />
+                                    <input type="text" name="git_remote" id="git_remote" value="${sickbeard.GIT_REMOTE}" class="form-control input-sm input300"  autocapitalize="off" />
                                     <div class="clear-left"><p>default:origin. Access repo configured remotes (save then refresh browser)</p></div>
                                 </span>
                             </label>
@@ -725,7 +725,7 @@
                             <label>
                                 <span class="component-title">Git executable path</span>
                                 <span class="component-desc">
-                                    <input type="text" name="git_path" value="${sickbeard.GIT_PATH}" class="form-control input-sm input300" />
+                                    <input type="text" name="git_path" value="${sickbeard.GIT_PATH}" class="form-control input-sm input300"  autocapitalize="off" />
                                     <div class="clear-left"><p>only needed if OS is unable to locate git from env</p></div>
                                 </span>
                             </label>
@@ -735,7 +735,7 @@
                             <label for="git_reset">
                                 <span class="component-title">Git reset</span>
                                 <span class="component-desc">
-                                    <input type="checkbox" name="git_reset" id="git_reset" ${('', 'checked="checked"')[bool(sickbeard.GIT_RESET)]}/>
+                                    <input type="checkbox" name="git_reset" id="git_reset" ${('', 'checked="checked"')[bool(sickbeard.GIT_RESET)]} autocapitalize="off" />
                                     <p>removes untracked files and performs a hard reset on git branch automatically to help resolve update issues</p>
                                 </span>
                             </label>
@@ -745,13 +745,13 @@
                             <label for="git_autoissues">
                                 <span class="component-title">Git auto-issues submit</span>
                                 <span class="component-desc">
-                                    <input type="checkbox" name="git_autoissues" id="git_autoissues" ${('', 'checked="checked"')[bool(sickbeard.GIT_AUTOISSUES)]} disable/>
+                                    <input type="checkbox" name="git_autoissues" id="git_autoissues" ${('', 'checked="checked"')[bool(sickbeard.GIT_AUTOISSUES)]} disable autocapitalize="off" />
                                     <p>automatically submit bug/issue reports to our issue tracker when errors are logged</p>
                                 </span>
                             </label>
                         </div>
 
-                        <input type="submit" class="btn config_submitter" value="Save Changes" />
+                        <input type="submit" class="btn config_submitter" value="Save Changes"  autocapitalize="off" />
                     </fieldset>
 
                 </div>
@@ -760,7 +760,7 @@
 
                 <br>
                 <h6 class="pull-right"><b>All non-absolute folder locations are relative to <span class="path">${sickbeard.DATA_DIR}</span></b> </h6>
-                <input type="submit" class="btn pull-left config_submitter button" value="Save Changes" />
+                <input type="submit" class="btn pull-left config_submitter button" value="Save Changes"  autocapitalize="off" />
 
             </div><!-- /config-components -->
 

--- a/gui/slick/views/config_notifications.mako
+++ b/gui/slick/views/config_notifications.mako
@@ -36,7 +36,7 @@
                             <label class="clearfix" for="use_kodi">
                                 <span class="component-title">Enable</span>
                                 <span class="component-desc">
-                                    <input type="checkbox" class="enabler" name="use_kodi" id="use_kodi" ${('', 'checked="checked"')[bool(sickbeard.USE_KODI)]}/>
+                                    <input type="checkbox" class="enabler" name="use_kodi" id="use_kodi" ${('', 'checked="checked"')[bool(sickbeard.USE_KODI)]} autocapitalize="off" />
                                     <p>should SickRage send KODI commands ?<p>
                                 </span>
                             </label>
@@ -47,7 +47,7 @@
                                 <label for="kodi_always_on">
                                     <span class="component-title">Always on</span>
                                     <span class="component-desc">
-                                        <input type="checkbox" name="kodi_always_on" id="kodi_always_on" ${('', 'checked="checked"')[bool(sickbeard.KODI_ALWAYS_ON)]}/>
+                                        <input type="checkbox" name="kodi_always_on" id="kodi_always_on" ${('', 'checked="checked"')[bool(sickbeard.KODI_ALWAYS_ON)]} autocapitalize="off" />
                                         <p>log errors when unreachable ?</p>
                                     </span>
                                 </label>
@@ -56,7 +56,7 @@
                                 <label for="kodi_notify_onsnatch">
                                     <span class="component-title">Notify on snatch</span>
                                     <span class="component-desc">
-                                        <input type="checkbox" name="kodi_notify_onsnatch" id="kodi_notify_onsnatch" ${('', 'checked="checked"')[bool(sickbeard.KODI_NOTIFY_ONSNATCH)]}/>
+                                        <input type="checkbox" name="kodi_notify_onsnatch" id="kodi_notify_onsnatch" ${('', 'checked="checked"')[bool(sickbeard.KODI_NOTIFY_ONSNATCH)]} autocapitalize="off" />
                                         <p>send a notification when a download starts ?</p>
                                     </span>
                                 </label>
@@ -65,7 +65,7 @@
                                 <label for="kodi_notify_ondownload">
                                     <span class="component-title">Notify on download</span>
                                     <span class="component-desc">
-                                        <input type="checkbox" name="kodi_notify_ondownload" id="kodi_notify_ondownload" ${('', 'checked="checked"')[bool(sickbeard.KODI_NOTIFY_ONDOWNLOAD)]}/>
+                                        <input type="checkbox" name="kodi_notify_ondownload" id="kodi_notify_ondownload" ${('', 'checked="checked"')[bool(sickbeard.KODI_NOTIFY_ONDOWNLOAD)]} autocapitalize="off" />
                                         <p>send a notification when a download finishes ?</p>
                                     </span>
                                 </label>
@@ -74,7 +74,7 @@
                                 <label for="kodi_notify_onsubtitledownload">
                                     <span class="component-title">Notify on subtitle download</span>
                                     <span class="component-desc">
-                                        <input type="checkbox" name="kodi_notify_onsubtitledownload" id="kodi_notify_onsubtitledownload" ${('', 'checked="checked"')[bool(sickbeard.KODI_NOTIFY_ONSUBTITLEDOWNLOAD)]}/>
+                                        <input type="checkbox" name="kodi_notify_onsubtitledownload" id="kodi_notify_onsubtitledownload" ${('', 'checked="checked"')[bool(sickbeard.KODI_NOTIFY_ONSUBTITLEDOWNLOAD)]} autocapitalize="off" />
                                         <p>send a notification when subtitles are downloaded ?</p>
                                     </span>
                                 </label>
@@ -83,7 +83,7 @@
                                 <label for="kodi_update_library">
                                     <span class="component-title">Update library</span>
                                     <span class="component-desc">
-                                        <input type="checkbox" name="kodi_update_library" id="kodi_update_library" ${('', 'checked="checked"')[bool(sickbeard.KODI_UPDATE_LIBRARY)]}/>
+                                        <input type="checkbox" name="kodi_update_library" id="kodi_update_library" ${('', 'checked="checked"')[bool(sickbeard.KODI_UPDATE_LIBRARY)]} autocapitalize="off" />
                                         <p>update KODI library when a download finishes ?</p>
                                     </span>
                                 </label>
@@ -92,7 +92,7 @@
                                 <label for="kodi_update_full">
                                     <span class="component-title">Full library update</span>
                                     <span class="component-desc">
-                                        <input type="checkbox" name="kodi_update_full" id="kodi_update_full" ${('', 'checked="checked"')[bool(sickbeard.KODI_UPDATE_FULL)]}/>
+                                        <input type="checkbox" name="kodi_update_full" id="kodi_update_full" ${('', 'checked="checked"')[bool(sickbeard.KODI_UPDATE_FULL)]} autocapitalize="off" />
                                         <p>perform a full library update if update per-show fails ?</p>
                                     </span>
                                 </label>
@@ -101,7 +101,7 @@
                                 <label for="kodi_update_onlyfirst">
                                     <span class="component-title">Only update first host</span>
                                     <span class="component-desc">
-                                        <input type="checkbox" name="kodi_update_onlyfirst" id="kodi_update_onlyfirst" ${('', 'checked="checked"')[bool(sickbeard.KODI_UPDATE_ONLYFIRST)]}/>
+                                        <input type="checkbox" name="kodi_update_onlyfirst" id="kodi_update_onlyfirst" ${('', 'checked="checked"')[bool(sickbeard.KODI_UPDATE_ONLYFIRST)]} autocapitalize="off" />
                                         <p>only send library updates to the first active host ?</p>
                                     </span>
                                 </label>
@@ -109,7 +109,7 @@
                             <div class="field-pair">
                                 <label for="kodi_host">
                                     <span class="component-title">KODI IP:Port</span>
-                                    <input type="text" name="kodi_host" id="kodi_host" value="${sickbeard.KODI_HOST}" class="form-control input-sm input350" />
+                                    <input type="text" name="kodi_host" id="kodi_host" value="${sickbeard.KODI_HOST}" class="form-control input-sm input350"  autocapitalize="off" />
                                 </label>
                                 <label>
                                     <span class="component-title">&nbsp;</span>
@@ -123,7 +123,7 @@
                             <div class="field-pair">
                                 <label for="kodi_username">
                                     <span class="component-title">KODI username</span>
-                                    <input type="text" name="kodi_username" id="kodi_username" value="${sickbeard.KODI_USERNAME}" class="form-control input-sm input250" />
+                                    <input type="text" name="kodi_username" id="kodi_username" value="${sickbeard.KODI_USERNAME}" class="form-control input-sm input250"  autocapitalize="off" />
                                 </label>
                                 <label>
                                     <span class="component-title">&nbsp;</span>
@@ -133,7 +133,7 @@
                             <div class="field-pair">
                                 <label for="kodi_password">
                                     <span class="component-title">KODI password</span>
-                                    <input type="password" name="kodi_password" id="kodi_password" value="${sickbeard.KODI_PASSWORD}" class="form-control input-sm input250" />
+                                    <input type="password" name="kodi_password" id="kodi_password" value="${sickbeard.KODI_PASSWORD}" class="form-control input-sm input250"  autocapitalize="off" />
                                 </label>
                                 <label>
                                     <span class="component-title">&nbsp;</span>
@@ -141,8 +141,8 @@
                                 </label>
                             </div>
                             <div class="testNotification" id="testKODI-result">Click below to test.</div>
-                            <input  class="btn" type="button" value="Test KODI" id="testKODI" />
-                            <input type="submit" class="config_submitter btn" value="Save Changes" />
+                            <input  class="btn" type="button" value="Test KODI" id="testKODI"  autocapitalize="off" />
+                            <input type="submit" class="config_submitter btn" value="Save Changes"  autocapitalize="off" />
                         </div><!-- /content_use_kodi //-->
 
                     </fieldset>
@@ -162,7 +162,7 @@
                             <label for="use_plex">
                                 <span class="component-title">Enable</span>
                                 <span class="component-desc">
-                                    <input type="checkbox" class="enabler" name="use_plex" id="use_plex" ${('', 'checked="checked"')[bool(sickbeard.USE_PLEX)]}/>
+                                    <input type="checkbox" class="enabler" name="use_plex" id="use_plex" ${('', 'checked="checked"')[bool(sickbeard.USE_PLEX)]} autocapitalize="off" />
                                     <p>should SickRage send Plex commands ?</p>
                                 </span>
                             </label>
@@ -172,7 +172,7 @@
                             <div class="field-pair">
                                 <label for="plex_server_token">
                                     <span class="component-title">Plex Media Server Auth Token</span>
-                                    <input type="text" name="plex_server_token" id="plex_server_token" value="${sickbeard.PLEX_SERVER_TOKEN}" class="form-control input-sm input250" />
+                                    <input type="text" name="plex_server_token" id="plex_server_token" value="${sickbeard.PLEX_SERVER_TOKEN}" class="form-control input-sm input250"  autocapitalize="off" />
                                 </label>
                                 <label>
                                     <span class="component-title">&nbsp;</span>
@@ -188,7 +188,7 @@
                                     <label for="plex_username">
                                         <span class="component-title">Server Username</span>
                                         <span class="component-desc">
-                                            <input type="text" name="plex_username" id="plex_username" value="${sickbeard.PLEX_USERNAME}" class="form-control input-sm input250" />
+                                            <input type="text" name="plex_username" id="plex_username" value="${sickbeard.PLEX_USERNAME}" class="form-control input-sm input250"  autocapitalize="off" />
                                             <p>blank = no authentication</p>
                                         </span>
                                     </label>
@@ -197,7 +197,7 @@
                                     <label for="plex_password">
                                         <span class="component-title">Server/client password</span>
                                         <span class="component-desc">
-                                            <input type="password" name="plex_password" id="plex_password" value="${'*' * len(sickbeard.PLEX_PASSWORD)}" class="form-control input-sm input250" />
+                                            <input type="password" name="plex_password" id="plex_password" value="${'*' * len(sickbeard.PLEX_PASSWORD)}" class="form-control input-sm input250"  autocapitalize="off" />
                                             <p>blank = no authentication</p>
                                         </span>
                                     </label>
@@ -209,7 +209,7 @@
                                     <label for="plex_update_library">
                                         <span class="component-title">Update server library</span>
                                         <span class="component-desc">
-                                            <input type="checkbox" class="enabler" name="plex_update_library" id="plex_update_library" ${('', 'checked="checked"')[bool(sickbeard.PLEX_UPDATE_LIBRARY)]}/>
+                                            <input type="checkbox" class="enabler" name="plex_update_library" id="plex_update_library" ${('', 'checked="checked"')[bool(sickbeard.PLEX_UPDATE_LIBRARY)]} autocapitalize="off" />
                                             <p>update Plex Media Server library when a download finishes</p>
                                         </span>
                                     </label>
@@ -219,7 +219,7 @@
                                         <label for="plex_server_host">
                                             <span class="component-title">Plex Media Server IP:Port</span>
                                             <span class="component-desc">
-                                                <input type="text" name="plex_server_host" id="plex_server_host" value="${re.sub(r'\b,\b', ', ', sickbeard.PLEX_SERVER_HOST)}" class="form-control input-sm input350" />
+                                                <input type="text" name="plex_server_host" id="plex_server_host" value="${re.sub(r'\b,\b', ', ', sickbeard.PLEX_SERVER_HOST)}" class="form-control input-sm input350"  autocapitalize="off" />
                                                 <div class="clear-left">
                                                     <p>one or more hosts running Plex Media Server<br>(eg. 192.168.1.1:32400, 192.168.1.2:32400)</p>
                                                 </div>
@@ -229,8 +229,8 @@
 
                                     <div class="field-pair">
                                         <div class="testNotification" id="testPMS-result">Click below to test Plex server(s)</div>
-                                        <input class="btn" type="button" value="Test Plex Server" id="testPMS" />
-                                        <input type="submit" class="config_submitter btn" value="Save Changes" />
+                                        <input class="btn" type="button" value="Test Plex Server" id="testPMS"  autocapitalize="off" />
+                                        <input type="submit" class="config_submitter btn" value="Save Changes"  autocapitalize="off" />
                                         <div class="clear-left">&nbsp;</div>
                                     </div>
                                 </div>
@@ -249,7 +249,7 @@
                             <label for="use_plex_client">
                                 <span class="component-title">Enable</span>
                                 <span class="component-desc">
-                                    <input type="checkbox" class="enabler" name="use_plex" id="use_plex_client" ${('', 'checked="checked"')[bool(sickbeard.USE_PLEX_CLIENT)]}/>
+                                    <input type="checkbox" class="enabler" name="use_plex" id="use_plex_client" ${('', 'checked="checked"')[bool(sickbeard.USE_PLEX_CLIENT)]} autocapitalize="off" />
                                     <p>should SickRage send Plex commands ?</p>
                                 </span>
                             </label>
@@ -260,7 +260,7 @@
                                 <label for="plex_notify_onsnatch">
                                     <span class="component-title">Notify on snatch</span>
                                     <span class="component-desc">
-                                        <input type="checkbox" name="plex_notify_onsnatch" id="plex_notify_onsnatch" ${('', 'checked="checked"')[bool(sickbeard.PLEX_NOTIFY_ONSNATCH)]}/>
+                                        <input type="checkbox" name="plex_notify_onsnatch" id="plex_notify_onsnatch" ${('', 'checked="checked"')[bool(sickbeard.PLEX_NOTIFY_ONSNATCH)]} autocapitalize="off" />
                                         <p>send a notification when a download starts ?</p>
                                     </span>
                                 </label>
@@ -269,7 +269,7 @@
                                 <label for="plex_notify_ondownload">
                                     <span class="component-title">Notify on download</span>
                                     <span class="component-desc">
-                                        <input type="checkbox" name="plex_notify_ondownload" id="plex_notify_ondownload" ${('', 'checked="checked"')[bool(sickbeard.PLEX_NOTIFY_ONDOWNLOAD)]}/>
+                                        <input type="checkbox" name="plex_notify_ondownload" id="plex_notify_ondownload" ${('', 'checked="checked"')[bool(sickbeard.PLEX_NOTIFY_ONDOWNLOAD)]} autocapitalize="off" />
                                         <p>send a notification when a download finishes ?</p>
                                     </span>
                                 </label>
@@ -278,7 +278,7 @@
                                 <label for="plex_notify_onsubtitledownload">
                                     <span class="component-title">Notify on subtitle download</span>
                                     <span class="component-desc">
-                                        <input type="checkbox" name="plex_notify_onsubtitledownload" id="plex_notify_onsubtitledownload" ${('', 'checked="checked"')[bool(sickbeard.PLEX_NOTIFY_ONSUBTITLEDOWNLOAD)]}/>
+                                        <input type="checkbox" name="plex_notify_onsubtitledownload" id="plex_notify_onsubtitledownload" ${('', 'checked="checked"')[bool(sickbeard.PLEX_NOTIFY_ONSUBTITLEDOWNLOAD)]} autocapitalize="off" />
                                         <p>send a notification when subtitles are downloaded ?</p>
                                     </span>
                                 </label>
@@ -287,7 +287,7 @@
                                 <label for="plex_host">
                                     <span class="component-title">Plex Client IP:Port</span>
                                     <span class="component-desc">
-                                        <input type="text" name="plex_host" id="plex_host" value="${sickbeard.PLEX_HOST}" class="form-control input-sm input350" />
+                                        <input type="text" name="plex_host" id="plex_host" value="${sickbeard.PLEX_HOST}" class="form-control input-sm input350"  autocapitalize="off" />
                                         <div class="clear-left">
                                             <p>one or more hosts running Plex client<br>(eg. 192.168.1.100:3000, 192.168.1.101:3000)</p>
                                         </div>
@@ -299,7 +299,7 @@
                                     <label for="plex_username">
                                         <span class="component-title">Server Username</span>
                                         <span class="component-desc">
-                                            <input type="text" name="plex_client_username" id="plex_client_username" value="${sickbeard.PLEX_CLIENT_USERNAME}" class="form-control input-sm input250" />
+                                            <input type="text" name="plex_client_username" id="plex_client_username" value="${sickbeard.PLEX_CLIENT_USERNAME}" class="form-control input-sm input250"  autocapitalize="off" />
                                             <p>blank = no authentication</p>
                                         </span>
                                     </label>
@@ -308,7 +308,7 @@
                                     <label for="plex_client_password">
                                         <span class="component-title">Client Password</span>
                                         <span class="component-desc">
-                                            <input type="password" name="plex_client_password" id="plex_client_password" value="${'*' * len(sickbeard.PLEX_CLIENT_PASSWORD)}" class="form-control input-sm input250" />
+                                            <input type="password" name="plex_client_password" id="plex_client_password" value="${'*' * len(sickbeard.PLEX_CLIENT_PASSWORD)}" class="form-control input-sm input250"  autocapitalize="off" />
                                             <p>blank = no authentication</p>
                                         </span>
                                     </label>
@@ -317,8 +317,8 @@
 
                             <div class="field-pair">
                                 <div class="testNotification" id="testPMC-result">Click below to test Plex client(s)</div>
-                                <input class="btn" type="button" value="Test Plex Client" id="testPMC" />
-                                <input type="submit" class="config_submitter btn" value="Save Changes" />
+                                <input class="btn" type="button" value="Test Plex Client" id="testPMC"  autocapitalize="off" />
+                                <input type="submit" class="config_submitter btn" value="Save Changes"  autocapitalize="off" />
                                 <div class=clear-left><p>Note: some Plex clients <b class="boldest">do not</b> support notifications e.g. Plexapp for Samsung TVs</p></div>
                             </div>
                         </div><!-- /content_use_plex_client -->
@@ -337,7 +337,7 @@
                             <label for="use_emby">
                                 <span class="component-title">Enable</span>
                                 <span class="component-desc">
-                                    <input type="checkbox" class="enabler" name="use_emby" id="use_emby" ${('', 'checked="checked"')[bool(sickbeard.USE_EMBY)]} />
+                                    <input type="checkbox" class="enabler" name="use_emby" id="use_emby" ${('', 'checked="checked"')[bool(sickbeard.USE_EMBY)]}  autocapitalize="off" />
                                     <p>should SickRage send update commands to Emby?<p>
                                 </span>
                             </label>
@@ -346,7 +346,7 @@
                             <div class="field-pair">
                                 <label for="emby_host">
                                     <span class="component-title">Emby IP:Port</span>
-                                    <input type="text" name="emby_host" id="emby_host" value="${sickbeard.EMBY_HOST}" class="form-control input-sm input250" />
+                                    <input type="text" name="emby_host" id="emby_host" value="${sickbeard.EMBY_HOST}" class="form-control input-sm input250"  autocapitalize="off" />
                                 </label>
                                 <label>
                                     <span class="component-title">&nbsp;</span>
@@ -356,12 +356,12 @@
                             <div class="field-pair">
                                 <label for="emby_apikey">
                                     <span class="component-title">Emby API Key</span>
-                                    <input type="text" name="emby_apikey" id="emby_apikey" value="${sickbeard.EMBY_APIKEY}" class="form-control input-sm input250" />
+                                    <input type="text" name="emby_apikey" id="emby_apikey" value="${sickbeard.EMBY_APIKEY}" class="form-control input-sm input250"  autocapitalize="off" />
                                 </label>
                             </div>
                             <div class="testNotification" id="testEMBY-result">Click below to test.</div>
-                                <input  class="btn" type="button" value="Test Emby" id="testEMBY" />
-                                <input type="submit" class="config_submitter btn" value="Save Changes" />
+                                <input  class="btn" type="button" value="Test Emby" id="testEMBY"  autocapitalize="off" />
+                                <input type="submit" class="config_submitter btn" value="Save Changes"  autocapitalize="off" />
                             </div>
                         <!-- /content_use_emby //-->
                     </fieldset>
@@ -379,7 +379,7 @@
                             <label for="use_nmj">
                                 <span class="component-title">Enable</span>
                                 <span class="component-desc">
-                                    <input type="checkbox" class="enabler" name="use_nmj" id="use_nmj" ${('', 'checked="checked"')[bool(sickbeard.USE_NMJ)]}/>
+                                    <input type="checkbox" class="enabler" name="use_nmj" id="use_nmj" ${('', 'checked="checked"')[bool(sickbeard.USE_NMJ)]} autocapitalize="off" />
                                     <p>should SickRage send update commands to NMJ ?</p>
                                 </span>
                             </label>
@@ -389,7 +389,7 @@
                             <div class="field-pair">
                                 <label for="nmj_host">
                                     <span class="component-title">Popcorn IP address</span>
-                                    <input type="text" name="nmj_host" id="nmj_host" value="${sickbeard.NMJ_HOST}" class="form-control input-sm input250" />
+                                    <input type="text" name="nmj_host" id="nmj_host" value="${sickbeard.NMJ_HOST}" class="form-control input-sm input250"  autocapitalize="off" />
                                 </label>
                                 <label>
                                     <span class="component-title">&nbsp;</span>
@@ -399,7 +399,7 @@
                             <div class="field-pair">
                                 <label>
                                     <span class="component-title">Get settings</span>
-                                    <input class="btn btn-inline" type="button" value="Get Settings" id="settingsNMJ" />
+                                    <input class="btn btn-inline" type="button" value="Get Settings" id="settingsNMJ"  autocapitalize="off" />
                                 </label>
                                 <label>
                                     <span class="component-title">&nbsp;</span>
@@ -409,7 +409,7 @@
                             <div class="field-pair">
                                 <label for="nmj_database">
                                     <span class="component-title">NMJ database</span>
-                                    <input type="text" name="nmj_database" id="nmj_database" value="${sickbeard.NMJ_DATABASE}" class="form-control input-sm input250" ${(' readonly="readonly"', '')[sickbeard.NMJ_DATABASE is True]}/>
+                                    <input type="text" name="nmj_database" id="nmj_database" value="${sickbeard.NMJ_DATABASE}" class="form-control input-sm input250" ${(' readonly="readonly"', '')[sickbeard.NMJ_DATABASE is True]} autocapitalize="off" />
                                 </label>
                                 <label>
                                     <span class="component-title">&nbsp;</span>
@@ -419,7 +419,7 @@
                             <div class="field-pair">
                                 <label for="nmj_mount">
                                     <span class="component-title">NMJ mount url</span>
-                                    <input type="text" name="nmj_mount" id="nmj_mount" value="${sickbeard.NMJ_MOUNT}" class="form-control input-sm input250" ${(' readonly="readonly"', '')[sickbeard.NMJ_MOUNT is True]}/>
+                                    <input type="text" name="nmj_mount" id="nmj_mount" value="${sickbeard.NMJ_MOUNT}" class="form-control input-sm input250" ${(' readonly="readonly"', '')[sickbeard.NMJ_MOUNT is True]} autocapitalize="off" />
                                 </label>
                                 <label>
                                     <span class="component-title">&nbsp;</span>
@@ -427,8 +427,8 @@
                                 </label>
                             </div>
                             <div class="testNotification" id="testNMJ-result">Click below to test.</div>
-                            <input class="btn" type="button" value="Test NMJ" id="testNMJ" />
-                            <input type="submit" class="config_submitter btn" value="Save Changes" />
+                            <input class="btn" type="button" value="Test NMJ" id="testNMJ"  autocapitalize="off" />
+                            <input type="submit" class="config_submitter btn" value="Save Changes"  autocapitalize="off" />
                         </div><!-- /content_use_nmj //-->
 
                     </fieldset>
@@ -445,7 +445,7 @@
                             <label for="use_nmjv2">
                                 <span class="component-title">Enable</span>
                                 <span class="component-desc">
-                                    <input type="checkbox" class="enabler" name="use_nmjv2" id="use_nmjv2" ${('', 'checked="checked"')[bool(sickbeard.USE_NMJv2)]}/>
+                                    <input type="checkbox" class="enabler" name="use_nmjv2" id="use_nmjv2" ${('', 'checked="checked"')[bool(sickbeard.USE_NMJv2)]} autocapitalize="off" />
                                     <p>should SickRage send update commands to NMJv2 ?</p>
                                 </span>
                             </label>
@@ -455,7 +455,7 @@
                             <div class="field-pair">
                                 <label for="nmjv2_host">
                                     <span class="component-title">Popcorn IP address</span>
-                                    <input type="text" name="nmjv2_host" id="nmjv2_host" value="${sickbeard.NMJv2_HOST}" class="form-control input-sm input250" />
+                                    <input type="text" name="nmjv2_host" id="nmjv2_host" value="${sickbeard.NMJv2_HOST}" class="form-control input-sm input250"  autocapitalize="off" />
                                 </label>
                                 <label>
                                     <span class="component-title">&nbsp;</span>
@@ -466,10 +466,10 @@
                                 <span class="component-title">Database location</span>
                                 <span class="component-desc">
                                     <label for="NMJV2_DBLOC_A" class="space-right">
-                                        <input type="radio" NAME="nmjv2_dbloc" VALUE="local" id="NMJV2_DBLOC_A" ${('', 'checked="checked"')[sickbeard.NMJv2_DBLOC == 'local']}/>PCH Local Media
+                                        <input type="radio" NAME="nmjv2_dbloc" VALUE="local" id="NMJV2_DBLOC_A" ${('', 'checked="checked"')[sickbeard.NMJv2_DBLOC == 'local']} autocapitalize="off" />PCH Local Media
                                     </label>
                                     <label for="NMJV2_DBLOC_B">
-                                        <input type="radio" NAME="nmjv2_dbloc" VALUE="network" id="NMJV2_DBLOC_B" ${('', 'checked="checked"')[sickbeard.NMJv2_DBLOC == 'network']}/>PCH Network Media
+                                        <input type="radio" NAME="nmjv2_dbloc" VALUE="network" id="NMJV2_DBLOC_B" ${('', 'checked="checked"')[sickbeard.NMJv2_DBLOC == 'network']} autocapitalize="off" />PCH Network Media
                                     </label>
                                 </span>
                             </div>
@@ -496,7 +496,7 @@
                             <div class="field-pair">
                                 <label for="settingsNMJv2">
                                     <span class="component-title">Find database</span>
-                                    <input type="button" class="btn btn-inline" value="Find Database" id="settingsNMJv2" />
+                                    <input type="button" class="btn btn-inline" value="Find Database" id="settingsNMJv2"  autocapitalize="off" />
                                 </label>
                                 <label>
                                     <span class="component-title">&nbsp;</span>
@@ -506,7 +506,7 @@
                             <div class="field-pair">
                                 <label for="nmjv2_database">
                                     <span class="component-title">NMJv2 database</span>
-                                    <input type="text" name="nmjv2_database" id="nmjv2_database" value="${sickbeard.NMJv2_DATABASE}" class="form-control input-sm input250" ${(' readonly="readonly"', '')[sickbeard.NMJv2_DATABASE is True]}/>
+                                    <input type="text" name="nmjv2_database" id="nmjv2_database" value="${sickbeard.NMJv2_DATABASE}" class="form-control input-sm input250" ${(' readonly="readonly"', '')[sickbeard.NMJv2_DATABASE is True]} autocapitalize="off" />
                                 </label>
                                 <label>
                                     <span class="component-title">&nbsp;</span>
@@ -514,8 +514,8 @@
                                 </label>
                             </div>
                         <div class="testNotification" id="testNMJv2-result">Click below to test.</div>
-                        <input class="btn" type="button" value="Test NMJv2" id="testNMJv2" />
-                        <input type="submit" class="config_submitter btn" value="Save Changes" />
+                        <input class="btn" type="button" value="Test NMJv2" id="testNMJv2"  autocapitalize="off" />
+                        <input type="submit" class="config_submitter btn" value="Save Changes"  autocapitalize="off" />
                         </div><!-- /content_use_nmjv2 //-->
 
                     </fieldset>
@@ -535,7 +535,7 @@
                             <label for="use_synoindex">
                                 <span class="component-title">Enable</span>
                                 <span class="component-desc">
-                                    <input type="checkbox" class="enabler" name="use_synoindex" id="use_synoindex" ${('', 'checked="checked"')[bool(sickbeard.USE_SYNOINDEX)]}/>
+                                    <input type="checkbox" class="enabler" name="use_synoindex" id="use_synoindex" ${('', 'checked="checked"')[bool(sickbeard.USE_SYNOINDEX)]} autocapitalize="off" />
                                     <p>should SickRage send Synology notifications ?</p>
                                 </span>
                             </label>
@@ -546,7 +546,7 @@
                         </div>
 
                         <div id="content_use_synoindex">
-                            <input type="submit" class="config_submitter btn" value="Save Changes" />
+                            <input type="submit" class="config_submitter btn" value="Save Changes"  autocapitalize="off" />
                         </div><!-- /content_use_synoindex //-->
 
                     </fieldset>
@@ -565,7 +565,7 @@
                             <label for="use_synologynotifier">
                                 <span class="component-title">Enable</span>
                                 <span class="component-desc">
-                                    <input type="checkbox" class="enabler" name="use_synologynotifier" id="use_synologynotifier" ${('', 'checked="checked"')[bool(sickbeard.USE_SYNOLOGYNOTIFIER)]}/>
+                                    <input type="checkbox" class="enabler" name="use_synologynotifier" id="use_synologynotifier" ${('', 'checked="checked"')[bool(sickbeard.USE_SYNOLOGYNOTIFIER)]} autocapitalize="off" />
                                     <p>should SickRage send notifications to the Synology Notifier ?</p>
                                 </span>
                             </label>
@@ -579,7 +579,7 @@
                                 <label for="synologynotifier_notify_onsnatch">
                                     <span class="component-title">Notify on snatch</span>
                                     <span class="component-desc">
-                                        <input type="checkbox" name="synologynotifier_notify_onsnatch" id="synologynotifier_notify_onsnatch" ${('', 'checked="checked"')[bool(sickbeard.SYNOLOGYNOTIFIER_NOTIFY_ONSNATCH)]}/>
+                                        <input type="checkbox" name="synologynotifier_notify_onsnatch" id="synologynotifier_notify_onsnatch" ${('', 'checked="checked"')[bool(sickbeard.SYNOLOGYNOTIFIER_NOTIFY_ONSNATCH)]} autocapitalize="off" />
                                         <p>send a notification when a download starts ?</p>
                                     </span>
                                 </label>
@@ -588,7 +588,7 @@
                                 <label for="synologynotifier_notify_ondownload">
                                     <span class="component-title">Notify on download</span>
                                     <span class="component-desc">
-                                        <input type="checkbox" name="synologynotifier_notify_ondownload" id="synologynotifier_notify_ondownload" ${('', 'checked="checked"')[bool(sickbeard.SYNOLOGYNOTIFIER_NOTIFY_ONDOWNLOAD)]}/>
+                                        <input type="checkbox" name="synologynotifier_notify_ondownload" id="synologynotifier_notify_ondownload" ${('', 'checked="checked"')[bool(sickbeard.SYNOLOGYNOTIFIER_NOTIFY_ONDOWNLOAD)]} autocapitalize="off" />
                                         <p>send a notification when a download finishes ?</p>
                                     </span>
                                 </label>
@@ -597,12 +597,12 @@
                                 <label for="synologynotifier_notify_onsubtitledownload">
                                     <span class="component-title">Notify on subtitle download</span>
                                     <span class="component-desc">
-                                        <input type="checkbox" name="synologynotifier_notify_onsubtitledownload" id="synologynotifier_notify_onsubtitledownload" ${('', 'checked="checked"')[bool(sickbeard.SYNOLOGYNOTIFIER_NOTIFY_ONSUBTITLEDOWNLOAD)]}/>
+                                        <input type="checkbox" name="synologynotifier_notify_onsubtitledownload" id="synologynotifier_notify_onsubtitledownload" ${('', 'checked="checked"')[bool(sickbeard.SYNOLOGYNOTIFIER_NOTIFY_ONSUBTITLEDOWNLOAD)]} autocapitalize="off" />
                                         <p>send a notification when subtitles are downloaded ?</p>
                                     </span>
                                 </label>
                             </div>
-                            <input type="submit" class="config_submitter btn" value="Save Changes" />
+                            <input type="submit" class="config_submitter btn" value="Save Changes"  autocapitalize="off" />
                            </div>
                     </fieldset>
                 </div><!-- /synology notifier component-group //-->
@@ -619,7 +619,7 @@
                             <label for="use_pytivo">
                                 <span class="component-title">Enable</span>
                                 <span class="component-desc">
-                                    <input type="checkbox" class="enabler" name="use_pytivo" id="use_pytivo" ${('', 'checked="checked"')[bool(sickbeard.USE_PYTIVO)]}/>
+                                    <input type="checkbox" class="enabler" name="use_pytivo" id="use_pytivo" ${('', 'checked="checked"')[bool(sickbeard.USE_PYTIVO)]} autocapitalize="off" />
                                     <p>should SickRage send notifications to pyTivo ?</p>
                                 </span>
                             </label>
@@ -633,7 +633,7 @@
                             <div class="field-pair">
                                 <label for="pytivo_host">
                                     <span class="component-title">pyTivo IP:Port</span>
-                                    <input type="text" name="pytivo_host" id="pytivo_host" value="${sickbeard.PYTIVO_HOST}" class="form-control input-sm input250" />
+                                    <input type="text" name="pytivo_host" id="pytivo_host" value="${sickbeard.PYTIVO_HOST}" class="form-control input-sm input250"  autocapitalize="off" />
                                 </label>
                                 <label>
                                     <span class="component-title">&nbsp;</span>
@@ -643,7 +643,7 @@
                             <div class="field-pair">
                                 <label for="pytivo_share_name">
                                     <span class="component-title">pyTivo share name</span>
-                                    <input type="text" name="pytivo_share_name" id="pytivo_share_name" value="${sickbeard.PYTIVO_SHARE_NAME}" class="form-control input-sm input250" />
+                                    <input type="text" name="pytivo_share_name" id="pytivo_share_name" value="${sickbeard.PYTIVO_SHARE_NAME}" class="form-control input-sm input250"  autocapitalize="off" />
                                 </label>
                                 <label>
                                     <span class="component-title">&nbsp;</span>
@@ -653,14 +653,14 @@
                             <div class="field-pair">
                                 <label for="pytivo_tivo_name">
                                     <span class="component-title">Tivo name</span>
-                                    <input type="text" name="pytivo_tivo_name" id="pytivo_tivo_name" value="${sickbeard.PYTIVO_TIVO_NAME}" class="form-control input-sm input250" />
+                                    <input type="text" name="pytivo_tivo_name" id="pytivo_tivo_name" value="${sickbeard.PYTIVO_TIVO_NAME}" class="form-control input-sm input250"  autocapitalize="off" />
                                 </label>
                                 <label>
                                     <span class="component-title">&nbsp;</span>
                                     <span class="component-desc">(Messages &amp; Settings > Account &amp; System Information > System Information > DVR name)</span>
                                 </label>
                             </div>
-                            <input type="submit" class="config_submitter btn" value="Save Changes" />
+                            <input type="submit" class="config_submitter btn" value="Save Changes"  autocapitalize="off" />
                         </div><!-- /content_use_pytivo //-->
 
                     </fieldset>
@@ -681,7 +681,7 @@
                             <label for="use_growl">
                                 <span class="component-title">Enable</span>
                                 <span class="component-desc">
-                                    <input type="checkbox" class="enabler" name="use_growl" id="use_growl" ${('', 'checked="checked"')[bool(sickbeard.USE_GROWL)]}/>
+                                    <input type="checkbox" class="enabler" name="use_growl" id="use_growl" ${('', 'checked="checked"')[bool(sickbeard.USE_GROWL)]} autocapitalize="off" />
                                     <p>should SickRage send Growl notifications ?</p>
                                 </span>
                             </label>
@@ -692,7 +692,7 @@
                                 <label for="growl_notify_onsnatch">
                                     <span class="component-title">Notify on snatch</span>
                                     <span class="component-desc">
-                                        <input type="checkbox" name="growl_notify_onsnatch" id="growl_notify_onsnatch" ${('', 'checked="checked"')[bool(sickbeard.GROWL_NOTIFY_ONSNATCH)]}/>
+                                        <input type="checkbox" name="growl_notify_onsnatch" id="growl_notify_onsnatch" ${('', 'checked="checked"')[bool(sickbeard.GROWL_NOTIFY_ONSNATCH)]} autocapitalize="off" />
                                         <p>send a notification when a download starts ?</p>
                                     </span>
                                 </label>
@@ -701,7 +701,7 @@
                                 <label for="growl_notify_ondownload">
                                     <span class="component-title">Notify on download</span>
                                     <span class="component-desc">
-                                        <input type="checkbox" name="growl_notify_ondownload" id="growl_notify_ondownload" ${('', 'checked="checked"')[bool(sickbeard.GROWL_NOTIFY_ONDOWNLOAD)]}/>
+                                        <input type="checkbox" name="growl_notify_ondownload" id="growl_notify_ondownload" ${('', 'checked="checked"')[bool(sickbeard.GROWL_NOTIFY_ONDOWNLOAD)]} autocapitalize="off" />
                                         <p>send a notification when a download finishes ?</p>
                                     </span>
                                 </label>
@@ -710,7 +710,7 @@
                                 <label for="growl_notify_onsubtitledownload">
                                     <span class="component-title">Notify on subtitle download</span>
                                     <span class="component-desc">
-                                        <input type="checkbox" name="growl_notify_onsubtitledownload" id="growl_notify_onsubtitledownload" ${('', 'checked="checked"')[bool(sickbeard.GROWL_NOTIFY_ONSUBTITLEDOWNLOAD)]}/>
+                                        <input type="checkbox" name="growl_notify_onsubtitledownload" id="growl_notify_onsubtitledownload" ${('', 'checked="checked"')[bool(sickbeard.GROWL_NOTIFY_ONSUBTITLEDOWNLOAD)]} autocapitalize="off" />
                                         <p>send a notification when subtitles are downloaded ?</p>
                                     </span>
                                 </label>
@@ -718,7 +718,7 @@
                             <div class="field-pair">
                                 <label for="growl_host">
                                     <span class="component-title">Growl IP:Port</span>
-                                    <input type="text" name="growl_host" id="growl_host" value="${sickbeard.GROWL_HOST}" class="form-control input-sm input250" />
+                                    <input type="text" name="growl_host" id="growl_host" value="${sickbeard.GROWL_HOST}" class="form-control input-sm input250"  autocapitalize="off" />
                                 </label>
                                 <label>
                                     <span class="component-title">&nbsp;</span>
@@ -728,7 +728,7 @@
                             <div class="field-pair">
                                 <label for="growl_password">
                                     <span class="component-title">Growl password</span>
-                                    <input type="password" name="growl_password" id="growl_password" value="${sickbeard.GROWL_PASSWORD}" class="form-control input-sm input250" />
+                                    <input type="password" name="growl_password" id="growl_password" value="${sickbeard.GROWL_PASSWORD}" class="form-control input-sm input250"  autocapitalize="off" />
                                 </label>
                                 <label>
                                     <span class="component-title">&nbsp;</span>
@@ -740,8 +740,8 @@
                                 </label>
                             </div>
                             <div class="testNotification" id="testGrowl-result">Click below to register and test Growl, this is required for Growl notifications to work.</div>
-                            <input  class="btn" type="button" value="Register Growl" id="testGrowl" />
-                            <input type="submit" class="config_submitter btn" value="Save Changes" />
+                            <input  class="btn" type="button" value="Register Growl" id="testGrowl"  autocapitalize="off" />
+                            <input type="submit" class="config_submitter btn" value="Save Changes"  autocapitalize="off" />
                         </div><!-- /content_use_growl //-->
 
                     </fieldset>
@@ -759,7 +759,7 @@
                             <label for="use_prowl">
                                 <span class="component-title">Enable</span>
                                 <span class="component-desc">
-                                    <input type="checkbox" class="enabler" name="use_prowl" id="use_prowl" ${('', 'checked="checked"')[bool(sickbeard.USE_PROWL)]}/>
+                                    <input type="checkbox" class="enabler" name="use_prowl" id="use_prowl" ${('', 'checked="checked"')[bool(sickbeard.USE_PROWL)]} autocapitalize="off" />
                                     <p>should SickRage send Prowl notifications ?</p>
                                 </span>
                             </label>
@@ -770,7 +770,7 @@
                                 <label for="prowl_notify_onsnatch">
                                     <span class="component-title">Notify on snatch</span>
                                     <span class="component-desc">
-                                        <input type="checkbox" name="prowl_notify_onsnatch" id="prowl_notify_onsnatch" ${('', 'checked="checked"')[bool(sickbeard.PROWL_NOTIFY_ONSNATCH)]}/>
+                                        <input type="checkbox" name="prowl_notify_onsnatch" id="prowl_notify_onsnatch" ${('', 'checked="checked"')[bool(sickbeard.PROWL_NOTIFY_ONSNATCH)]} autocapitalize="off" />
                                         <p>send a notification when a download starts ?</p>
                                     </span>
                                 </label>
@@ -779,7 +779,7 @@
                                 <label for="prowl_notify_ondownload">
                                     <span class="component-title">Notify on download</span>
                                     <span class="component-desc">
-                                        <input type="checkbox" name="prowl_notify_ondownload" id="prowl_notify_ondownload" ${('', 'checked="checked"')[bool(sickbeard.PROWL_NOTIFY_ONDOWNLOAD)]}/>
+                                        <input type="checkbox" name="prowl_notify_ondownload" id="prowl_notify_ondownload" ${('', 'checked="checked"')[bool(sickbeard.PROWL_NOTIFY_ONDOWNLOAD)]} autocapitalize="off" />
                                         <p>send a notification when a download finishes ?</p>
                                     </span>
                                 </label>
@@ -788,7 +788,7 @@
                                 <label for="prowl_notify_onsubtitledownload">
                                     <span class="component-title">Notify on subtitle download</span>
                                     <span class="component-desc">
-                                        <input type="checkbox" name="prowl_notify_onsubtitledownload" id="prowl_notify_onsubtitledownload" ${('', 'checked="checked"')[bool(sickbeard.PROWL_NOTIFY_ONSUBTITLEDOWNLOAD)]}/>
+                                        <input type="checkbox" name="prowl_notify_onsubtitledownload" id="prowl_notify_onsubtitledownload" ${('', 'checked="checked"')[bool(sickbeard.PROWL_NOTIFY_ONSUBTITLEDOWNLOAD)]} autocapitalize="off" />
                                         <p>send a notification when subtitles are downloaded ?</p>
                                     </span>
                                 </label>
@@ -796,13 +796,13 @@
                             <div class="field-pair">
                                  <label for="prowl_message_title">
                                      <span class="component-title">Prowl Message Title:</span>
-                                     <input type="text" name="prowl_message_title" id="prowl_message_title" value="${sickbeard.PROWL_MESSAGE_TITLE}" class="form-control input-sm input250" />
+                                     <input type="text" name="prowl_message_title" id="prowl_message_title" value="${sickbeard.PROWL_MESSAGE_TITLE}" class="form-control input-sm input250"  autocapitalize="off" />
                                  </label>
                             </div>
                             <div class="field-pair">
                                 <label for="prowl_api">
                                     <span class="component-title">Global Prowl API key(s):</span>
-                                    <input type="text" name="prowl_api" id="prowl_api" value="${sickbeard.PROWL_API}" class="form-control input-sm input250" />
+                                    <input type="text" name="prowl_api" id="prowl_api" value="${sickbeard.PROWL_API}" class="form-control input-sm input250"  autocapitalize="off" />
                                 </label>
                                 <label>
                                     <span class="component-title">&nbsp;</span>
@@ -822,7 +822,7 @@
                                 </label>
                                 <label>
                                     <span class="component-title">&nbsp;</span>
-                                    <input type="text" name="prowl_show_list" id="prowl_show_list" class="form-control input-sm input350" />
+                                    <input type="text" name="prowl_show_list" id="prowl_show_list" class="form-control input-sm input350"  autocapitalize="off" />
                                 </label>
                                 <label>
                                     <span class="component-title">&nbsp;</span>
@@ -832,7 +832,7 @@
                                 </label>
                                 <label>
                                     <span class="component-title">&nbsp;</span>
-                                    <input id="prowl_show_save" class="btn" type="button" value="Save for this show" />
+                                    <input id="prowl_show_save" class="btn" type="button" value="Save for this show"  autocapitalize="off" />
                                 </label>
                             </div>
                             <div class="field-pair">
@@ -852,8 +852,8 @@
                                 </label>
                             </div>
                             <div class="testNotification" id="testProwl-result">Click below to test.</div>
-                            <input  class="btn" type="button" value="Test Prowl" id="testProwl" />
-                            <input type="submit" class="config_submitter btn" value="Save Changes" />
+                            <input  class="btn" type="button" value="Test Prowl" id="testProwl"  autocapitalize="off" />
+                            <input type="submit" class="config_submitter btn" value="Save Changes"  autocapitalize="off" />
                         </div><!-- /content_use_prowl //-->
 
                     </fieldset>
@@ -871,7 +871,7 @@
                             <label for="use_libnotify">
                                 <span class="component-title">Enable</span>
                                 <span class="component-desc">
-                                    <input type="checkbox" class="enabler" name="use_libnotify" id="use_libnotify" ${('', 'checked="checked"')[bool(sickbeard.USE_LIBNOTIFY)]}/>
+                                    <input type="checkbox" class="enabler" name="use_libnotify" id="use_libnotify" ${('', 'checked="checked"')[bool(sickbeard.USE_LIBNOTIFY)]} autocapitalize="off" />
                                     <p>should SickRage send Libnotify notifications ?</p>
                                 </span>
                             </label>
@@ -882,7 +882,7 @@
                                 <label for="libnotify_notify_onsnatch">
                                     <span class="component-title">Notify on snatch</span>
                                     <span class="component-desc">
-                                        <input type="checkbox" name="libnotify_notify_onsnatch" id="libnotify_notify_onsnatch" ${('', 'checked="checked"')[bool(sickbeard.LIBNOTIFY_NOTIFY_ONSNATCH)]}/>
+                                        <input type="checkbox" name="libnotify_notify_onsnatch" id="libnotify_notify_onsnatch" ${('', 'checked="checked"')[bool(sickbeard.LIBNOTIFY_NOTIFY_ONSNATCH)]} autocapitalize="off" />
                                         <p>send a notification when a download starts ?</p>
                                     </span>
                                 </label>
@@ -891,7 +891,7 @@
                                 <label for="libnotify_notify_ondownload">
                                     <span class="component-title">Notify on download</span>
                                     <span class="component-desc">
-                                        <input type="checkbox" name="libnotify_notify_ondownload" id="libnotify_notify_ondownload" ${('', 'checked="checked"')[bool(sickbeard.LIBNOTIFY_NOTIFY_ONDOWNLOAD)]}/>
+                                        <input type="checkbox" name="libnotify_notify_ondownload" id="libnotify_notify_ondownload" ${('', 'checked="checked"')[bool(sickbeard.LIBNOTIFY_NOTIFY_ONDOWNLOAD)]} autocapitalize="off" />
                                         <p>send a notification when a download finishes ?</p>
                                     </span>
                                 </label>
@@ -900,14 +900,14 @@
                                 <label for="libnotify_notify_onsubtitledownload">
                                     <span class="component-title">Notify on subtitle download</span>
                                     <span class="component-desc">
-                                        <input type="checkbox" name="libnotify_notify_onsubtitledownload" id="libnotify_notify_onsubtitledownload" ${('', 'checked="checked"')[bool(sickbeard.LIBNOTIFY_NOTIFY_ONSUBTITLEDOWNLOAD)]}/>
+                                        <input type="checkbox" name="libnotify_notify_onsubtitledownload" id="libnotify_notify_onsubtitledownload" ${('', 'checked="checked"')[bool(sickbeard.LIBNOTIFY_NOTIFY_ONSUBTITLEDOWNLOAD)]} autocapitalize="off" />
                                         <p>send a notification when subtitles are downloaded ?</p>
                                     </span>
                                 </label>
                             </div>
                             <div class="testNotification" id="testLibnotify-result">Click below to test.</div>
-                            <input  class="btn" type="button" value="Test Libnotify" id="testLibnotify" />
-                            <input type="submit" class="config_submitter btn" value="Save Changes" />
+                            <input  class="btn" type="button" value="Test Libnotify" id="testLibnotify"  autocapitalize="off" />
+                            <input type="submit" class="config_submitter btn" value="Save Changes"  autocapitalize="off" />
                         </div><!-- /content_use_libnotify //-->
 
                     </fieldset>
@@ -925,7 +925,7 @@
                             <label for="use_pushover">
                                 <span class="component-title">Enable</span>
                                 <span class="component-desc">
-                                    <input type="checkbox" class="enabler" name="use_pushover" id="use_pushover" ${('', 'checked="checked"')[bool(sickbeard.USE_PUSHOVER)]}/>
+                                    <input type="checkbox" class="enabler" name="use_pushover" id="use_pushover" ${('', 'checked="checked"')[bool(sickbeard.USE_PUSHOVER)]} autocapitalize="off" />
                                     <p>should SickRage send Pushover notifications ?</p>
                                 </span>
                             </label>
@@ -936,7 +936,7 @@
                                 <label for="pushover_notify_onsnatch">
                                     <span class="component-title">Notify on snatch</span>
                                     <span class="component-desc">
-                                        <input type="checkbox" name="pushover_notify_onsnatch" id="pushover_notify_onsnatch" ${('', 'checked="checked"')[bool(sickbeard.PUSHOVER_NOTIFY_ONSNATCH)]}/>
+                                        <input type="checkbox" name="pushover_notify_onsnatch" id="pushover_notify_onsnatch" ${('', 'checked="checked"')[bool(sickbeard.PUSHOVER_NOTIFY_ONSNATCH)]} autocapitalize="off" />
                                         <p>send a notification when a download starts ?</p>
                                     </span>
                                 </label>
@@ -945,7 +945,7 @@
                                 <label for="pushover_notify_ondownload">
                                     <span class="component-title">Notify on download</span>
                                     <span class="component-desc">
-                                        <input type="checkbox" name="pushover_notify_ondownload" id="pushover_notify_ondownload" ${('', 'checked="checked"')[bool(sickbeard.PUSHOVER_NOTIFY_ONDOWNLOAD)]}/>
+                                        <input type="checkbox" name="pushover_notify_ondownload" id="pushover_notify_ondownload" ${('', 'checked="checked"')[bool(sickbeard.PUSHOVER_NOTIFY_ONDOWNLOAD)]} autocapitalize="off" />
                                         <p>send a notification when a download finishes ?</p>
                                     </span>
                                 </label>
@@ -954,7 +954,7 @@
                                 <label for="pushover_notify_onsubtitledownload">
                                     <span class="component-title">Notify on subtitle download</span>
                                     <span class="component-desc">
-                                        <input type="checkbox" name="pushover_notify_onsubtitledownload" id="pushover_notify_onsubtitledownload" ${('', 'checked="checked"')[bool(sickbeard.PUSHOVER_NOTIFY_ONSUBTITLEDOWNLOAD)]}/>
+                                        <input type="checkbox" name="pushover_notify_onsubtitledownload" id="pushover_notify_onsubtitledownload" ${('', 'checked="checked"')[bool(sickbeard.PUSHOVER_NOTIFY_ONSUBTITLEDOWNLOAD)]} autocapitalize="off" />
                                         <p>send a notification when subtitles are downloaded ?</p>
                                     </span>
                                 </label>
@@ -962,7 +962,7 @@
                             <div class="field-pair">
                                 <label for="pushover_userkey">
                                     <span class="component-title">Pushover key</span>
-                                    <input type="text" name="pushover_userkey" id="pushover_userkey" value="${sickbeard.PUSHOVER_USERKEY}" class="form-control input-sm input250" />
+                                    <input type="text" name="pushover_userkey" id="pushover_userkey" value="${sickbeard.PUSHOVER_USERKEY}" class="form-control input-sm input250"  autocapitalize="off" />
                                 </label>
                                 <label>
                                     <span class="component-title">&nbsp;</span>
@@ -972,7 +972,7 @@
                             <div class="field-pair">
                                 <label for="pushover_apikey">
                                     <span class="component-title">Pushover API key</span>
-                                    <input type="text" name="pushover_apikey" id="pushover_apikey" value="${sickbeard.PUSHOVER_APIKEY}" class="form-control input-sm input250" />
+                                    <input type="text" name="pushover_apikey" id="pushover_apikey" value="${sickbeard.PUSHOVER_APIKEY}" class="form-control input-sm input250"  autocapitalize="off" />
                                 </label>
                                 <label>
                                     <span class="component-title">&nbsp;</span>
@@ -982,7 +982,7 @@
                             <div class="field-pair">
                                 <label for="pushover_device">
                                     <span class="component-title">Pushover devices</span>
-                                    <input type="text" name="pushover_device" id="pushover_device" value="${sickbeard.PUSHOVER_DEVICE}" class="form-control input-sm input250" />
+                                    <input type="text" name="pushover_device" id="pushover_device" value="${sickbeard.PUSHOVER_DEVICE}" class="form-control input-sm input250"  autocapitalize="off" />
                                 </label>
                                 <label>
                                     <span class="component-title">&nbsp;</span>
@@ -1024,8 +1024,8 @@
                                 </label>
                             </div>
                             <div class="testNotification" id="testPushover-result">Click below to test.</div>
-                            <input  class="btn" type="button" value="Test Pushover" id="testPushover" />
-                            <input type="submit" class="config_submitter btn" value="Save Changes" />
+                            <input  class="btn" type="button" value="Test Pushover" id="testPushover"  autocapitalize="off" />
+                            <input type="submit" class="config_submitter btn" value="Save Changes"  autocapitalize="off" />
                         </div><!-- /content_use_pushover //-->
 
                     </fieldset>
@@ -1042,7 +1042,7 @@
                             <label for="use_boxcar2">
                                 <span class="component-title">Enable</span>
                                 <span class="component-desc">
-                                    <input type="checkbox" class="enabler" name="use_boxcar2" id="use_boxcar2" ${('', 'checked="checked"')[bool(sickbeard.USE_BOXCAR2)]}/>
+                                    <input type="checkbox" class="enabler" name="use_boxcar2" id="use_boxcar2" ${('', 'checked="checked"')[bool(sickbeard.USE_BOXCAR2)]} autocapitalize="off" />
                                     <p>should SickRage send Boxcar notifications ?</p>
                                 </span>
                             </label>
@@ -1053,7 +1053,7 @@
                                 <label for="boxcar2_notify_onsnatch">
                                     <span class="component-title">Notify on snatch</span>
                                     <span class="component-desc">
-                                        <input type="checkbox" name="boxcar2_notify_onsnatch" id="boxcar2_notify_onsnatch" ${('', 'checked="checked"')[bool(sickbeard.BOXCAR2_NOTIFY_ONSNATCH)]}/>
+                                        <input type="checkbox" name="boxcar2_notify_onsnatch" id="boxcar2_notify_onsnatch" ${('', 'checked="checked"')[bool(sickbeard.BOXCAR2_NOTIFY_ONSNATCH)]} autocapitalize="off" />
                                         <p>send a notification when a download starts ?</p>
                                     </span>
                                 </label>
@@ -1062,7 +1062,7 @@
                                 <label for="boxcar2_notify_ondownload">
                                     <span class="component-title">Notify on download</span>
                                     <span class="component-desc">
-                                        <input type="checkbox" name="boxcar2_notify_ondownload" id="boxcar2_notify_ondownload" ${('', 'checked="checked"')[bool(sickbeard.BOXCAR2_NOTIFY_ONDOWNLOAD)]}/>
+                                        <input type="checkbox" name="boxcar2_notify_ondownload" id="boxcar2_notify_ondownload" ${('', 'checked="checked"')[bool(sickbeard.BOXCAR2_NOTIFY_ONDOWNLOAD)]} autocapitalize="off" />
                                         <p>send a notification when a download finishes ?</p>
                                     </span>
                                 </label>
@@ -1071,7 +1071,7 @@
                                 <label for="boxcar2_notify_onsubtitledownload">
                                     <span class="component-title">Notify on subtitle download</span>
                                     <span class="component-desc">
-                                        <input type="checkbox" name="boxcar2_notify_onsubtitledownload" id="boxcar2_notify_onsubtitledownload" ${('', 'checked="checked"')[bool(sickbeard.BOXCAR2_NOTIFY_ONSUBTITLEDOWNLOAD)]}/>
+                                        <input type="checkbox" name="boxcar2_notify_onsubtitledownload" id="boxcar2_notify_onsubtitledownload" ${('', 'checked="checked"')[bool(sickbeard.BOXCAR2_NOTIFY_ONSUBTITLEDOWNLOAD)]} autocapitalize="off" />
                                         <p>send a notification when subtitles are downloaded ?</p>
                                     </span>
                                 </label>
@@ -1079,7 +1079,7 @@
                             <div class="field-pair">
                                 <label for="boxcar2_accesstoken">
                                     <span class="component-title">Boxcar2 access token</span>
-                                    <input type="text" name="boxcar2_accesstoken" id="boxcar2_accesstoken" value="${sickbeard.BOXCAR2_ACCESSTOKEN}" class="form-control input-sm input250" />
+                                    <input type="text" name="boxcar2_accesstoken" id="boxcar2_accesstoken" value="${sickbeard.BOXCAR2_ACCESSTOKEN}" class="form-control input-sm input250"  autocapitalize="off" />
                                 </label>
                                 <label>
                                     <span class="component-title">&nbsp;</span>
@@ -1087,8 +1087,8 @@
                                 </label>
                             </div>
                             <div class="testNotification" id="testBoxcar2-result">Click below to test.</div>
-                            <input  class="btn" type="button" value="Test Boxcar" id="testBoxcar2" />
-                            <input type="submit" class="config_submitter btn" value="Save Changes" />
+                            <input  class="btn" type="button" value="Test Boxcar" id="testBoxcar2"  autocapitalize="off" />
+                            <input type="submit" class="config_submitter btn" value="Save Changes"  autocapitalize="off" />
                         </div><!-- /content_use_boxcar2 //-->
 
                     </fieldset>
@@ -1105,7 +1105,7 @@
                             <label for="use_nma">
                                 <span class="component-title">Enable</span>
                                 <span class="component-desc">
-                                    <input type="checkbox" class="enabler" name="use_nma" id="use_nma" ${('', 'checked="checked"')[bool(sickbeard.USE_NMA)]}/>
+                                    <input type="checkbox" class="enabler" name="use_nma" id="use_nma" ${('', 'checked="checked"')[bool(sickbeard.USE_NMA)]} autocapitalize="off" />
                                     <p>should SickRage send NMA notifications ?</p>
                                 </span>
                             </label>
@@ -1116,7 +1116,7 @@
                                 <label for="nma_notify_onsnatch">
                                     <span class="component-title">Notify on snatch</span>
                                     <span class="component-desc">
-                                        <input type="checkbox" name="nma_notify_onsnatch" id="nma_notify_onsnatch" ${('', 'checked="checked"')[bool(sickbeard.NMA_NOTIFY_ONSNATCH)]}/>
+                                        <input type="checkbox" name="nma_notify_onsnatch" id="nma_notify_onsnatch" ${('', 'checked="checked"')[bool(sickbeard.NMA_NOTIFY_ONSNATCH)]} autocapitalize="off" />
                                         <p>send a notification when a download starts ?</p>
                                     </span>
                                 </label>
@@ -1125,7 +1125,7 @@
                                 <label for="nma_notify_ondownload">
                                     <span class="component-title">Notify on download</span>
                                     <span class="component-desc">
-                                        <input type="checkbox" name="nma_notify_ondownload" id="nma_notify_ondownload" ${('', 'checked="checked"')[bool(sickbeard.NMA_NOTIFY_ONDOWNLOAD)]}/>
+                                        <input type="checkbox" name="nma_notify_ondownload" id="nma_notify_ondownload" ${('', 'checked="checked"')[bool(sickbeard.NMA_NOTIFY_ONDOWNLOAD)]} autocapitalize="off" />
                                         <p>send a notification when a download finishes ?</p>
                                     </span>
                                 </label>
@@ -1134,7 +1134,7 @@
                                 <label for="nma_notify_onsubtitledownload">
                                     <span class="component-title">Notify on subtitle download</span>
                                     <span class="component-desc">
-                                        <input type="checkbox" name="nma_notify_onsubtitledownload" id="nma_notify_onsubtitledownload" ${('', 'checked="checked"')[bool(sickbeard.NMA_NOTIFY_ONSUBTITLEDOWNLOAD)]}/>
+                                        <input type="checkbox" name="nma_notify_onsubtitledownload" id="nma_notify_onsubtitledownload" ${('', 'checked="checked"')[bool(sickbeard.NMA_NOTIFY_ONSUBTITLEDOWNLOAD)]} autocapitalize="off" />
                                         <p>send a notification when subtitles are downloaded ?</p>
                                     </span>
                                 </label>
@@ -1142,7 +1142,7 @@
                             <div class="field-pair">
                                 <label for="nma_api">
                                        <span class="component-title">NMA API key:</span>
-                                    <input type="text" name="nma_api" id="nma_api" value="${sickbeard.NMA_API}" class="form-control input-sm input350" />
+                                    <input type="text" name="nma_api" id="nma_api" value="${sickbeard.NMA_API}" class="form-control input-sm input350"  autocapitalize="off" />
                                 </label>
                                 <label>
                                     <span class="component-title">&nbsp;</span>
@@ -1166,8 +1166,8 @@
                                 </label>
                             </div>
                             <div class="testNotification" id="testNMA-result">Click below to test.</div>
-                            <input  class="btn" type="button" value="Test NMA" id="testNMA" />
-                            <input type="submit" class="config_submitter btn" value="Save Changes" />
+                            <input  class="btn" type="button" value="Test NMA" id="testNMA"  autocapitalize="off" />
+                            <input type="submit" class="config_submitter btn" value="Save Changes"  autocapitalize="off" />
                         </div><!-- /content_use_nma //-->
 
                     </fieldset>
@@ -1184,7 +1184,7 @@
                             <label for="use_pushalot">
                                 <span class="component-title">Enable</span>
                                 <span class="component-desc">
-                                    <input type="checkbox" class="enabler" name="use_pushalot" id="use_pushalot" ${('', 'checked="checked"')[bool(sickbeard.USE_PUSHALOT)]}/>
+                                    <input type="checkbox" class="enabler" name="use_pushalot" id="use_pushalot" ${('', 'checked="checked"')[bool(sickbeard.USE_PUSHALOT)]} autocapitalize="off" />
                                     <p>should SickRage send Pushalot notifications ?
                                 </span>
                             </label>
@@ -1195,7 +1195,7 @@
                                 <label for="pushalot_notify_onsnatch">
                                     <span class="component-title">Notify on snatch</span>
                                     <span class="component-desc">
-                                        <input type="checkbox" name="pushalot_notify_onsnatch" id="pushalot_notify_onsnatch" ${('', 'checked="checked"')[bool(sickbeard.PUSHALOT_NOTIFY_ONSNATCH)]}/>
+                                        <input type="checkbox" name="pushalot_notify_onsnatch" id="pushalot_notify_onsnatch" ${('', 'checked="checked"')[bool(sickbeard.PUSHALOT_NOTIFY_ONSNATCH)]} autocapitalize="off" />
                                         <p>send a notification when a download starts ?</p>
                                     </span>
                                 </label>
@@ -1204,7 +1204,7 @@
                                 <label for="pushalot_notify_ondownload">
                                     <span class="component-title">Notify on download</span>
                                     <span class="component-desc">
-                                        <input type="checkbox" name="pushalot_notify_ondownload" id="pushalot_notify_ondownload" ${('', 'checked="checked"')[bool(sickbeard.PUSHALOT_NOTIFY_ONDOWNLOAD)]}/>
+                                        <input type="checkbox" name="pushalot_notify_ondownload" id="pushalot_notify_ondownload" ${('', 'checked="checked"')[bool(sickbeard.PUSHALOT_NOTIFY_ONDOWNLOAD)]} autocapitalize="off" />
                                         <p>send a notification when a download finishes ?</p>
                                     </span>
                                 </label>
@@ -1213,7 +1213,7 @@
                                 <label for="pushalot_notify_onsubtitledownload">
                                     <span class="component-title">Notify on subtitle download</span>
                                     <span class="component-desc">
-                                        <input type="checkbox" name="pushalot_notify_onsubtitledownload" id="pushalot_notify_onsubtitledownload" ${('', 'checked="checked"')[bool(sickbeard.PUSHALOT_NOTIFY_ONSUBTITLEDOWNLOAD)]}/>
+                                        <input type="checkbox" name="pushalot_notify_onsubtitledownload" id="pushalot_notify_onsubtitledownload" ${('', 'checked="checked"')[bool(sickbeard.PUSHALOT_NOTIFY_ONSUBTITLEDOWNLOAD)]} autocapitalize="off" />
                                         <p>send a notification when subtitles are downloaded ?</p>
                                     </span>
                                 </label>
@@ -1221,7 +1221,7 @@
                             <div class="field-pair">
                                 <label for="pushalot_authorizationtoken">
                                     <span class="component-title">Pushalot authorization token</span>
-                                    <input type="text" name="pushalot_authorizationtoken" id="pushalot_authorizationtoken" value="${sickbeard.PUSHALOT_AUTHORIZATIONTOKEN}" class="form-control input-sm input350" />
+                                    <input type="text" name="pushalot_authorizationtoken" id="pushalot_authorizationtoken" value="${sickbeard.PUSHALOT_AUTHORIZATIONTOKEN}" class="form-control input-sm input350"  autocapitalize="off" />
                                 </label>
                                 <label>
                                     <span class="component-title">&nbsp;</span>
@@ -1229,8 +1229,8 @@
                                 </label>
                             </div>
                             <div class="testNotification" id="testPushalot-result">Click below to test.</div>
-                            <input type="button" class="btn" value="Test Pushalot" id="testPushalot" />
-                            <input type="submit" class="btn config_submitter" value="Save Changes" />
+                            <input type="button" class="btn" value="Test Pushalot" id="testPushalot"  autocapitalize="off" />
+                            <input type="submit" class="btn config_submitter" value="Save Changes"  autocapitalize="off" />
                         </div><!-- /content_use_pushalot //-->
 
                     </fieldset>
@@ -1247,7 +1247,7 @@
                             <label for="use_pushbullet">
                                 <span class="component-title">Enable</span>
                                 <span class="component-desc">
-                                    <input type="checkbox" class="enabler" name="use_pushbullet" id="use_pushbullet" ${('', 'checked="checked"')[bool(sickbeard.USE_PUSHBULLET)]}/>
+                                    <input type="checkbox" class="enabler" name="use_pushbullet" id="use_pushbullet" ${('', 'checked="checked"')[bool(sickbeard.USE_PUSHBULLET)]} autocapitalize="off" />
                                     <p>should SickRage send Pushbullet notifications ?</p>
                                 </span>
                             </label>
@@ -1258,7 +1258,7 @@
                                 <label for="pushbullet_notify_onsnatch">
                                     <span class="component-title">Notify on snatch</span>
                                     <span class="component-desc">
-                                        <input type="checkbox" name="pushbullet_notify_onsnatch" id="pushbullet_notify_onsnatch" ${('', 'checked="checked"')[bool(sickbeard.PUSHBULLET_NOTIFY_ONSNATCH)]}/>
+                                        <input type="checkbox" name="pushbullet_notify_onsnatch" id="pushbullet_notify_onsnatch" ${('', 'checked="checked"')[bool(sickbeard.PUSHBULLET_NOTIFY_ONSNATCH)]} autocapitalize="off" />
                                         <p>send a notification when a download starts ?</p>
                                     </span>
                                 </label>
@@ -1267,7 +1267,7 @@
                                 <label for="pushbullet_notify_ondownload">
                                     <span class="component-title">Notify on download</span>
                                     <span class="component-desc">
-                                        <input type="checkbox" name="pushbullet_notify_ondownload" id="pushbullet_notify_ondownload" ${('', 'checked="checked"')[bool(sickbeard.PUSHBULLET_NOTIFY_ONDOWNLOAD)]}/>
+                                        <input type="checkbox" name="pushbullet_notify_ondownload" id="pushbullet_notify_ondownload" ${('', 'checked="checked"')[bool(sickbeard.PUSHBULLET_NOTIFY_ONDOWNLOAD)]} autocapitalize="off" />
                                         <p>send a notification when a download finishes ?</p>
                                     </span>
                                 </label>
@@ -1276,7 +1276,7 @@
                                 <label for="pushbullet_notify_onsubtitledownload">
                                     <span class="component-title">Notify on subtitle download</span>
                                     <span class="component-desc">
-                                        <input type="checkbox" name="pushbullet_notify_onsubtitledownload" id="pushbullet_notify_onsubtitledownload" ${('', 'checked="checked"')[bool(sickbeard.PUSHBULLET_NOTIFY_ONSUBTITLEDOWNLOAD)]}/>
+                                        <input type="checkbox" name="pushbullet_notify_onsubtitledownload" id="pushbullet_notify_onsubtitledownload" ${('', 'checked="checked"')[bool(sickbeard.PUSHBULLET_NOTIFY_ONSUBTITLEDOWNLOAD)]} autocapitalize="off" />
                                         <p>send a notification when subtitles are downloaded ?</p>
                                     </span>
                                 </label>
@@ -1284,7 +1284,7 @@
                             <div class="field-pair">
                                 <label for="pushbullet_api">
                                     <span class="component-title">Pushbullet API key</span>
-                                    <input type="text" name="pushbullet_api" id="pushbullet_api" value="${sickbeard.PUSHBULLET_API}" class="form-control input-sm input350" />
+                                    <input type="text" name="pushbullet_api" id="pushbullet_api" value="${sickbeard.PUSHBULLET_API}" class="form-control input-sm input350"  autocapitalize="off" />
                                 </label>
                                 <label>
                                     <span class="component-title">&nbsp;</span>
@@ -1296,7 +1296,7 @@
                                     <span class="component-title">Pushbullet devices</span>
                                     <select name="pushbullet_device_list" id="pushbullet_device_list" class="form-control input-sm"></select>
                                     <input type="hidden" id="pushbullet_device" value="${sickbeard.PUSHBULLET_DEVICE}">
-                                    <input type="button" class="btn btn-inline" value="Update device list" id="getPushbulletDevices" />
+                                    <input type="button" class="btn btn-inline" value="Update device list" id="getPushbulletDevices"  autocapitalize="off" />
                                 </label>
                                 <label>
                                     <span class="component-title">&nbsp;</span>
@@ -1304,8 +1304,8 @@
                                 </label>
                             </div>
                             <div class="testNotification" id="testPushbullet-result">Click below to test.</div>
-                            <input type="button" class="btn" value="Test Pushbullet" id="testPushbullet" />
-                            <input type="submit" class="btn config_submitter" value="Save Changes" />
+                            <input type="button" class="btn" value="Test Pushbullet" id="testPushbullet"  autocapitalize="off" />
+                            <input type="submit" class="btn config_submitter" value="Save Changes"  autocapitalize="off" />
                         </div><!-- /content_use_pushbullet //-->
 
                     </fieldset>
@@ -1321,7 +1321,7 @@
                             <label for="use_freemobile">
                                 <span class="component-title">Enable</span>
                                 <span class="component-desc">
-                                    <input type="checkbox" class="enabler" name="use_freemobile" id="use_freemobile" ${('', 'checked="checked"')[bool(sickbeard.USE_FREEMOBILE)]}/>
+                                    <input type="checkbox" class="enabler" name="use_freemobile" id="use_freemobile" ${('', 'checked="checked"')[bool(sickbeard.USE_FREEMOBILE)]} autocapitalize="off" />
                                     <p>should SickRage send SMS notifications ?</p>
                                 </span>
                             </label>
@@ -1332,7 +1332,7 @@
                                 <label for="freemobile_notify_onsnatch">
                                     <span class="component-title">Notify on snatch</span>
                                     <span class="component-desc">
-                                        <input type="checkbox" name="freemobile_notify_onsnatch" id="freemobile_notify_onsnatch" ${('', 'checked="checked"')[bool(sickbeard.FREEMOBILE_NOTIFY_ONSNATCH)]}/>
+                                        <input type="checkbox" name="freemobile_notify_onsnatch" id="freemobile_notify_onsnatch" ${('', 'checked="checked"')[bool(sickbeard.FREEMOBILE_NOTIFY_ONSNATCH)]} autocapitalize="off" />
                                         <p>send a SMS when a download starts ?</p>
                                     </span>
                                 </label>
@@ -1341,7 +1341,7 @@
                                 <label for="freemobile_notify_ondownload">
                                     <span class="component-title">Notify on download</span>
                                     <span class="component-desc">
-                                        <input type="checkbox" name="freemobile_notify_ondownload" id="freemobile_notify_ondownload" ${('', 'checked="checked"')[bool(sickbeard.FREEMOBILE_NOTIFY_ONDOWNLOAD)]}/>
+                                        <input type="checkbox" name="freemobile_notify_ondownload" id="freemobile_notify_ondownload" ${('', 'checked="checked"')[bool(sickbeard.FREEMOBILE_NOTIFY_ONDOWNLOAD)]} autocapitalize="off" />
                                         <p>send a SMS when a download finishes ?</p>
                                     </span>
                                 </label>
@@ -1350,7 +1350,7 @@
                                 <label for="freemobile_notify_onsubtitledownload">
                                     <span class="component-title">Notify on subtitle download</span>
                                     <span class="component-desc">
-                                        <input type="checkbox" name="freemobile_notify_onsubtitledownload" id="freemobile_notify_onsubtitledownload" ${('', 'checked="checked"')[bool(sickbeard.FREEMOBILE_NOTIFY_ONSUBTITLEDOWNLOAD)]}/>
+                                        <input type="checkbox" name="freemobile_notify_onsubtitledownload" id="freemobile_notify_onsubtitledownload" ${('', 'checked="checked"')[bool(sickbeard.FREEMOBILE_NOTIFY_ONSUBTITLEDOWNLOAD)]} autocapitalize="off" />
                                         <p>send a SMS when subtitles are downloaded ?</p>
                                     </span>
                                 </label>
@@ -1358,7 +1358,7 @@
                             <div class="field-pair">
                                 <label for="freemobile_id">
                                     <span class="component-title">Free Mobile customer ID</span>
-                                    <input type="text" name="freemobile_id" id="freemobile_id" value="${sickbeard.FREEMOBILE_ID}" class="form-control input-sm input250" />
+                                    <input type="text" name="freemobile_id" id="freemobile_id" value="${sickbeard.FREEMOBILE_ID}" class="form-control input-sm input250"  autocapitalize="off" />
                                 </label>
                                 <label>
                                     <span class="component-title">&nbsp;</span>
@@ -1368,7 +1368,7 @@
                             <div class="field-pair">
                                 <label for="freemobile_password">
                                     <span class="component-title">Free Mobile API Key</span>
-                                    <input type="text" name="freemobile_apikey" id="freemobile_apikey" value="${sickbeard.FREEMOBILE_APIKEY}" class="form-control input-sm input250" />
+                                    <input type="text" name="freemobile_apikey" id="freemobile_apikey" value="${sickbeard.FREEMOBILE_APIKEY}" class="form-control input-sm input250"  autocapitalize="off" />
                                 </label>
                                 <label>
                                     <span class="component-title">&nbsp;</span>
@@ -1376,8 +1376,8 @@
                                 </label>
                             </div>
                             <div class="testNotification" id="testFreeMobile-result">Click below to test your settings.</div>
-                            <input  class="btn" type="button" value="Test SMS" id="testFreeMobile" />
-                            <input type="submit" class="config_submitter btn" value="Save Changes" />
+                            <input  class="btn" type="button" value="Test SMS" id="testFreeMobile"  autocapitalize="off" />
+                            <input type="submit" class="config_submitter btn" value="Save Changes"  autocapitalize="off" />
                         </div><!-- /content_use_freemobile //-->
 
                     </fieldset>
@@ -1397,7 +1397,7 @@
                             <label for="use_twitter">
                                 <span class="component-title">Enable</span>
                                 <span class="component-desc">
-                                    <input type="checkbox" class="enabler" name="use_twitter" id="use_twitter" ${('', 'checked="checked"')[bool(sickbeard.USE_TWITTER)]}/>
+                                    <input type="checkbox" class="enabler" name="use_twitter" id="use_twitter" ${('', 'checked="checked"')[bool(sickbeard.USE_TWITTER)]} autocapitalize="off" />
                                     <p>should SickRage post tweets on Twitter ?</p>
                                 </span>
                             </label>
@@ -1412,7 +1412,7 @@
                                 <label for="twitter_notify_onsnatch">
                                     <span class="component-title">Notify on snatch</span>
                                     <span class="component-desc">
-                                        <input type="checkbox" name="twitter_notify_onsnatch" id="twitter_notify_onsnatch" ${('', 'checked="checked"')[bool(sickbeard.TWITTER_NOTIFY_ONSNATCH)]}/>
+                                        <input type="checkbox" name="twitter_notify_onsnatch" id="twitter_notify_onsnatch" ${('', 'checked="checked"')[bool(sickbeard.TWITTER_NOTIFY_ONSNATCH)]} autocapitalize="off" />
                                         <p>send a notification when a download starts ?</p>
                                     </span>
                                 </label>
@@ -1421,7 +1421,7 @@
                                 <label for="twitter_notify_ondownload">
                                     <span class="component-title">Notify on download</span>
                                     <span class="component-desc">
-                                        <input type="checkbox" name="twitter_notify_ondownload" id="twitter_notify_ondownload" ${('', 'checked="checked"')[bool(sickbeard.TWITTER_NOTIFY_ONDOWNLOAD)]}/>
+                                        <input type="checkbox" name="twitter_notify_ondownload" id="twitter_notify_ondownload" ${('', 'checked="checked"')[bool(sickbeard.TWITTER_NOTIFY_ONDOWNLOAD)]} autocapitalize="off" />
                                         <p>send a notification when a download finishes ?</p>
                                     </span>
                                 </label>
@@ -1430,7 +1430,7 @@
                                 <label for="twitter_notify_onsubtitledownload">
                                     <span class="component-title">Notify on subtitle download</span>
                                     <span class="component-desc">
-                                        <input type="checkbox" name="twitter_notify_onsubtitledownload" id="twitter_notify_onsubtitledownload" ${('', 'checked="checked"')[bool(sickbeard.TWITTER_NOTIFY_ONSUBTITLEDOWNLOAD)]}/>
+                                        <input type="checkbox" name="twitter_notify_onsubtitledownload" id="twitter_notify_onsubtitledownload" ${('', 'checked="checked"')[bool(sickbeard.TWITTER_NOTIFY_ONSUBTITLEDOWNLOAD)]} autocapitalize="off" />
                                         <p>send a notification when subtitles are downloaded ?</p>
                                     </span>
                                 </label>
@@ -1439,7 +1439,7 @@
                                 <label for="twitter_usedm">
                                     <span class="component-title">Send direct message</span>
                                     <span class="component-desc">
-                                        <input type="checkbox" name="twitter_usedm" id="twitter_usedm" ${('', 'checked="checked"')[bool(sickbeard.TWITTER_USEDM)]}/>
+                                        <input type="checkbox" name="twitter_usedm" id="twitter_usedm" ${('', 'checked="checked"')[bool(sickbeard.TWITTER_USEDM)]} autocapitalize="off" />
                                         <p>send a notification via Direct Message, not via status update</p>
                                     </span>
                                 </label>
@@ -1447,7 +1447,7 @@
                             <div class="field-pair">
                                 <label for="twitter_dmto">
                                     <span class="component-title">Send DM to</span>
-                                    <input type="text" name="twitter_dmto" id="twitter_dmto" value="${sickbeard.TWITTER_DMTO}" class="form-control input-sm input250" />
+                                    <input type="text" name="twitter_dmto" id="twitter_dmto" value="${sickbeard.TWITTER_DMTO}" class="form-control input-sm input250"  autocapitalize="off" />
                                 </label>
                                 <p>
                                     <span class="component-desc">Twitter account to send Direct Messages to (must follow you)</span>
@@ -1459,7 +1459,7 @@
                                 </label>
                                 <label>
                                     <span style="font-size: 11px;">Click the "Request Authorization" button.<br> This will open a new page containing an auth key.<br> <b>Note:</b> if nothing happens check your popup blocker.<br></span>
-                                    <input class="btn" type="button" value="Request Authorization" id="twitterStep1" />
+                                    <input class="btn" type="button" value="Request Authorization" id="twitterStep1"  autocapitalize="off" />
                                 </label>
                             </div>
                             <div class="field-pair">
@@ -1468,8 +1468,8 @@
                                 </label>
                                 <label>
                                     <span style="font-size: 11px;">Enter the key Twitter gave you below, and click "Verify Key".<br><br></span>
-                                    <input type="text" id="twitter_key" value="" class="form-control input-sm input350" />
-                                    <input class="btn btn-inline" type="button" value="Verify Key" id="twitterStep2" />
+                                    <input type="text" id="twitter_key" value="" class="form-control input-sm input350"  autocapitalize="off" />
+                                    <input class="btn btn-inline" type="button" value="Verify Key" id="twitterStep2"  autocapitalize="off" />
                                 </label>
                             </div>
                             <!--
@@ -1480,8 +1480,8 @@
                             </div>
                             //-->
                             <div class="testNotification" id="testTwitter-result">Click below to test.</div>
-                            <input  class="btn" type="button" value="Test Twitter" id="testTwitter" />
-                            <input type="submit" class="config_submitter btn" value="Save Changes" />
+                            <input  class="btn" type="button" value="Test Twitter" id="testTwitter"  autocapitalize="off" />
+                            <input type="submit" class="config_submitter btn" value="Save Changes"  autocapitalize="off" />
                         </div><!-- /content_use_twitter //-->
 
                     </fieldset>
@@ -1499,7 +1499,7 @@
                             <label for="use_trakt">
                                 <span class="component-title">Enable</span>
                                 <span class="component-desc">
-                                    <input type="checkbox" class="enabler" name="use_trakt" id="use_trakt" ${('', 'checked="checked"')[bool(sickbeard.USE_TRAKT)]}/>
+                                    <input type="checkbox" class="enabler" name="use_trakt" id="use_trakt" ${('', 'checked="checked"')[bool(sickbeard.USE_TRAKT)]} autocapitalize="off" />
                                     <p>should SickRage send Trakt.tv notifications ?</p>
                                 </span>
                             </label>
@@ -1509,28 +1509,28 @@
                             <div class="field-pair">
                                 <label for="trakt_username">
                                     <span class="component-title">Trakt username</span>
-                                    <input type="text" name="trakt_username" id="trakt_username" value="${sickbeard.TRAKT_USERNAME}" class="form-control input-sm input250" />
+                                    <input type="text" name="trakt_username" id="trakt_username" value="${sickbeard.TRAKT_USERNAME}" class="form-control input-sm input250"  autocapitalize="off" />
                                 </label>
                                 <p>
                                     <span class="component-desc">username of your Trakt account.</span>
                                 </p>
                             </div>
                             <input type="hidden" id="trakt_pin_url" value="${sickbeard.TRAKT_PIN_URL}">
-                            <input type="button" class="btn ${('', 'hide')[bool(sickbeard.TRAKT_ACCESS_TOKEN)]}" value="Get Trakt PIN" id="TraktGetPin" />
+                            <input type="button" class="btn ${('', 'hide')[bool(sickbeard.TRAKT_ACCESS_TOKEN)]}" value="Get Trakt PIN" id="TraktGetPin"  autocapitalize="off" />
                             <div class="field-pair">
                                 <label for="trakt_pin">
                                     <span class="component-title">Trakt PIN</span>
-                                    <input type="text" name="trakt_pin" id="trakt_pin" value="" class="form-control input-sm input250" />
+                                    <input type="text" name="trakt_pin" id="trakt_pin" value="" class="form-control input-sm input250"  autocapitalize="off" />
                                 </label>
                                 <p>
                                     <span class="component-desc">PIN code to authorize SickRage to access Trakt on your behalf.</span>
                                 </p>
                             </div>
-                            <input type="button" class="btn hide" value="Authorize SickRage" id="authTrakt" />
+                            <input type="button" class="btn hide" value="Authorize SickRage" id="authTrakt"  autocapitalize="off" />
                             <div class="field-pair">
                                 <label for="trakt_timeout">
                                     <span class="component-title">API Timeout</span>
-                                    <input type="text" name="trakt_timeout" id="trakt_timeout" value="${sickbeard.TRAKT_TIMEOUT}" class="form-control input-sm input75" />
+                                    <input type="text" name="trakt_timeout" id="trakt_timeout" value="${sickbeard.TRAKT_TIMEOUT}" class="form-control input-sm input75"  autocapitalize="off" />
                                 </label>
                                 <p>
                                     <span class="component-desc">
@@ -1554,7 +1554,7 @@
                                 <label for="trakt_sync">
                                     <span class="component-title">Sync libraries</span>
                                     <span class="component-desc">
-                                        <input type="checkbox" class="enabler" name="trakt_sync" id="trakt_sync" ${('', 'checked="checked"')[bool(sickbeard.TRAKT_SYNC)]}/>
+                                        <input type="checkbox" class="enabler" name="trakt_sync" id="trakt_sync" ${('', 'checked="checked"')[bool(sickbeard.TRAKT_SYNC)]} autocapitalize="off" />
                                         <p>sync your SickRage show library with your trakt show library.</p>
                                     </span>
                                 </label>
@@ -1564,7 +1564,7 @@
                                     <label for="trakt_sync_remove">
                                         <span class="component-title">Remove Episodes From Collection</span>
                                         <span class="component-desc">
-                                            <input type="checkbox" name="trakt_sync_remove" id="trakt_sync_remove" ${('', 'checked="checked"')[bool(sickbeard.TRAKT_SYNC_REMOVE)]}/>
+                                            <input type="checkbox" name="trakt_sync_remove" id="trakt_sync_remove" ${('', 'checked="checked"')[bool(sickbeard.TRAKT_SYNC_REMOVE)]} autocapitalize="off" />
                                             <p>Remove an Episode from your Trakt Collection if it is not in your SickRage Library.</p>
                                         </span>
                                     </label>
@@ -1574,7 +1574,7 @@
                                 <label for="trakt_sync_watchlist">
                                     <span class="component-title">Sync watchlist</span>
                                     <span class="component-desc">
-                                        <input type="checkbox" class="enabler" name="trakt_sync_watchlist" id="trakt_sync_watchlist" ${('', 'checked="checked"')[bool(sickbeard.TRAKT_SYNC_WATCHLIST)]}/>
+                                        <input type="checkbox" class="enabler" name="trakt_sync_watchlist" id="trakt_sync_watchlist" ${('', 'checked="checked"')[bool(sickbeard.TRAKT_SYNC_WATCHLIST)]} autocapitalize="off" />
                                         <p>sync your SickRage show watchlist with your trakt show watchlist (either Show and Episode).</p>
                                         <p>Episode will be added on watch list when wanted or snatched and will be removed when downloaded </p>
                                     </span>
@@ -1599,7 +1599,7 @@
                                     <label for="trakt_remove_watchlist">
                                         <span class="component-title">Remove episode</span>
                                         <span class="component-desc">
-                                            <input type="checkbox" name="trakt_remove_watchlist" id="trakt_remove_watchlist" ${('', 'checked="checked"')[bool(sickbeard.TRAKT_REMOVE_WATCHLIST)]}/>
+                                            <input type="checkbox" name="trakt_remove_watchlist" id="trakt_remove_watchlist" ${('', 'checked="checked"')[bool(sickbeard.TRAKT_REMOVE_WATCHLIST)]} autocapitalize="off" />
                                             <p>remove an episode from your watchlist after it is downloaded.</p>
                                         </span>
                                     </label>
@@ -1608,7 +1608,7 @@
                                     <label for="trakt_remove_serieslist">
                                         <span class="component-title">Remove series</span>
                                         <span class="component-desc">
-                                            <input type="checkbox" name="trakt_remove_serieslist" id="trakt_remove_serieslist" ${('', 'checked="checked"')[bool(sickbeard.TRAKT_REMOVE_SERIESLIST)]}/>
+                                            <input type="checkbox" name="trakt_remove_serieslist" id="trakt_remove_serieslist" ${('', 'checked="checked"')[bool(sickbeard.TRAKT_REMOVE_SERIESLIST)]} autocapitalize="off" />
                                             <p>remove the whole series from your watchlist after any download.</p>
                                         </span>
                                     </label>
@@ -1617,7 +1617,7 @@
                                     <label for="trakt_remove_show_from_sickrage">
                                         <span class="component-title">Remove watched show:</span>
                                         <span class="component-desc">
-                                            <input type="checkbox" name="trakt_remove_show_from_sickrage" id="trakt_remove_show_from_sickrage" ${('', 'checked="checked"')[bool(sickbeard.TRAKT_REMOVE_SHOW_FROM_SICKRAGE)]}/>
+                                            <input type="checkbox" name="trakt_remove_show_from_sickrage" id="trakt_remove_show_from_sickrage" ${('', 'checked="checked"')[bool(sickbeard.TRAKT_REMOVE_SHOW_FROM_SICKRAGE)]} autocapitalize="off" />
                                             <p>remove the show from sickrage if it's ended and completely watched</p>
                                         </span>
                                     </label>
@@ -1626,7 +1626,7 @@
                                     <label for="trakt_start_paused">
                                         <span class="component-title">Start paused</span>
                                         <span class="component-desc">
-                                            <input type="checkbox" name="trakt_start_paused" id="trakt_start_paused" ${('', 'checked="checked"')[bool(sickbeard.TRAKT_START_PAUSED)]}/>
+                                            <input type="checkbox" name="trakt_start_paused" id="trakt_start_paused" ${('', 'checked="checked"')[bool(sickbeard.TRAKT_START_PAUSED)]} autocapitalize="off" />
                                             <p>shows grabbed from your trakt watchlist start paused.</p>
                                         </span>
                                     </label>
@@ -1635,7 +1635,7 @@
                             <div class="field-pair">
                                 <label for="trakt_blacklist_name">
                                     <span class="component-title">Trakt blackList name</span>
-                                    <input type="text" name="trakt_blacklist_name" id="trakt_blacklist_name" value="${sickbeard.TRAKT_BLACKLIST_NAME}" class="form-control input-sm input150" />
+                                    <input type="text" name="trakt_blacklist_name" id="trakt_blacklist_name" value="${sickbeard.TRAKT_BLACKLIST_NAME}" class="form-control input-sm input150"  autocapitalize="off" />
                                 </label>
                                 <label>
                                     <span class="component-title">&nbsp;</span>
@@ -1643,8 +1643,8 @@
                                 </label>
                             </div>
                             <div class="testNotification" id="testTrakt-result">Click below to test.</div>
-                            <input type="button" class="btn" value="Test Trakt" id="testTrakt" />
-                            <input type="submit" class="btn config_submitter" value="Save Changes" />
+                            <input type="button" class="btn" value="Test Trakt" id="testTrakt"  autocapitalize="off" />
+                            <input type="submit" class="btn config_submitter" value="Save Changes"  autocapitalize="off" />
                         </div><!-- /content_use_trakt //-->
                     </fieldset>
                 </div><!-- /trakt component-group //-->
@@ -1660,7 +1660,7 @@
                             <label for="use_email">
                                 <span class="component-title">Enable</span>
                                 <span class="component-desc">
-                                    <input type="checkbox" class="enabler" name="use_email" id="use_email" ${('', 'checked="checked"')[bool(sickbeard.USE_EMAIL)]}/>
+                                    <input type="checkbox" class="enabler" name="use_email" id="use_email" ${('', 'checked="checked"')[bool(sickbeard.USE_EMAIL)]} autocapitalize="off" />
                                     <p>should SickRage send email notifications ?</p>
                                 </span>
                             </label>
@@ -1671,7 +1671,7 @@
                                 <label for="email_notify_onsnatch">
                                     <span class="component-title">Notify on snatch</span>
                                     <span class="component-desc">
-                                        <input type="checkbox" name="email_notify_onsnatch" id="email_notify_onsnatch" ${('', 'checked="checked"')[bool(sickbeard.EMAIL_NOTIFY_ONSNATCH)]}/>
+                                        <input type="checkbox" name="email_notify_onsnatch" id="email_notify_onsnatch" ${('', 'checked="checked"')[bool(sickbeard.EMAIL_NOTIFY_ONSNATCH)]} autocapitalize="off" />
                                         <p>send a notification when a download starts ?</p>
                                     </span>
                                 </label>
@@ -1680,7 +1680,7 @@
                                 <label for="email_notify_ondownload">
                                     <span class="component-title">Notify on download</span>
                                     <span class="component-desc">
-                                        <input type="checkbox" name="email_notify_ondownload" id="email_notify_ondownload" ${('', 'checked="checked"')[bool(sickbeard.EMAIL_NOTIFY_ONDOWNLOAD)]}/>
+                                        <input type="checkbox" name="email_notify_ondownload" id="email_notify_ondownload" ${('', 'checked="checked"')[bool(sickbeard.EMAIL_NOTIFY_ONDOWNLOAD)]} autocapitalize="off" />
                                         <p>send a notification when a download finishes ?</p>
                                     </span>
                                 </label>
@@ -1689,7 +1689,7 @@
                                 <label for="email_notify_onsubtitledownload">
                                     <span class="component-title">Notify on subtitle download</span>
                                     <span class="component-desc">
-                                        <input type="checkbox" name="email_notify_onsubtitledownload" id="email_notify_onsubtitledownload" ${('', 'checked="checked"')[bool(sickbeard.EMAIL_NOTIFY_ONSUBTITLEDOWNLOAD)]}/>
+                                        <input type="checkbox" name="email_notify_onsubtitledownload" id="email_notify_onsubtitledownload" ${('', 'checked="checked"')[bool(sickbeard.EMAIL_NOTIFY_ONSUBTITLEDOWNLOAD)]} autocapitalize="off" />
                                         <p>send a notification when subtitles are downloaded ?</p>
                                     </span>
                                 </label>
@@ -1697,7 +1697,7 @@
                             <div class="field-pair">
                                 <label for="email_host">
                                     <span class="component-title">SMTP host</span>
-                                    <input type="text" name="email_host" id="email_host" value="${sickbeard.EMAIL_HOST}" class="form-control input-sm input250" />
+                                    <input type="text" name="email_host" id="email_host" value="${sickbeard.EMAIL_HOST}" class="form-control input-sm input250"  autocapitalize="off" />
                                 </label>
                                 <label>
                                     <span class="component-title">&nbsp;</span>
@@ -1707,7 +1707,7 @@
                             <div class="field-pair">
                                 <label for="email_port">
                                     <span class="component-title">SMTP port</span>
-                                    <input type="text" name="email_port" id="email_port" value="${sickbeard.EMAIL_PORT}" class="form-control input-sm input75" />
+                                    <input type="text" name="email_port" id="email_port" value="${sickbeard.EMAIL_PORT}" class="form-control input-sm input75"  autocapitalize="off" />
                                 </label>
                                 <label>
                                     <span class="component-title">&nbsp;</span>
@@ -1717,7 +1717,7 @@
                             <div class="field-pair">
                                 <label for="email_from">
                                     <span class="component-title">SMTP from</span>
-                                    <input type="text" name="email_from" id="email_from" value="${sickbeard.EMAIL_FROM}" class="form-control input-sm input250" />
+                                    <input type="text" name="email_from" id="email_from" value="${sickbeard.EMAIL_FROM}" class="form-control input-sm input250"  autocapitalize="off" />
                                 </label>
                                 <label>
                                     <span class="component-title">&nbsp;</span>
@@ -1728,7 +1728,7 @@
                                 <label for="email_tls">
                                     <span class="component-title">Use TLS</span>
                                     <span class="component-desc">
-                                        <input type="checkbox" name="email_tls" id="email_tls" ${('', 'checked="checked"')[bool(sickbeard.EMAIL_TLS)]}/>
+                                        <input type="checkbox" name="email_tls" id="email_tls" ${('', 'checked="checked"')[bool(sickbeard.EMAIL_TLS)]} autocapitalize="off" />
                                         <p>check to use TLS encryption.</p>
                                     </span>
                                 </label>
@@ -1736,7 +1736,7 @@
                             <div class="field-pair">
                                 <label for="email_user">
                                     <span class="component-title">SMTP user</span>
-                                    <input type="text" name="email_user" id="email_user" value="${sickbeard.EMAIL_USER}" class="form-control input-sm input250" />
+                                    <input type="text" name="email_user" id="email_user" value="${sickbeard.EMAIL_USER}" class="form-control input-sm input250"  autocapitalize="off" />
                                 </label>
                                 <label>
                                     <span class="component-title">&nbsp;</span>
@@ -1746,7 +1746,7 @@
                             <div class="field-pair">
                                 <label for="email_password">
                                     <span class="component-title">SMTP password</span>
-                                    <input type="password" name="email_password" id="email_password" value="${sickbeard.EMAIL_PASSWORD}" class="form-control input-sm input250" />
+                                    <input type="password" name="email_password" id="email_password" value="${sickbeard.EMAIL_PASSWORD}" class="form-control input-sm input250"  autocapitalize="off" />
                                 </label>
                                 <label>
                                     <span class="component-title">&nbsp;</span>
@@ -1756,7 +1756,7 @@
                             <div class="field-pair">
                                 <label for="email_list">
                                     <span class="component-title">Global email list</span>
-                                    <input type="text" name="email_list" id="email_list" value="${sickbeard.EMAIL_LIST}" class="form-control input-sm input350" />
+                                    <input type="text" name="email_list" id="email_list" value="${sickbeard.EMAIL_LIST}" class="form-control input-sm input350"  autocapitalize="off" />
                                 </label>
                                 <label>
                                     <span class="component-title">&nbsp;</span>
@@ -1773,7 +1773,7 @@
                                 </label>
                                 <label>
                                     <span class="component-title">&nbsp;</span>
-                                    <input type="text" name="email_show_list" id="email_show_list" class="form-control input-sm input350" />
+                                    <input type="text" name="email_show_list" id="email_show_list" class="form-control input-sm input350"  autocapitalize="off" />
                                 </label>
                                 <label>
                                     <span class="component-title">&nbsp;</span>
@@ -1783,13 +1783,13 @@
                                 </label>
                                 <label>
                                     <span class="component-title">&nbsp;</span>
-                                    <input id="email_show_save" class="btn" type="button" value="Save for this show" />
+                                    <input id="email_show_save" class="btn" type="button" value="Save for this show"  autocapitalize="off" />
                                 </label>
                             </div>
 
                             <div class="testNotification" id="testEmail-result">Click below to test.</div>
-                            <input class="btn" type="button" value="Test Email" id="testEmail" />
-                            <input class="btn" type="submit" class="config_submitter" value="Save Changes" />
+                            <input class="btn" type="button" value="Test Email" id="testEmail"  autocapitalize="off" />
+                            <input class="btn" type="submit" class="config_submitter" value="Save Changes"  autocapitalize="off" />
                         </div><!-- /content_use_email //-->
                     </fieldset>
                 </div><!-- /email component-group //-->
@@ -1797,7 +1797,7 @@
             </div><!-- /config-components //-->
         </form>
 
-        <br><input type="submit" class="config_submitter btn" value="Save Changes" /><br>
+        <br><input type="submit" class="config_submitter btn" value="Save Changes"  autocapitalize="off" /><br>
 
     </div>
 </div>

--- a/gui/slick/views/config_postProcessing.mako
+++ b/gui/slick/views/config_postProcessing.mako
@@ -33,7 +33,7 @@
                     </div>
                     <fieldset class="component-group-list">
                         <div class="field-pair">
-                            <input type="checkbox" name="process_automatically" id="process_automatically" ${('', 'checked="checked"')[bool(sickbeard.PROCESS_AUTOMATICALLY)]}/>
+                            <input type="checkbox" name="process_automatically" id="process_automatically" ${('', 'checked="checked"')[bool(sickbeard.PROCESS_AUTOMATICALLY)]} autocapitalize="off" />
                             <label for="process_automatically">
                                 <span class="component-title">Enable</span>
                                 <span class="component-desc">Enable the automatic post processor to scan and process any files in your <i>Post Processing Dir</i>?</span>
@@ -46,7 +46,7 @@
                         <div class="field-pair">
                             <label class="nocheck" for="tv_download_dir">
                                 <span class="component-title">Post Processing Dir</span>
-                                <input type="text" name="tv_download_dir" id="tv_download_dir" value="${sickbeard.TV_DOWNLOAD_DIR}" class="form-control input-sm input350" />
+                                <input type="text" name="tv_download_dir" id="tv_download_dir" value="${sickbeard.TV_DOWNLOAD_DIR}" class="form-control input-sm input350"  autocapitalize="off" />
                             </label>
                             <label class="nocheck">
                                 <span class="component-title">&nbsp;</span>
@@ -81,7 +81,7 @@
                         <div class="field-pair">
                             <label class="nocheck">
                                 <span class="component-title">Auto Post-Processing Frequency</span>
-                                <input type="number" min="10" name="autopostprocesser_frequency" id="autopostprocesser_frequency" value="${sickbeard.AUTOPOSTPROCESSER_FREQUENCY}" class="form-control input-sm input75" />
+                                <input type="number" min="10" name="autopostprocesser_frequency" id="autopostprocesser_frequency" value="${sickbeard.AUTOPOSTPROCESSER_FREQUENCY}" class="form-control input-sm input75"  autocapitalize="off" />
                             </label>
                             <label class="nocheck">
                                 <span class="component-title">&nbsp;</span>
@@ -89,7 +89,7 @@
                             </label>
                         </div>
                         <div class="field-pair">
-                            <input type="checkbox" name="postpone_if_sync_files" id="postpone_if_sync_files" ${('', 'checked="checked"')[bool(sickbeard.POSTPONE_IF_SYNC_FILES)]}/>
+                            <input type="checkbox" name="postpone_if_sync_files" id="postpone_if_sync_files" ${('', 'checked="checked"')[bool(sickbeard.POSTPONE_IF_SYNC_FILES)]} autocapitalize="off" />
                             <label for="postpone_if_sync_files">
                                 <span class="component-title">Postpone post processing</span>
                                 <span class="component-desc">Wait to process a folder if sync files are present.</span>
@@ -98,7 +98,7 @@
                         <div class="field-pair">
                             <label class="nocheck">
                                 <span class="component-title">Sync File Extensions</span>
-                                <input type="text" name="sync_files" id="sync_files" value="${sickbeard.SYNC_FILES}" class="form-control input-sm input350" />
+                                <input type="text" name="sync_files" id="sync_files" value="${sickbeard.SYNC_FILES}" class="form-control input-sm input350"  autocapitalize="off" />
                             </label>
                             <label class="nocheck">
                                 <span class="component-title">&nbsp;</span>
@@ -106,7 +106,7 @@
                             </label>
                         </div>
                         <div class="field-pair">
-                            <input type="checkbox" name="postpone_if_no_subs" id="postpone_if_no_subs" ${('', 'checked="checked"')[bool(sickbeard.POSTPONE_IF_NO_SUBS)]}/>
+                            <input type="checkbox" name="postpone_if_no_subs" id="postpone_if_no_subs" ${('', 'checked="checked"')[bool(sickbeard.POSTPONE_IF_NO_SUBS)]} autocapitalize="off" />
                             <label for="postpone_if_no_subs">
                                 <span class="component-title">Postpone if no subtitle</span>
                                 <span class="component-desc">Wait to process a file until subtitles are present</span>
@@ -114,28 +114,28 @@
                             </label>
                         </div>
                         <div class="field-pair">
-                            <input type="checkbox" name="rename_episodes" id="rename_episodes" ${('', 'checked="checked"')[bool(sickbeard.RENAME_EPISODES)]}/>
+                            <input type="checkbox" name="rename_episodes" id="rename_episodes" ${('', 'checked="checked"')[bool(sickbeard.RENAME_EPISODES)]} autocapitalize="off" />
                             <label for="rename_episodes">
                                 <span class="component-title">Rename Episodes</span>
                                 <span class="component-desc">Rename episode using the Episode Naming settings?</span>
                             </label>
                         </div>
                         <div class="field-pair">
-                            <input type="checkbox" name="create_missing_show_dirs" id="create_missing_show_dirs" ${('', 'checked="checked"')[bool(sickbeard.CREATE_MISSING_SHOW_DIRS)]}/>
+                            <input type="checkbox" name="create_missing_show_dirs" id="create_missing_show_dirs" ${('', 'checked="checked"')[bool(sickbeard.CREATE_MISSING_SHOW_DIRS)]} autocapitalize="off" />
                             <label for="create_missing_show_dirs">
                                 <span class="component-title">Create missing show directories</span>
                                 <span class="component-desc">Create missing show directories when they get deleted</span>
                             </label>
                         </div>
                         <div class="field-pair">
-                            <input type="checkbox" name="add_shows_wo_dir" id="add_shows_wo_dir" ${('', 'checked="checked"')[bool(sickbeard.ADD_SHOWS_WO_DIR)]}/>
+                            <input type="checkbox" name="add_shows_wo_dir" id="add_shows_wo_dir" ${('', 'checked="checked"')[bool(sickbeard.ADD_SHOWS_WO_DIR)]} autocapitalize="off" />
                             <label for="add_shows_wo_dir">
                                 <span class="component-title">Add shows without directory</span>
                                 <span class="component-desc">Add shows without creating a directory (not recommended)</span>
                             </label>
                         </div>
                         <div class="field-pair">
-                            <input type="checkbox" name="move_associated_files" id="move_associated_files" ${('', 'checked="checked"')[bool(sickbeard.MOVE_ASSOCIATED_FILES)]}/>
+                            <input type="checkbox" name="move_associated_files" id="move_associated_files" ${('', 'checked="checked"')[bool(sickbeard.MOVE_ASSOCIATED_FILES)]} autocapitalize="off" />
                             <label for="move_associated_files">
                                 <span class="component-title">Move Associated Files</span>
                                 <span class="component-desc">Move srr/sfv/etc files with the episode when processed?</span>
@@ -144,7 +144,7 @@
                         <div class="field-pair">
                             <label class="nocheck">
                                 <span class="component-title">Allowed associated file extensions</span>
-                                <input type="text" name="allowed_extensions" id="allowed_extensions" value="${sickbeard.ALLOWED_EXTENSIONS}" class="form-control input-sm input350" />
+                                <input type="text" name="allowed_extensions" id="allowed_extensions" value="${sickbeard.ALLOWED_EXTENSIONS}" class="form-control input-sm input350"  autocapitalize="off" />
                             </label>
                             <label class="nocheck">
                                 <span class="component-title">&nbsp;</span>
@@ -152,14 +152,14 @@
                             </label>
                         </div>
                         <div class="field-pair">
-                            <input type="checkbox" name="nfo_rename" id="nfo_rename" ${('', 'checked="checked"')[bool(sickbeard.NFO_RENAME)]}/>
+                            <input type="checkbox" name="nfo_rename" id="nfo_rename" ${('', 'checked="checked"')[bool(sickbeard.NFO_RENAME)]} autocapitalize="off" />
                             <label for="nfo_rename">
                                 <span class="component-title">Rename .nfo file</span>
                                 <span class="component-desc">Rename the original .nfo file to .nfo-orig to avoid conflicts?</span>
                             </label>
                         </div>
                         <div class="field-pair">
-                            <input type="checkbox" name="airdate_episodes" id="airdate_episodes" ${('', 'checked="checked"')[bool(sickbeard.AIRDATE_EPISODES)]}/>
+                            <input type="checkbox" name="airdate_episodes" id="airdate_episodes" ${('', 'checked="checked"')[bool(sickbeard.AIRDATE_EPISODES)]} autocapitalize="off" />
                             <label for="airdate_episodes">
                                 <span class="component-title">Change File Date</span>
                                 <span class="component-desc">Set last modified filedate to the date that the episode aired?</span>
@@ -186,7 +186,7 @@
                             </label>
                         </div>
                         <div class="field-pair">
-                            <input id="unpack" type="checkbox" name="unpack" ${('', 'checked="checked"')[bool(sickbeard.UNPACK)]} />
+                            <input id="unpack" type="checkbox" name="unpack" ${('', 'checked="checked"')[bool(sickbeard.UNPACK)]}  autocapitalize="off" />
                             <label for="unpack">
                                 <span class="component-title">Unpack</span>
                                 <span class="component-desc">Unpack any TV releases in your <i>TV Download Dir</i>?</span>
@@ -197,14 +197,14 @@
                             </label>
                         </div>
                         <div class="field-pair">
-                            <input type="checkbox" name="del_rar_contents" id="del_rar_contents" ${('', 'checked="checked"')[bool(sickbeard.DELRARCONTENTS)]}/>
+                            <input type="checkbox" name="del_rar_contents" id="del_rar_contents" ${('', 'checked="checked"')[bool(sickbeard.DELRARCONTENTS)]} autocapitalize="off" />
                             <label for="del_rar_contents">
                                 <span class="component-title">Delete RAR contents</span>
                                 <span class="component-desc">Delete content of RAR files, even if Process Method not set to move?</span>
                             </label>
                         </div>
                         <div class="field-pair">
-                            <input type="checkbox" name="no_delete" id="no_delete" ${('', 'checked="checked"')[bool(sickbeard.NO_DELETE)]}/>
+                            <input type="checkbox" name="no_delete" id="no_delete" ${('', 'checked="checked"')[bool(sickbeard.NO_DELETE)]} autocapitalize="off" />
                             <label for="no_delete">
                                 <span class="component-title">Don't delete empty folders</span>
                                 <span class="component-desc">Leave empty folders when Post Processing?</span>
@@ -215,7 +215,7 @@
                             </label>
                         </div>
                         <div class="field-pair">
-                            <input id="use_failed_downloads" type="checkbox" class="enabler" name="use_failed_downloads" ${('', 'checked="checked"')[bool(sickbeard.USE_FAILED_DOWNLOADS)]}/>
+                            <input id="use_failed_downloads" type="checkbox" class="enabler" name="use_failed_downloads" ${('', 'checked="checked"')[bool(sickbeard.USE_FAILED_DOWNLOADS)]} autocapitalize="off" />
                             <label for="use_failed_downloads">
                                 <span class="component-title">Use Failed Downloads</span>
                                 <span class="component-desc">Use Failed Download Handling?</span>
@@ -226,7 +226,7 @@
                         </div>
                         <div id="content_use_failed_downloads">
                             <div class="field-pair">
-                                <input id="delete_failed" type="checkbox" name="delete_failed" ${('', 'checked="checked"')[bool(sickbeard.DELETE_FAILED)]}/>
+                                <input id="delete_failed" type="checkbox" name="delete_failed" ${('', 'checked="checked"')[bool(sickbeard.DELETE_FAILED)]} autocapitalize="off" />
                                 <label for="delete_failed">
                                     <span class="component-title">Delete Failed</span>
                                     <span class="component-desc">Delete files left over from a failed download?</span>
@@ -240,14 +240,14 @@
                         <div class="field-pair">
                             <label class="nocheck">
                                 <span class="component-title">Extra Scripts</span>
-                                <input type="text" name="extra_scripts" value="${'|'.join(sickbeard.EXTRA_SCRIPTS)}" class="form-control input-sm input350" />
+                                <input type="text" name="extra_scripts" value="${'|'.join(sickbeard.EXTRA_SCRIPTS)}" class="form-control input-sm input350"  autocapitalize="off" />
                             </label>
                             <label class="nocheck">
                                 <span class="component-title">&nbsp;</span>
                                 <span class="component-desc">See <a href="https://github.com/SickRage/sickrage-issues/wiki/Post-Processing#extra-scripts"><font color='red'><b>Wiki</b></font></a> for script arguments description and usage.</span>
                             </label>
                         </div>
-                        <input type="submit" class="btn config_submitter" value="Save Changes" /><br>
+                        <input type="submit" class="btn config_submitter" value="Save Changes"  autocapitalize="off" /><br>
                     </fieldset>
                 </div><!-- /component-group1 //-->
                 <div id="core-component-group2" class="component-group">
@@ -284,7 +284,7 @@
                                         &nbsp;
                                     </span>
                                     <span class="component-desc">
-                                        <input type="text" name="naming_pattern" id="naming_pattern" value="${sickbeard.NAMING_PATTERN}" class="form-control input-sm input350" />
+                                        <input type="text" name="naming_pattern" id="naming_pattern" value="${sickbeard.NAMING_PATTERN}" class="form-control input-sm input350"  autocapitalize="off" />
                                         <img src="${srRoot}/images/legend16.png" width="16" height="16" alt="[Toggle Key]" id="show_naming_key" title="Toggle Naming Legend" class="legend" class="legend" />
                                     </span>
                                 </label>
@@ -490,7 +490,7 @@
                         </div>
 
                         <div class="field-pair">
-                            <input type="checkbox" id="naming_strip_year"  name="naming_strip_year" ${('', 'checked="checked"')[bool(sickbeard.NAMING_STRIP_YEAR)]}/>
+                            <input type="checkbox" id="naming_strip_year"  name="naming_strip_year" ${('', 'checked="checked"')[bool(sickbeard.NAMING_STRIP_YEAR)]} autocapitalize="off" />
                             <label for="naming_strip_year">
                                 <span class="component-title">Strip Show Year</span>
                                 <span class="component-desc">Remove the TV show's year when renaming the file?</span>
@@ -502,7 +502,7 @@
                         </div>
 
                         <div class="field-pair">
-                            <input type="checkbox" class="enabler" id="naming_custom_abd" name="naming_custom_abd" ${('', 'checked="checked"')[bool(sickbeard.NAMING_CUSTOM_ABD)]}/>
+                            <input type="checkbox" class="enabler" id="naming_custom_abd" name="naming_custom_abd" ${('', 'checked="checked"')[bool(sickbeard.NAMING_CUSTOM_ABD)]} autocapitalize="off" />
                             <label for="naming_custom_abd">
                                 <span class="component-title">Custom Air-By-Date</span>
                                 <span class="component-desc">Name Air-By-Date shows differently than regular shows?</span>
@@ -536,7 +536,7 @@
                                             &nbsp;
                                         </span>
                                         <span class="component-desc">
-                                            <input type="text" name="naming_abd_pattern" id="naming_abd_pattern" value="${sickbeard.NAMING_ABD_PATTERN}" class="form-control input-sm input350" />
+                                            <input type="text" name="naming_abd_pattern" id="naming_abd_pattern" value="${sickbeard.NAMING_ABD_PATTERN}" class="form-control input-sm input350"  autocapitalize="off" />
                                             <img src="${srRoot}/images/legend16.png" width="16" height="16" alt="[Toggle Key]" id="show_naming_abd_key" title="Toggle ABD Naming Legend" class="legend" />
                                         </span>
                                     </label>
@@ -679,7 +679,7 @@
                         </div><!-- /naming_abd_different -->
 
                         <div class="field-pair">
-                            <input type="checkbox" class="enabler" id="naming_custom_sports" name="naming_custom_sports" ${('', 'checked="checked"')[bool(sickbeard.NAMING_CUSTOM_SPORTS)]}/>
+                            <input type="checkbox" class="enabler" id="naming_custom_sports" name="naming_custom_sports" ${('', 'checked="checked"')[bool(sickbeard.NAMING_CUSTOM_SPORTS)]} autocapitalize="off" />
                             <label for="naming_custom_sports">
                                 <span class="component-title">Custom Sports</span>
                                 <span class="component-desc">Name Sports shows differently than regular shows?</span>
@@ -713,7 +713,7 @@
                                             &nbsp;
                                         </span>
                                         <span class="component-desc">
-                                            <input type="text" name="naming_sports_pattern" id="naming_sports_pattern" value="${sickbeard.NAMING_SPORTS_PATTERN}" class="form-control input-sm input350" />
+                                            <input type="text" name="naming_sports_pattern" id="naming_sports_pattern" value="${sickbeard.NAMING_SPORTS_PATTERN}" class="form-control input-sm input350"  autocapitalize="off" />
                                             <img src="${srRoot}/images/legend16.png" width="16" height="16" alt="[Toggle Key]" id="show_naming_sports_key" title="Toggle Sports Naming Legend" class="legend" />
                                         </span>
                                     </label>
@@ -857,7 +857,7 @@
 
                         <!-- naming_anime_custom -->
                         <div class="field-pair">
-                            <input type="checkbox" class="enabler" id="naming_custom_anime" name="naming_custom_anime" ${('', 'checked="checked"')[bool(sickbeard.NAMING_CUSTOM_ANIME)]}/>
+                            <input type="checkbox" class="enabler" id="naming_custom_anime" name="naming_custom_anime" ${('', 'checked="checked"')[bool(sickbeard.NAMING_CUSTOM_ANIME)]} autocapitalize="off" />
                             <label for="naming_custom_anime">
                                 <span class="component-title">Custom Anime</span>
                                 <span class="component-desc">Name Anime shows differently than regular shows?</span>
@@ -891,7 +891,7 @@
                                             &nbsp;
                                         </span>
                                         <span class="component-desc">
-                                            <input type="text" name="naming_anime_pattern" id="naming_anime_pattern" value="${sickbeard.NAMING_ANIME_PATTERN}" class="form-control input-sm input350" />
+                                            <input type="text" name="naming_anime_pattern" id="naming_anime_pattern" value="${sickbeard.NAMING_ANIME_PATTERN}" class="form-control input-sm input350"  autocapitalize="off" />
                                             <img src="${srRoot}/images/legend16.png" width="16" height="16" alt="[Toggle Key]" id="show_naming_anime_key" title="Toggle Anime Naming Legend" class="legend" />
                                         </span>
                                     </label>
@@ -1048,7 +1048,7 @@
                             </div>
 
                             <div class="field-pair">
-                                <input type="radio" name="naming_anime" id="naming_anime" value="1" ${('', 'checked="checked"')[sickbeard.NAMING_ANIME == 1]}/>
+                                <input type="radio" name="naming_anime" id="naming_anime" value="1" ${('', 'checked="checked"')[sickbeard.NAMING_ANIME == 1]} autocapitalize="off" />
                                 <label for="naming_anime">
                                     <span class="component-title">Add Absolute Number</span>
                                     <span class="component-desc">Add the absolute number to the season/episode format?</span>
@@ -1060,7 +1060,7 @@
                             </div>
 
                             <div class="field-pair">
-                                <input type="radio" name="naming_anime" id="naming_anime_only" value="2" ${('', 'checked="checked"')[sickbeard.NAMING_ANIME == 2]}/>
+                                <input type="radio" name="naming_anime" id="naming_anime_only" value="2" ${('', 'checked="checked"')[sickbeard.NAMING_ANIME == 2]} autocapitalize="off" />
                                 <label for="naming_anime_only">
                                     <span class="component-title">Only Absolute Number</span>
                                     <span class="component-desc">Replace season/episode format with absolute number</span>
@@ -1072,7 +1072,7 @@
                             </div>
 
                             <div class="field-pair">
-                                <input type="radio" name="naming_anime" id="naming_anime_none" value="3" ${('', 'checked="checked"')[sickbeard.NAMING_ANIME == 3]}/>
+                                <input type="radio" name="naming_anime" id="naming_anime_none" value="3" ${('', 'checked="checked"')[sickbeard.NAMING_ANIME == 3]} autocapitalize="off" />
                                 <label for="naming_anime_none">
                                     <span class="component-title">No Absolute Number</span>
                                     <span class="component-desc">Dont include the absolute number</span>
@@ -1085,7 +1085,7 @@
 
                         </div><!-- /naming_anime_different -->
 
-                        <input type="submit" class="btn config_submitter" value="Save Changes" /><br>
+                        <input type="submit" class="btn config_submitter" value="Save Changes"  autocapitalize="off" /><br>
                     </fieldset>
                 </div><!-- /component-group2 //-->
 
@@ -1118,16 +1118,16 @@
                             <div class="metadata_options_wrapper">
                                 <h4>Create:</h4>
                                 <div class="metadata_options">
-                                    <label for="${cur_id}_show_metadata"><input type="checkbox" class="metadata_checkbox" id="${cur_id}_show_metadata" ${('', 'checked="checked"')[bool(cur_metadata_inst.show_metadata)]}/>&nbsp;Show Metadata</label>
-                                    <label for="${cur_id}_episode_metadata"><input type="checkbox" class="metadata_checkbox" id="${cur_id}_episode_metadata" ${('', 'checked="checked"')[bool(cur_metadata_inst.episode_metadata)]}/>&nbsp;Episode Metadata</label>
-                                    <label for="${cur_id}_fanart"><input type="checkbox" class="float-left metadata_checkbox" id="${cur_id}_fanart" ${('', 'checked="checked"')[bool(cur_metadata_inst.fanart)]}/>&nbsp;Show Fanart</label>
-                                    <label for="${cur_id}_poster"><input type="checkbox" class="float-left metadata_checkbox" id="${cur_id}_poster" ${('', 'checked="checked"')[bool(cur_metadata_inst.poster)]}/>&nbsp;Show Poster</label>
-                                    <label for="${cur_id}_banner"><input type="checkbox" class="float-left metadata_checkbox" id="${cur_id}_banner" ${('', 'checked="checked"')[bool(cur_metadata_inst.banner)]}/>&nbsp;Show Banner</label>
-                                    <label for="${cur_id}_episode_thumbnails"><input type="checkbox" class="float-left metadata_checkbox" id="${cur_id}_episode_thumbnails" ${('', 'checked="checked"')[bool(cur_metadata_inst.episode_thumbnails)]}/>&nbsp;Episode Thumbnails</label>
-                                    <label for="${cur_id}_season_posters"><input type="checkbox" class="float-left metadata_checkbox" id="${cur_id}_season_posters" ${('', 'checked="checked"')[bool(cur_metadata_inst.season_posters)]}/>&nbsp;Season Posters</label>
-                                    <label for="${cur_id}_season_banners"><input type="checkbox" class="float-left metadata_checkbox" id="${cur_id}_season_banners" ${('', 'checked="checked"')[bool(cur_metadata_inst.season_banners)]}/>&nbsp;Season Banners</label>
-                                    <label for="${cur_id}_season_all_poster"><input type="checkbox" class="float-left metadata_checkbox" id="${cur_id}_season_all_poster" ${('', 'checked="checked"')[bool(cur_metadata_inst.season_all_poster)]}/>&nbsp;Season All Poster</label>
-                                    <label for="${cur_id}_season_all_banner"><input type="checkbox" class="float-left metadata_checkbox" id="${cur_id}_season_all_banner" ${('', 'checked="checked"')[bool(cur_metadata_inst.season_all_banner)]}/>&nbsp;Season All Banner</label>
+                                    <label for="${cur_id}_show_metadata"><input type="checkbox" class="metadata_checkbox" id="${cur_id}_show_metadata" ${('', 'checked="checked"')[bool(cur_metadata_inst.show_metadata)]} autocapitalize="off" />&nbsp;Show Metadata</label>
+                                    <label for="${cur_id}_episode_metadata"><input type="checkbox" class="metadata_checkbox" id="${cur_id}_episode_metadata" ${('', 'checked="checked"')[bool(cur_metadata_inst.episode_metadata)]} autocapitalize="off" />&nbsp;Episode Metadata</label>
+                                    <label for="${cur_id}_fanart"><input type="checkbox" class="float-left metadata_checkbox" id="${cur_id}_fanart" ${('', 'checked="checked"')[bool(cur_metadata_inst.fanart)]} autocapitalize="off" />&nbsp;Show Fanart</label>
+                                    <label for="${cur_id}_poster"><input type="checkbox" class="float-left metadata_checkbox" id="${cur_id}_poster" ${('', 'checked="checked"')[bool(cur_metadata_inst.poster)]} autocapitalize="off" />&nbsp;Show Poster</label>
+                                    <label for="${cur_id}_banner"><input type="checkbox" class="float-left metadata_checkbox" id="${cur_id}_banner" ${('', 'checked="checked"')[bool(cur_metadata_inst.banner)]} autocapitalize="off" />&nbsp;Show Banner</label>
+                                    <label for="${cur_id}_episode_thumbnails"><input type="checkbox" class="float-left metadata_checkbox" id="${cur_id}_episode_thumbnails" ${('', 'checked="checked"')[bool(cur_metadata_inst.episode_thumbnails)]} autocapitalize="off" />&nbsp;Episode Thumbnails</label>
+                                    <label for="${cur_id}_season_posters"><input type="checkbox" class="float-left metadata_checkbox" id="${cur_id}_season_posters" ${('', 'checked="checked"')[bool(cur_metadata_inst.season_posters)]} autocapitalize="off" />&nbsp;Season Posters</label>
+                                    <label for="${cur_id}_season_banners"><input type="checkbox" class="float-left metadata_checkbox" id="${cur_id}_season_banners" ${('', 'checked="checked"')[bool(cur_metadata_inst.season_banners)]} autocapitalize="off" />&nbsp;Season Banners</label>
+                                    <label for="${cur_id}_season_all_poster"><input type="checkbox" class="float-left metadata_checkbox" id="${cur_id}_season_all_poster" ${('', 'checked="checked"')[bool(cur_metadata_inst.season_all_poster)]} autocapitalize="off" />&nbsp;Season All Poster</label>
+                                    <label for="${cur_id}_season_all_banner"><input type="checkbox" class="float-left metadata_checkbox" id="${cur_id}_season_all_banner" ${('', 'checked="checked"')[bool(cur_metadata_inst.season_all_banner)]} autocapitalize="off" />&nbsp;Season All Banner</label>
                                 </div>
                             </div>
                             <div class="metadata_example_wrapper">
@@ -1145,19 +1145,19 @@
                                     <label for="${cur_id}_season_all_banner"><span id="${cur_id}_eg_season_all_banner">${cur_metadata_inst.eg_season_all_banner}</span></label>
                                 </div>
                             </div>
-                            <input type="hidden" name="${cur_id}_data" id="${cur_id}_data" value="${cur_metadata_inst.get_config()}" />
+                            <input type="hidden" name="${cur_id}_data" id="${cur_id}_data" value="${cur_metadata_inst.get_config()}"  autocapitalize="off" />
                         </div>
                         % endfor
 
                         <div class="clearfix"></div><br>
 
-                        <input type="submit" class="btn config_submitter" value="Save Changes" /><br>
+                        <input type="submit" class="btn config_submitter" value="Save Changes"  autocapitalize="off" /><br>
                     </fieldset>
                 </div><!-- /component-group3 //-->
 
                 <br>
                 <h6 class="pull-right"><b>All non-absolute folder locations are relative to <span class="path">${sickbeard.DATA_DIR}</span></b> </h6>
-                <input type="submit" class="btn pull-left config_submitter button" value="Save Changes" />
+                <input type="submit" class="btn pull-left config_submitter button" value="Save Changes"  autocapitalize="off" />
         </form>
     </div>
 </div>

--- a/gui/slick/views/config_providers.mako
+++ b/gui/slick/views/config_providers.mako
@@ -82,7 +82,7 @@ $('#config-components').tabs();
                                     curURL = curProvider.url
                             %>
                             <li class="ui-state-default ${('nzb-provider', 'torrent-provider')[bool(curProvider.providerType == "torrent")]}" id="${curName}">
-                                <input type="checkbox" id="enable_${curName}" class="provider_enabler" ${('', 'checked="checked"')[curProvider.isEnabled() is True]}/>
+                                <input type="checkbox" id="enable_${curName}" class="provider_enabler" ${('', 'checked="checked"')[curProvider.isEnabled() is True]} autocapitalize="off" />
                                 <a href="${anon_url(curURL)}" class="imgLink" rel="noreferrer" onclick="window.open(this.href, '_blank'); return false;"><img src="${srRoot}/images/providers/${curProvider.imageName()}" alt="${curProvider.name}" title="${curProvider.name}" width="16" height="16" style="vertical-align:middle;"/></a>
                                 <span style="vertical-align:middle;">${curProvider.name}</span>
                                 ${('*', '')[bool(curProvider.supportsBacklog)]}
@@ -91,8 +91,8 @@ $('#config-components').tabs();
                             </li>
                         % endfor
                         </ul>
-                        <input type="hidden" name="provider_order" id="provider_order" value="${" ".join([x.getID()+':'+str(int(x.isEnabled())) for x in sickbeard.providers.sortedProviderList()])}"/>
-                        <br><input type="submit" class="btn config_submitter" value="Save Changes" /><br>
+                        <input type="hidden" name="provider_order" id="provider_order" value="${" ".join([x.getID()+':'+str(int(x.isEnabled())) for x in sickbeard.providers.sortedProviderList()])}" autocapitalize="off" />
+                        <br><input type="submit" class="btn config_submitter" value="Save Changes"  autocapitalize="off" /><br>
                     </fieldset>
                 </div><!-- /component-group1 //-->
 
@@ -140,7 +140,7 @@ $('#config-components').tabs();
                             <label for="${curNewznabProvider.getID()}_url">
                                 <span class="component-title">URL:</span>
                                 <span class="component-desc">
-                                    <input type="text" id="${curNewznabProvider.getID()}_url" value="${curNewznabProvider.url}" class="form-control input-sm input350" disabled/>
+                                    <input type="text" id="${curNewznabProvider.getID()}_url" value="${curNewznabProvider.url}" class="form-control input-sm input350" disabled autocapitalize="off" />
                                 </span>
                             </label>
                         </div>
@@ -148,7 +148,7 @@ $('#config-components').tabs();
                             <label for="${curNewznabProvider.getID()}_hash">
                                 <span class="component-title">API key:</span>
                                 <span class="component-desc">
-                                    <input type="text" id="${curNewznabProvider.getID()}_hash" value="${curNewznabProvider.key}" newznab_name="${curNewznabProvider.getID()}_hash" class="newznab_key form-control input-sm input350" />
+                                    <input type="text" id="${curNewznabProvider.getID()}_hash" value="${curNewznabProvider.key}" newznab_name="${curNewznabProvider.getID()}_hash" class="newznab_key form-control input-sm input350"  autocapitalize="off" />
                                 </span>
                             </label>
                         </div>
@@ -159,7 +159,7 @@ $('#config-components').tabs();
                             <label for="${curNewznabProvider.getID()}_enable_daily">
                                 <span class="component-title">Enable daily searches</span>
                                 <span class="component-desc">
-                                    <input type="checkbox" name="${curNewznabProvider.getID()}_enable_daily" id="${curNewznabProvider.getID()}_enable_daily" ${('', 'checked="checked"')[bool(curNewznabProvider.enable_daily)]}/>
+                                    <input type="checkbox" name="${curNewznabProvider.getID()}_enable_daily" id="${curNewznabProvider.getID()}_enable_daily" ${('', 'checked="checked"')[bool(curNewznabProvider.enable_daily)]} autocapitalize="off" />
                                     <p>enable provider to perform daily searches.</p>
                                 </span>
                             </label>
@@ -171,7 +171,7 @@ $('#config-components').tabs();
                             <label for="${curNewznabProvider.getID()}_enable_backlog">
                                 <span class="component-title">Enable backlog searches</span>
                                 <span class="component-desc">
-                                    <input type="checkbox" name="${curNewznabProvider.getID()}_enable_backlog" id="${curNewznabProvider.getID()}_enable_backlog" ${('', 'checked="checked"')[bool(curNewznabProvider.enable_backlog and curNewznabProvider.supportsBacklog)]}/>
+                                    <input type="checkbox" name="${curNewznabProvider.getID()}_enable_backlog" id="${curNewznabProvider.getID()}_enable_backlog" ${('', 'checked="checked"')[bool(curNewznabProvider.enable_backlog and curNewznabProvider.supportsBacklog)]} autocapitalize="off" />
                                     <p>enable provider to perform backlog searches.</p>
                                 </span>
                             </label>
@@ -183,7 +183,7 @@ $('#config-components').tabs();
                             <label for="${curNewznabProvider.getID()}_search_fallback">
                                 <span class="component-title">Season search fallback</span>
                                 <span class="component-desc">
-                                    <input type="checkbox" name="${curNewznabProvider.getID()}_search_fallback" id="${curNewznabProvider.getID()}_search_fallback" ${('', 'checked="checked"')[bool(curNewznabProvider.search_fallback)]}/>
+                                    <input type="checkbox" name="${curNewznabProvider.getID()}_search_fallback" id="${curNewznabProvider.getID()}_search_fallback" ${('', 'checked="checked"')[bool(curNewznabProvider.search_fallback)]} autocapitalize="off" />
                                     <p>when searching for a complete season depending on search mode you may return no results, this helps by restarting the search using the opposite search mode.</p>
                                 </span>
                             </label>
@@ -201,13 +201,13 @@ $('#config-components').tabs();
                             <label>
                                 <span class="component-title"></span>
                                 <span class="component-desc">
-                                    <input type="radio" name="${curNewznabProvider.getID()}_search_mode" id="${curNewznabProvider.getID()}_search_mode_sponly" value="sponly" ${('', 'checked="checked"')[curNewznabProvider.search_mode=="sponly"]}/>season packs only.
+                                    <input type="radio" name="${curNewznabProvider.getID()}_search_mode" id="${curNewznabProvider.getID()}_search_mode_sponly" value="sponly" ${('', 'checked="checked"')[curNewznabProvider.search_mode=="sponly"]} autocapitalize="off" />season packs only.
                                 </span>
                             </label>
                             <label>
                                 <span class="component-title"></span>
                                 <span class="component-desc">
-                                    <input type="radio" name="${curNewznabProvider.getID()}_search_mode" id="${curNewznabProvider.getID()}_search_mode_eponly" value="eponly" ${('', 'checked="checked"')[curNewznabProvider.search_mode=="eponly"]}/>episodes only.
+                                    <input type="radio" name="${curNewznabProvider.getID()}_search_mode" id="${curNewznabProvider.getID()}_search_mode_eponly" value="eponly" ${('', 'checked="checked"')[curNewznabProvider.search_mode=="eponly"]} autocapitalize="off" />episodes only.
                                 </span>
                             </label>
                         </div>
@@ -223,7 +223,7 @@ $('#config-components').tabs();
                             <label for="${curNzbProvider.getID()}_username">
                                 <span class="component-title">Username:</span>
                                 <span class="component-desc">
-                                    <input type="text" name="${curNzbProvider.getID()}_username" value="${curNzbProvider.username}" class="form-control input-sm input350" />
+                                    <input type="text" name="${curNzbProvider.getID()}_username" value="${curNzbProvider.username}" class="form-control input-sm input350"  autocapitalize="off" />
                                 </span>
                             </label>
                         </div>
@@ -234,7 +234,7 @@ $('#config-components').tabs();
                             <label for="${curNzbProvider.getID()}_api_key">
                                 <span class="component-title">API key:</span>
                                 <span class="component-desc">
-                                    <input type="text" name="${curNzbProvider.getID()}_api_key" value="${curNzbProvider.api_key}" class="form-control input-sm input350" />
+                                    <input type="text" name="${curNzbProvider.getID()}_api_key" value="${curNzbProvider.api_key}" class="form-control input-sm input350"  autocapitalize="off" />
                                 </span>
                             </label>
                         </div>
@@ -246,7 +246,7 @@ $('#config-components').tabs();
                             <label for="${curNzbProvider.getID()}_enable_daily">
                                 <span class="component-title">Enable daily searches</span>
                                 <span class="component-desc">
-                                    <input type="checkbox" name="${curNzbProvider.getID()}_enable_daily" id="${curNzbProvider.getID()}_enable_daily" ${('', 'checked="checked"')[bool(curNzbProvider.enable_daily)]}/>
+                                    <input type="checkbox" name="${curNzbProvider.getID()}_enable_daily" id="${curNzbProvider.getID()}_enable_daily" ${('', 'checked="checked"')[bool(curNzbProvider.enable_daily)]} autocapitalize="off" />
                                     <p>enable provider to perform daily searches.</p>
                                 </span>
                             </label>
@@ -258,7 +258,7 @@ $('#config-components').tabs();
                             <label for="${curNzbProvider.getID()}_enable_backlog">
                                 <span class="component-title">Enable backlog searches</span>
                                 <span class="component-desc">
-                                    <input type="checkbox" name="${curNzbProvider.getID()}_enable_backlog" id="${curNzbProvider.getID()}_enable_backlog" ${('', 'checked="checked"')[bool(curNzbProvider.enable_backlog and curNzbProvider.supportsBacklog)]}/>
+                                    <input type="checkbox" name="${curNzbProvider.getID()}_enable_backlog" id="${curNzbProvider.getID()}_enable_backlog" ${('', 'checked="checked"')[bool(curNzbProvider.enable_backlog and curNzbProvider.supportsBacklog)]} autocapitalize="off" />
                                     <p>enable provider to perform backlog searches.</p>
                                 </span>
                             </label>
@@ -270,7 +270,7 @@ $('#config-components').tabs();
                             <label for="${curNzbProvider.getID()}_search_fallback">
                                 <span class="component-title">Season search fallback</span>
                                 <span class="component-desc">
-                                    <input type="checkbox" name="${curNzbProvider.getID()}_search_fallback" id="${curNzbProvider.getID()}_search_fallback" ${('', 'checked="checked"')[bool(curNzbProvider.search_fallback)]}/>
+                                    <input type="checkbox" name="${curNzbProvider.getID()}_search_fallback" id="${curNzbProvider.getID()}_search_fallback" ${('', 'checked="checked"')[bool(curNzbProvider.search_fallback)]} autocapitalize="off" />
                                     <p>when searching for a complete season depending on search mode you may return no results, this helps by restarting the search using the opposite search mode.</p>
                                 </span>
                             </label>
@@ -288,13 +288,13 @@ $('#config-components').tabs();
                             <label>
                                 <span class="component-title"></span>
                                 <span class="component-desc">
-                                    <input type="radio" name="${curNzbProvider.getID()}_search_mode" id="${curNzbProvider.getID()}_search_mode_sponly" value="sponly" ${('', 'checked="checked"')[curNzbProvider.search_mode=="sponly"]}/>season packs only.
+                                    <input type="radio" name="${curNzbProvider.getID()}_search_mode" id="${curNzbProvider.getID()}_search_mode_sponly" value="sponly" ${('', 'checked="checked"')[curNzbProvider.search_mode=="sponly"]} autocapitalize="off" />season packs only.
                                 </span>
                             </label>
                             <label>
                                 <span class="component-title"></span>
                                 <span class="component-desc">
-                                    <input type="radio" name="${curNzbProvider.getID()}_search_mode" id="${curNzbProvider.getID()}_search_mode_eponly" value="eponly" ${('', 'checked="checked"')[curNzbProvider.search_mode=="eponly"]}/>episodes only.
+                                    <input type="radio" name="${curNzbProvider.getID()}_search_mode" id="${curNzbProvider.getID()}_search_mode_eponly" value="eponly" ${('', 'checked="checked"')[curNzbProvider.search_mode=="eponly"]} autocapitalize="off" />episodes only.
                                 </span>
                             </label>
                         </div>
@@ -311,7 +311,7 @@ $('#config-components').tabs();
                             <label for="${curTorrentProvider.getID()}_custom_url">
                                 <span class="component-title">Custom URL:</span>
                                 <span class="component-desc">
-                                    <input type="text" name="${curTorrentProvider.getID()}_custom_url" id="${curTorrentProvider.getID()}_custom_url" value="${curTorrentProvider.custom_url}" class="form-control input-sm input350" />
+                                    <input type="text" name="${curTorrentProvider.getID()}_custom_url" id="${curTorrentProvider.getID()}_custom_url" value="${curTorrentProvider.custom_url}" class="form-control input-sm input350"  autocapitalize="off" />
                                 </span>
                             </label>
                             <label>
@@ -328,7 +328,7 @@ $('#config-components').tabs();
                             <label for="${curTorrentProvider.getID()}_api_key">
                                 <span class="component-title">Api key:</span>
                                 <span class="component-desc">
-                                    <input type="text" name="${curTorrentProvider.getID()}_api_key" id="${curTorrentProvider.getID()}_api_key" value="${curTorrentProvider.api_key}" class="form-control input-sm input350" />
+                                    <input type="text" name="${curTorrentProvider.getID()}_api_key" id="${curTorrentProvider.getID()}_api_key" value="${curTorrentProvider.api_key}" class="form-control input-sm input350"  autocapitalize="off" />
                                 </span>
                             </label>
                         </div>
@@ -339,7 +339,7 @@ $('#config-components').tabs();
                             <label for="${curTorrentProvider.getID()}_digest">
                                 <span class="component-title">Digest:</span>
                                 <span class="component-desc">
-                                    <input type="text" name="${curTorrentProvider.getID()}_digest" id="${curTorrentProvider.getID()}_digest" value="${curTorrentProvider.digest}" class="form-control input-sm input350" />
+                                    <input type="text" name="${curTorrentProvider.getID()}_digest" id="${curTorrentProvider.getID()}_digest" value="${curTorrentProvider.digest}" class="form-control input-sm input350"  autocapitalize="off" />
                                 </span>
                             </label>
                         </div>
@@ -350,7 +350,7 @@ $('#config-components').tabs();
                             <label for="${curTorrentProvider.getID()}_hash">
                                 <span class="component-title">Hash:</span>
                                 <span class="component-desc">
-                                    <input type="text" name="${curTorrentProvider.getID()}_hash" id="${curTorrentProvider.getID()}_hash" value="${curTorrentProvider.hash}" class="form-control input-sm input350" />
+                                    <input type="text" name="${curTorrentProvider.getID()}_hash" id="${curTorrentProvider.getID()}_hash" value="${curTorrentProvider.hash}" class="form-control input-sm input350"  autocapitalize="off" />
                                 </span>
                             </label>
                         </div>
@@ -361,7 +361,7 @@ $('#config-components').tabs();
                             <label for="${curTorrentProvider.getID()}_username">
                                 <span class="component-title">Username:</span>
                                 <span class="component-desc">
-                                    <input type="text" name="${curTorrentProvider.getID()}_username" id="${curTorrentProvider.getID()}_username" value="${curTorrentProvider.username}" class="form-control input-sm input350" />
+                                    <input type="text" name="${curTorrentProvider.getID()}_username" id="${curTorrentProvider.getID()}_username" value="${curTorrentProvider.username}" class="form-control input-sm input350"  autocapitalize="off" />
                                 </span>
                             </label>
                         </div>
@@ -372,7 +372,7 @@ $('#config-components').tabs();
                             <label for="${curTorrentProvider.getID()}_password">
                                 <span class="component-title">Password:</span>
                                 <span class="component-desc">
-                                    <input type="password" name="${curTorrentProvider.getID()}_password" id="${curTorrentProvider.getID()}_password" value="${curTorrentProvider.password}" class="form-control input-sm input350" />
+                                    <input type="password" name="${curTorrentProvider.getID()}_password" id="${curTorrentProvider.getID()}_password" value="${curTorrentProvider.password}" class="form-control input-sm input350"  autocapitalize="off" />
                                 </span>
                             </label>
                         </div>
@@ -383,7 +383,7 @@ $('#config-components').tabs();
                             <label for="${curTorrentProvider.getID()}_passkey">
                                 <span class="component-title">Passkey:</span>
                                 <span class="component-desc">
-                                    <input type="text" name="${curTorrentProvider.getID()}_passkey" id="${curTorrentProvider.getID()}_passkey" value="${curTorrentProvider.passkey}" class="form-control input-sm input350" />
+                                    <input type="text" name="${curTorrentProvider.getID()}_passkey" id="${curTorrentProvider.getID()}_passkey" value="${curTorrentProvider.passkey}" class="form-control input-sm input350"  autocapitalize="off" />
                                 </span>
                             </label>
                         </div>
@@ -394,7 +394,7 @@ $('#config-components').tabs();
                             <label for="${curTorrentProvider.getID()}_pin">
                                 <span class="component-title">Pin:</span>
                                 <span class="component-desc">
-                                    <input type="password" name="${curTorrentProvider.getID()}_pin" id="${curTorrentProvider.getID()}_pin" value="${curTorrentProvider.pin}" class="form-control input-sm input100" />
+                                    <input type="password" name="${curTorrentProvider.getID()}_pin" id="${curTorrentProvider.getID()}_pin" value="${curTorrentProvider.pin}" class="form-control input-sm input100"  autocapitalize="off" />
                                 </span>
                             </label>
                         </div>
@@ -405,7 +405,7 @@ $('#config-components').tabs();
                             <label for="${curTorrentProvider.getID()}_ratio">
                                 <span class="component-title" id="${curTorrentProvider.getID()}_ratio_desc">Seed ratio:</span>
                                 <span class="component-desc">
-                                    <input type="number" step="0.1" name="${curTorrentProvider.getID()}_ratio" id="${curTorrentProvider.getID()}_ratio" value="${curTorrentProvider.ratio}" class="form-control input-sm input75" />
+                                    <input type="number" step="0.1" name="${curTorrentProvider.getID()}_ratio" id="${curTorrentProvider.getID()}_ratio" value="${curTorrentProvider.ratio}" class="form-control input-sm input75"  autocapitalize="off" />
                                 </span>
                             </label>
                             <label>
@@ -422,7 +422,7 @@ $('#config-components').tabs();
                             <label for="${curTorrentProvider.getID()}_minseed">
                                 <span class="component-title" id="${curTorrentProvider.getID()}_minseed_desc">Minimum seeders:</span>
                                 <span class="component-desc">
-                                    <input type="number" name="${curTorrentProvider.getID()}_minseed" id="${curTorrentProvider.getID()}_minseed" value="${curTorrentProvider.minseed}" class="form-control input-sm input75" />
+                                    <input type="number" name="${curTorrentProvider.getID()}_minseed" id="${curTorrentProvider.getID()}_minseed" value="${curTorrentProvider.minseed}" class="form-control input-sm input75"  autocapitalize="off" />
                                 </span>
                             </label>
                         </div>
@@ -433,7 +433,7 @@ $('#config-components').tabs();
                             <label for="${curTorrentProvider.getID()}_minleech">
                                 <span class="component-title" id="${curTorrentProvider.getID()}_minleech_desc">Minimum leechers:</span>
                                 <span class="component-desc">
-                                    <input type="number" name="${curTorrentProvider.getID()}_minleech" id="${curTorrentProvider.getID()}_minleech" value="${curTorrentProvider.minleech}" class="form-control input-sm input75" />
+                                    <input type="number" name="${curTorrentProvider.getID()}_minleech" id="${curTorrentProvider.getID()}_minleech" value="${curTorrentProvider.minleech}" class="form-control input-sm input75"  autocapitalize="off" />
                                 </span>
                             </label>
                         </div>
@@ -444,7 +444,7 @@ $('#config-components').tabs();
                             <label for="${curTorrentProvider.getID()}_confirmed">
                                 <span class="component-title">Confirmed download</span>
                                 <span class="component-desc">
-                                    <input type="checkbox" name="${curTorrentProvider.getID()}_confirmed" id="${curTorrentProvider.getID()}_confirmed" ${('', 'checked="checked"')[bool(curTorrentProvider.confirmed)]}/>
+                                    <input type="checkbox" name="${curTorrentProvider.getID()}_confirmed" id="${curTorrentProvider.getID()}_confirmed" ${('', 'checked="checked"')[bool(curTorrentProvider.confirmed)]} autocapitalize="off" />
                                     <p>only download torrents from trusted or verified uploaders ?</p>
                                 </span>
                             </label>
@@ -456,7 +456,7 @@ $('#config-components').tabs();
                             <label for="${curTorrentProvider.getID()}_ranked">
                                 <span class="component-title">Ranked torrents</span>
                                 <span class="component-desc">
-                                    <input type="checkbox" name="${curTorrentProvider.getID()}_ranked" id="${curTorrentProvider.getID()}_ranked" ${('', 'checked="checked"')[bool(curTorrentProvider.ranked)]} />
+                                    <input type="checkbox" name="${curTorrentProvider.getID()}_ranked" id="${curTorrentProvider.getID()}_ranked" ${('', 'checked="checked"')[bool(curTorrentProvider.ranked)]}  autocapitalize="off" />
                                     <p>only download ranked torrents (internal releases)</p>
                                 </span>
                             </label>
@@ -468,7 +468,7 @@ $('#config-components').tabs();
                             <label for="${curTorrentProvider.getID()}_engrelease">
                                 <span class="component-title">English torrents</span>
                                 <span class="component-desc">
-                                    <input type="checkbox" name="${curTorrentProvider.getID()}_engrelease" id="${curTorrentProvider.getID()}_engrelease" ${('', 'checked="checked"')[bool(curTorrentProvider.engrelease)]} />
+                                    <input type="checkbox" name="${curTorrentProvider.getID()}_engrelease" id="${curTorrentProvider.getID()}_engrelease" ${('', 'checked="checked"')[bool(curTorrentProvider.engrelease)]}  autocapitalize="off" />
                                     <p>only download english torrents ,or torrents containing english subtitles</p>
                                 </span>
                             </label>
@@ -480,7 +480,7 @@ $('#config-components').tabs();
                             <label for="${curTorrentProvider.getID()}_onlyspasearch">
                                 <span class="component-title">For Spanish torrents</span>
                                 <span class="component-desc">
-                                    <input type="checkbox" name="${curTorrentProvider.getID()}_onlyspasearch" id="${curTorrentProvider.getID()}_onlyspasearch" ${('', 'checked="checked"')[bool(curTorrentProvider.onlyspasearch)]} />
+                                    <input type="checkbox" name="${curTorrentProvider.getID()}_onlyspasearch" id="${curTorrentProvider.getID()}_onlyspasearch" ${('', 'checked="checked"')[bool(curTorrentProvider.onlyspasearch)]}  autocapitalize="off" />
                                     <p>ONLY search on this provider if show info is defined as "Spanish" (avoid provider's use for VOS shows)</p>
                                 </span>
                             </label>
@@ -507,7 +507,7 @@ $('#config-components').tabs();
                             <label for="${curTorrentProvider.getID()}_freeleech">
                                 <span class="component-title">Freeleech</span>
                                 <span class="component-desc">
-                                    <input type="checkbox" name="${curTorrentProvider.getID()}_freeleech" id="${curTorrentProvider.getID()}_freeleech" ${('', 'checked="checked"')[bool(curTorrentProvider.freeleech)]}/>
+                                    <input type="checkbox" name="${curTorrentProvider.getID()}_freeleech" id="${curTorrentProvider.getID()}_freeleech" ${('', 'checked="checked"')[bool(curTorrentProvider.freeleech)]} autocapitalize="off" />
                                     <p>only download <b>[FreeLeech]</b> torrents.</p>
                                 </span>
                             </label>
@@ -519,7 +519,7 @@ $('#config-components').tabs();
                             <label for="${curTorrentProvider.getID()}_enable_daily">
                                 <span class="component-title">Enable daily searches</span>
                                 <span class="component-desc">
-                                    <input type="checkbox" name="${curTorrentProvider.getID()}_enable_daily" id="${curTorrentProvider.getID()}_enable_daily" ${('', 'checked="checked"')[bool(curTorrentProvider.enable_daily)]}/>
+                                    <input type="checkbox" name="${curTorrentProvider.getID()}_enable_daily" id="${curTorrentProvider.getID()}_enable_daily" ${('', 'checked="checked"')[bool(curTorrentProvider.enable_daily)]} autocapitalize="off" />
                                     <p>enable provider to perform daily searches.</p>
                                 </span>
                             </label>
@@ -531,7 +531,7 @@ $('#config-components').tabs();
                             <label for="${curTorrentProvider.getID()}_enable_backlog">
                                 <span class="component-title">Enable backlog searches</span>
                                 <span class="component-desc">
-                                    <input type="checkbox" name="${curTorrentProvider.getID()}_enable_backlog" id="${curTorrentProvider.getID()}_enable_backlog" ${('', 'checked="checked"')[bool(curTorrentProvider.enable_backlog and curTorrentProvider.supportsBacklog)]}/>
+                                    <input type="checkbox" name="${curTorrentProvider.getID()}_enable_backlog" id="${curTorrentProvider.getID()}_enable_backlog" ${('', 'checked="checked"')[bool(curTorrentProvider.enable_backlog and curTorrentProvider.supportsBacklog)]} autocapitalize="off" />
                                     <p>enable provider to perform backlog searches.</p>
                                 </span>
                             </label>
@@ -543,7 +543,7 @@ $('#config-components').tabs();
                             <label for="${curTorrentProvider.getID()}_search_fallback">
                                 <span class="component-title">Season search fallback</span>
                                 <span class="component-desc">
-                                    <input type="checkbox" name="${curTorrentProvider.getID()}_search_fallback" id="${curTorrentProvider.getID()}_search_fallback" ${('', 'checked="checked"')[bool(curTorrentProvider.search_fallback)]}/>
+                                    <input type="checkbox" name="${curTorrentProvider.getID()}_search_fallback" id="${curTorrentProvider.getID()}_search_fallback" ${('', 'checked="checked"')[bool(curTorrentProvider.search_fallback)]} autocapitalize="off" />
                                     <p>when searching for a complete season depending on search mode you may return no results, this helps by restarting the search using the opposite search mode.</p>
                                 </span>
                             </label>
@@ -561,13 +561,13 @@ $('#config-components').tabs();
                             <label>
                                 <span class="component-title"></span>
                                 <span class="component-desc">
-                                    <input type="radio" name="${curTorrentProvider.getID()}_search_mode" id="${curTorrentProvider.getID()}_search_mode_sponly" value="sponly" ${('', 'checked="checked"')[curTorrentProvider.search_mode=="sponly"]}/>season packs only.
+                                    <input type="radio" name="${curTorrentProvider.getID()}_search_mode" id="${curTorrentProvider.getID()}_search_mode_sponly" value="sponly" ${('', 'checked="checked"')[curTorrentProvider.search_mode=="sponly"]} autocapitalize="off" />season packs only.
                                 </span>
                             </label>
                             <label>
                                 <span class="component-title"></span>
                                 <span class="component-desc">
-                                    <input type="radio" name="${curTorrentProvider.getID()}_search_mode" id="${curTorrentProvider.getID()}_search_mode_eponly" value="eponly" ${('', 'checked="checked"')[curTorrentProvider.search_mode=="eponly"]}/>episodes only.
+                                    <input type="radio" name="${curTorrentProvider.getID()}_search_mode" id="${curTorrentProvider.getID()}_search_mode_eponly" value="eponly" ${('', 'checked="checked"')[curTorrentProvider.search_mode=="eponly"]} autocapitalize="off" />episodes only.
                                 </span>
                             </label>
                         </div>
@@ -593,7 +593,7 @@ $('#config-components').tabs();
                             <label for="${curTorrentProvider.getID()}_subtitle">
                                 <span class="component-title">Subtitled</span>
                                 <span class="component-desc">
-                                    <input type="checkbox" name="${curTorrentProvider.getID()}_subtitle" id="${curTorrentProvider.getID()}_subtitle" ${('', 'checked="checked"')[bool(curTorrentProvider.subtitle)]}/>
+                                    <input type="checkbox" name="${curTorrentProvider.getID()}_subtitle" id="${curTorrentProvider.getID()}_subtitle" ${('', 'checked="checked"')[bool(curTorrentProvider.subtitle)]} autocapitalize="off" />
                                     <p>select torrent with Italian subtitle</p>
                                 </span>
                             </label>
@@ -606,7 +606,7 @@ $('#config-components').tabs();
 
                     <!-- end div for editing providers -->
 
-                    <input type="submit" class="btn config_submitter" value="Save Changes" /><br>
+                    <input type="submit" class="btn config_submitter" value="Save Changes"  autocapitalize="off" /><br>
 
                     </fieldset>
                 </div><!-- /component-group2 //-->
@@ -624,7 +624,7 @@ $('#config-components').tabs();
                             <label for="newznab_string">
                                 <span class="component-title">Select provider:</span>
                                 <span class="component-desc">
-                                    <input type="hidden" name="newznab_string" id="newznab_string" />
+                                    <input type="hidden" name="newznab_string" id="newznab_string"  autocapitalize="off" />
                                     <select id="editANewznabProvider" class="form-control input-sm">
                                         <option value="addNewznab">-- add new provider --</option>
                                     </select>
@@ -636,19 +636,19 @@ $('#config-components').tabs();
                         <div class="field-pair">
                             <label for="newznab_name">
                                 <span class="component-title">Provider name:</span>
-                                <input type="text" id="newznab_name" class="form-control input-sm input200" />
+                                <input type="text" id="newznab_name" class="form-control input-sm input200"  autocapitalize="off" />
                             </label>
                         </div>
                         <div class="field-pair">
                             <label for="newznab_url">
                                 <span class="component-title">Site URL:</span>
-                                <input type="text" id="newznab_url" class="form-control input-sm input350" />
+                                <input type="text" id="newznab_url" class="form-control input-sm input350"  autocapitalize="off" />
                             </label>
                         </div>
                         <div class="field-pair">
                             <label for="newznab_key">
                                 <span class="component-title">API key:</span>
-                                <input type="text" id="newznab_key" class="form-control input-sm input350" />
+                                <input type="text" id="newznab_key" class="form-control input-sm input350"  autocapitalize="off" />
                             </label>
                             <label>
                                 <span class="component-title">&nbsp;</span>
@@ -668,17 +668,17 @@ $('#config-components').tabs();
                             </label>
                             <label>
                                 <span class="component-title">&nbsp;</span>
-                                <span class="component-desc"><input class="btn" type="button" class="newznab_cat_update" id="newznab_cat_update" value="Update Categories" />
+                                <span class="component-desc"><input class="btn" type="button" class="newznab_cat_update" id="newznab_cat_update" value="Update Categories"  autocapitalize="off" />
                                     <span class="updating_categories"></span>
                                 </span>
                             </label>
                         </div>
 
                         <div id="newznab_add_div">
-                            <input class="btn" type="button" class="newznab_save" id="newznab_add" value="Add" />
+                            <input class="btn" type="button" class="newznab_save" id="newznab_add" value="Add"  autocapitalize="off" />
                         </div>
                         <div id="newznab_update_div" style="display: none;">
-                            <input class="btn btn-danger newznab_delete" type="button" class="newznab_delete" id="newznab_delete" value="Delete" />
+                            <input class="btn btn-danger newznab_delete" type="button" class="newznab_delete" id="newznab_delete" value="Delete"  autocapitalize="off" />
                         </div>
                     </div>
 
@@ -700,7 +700,7 @@ $('#config-components').tabs();
                         <label for="torrentrss_string">
                             <span class="component-title">Select provider:</span>
                             <span class="component-desc">
-                            <input type="hidden" name="torrentrss_string" id="torrentrss_string" />
+                            <input type="hidden" name="torrentrss_string" id="torrentrss_string"  autocapitalize="off" />
                                 <select id="editATorrentRssProvider" class="form-control input-sm">
                                     <option value="addTorrentRss">-- add new provider --</option>
                                 </select>
@@ -712,19 +712,19 @@ $('#config-components').tabs();
                         <div class="field-pair">
                             <label for="torrentrss_name">
                                 <span class="component-title">Provider name:</span>
-                                <input type="text" id="torrentrss_name" class="form-control input-sm input200" />
+                                <input type="text" id="torrentrss_name" class="form-control input-sm input200"  autocapitalize="off" />
                             </label>
                         </div>
                         <div class="field-pair">
                             <label for="torrentrss_url">
                                 <span class="component-title">RSS URL:</span>
-                                <input type="text" id="torrentrss_url" class="form-control input-sm input350" />
+                                <input type="text" id="torrentrss_url" class="form-control input-sm input350"  autocapitalize="off" />
                             </label>
                         </div>
                         <div class="field-pair">
                             <label for="torrentrss_cookies">
                                 <span class="component-title">Cookies:</span>
-                                <input type="text" id="torrentrss_cookies" class="form-control input-sm input350" />
+                                <input type="text" id="torrentrss_cookies" class="form-control input-sm input350"  autocapitalize="off" />
                             </label>
                             <label>
                                 <span class="component-title">&nbsp;</span>
@@ -734,7 +734,7 @@ $('#config-components').tabs();
                         <div class="field-pair">
                             <label for="torrentrss_titleTAG">
                                 <span class="component-title">Search element:</span>
-                                <input type="text" id="torrentrss_titleTAG" class="form-control input-sm input200" value="title"/>
+                                <input type="text" id="torrentrss_titleTAG" class="form-control input-sm input200" value="title" autocapitalize="off" />
                             </label>
                             <label>
                                 <span class="component-title">&nbsp;</span>
@@ -742,17 +742,17 @@ $('#config-components').tabs();
                             </label>
                         </div>
                         <div id="torrentrss_add_div">
-                            <input type="button" class="btn torrentrss_save" id="torrentrss_add" value="Add" />
+                            <input type="button" class="btn torrentrss_save" id="torrentrss_add" value="Add"  autocapitalize="off" />
                         </div>
                         <div id="torrentrss_update_div" style="display: none;">
-                            <input type="button" class="btn btn-danger torrentrss_delete" id="torrentrss_delete" value="Delete" />
+                            <input type="button" class="btn btn-danger torrentrss_delete" id="torrentrss_delete" value="Delete"  autocapitalize="off" />
                         </div>
                     </div>
                 </fieldset>
             </div><!-- /component-group4 //-->
             % endif
 
-            <br><input type="submit" class="btn config_submitter_refresh" value="Save Changes" /><br>
+            <br><input type="submit" class="btn config_submitter_refresh" value="Save Changes"  autocapitalize="off" /><br>
 
             </div><!-- /config-components //-->
 

--- a/gui/slick/views/config_search.mako
+++ b/gui/slick/views/config_search.mako
@@ -31,7 +31,7 @@
                             <label for="randomize_providers">
                                 <span class="component-title">Randomize Providers</span>
                                 <span class="component-desc">
-                                    <input type="checkbox" name="randomize_providers" id="randomize_providers" class="enabler" ${('', 'checked="checked"')[bool(sickbeard.RANDOMIZE_PROVIDERS)]}/>
+                                    <input type="checkbox" name="randomize_providers" id="randomize_providers" class="enabler" ${('', 'checked="checked"')[bool(sickbeard.RANDOMIZE_PROVIDERS)]} autocapitalize="off" />
                                     <p>randomize the provider search order instead of going in order of placement</p>
                                 </span>
                             </label>
@@ -40,7 +40,7 @@
                             <label for="download_propers">
                                 <span class="component-title">Download propers</span>
                                 <span class="component-desc">
-                                    <input type="checkbox" name="download_propers" id="download_propers" class="enabler" ${('', 'checked="checked"')[bool(sickbeard.DOWNLOAD_PROPERS)]}/>
+                                    <input type="checkbox" name="download_propers" id="download_propers" class="enabler" ${('', 'checked="checked"')[bool(sickbeard.DOWNLOAD_PROPERS)]} autocapitalize="off" />
                                     <p>replace original download with "Proper" or "Repack" if nuked</p>
                                 </span>
                             </label>
@@ -65,7 +65,7 @@
                             <label>
                                 <span class="component-title">Backlog search day(s)</span>
                                 <span class="component-desc">
-                                    <input type="text" name="backlog_days" value="${sickbeard.BACKLOG_DAYS}" class="form-control input-sm input75" />
+                                    <input type="text" name="backlog_days" value="${sickbeard.BACKLOG_DAYS}" class="form-control input-sm input75"  autocapitalize="off" />
                                     <p>number of day(s) that the "Forced Backlog Search" will cover (e.g. 7 Days)</p>
                                 </span>
                             </label>
@@ -75,7 +75,7 @@
                             <label>
                                 <span class="component-title">Backlog search frequency</span>
                                 <span class="component-desc">
-                                    <input type="text" name="backlog_frequency" value="${sickbeard.BACKLOG_FREQUENCY}" class="form-control input-sm input75" />
+                                    <input type="text" name="backlog_frequency" value="${sickbeard.BACKLOG_FREQUENCY}" class="form-control input-sm input75"  autocapitalize="off" />
                                     <p>time in minutes between searches (min. ${sickbeard.MIN_BACKLOG_FREQUENCY})</p>
                                 </span>
                             </label>
@@ -85,7 +85,7 @@
                             <label>
                                 <span class="component-title">Daily search frequency</span>
                                 <span class="component-desc">
-                                    <input type="text" name="dailysearch_frequency" value="${sickbeard.DAILYSEARCH_FREQUENCY}" class="form-control input-sm input75" />
+                                    <input type="text" name="dailysearch_frequency" value="${sickbeard.DAILYSEARCH_FREQUENCY}" class="form-control input-sm input75"  autocapitalize="off" />
                                     <p>time in minutes between searches (min. ${sickbeard.MIN_DAILYSEARCH_FREQUENCY})</p>
                                     </span>
                             </label>
@@ -95,7 +95,7 @@
                             <label>
                                 <span class="component-title">Usenet retention</span>
                                 <span class="component-desc">
-                                    <input type="text" name="usenet_retention" value="${sickbeard.USENET_RETENTION}" class="form-control input-sm input75" />
+                                    <input type="text" name="usenet_retention" value="${sickbeard.USENET_RETENTION}" class="form-control input-sm input75"  autocapitalize="off" />
                                     <p>age limit in days for usenet articles to be used (e.g. 500)</p>
                                 </span>
                             </label>
@@ -105,7 +105,7 @@
                             <label>
                                 <span class="component-title">Ignore words</span>
                                 <span class="component-desc">
-                                    <input type="text" name="ignore_words" value="${sickbeard.IGNORE_WORDS}" class="form-control input-sm input350" />
+                                    <input type="text" name="ignore_words" value="${sickbeard.IGNORE_WORDS}" class="form-control input-sm input350"  autocapitalize="off" />
                                     <div class="clear-left">results with one or more word from this list will be ignored<br>
                                     separate words with a comma, e.g. "word1,word2,word3"
                                     </div>
@@ -117,7 +117,7 @@
                             <label>
                                 <span class="component-title">Require words</span>
                                 <span class="component-desc">
-                                    <input type="text" name="require_words" value="${sickbeard.REQUIRE_WORDS}" class="form-control input-sm input350" />
+                                    <input type="text" name="require_words" value="${sickbeard.REQUIRE_WORDS}" class="form-control input-sm input350"  autocapitalize="off" />
                                     <div class="clear-left">results with no word from this list will be ignored<br>
                                     separate words with a comma, e.g. "word1,word2,word3"
                                     </div>
@@ -129,7 +129,7 @@
                             <label>
                                 <span class="component-title">Trackers list</span>
                                 <span class="component-desc">
-                                    <input type="text" name="trackers_list" value="${sickbeard.TRACKERS_LIST}" class="form-control input-sm input350" />
+                                    <input type="text" name="trackers_list" value="${sickbeard.TRACKERS_LIST}" class="form-control input-sm input350"  autocapitalize="off" />
                                     <div class="clear-left">Trackers that will be added to magnets without trackers<br>
                                     separate trackers with a comma, e.g. "tracker1,tracker2,tracker3"
                                     </div>
@@ -141,7 +141,7 @@
                             <label>
                                 <span class="component-title">Ignore language names in subbed results</span>
                                 <span class="component-desc">
-                                    <input type="text" name="ignored_subs_list" value="${sickbeard.IGNORED_SUBS_LIST}" class="form-control input-sm input350" />
+                                    <input type="text" name="ignored_subs_list" value="${sickbeard.IGNORED_SUBS_LIST}" class="form-control input-sm input350"  autocapitalize="off" />
                                     <div class="clear-left">Ignore subbed releases based on language names <br>
                                     Example: "dk" will ignore words: dksub, dksubs, dksubbed, dksubed <br>
                                     separate languages with a comma, e.g. "lang1,lang2,lang3
@@ -154,14 +154,14 @@
                             <label for="allow_high_priority">
                                 <span class="component-title">Allow high priority</span>
                                 <span class="component-desc">
-                                    <input type="checkbox" name="allow_high_priority" id="allow_high_priority" ${('', 'checked="checked"')[bool(sickbeard.ALLOW_HIGH_PRIORITY)]}/>
+                                    <input type="checkbox" name="allow_high_priority" id="allow_high_priority" ${('', 'checked="checked"')[bool(sickbeard.ALLOW_HIGH_PRIORITY)]} autocapitalize="off" />
                                     <p>set downloads of recently aired episodes to high priority</p>
                                 </span>
                             </label>
                         </div>
 
                          <div class="field-pair">
-                             <input id="use_failed_downloads" type="checkbox" class="enabler" name="use_failed_downloads" ${('', 'checked="checked"')[bool(sickbeard.USE_FAILED_DOWNLOADS)]} />
+                             <input id="use_failed_downloads" type="checkbox" class="enabler" name="use_failed_downloads" ${('', 'checked="checked"')[bool(sickbeard.USE_FAILED_DOWNLOADS)]}  autocapitalize="off" />
                              <label for="use_failed_downloads">
                                  <span class="component-title">Use Failed Downloads</span>
                                  <span class="component-desc">Use Failed Download Handling?</span>
@@ -174,7 +174,7 @@
 
                         <div id="content_use_failed_downloads">
                             <div class="field-pair">
-                                <input id="delete_failed" type="checkbox" name="delete_failed" ${('', 'checked="checked"')[bool(sickbeard.DELETE_FAILED)]}/>
+                                <input id="delete_failed" type="checkbox" name="delete_failed" ${('', 'checked="checked"')[bool(sickbeard.DELETE_FAILED)]} autocapitalize="off" />
                                 <label for="delete_failed">
                                     <span class="component-title">Delete Failed</span>
                                     <span class="component-desc">Delete files left over from a failed download?</span>
@@ -186,7 +186,7 @@
                             </div>
                         </div>
 
-                        <input type="submit" class="btn config_submitter" value="Save Changes" />
+                        <input type="submit" class="btn config_submitter" value="Save Changes"  autocapitalize="off" />
 
                     </fieldset>
                 </div><!-- /component-group1 //-->
@@ -204,7 +204,7 @@
                             <label for="use_nzbs">
                                 <span class="component-title">Search NZBs</span>
                                 <span class="component-desc">
-                                    <input type="checkbox" name="use_nzbs" class="enabler" id="use_nzbs" ${('', 'checked="checked"')[bool(sickbeard.USE_NZBS)]}/>
+                                    <input type="checkbox" name="use_nzbs" class="enabler" id="use_nzbs" ${('', 'checked="checked"')[bool(sickbeard.USE_NZBS)]} autocapitalize="off" />
                                     <p>enable NZB search providers</p></span>
                             </label>
                         </div>
@@ -229,7 +229,7 @@
                                 <label>
                                     <span class="component-title">Black hole folder location</span>
                                     <span class="component-desc">
-                                        <input type="text" name="nzb_dir" id="nzb_dir" value="${sickbeard.NZB_DIR}" class="form-control input-sm input350" />
+                                        <input type="text" name="nzb_dir" id="nzb_dir" value="${sickbeard.NZB_DIR}" class="form-control input-sm input350"  autocapitalize="off" />
                                         <div class="clear-left"><p><b>.nzb</b> files are stored at this location for external software to find and use</p></div>
                                     </span>
                                 </label>
@@ -241,7 +241,7 @@
                                 <label>
                                     <span class="component-title">SABnzbd server URL</span>
                                     <span class="component-desc">
-                                        <input type="text" id="sab_host" name="sab_host" value="${sickbeard.SAB_HOST}" class="form-control input-sm input350" />
+                                        <input type="text" id="sab_host" name="sab_host" value="${sickbeard.SAB_HOST}" class="form-control input-sm input350"  autocapitalize="off" />
                                         <div class="clear-left"><p>URL to your SABnzbd server (e.g. http://localhost:8080/)</p></div>
                                     </span>
                                 </label>
@@ -251,7 +251,7 @@
                                 <label>
                                     <span class="component-title">SABnzbd username</span>
                                     <span class="component-desc">
-                                        <input type="text" name="sab_username" id="sab_username" value="${sickbeard.SAB_USERNAME}" class="form-control input-sm input200" />
+                                        <input type="text" name="sab_username" id="sab_username" value="${sickbeard.SAB_USERNAME}" class="form-control input-sm input200"  autocapitalize="off" />
                                         <p>(blank for none)</p>
                                     </span>
                                 </label>
@@ -261,7 +261,7 @@
                                 <label>
                                     <span class="component-title">SABnzbd password</span>
                                     <span class="component-desc">
-                                        <input type="password" name="sab_password" id="sab_password" value="${sickbeard.SAB_PASSWORD}" class="form-control input-sm input200" />
+                                        <input type="password" name="sab_password" id="sab_password" value="${sickbeard.SAB_PASSWORD}" class="form-control input-sm input200"  autocapitalize="off" />
                                         <p>(blank for none)</p>
                                     </span>
                                 </label>
@@ -271,7 +271,7 @@
                                 <label>
                                     <span class="component-title">SABnzbd API key</span>
                                     <span class="component-desc">
-                                        <input type="text" name="sab_apikey" id="sab_apikey" value="${sickbeard.SAB_APIKEY}" class="form-control input-sm input350" />
+                                        <input type="text" name="sab_apikey" id="sab_apikey" value="${sickbeard.SAB_APIKEY}" class="form-control input-sm input350"  autocapitalize="off" />
                                         <div class="clear-left"><p>locate at... SABnzbd Config -> General -> API Key</p></div>
                                     </span>
                                 </label>
@@ -281,7 +281,7 @@
                                 <label>
                                     <span class="component-title">Use SABnzbd category</span>
                                     <span class="component-desc">
-                                        <input type="text" name="sab_category" id="sab_category" value="${sickbeard.SAB_CATEGORY}" class="form-control input-sm input200" />
+                                        <input type="text" name="sab_category" id="sab_category" value="${sickbeard.SAB_CATEGORY}" class="form-control input-sm input200"  autocapitalize="off" />
                                         <p>add downloads to this category (e.g. TV)</p>
                                     </span>
                                 </label>
@@ -291,7 +291,7 @@
                                 <label>
                                     <span class="component-title">Use SABnzbd category (backlog episodes)</span>
                                     <span class="component-desc">
-                                        <input type="text" name="sab_category_backlog" id="sab_category_backlog" value="${sickbeard.SAB_CATEGORY_BACKLOG}" class="form-control input-sm input200" />
+                                        <input type="text" name="sab_category_backlog" id="sab_category_backlog" value="${sickbeard.SAB_CATEGORY_BACKLOG}" class="form-control input-sm input200"  autocapitalize="off" />
                                         <p>add downloads of old episodes to this category (e.g. TV)</p>
                                     </span>
                                 </label>
@@ -301,7 +301,7 @@
                                 <label>
                                     <span class="component-title">Use SABnzbd category for anime</span>
                                     <span class="component-desc">
-                                        <input type="text" name="sab_category_anime" id="sab_category_anime" value="${sickbeard.SAB_CATEGORY_ANIME}" class="form-control input-sm input200" />
+                                        <input type="text" name="sab_category_anime" id="sab_category_anime" value="${sickbeard.SAB_CATEGORY_ANIME}" class="form-control input-sm input200"  autocapitalize="off" />
                                         <p>add anime downloads to this category (e.g. anime)</p>
                                     </span>
                                 </label>
@@ -312,7 +312,7 @@
                                 <label>
                                     <span class="component-title">Use SABnzbd category for anime (backlog episodes)</span>
                                     <span class="component-desc">
-                                        <input type="text" name="sab_category_anime_backlog" id="sab_category_anime_backlog" value="${sickbeard.SAB_CATEGORY_ANIME_BACKLOG}" class="form-control input-sm input200" />
+                                        <input type="text" name="sab_category_anime_backlog" id="sab_category_anime_backlog" value="${sickbeard.SAB_CATEGORY_ANIME_BACKLOG}" class="form-control input-sm input200"  autocapitalize="off" />
                                         <p>add anime downloads of old episodes to this category (e.g. anime)</p>
                                     </span>
                                 </label>
@@ -323,7 +323,7 @@
                                 <label for="sab_forced">
                                     <span class="component-title">Use forced priority</span>
                                     <span class="component-desc">
-                                        <input type="checkbox" name="sab_forced" class="enabler" id="sab_forced" ${('', 'selected="selected"')[bool(sickbeard.SAB_FORCED)]}/>
+                                        <input type="checkbox" name="sab_forced" class="enabler" id="sab_forced" ${('', 'selected="selected"')[bool(sickbeard.SAB_FORCED)]} autocapitalize="off" />
                                         <p>enable to change priority from HIGH to FORCED</p></span>
                                 </label>
                             </div>
@@ -335,7 +335,7 @@
                                 <label for="nzbget_use_https">
                                     <span class="component-title">Connect using HTTPS</span>
                                     <span class="component-desc">
-                                        <input id="nzbget_use_https" type="checkbox" class="enabler" name="nzbget_use_https" ${('', 'selected="selected"')[bool(sickbeard.NZBGET_USE_HTTPS)]}/>
+                                        <input id="nzbget_use_https" type="checkbox" class="enabler" name="nzbget_use_https" ${('', 'selected="selected"')[bool(sickbeard.NZBGET_USE_HTTPS)]} autocapitalize="off" />
                                         <p><b>note:</b> enable Secure control in NZBGet and set the correct Secure Port here</p>
                                     </span>
                                 </label>
@@ -346,7 +346,7 @@
                                 <label>
                                     <span class="component-title">NZBget host:port</span>
                                     <span class="component-desc">
-                                        <input type="text" name="nzbget_host" id="nzbget_host" value="${sickbeard.NZBGET_HOST}" class="form-control input-sm input350" />
+                                        <input type="text" name="nzbget_host" id="nzbget_host" value="${sickbeard.NZBGET_HOST}" class="form-control input-sm input350"  autocapitalize="off" />
                                         <p>(e.g. localhost:6789)</p>
                                         <div class="clear-left"><p>NZBget RPC host name and port number (not NZBgetweb!)</p></div>
                                     </span>
@@ -357,7 +357,7 @@
                                 <label>
                                     <span class="component-title">NZBget username</span>
                                     <span class="component-desc">
-                                        <input type="text" name="nzbget_username" value="${sickbeard.NZBGET_USERNAME}" class="form-control input-sm input200" />
+                                        <input type="text" name="nzbget_username" value="${sickbeard.NZBGET_USERNAME}" class="form-control input-sm input200"  autocapitalize="off" />
                                         <p>locate in nzbget.conf (default:nzbget)</p>
                                     </span>
                                 </label>
@@ -367,7 +367,7 @@
                                 <label>
                                     <span class="component-title">NZBget password</span>
                                     <span class="component-desc">
-                                        <input type="password" name="nzbget_password" id="nzbget_password" value="${sickbeard.NZBGET_PASSWORD}" class="form-control input-sm input200" />
+                                        <input type="password" name="nzbget_password" id="nzbget_password" value="${sickbeard.NZBGET_PASSWORD}" class="form-control input-sm input200"  autocapitalize="off" />
                                         <p>locate in nzbget.conf (default:tegbzn6789)</p>
                                     </span>
                                 </label>
@@ -377,7 +377,7 @@
                                 <label>
                                     <span class="component-title">Use NZBget category</span>
                                     <span class="component-desc">
-                                        <input type="text" name="nzbget_category" id="nzbget_category" value="${sickbeard.NZBGET_CATEGORY}" class="form-control input-sm input200" />
+                                        <input type="text" name="nzbget_category" id="nzbget_category" value="${sickbeard.NZBGET_CATEGORY}" class="form-control input-sm input200"  autocapitalize="off" />
                                         <p>send downloads marked this category (e.g. TV)</p>
                                     </span>
                                 </label>
@@ -387,7 +387,7 @@
                                 <label>
                                     <span class="component-title">Use NZBget category (backlog episodes)</span>
                                     <span class="component-desc">
-                                        <input type="text" name="nzbget_category_backlog" id="nzbget_category_backlog" value="${sickbeard.NZBGET_CATEGORY_BACKLOG}" class="form-control input-sm input200" />
+                                        <input type="text" name="nzbget_category_backlog" id="nzbget_category_backlog" value="${sickbeard.NZBGET_CATEGORY_BACKLOG}" class="form-control input-sm input200"  autocapitalize="off" />
                                         <p>send downloads of old episodes marked this category (e.g. TV)</p>
                                     </span>
                                 </label>
@@ -397,7 +397,7 @@
                                 <label>
                                     <span class="component-title">Use NZBget category for anime</span>
                                     <span class="component-desc">
-                                        <input type="text" name="nzbget_category_anime" id="nzbget_category_anime" value="${sickbeard.NZBGET_CATEGORY_ANIME}" class="form-control input-sm input200" />
+                                        <input type="text" name="nzbget_category_anime" id="nzbget_category_anime" value="${sickbeard.NZBGET_CATEGORY_ANIME}" class="form-control input-sm input200"  autocapitalize="off" />
                                         <p>send anime downloads marked this category (e.g. anime)</p>
                                     </span>
                                 </label>
@@ -407,7 +407,7 @@
                                 <label>
                                     <span class="component-title">Use NZBget category for anime (backlog episodes)</span>
                                     <span class="component-desc">
-                                        <input type="text" name="nzbget_category_anime_backlog" id="nzbget_category_anime_backlog" value="${sickbeard.NZBGET_CATEGORY_ANIME_BACKLOG}" class="form-control input-sm input200" />
+                                        <input type="text" name="nzbget_category_anime_backlog" id="nzbget_category_anime_backlog" value="${sickbeard.NZBGET_CATEGORY_ANIME_BACKLOG}" class="form-control input-sm input200"  autocapitalize="off" />
                                         <p>send anime downloads of old episodes marked this category (e.g. anime)</p>
                                     </span>
                                 </label>
@@ -432,8 +432,8 @@
                         </div>
 
                         <div class="testNotification" id="testSABnzbd_result">Click below to test</div>
-                        <input class="btn" type="button" value="Test SABnzbd" id="testSABnzbd" class="btn test-button"/>
-                        <input type="submit" class="btn config_submitter" value="Save Changes" /><br>
+                        <input class="btn" type="button" value="Test SABnzbd" id="testSABnzbd" class="btn test-button" autocapitalize="off" />
+                        <input type="submit" class="btn config_submitter" value="Save Changes"  autocapitalize="off" /><br>
 
                         </div><!-- /content_use_nzbs //-->
 
@@ -451,7 +451,7 @@
                             <label for="use_torrents">
                                 <span class="component-title">Search torrents</span>
                                 <span class="component-desc">
-                                    <input type="checkbox" name="use_torrents" class="enabler" id="use_torrents" ${('', 'checked="checked"')[bool(sickbeard.USE_TORRENTS)]}/>
+                                    <input type="checkbox" name="use_torrents" class="enabler" id="use_torrents" ${('', 'checked="checked"')[bool(sickbeard.USE_TORRENTS)]} autocapitalize="off" />
                                     <p>enable torrent search providers</p>
                                 </span>
                             </label>
@@ -475,14 +475,14 @@
                                         <label>
                                             <span class="component-title">Black hole folder location</span>
                                             <span class="component-desc">
-                                                <input type="text" name="torrent_dir" id="torrent_dir" value="${sickbeard.TORRENT_DIR}" class="form-control input-sm input350" />
+                                                <input type="text" name="torrent_dir" id="torrent_dir" value="${sickbeard.TORRENT_DIR}" class="form-control input-sm input350"  autocapitalize="off" />
                                                 <div class="clear-left"><p><b>.torrent</b> files are stored at this location for external software to find and use</p></div>
                                             </span>
                                         </label>
                                     </div>
 
                                     <div></div>
-                                    <input type="submit" class="btn config_submitter" value="Save Changes" /><br>
+                                    <input type="submit" class="btn config_submitter" value="Save Changes"  autocapitalize="off" /><br>
                                 </div>
                             </div>
 
@@ -491,7 +491,7 @@
                                     <label>
                                         <span class="component-title" id="host_title">Torrent host:port</span>
                                         <span class="component-desc">
-                                            <input type="text" name="torrent_host" id="torrent_host" value="${sickbeard.TORRENT_HOST}" class="form-control input-sm input350" />
+                                            <input type="text" name="torrent_host" id="torrent_host" value="${sickbeard.TORRENT_HOST}" class="form-control input-sm input350"  autocapitalize="off" />
                                             <div class="clear-left">
                                                 <p id="host_desc_torrent">URL to your torrent client (e.g. http://localhost:8000/)</p>
                                             </div>
@@ -503,7 +503,7 @@
                                     <label>
                                         <span class="component-title" id="rpcurl_title">Torrent RPC URL</span>
                                         <span class="component-desc">
-                                            <input type="text" name="torrent_rpcurl" id="torrent_rpcurl" value="${sickbeard.TORRENT_RPCURL}" class="form-control input-sm input350"/>
+                                            <input type="text" name="torrent_rpcurl" id="torrent_rpcurl" value="${sickbeard.TORRENT_RPCURL}" class="form-control input-sm input350" autocapitalize="off" />
                                             <div class="clear-left">
                                                 <p id="rpcurl_desc_">The path without leading and trailing slashes (e.g. transmission)</p>
                                             </div>
@@ -530,7 +530,7 @@
                                     <label for="torrent_verify_cert">
                                         <span class="component-title">Verify certificate</span>
                                         <span class="component-desc">
-                                            <input type="checkbox" name="torrent_verify_cert" class="enabler" id="torrent_verify_cert" ${('', 'checked="checked"')[bool(sickbeard.TORRENT_VERIFY_CERT)]}/>
+                                            <input type="checkbox" name="torrent_verify_cert" class="enabler" id="torrent_verify_cert" ${('', 'checked="checked"')[bool(sickbeard.TORRENT_VERIFY_CERT)]} autocapitalize="off" />
                                             <p id="torrent_verify_deluge">disable if you get "Deluge: Authentication Error" in your log</p>
                                             <p id="torrent_verify_rtorrent">Verify SSL certificates for HTTPS requests</p>
                                         </span>
@@ -541,7 +541,7 @@
                                     <label>
                                         <span class="component-title" id="username_title">Client username</span>
                                         <span class="component-desc">
-                                            <input type="text" name="torrent_username" id="torrent_username" value="${sickbeard.TORRENT_USERNAME}" class="form-control input-sm input200" />
+                                            <input type="text" name="torrent_username" id="torrent_username" value="${sickbeard.TORRENT_USERNAME}" class="form-control input-sm input200"  autocapitalize="off" />
                                             <p>(blank for none)</p>
                                         </span>
                                     </label>
@@ -551,7 +551,7 @@
                                     <label>
                                         <span class="component-title" id="password_title">Client password</span>
                                         <span class="component-desc">
-                                            <input type="password" name="torrent_password" id="torrent_password" value="${sickbeard.TORRENT_PASSWORD}" class="form-control input-sm input200" />
+                                            <input type="password" name="torrent_password" id="torrent_password" value="${sickbeard.TORRENT_PASSWORD}" class="form-control input-sm input200"  autocapitalize="off" />
                                             <p>(blank for none)</p>
                                         </span>
                                     </label>
@@ -561,7 +561,7 @@
                                     <label>
                                         <span class="component-title">Add label to torrent</span>
                                         <span class="component-desc">
-                                            <input type="text" name="torrent_label" id="torrent_label" value="${sickbeard.TORRENT_LABEL}" class="form-control input-sm input200" />
+                                            <input type="text" name="torrent_label" id="torrent_label" value="${sickbeard.TORRENT_LABEL}" class="form-control input-sm input200"  autocapitalize="off" />
                                             <span id="label_warning_deluge" style="display:none"><p>(blank spaces are not allowed)</p>
                                                 <div class="clear-left"><p>note: label plugin must be enabled in Deluge clients</p></div>
                                             </span>
@@ -573,7 +573,7 @@
                                     <label>
                                         <span class="component-title">Add label to torrent for anime</span>
                                         <span class="component-desc">
-                                            <input type="text" name="torrent_label_anime" id="torrent_label_anime" value="${sickbeard.TORRENT_LABEL_ANIME}" class="form-control input-sm input200" />
+                                            <input type="text" name="torrent_label_anime" id="torrent_label_anime" value="${sickbeard.TORRENT_LABEL_ANIME}" class="form-control input-sm input200"  autocapitalize="off" />
                                             <span id="label_anime_warning_deluge" style="display:none"><p>(blank spaces are not allowed)</p>
                                                 <div class="clear-left"><p>note: label plugin must be enabled in Deluge clients</p></div>
                                             </span>
@@ -585,7 +585,7 @@
                                     <label>
                                         <span class="component-title" id="directory_title">Downloaded files location</span>
                                         <span class="component-desc">
-                                            <input type="text" name="torrent_path" id="torrent_path" value="${sickbeard.TORRENT_PATH}" class="form-control input-sm input350" />
+                                            <input type="text" name="torrent_path" id="torrent_path" value="${sickbeard.TORRENT_PATH}" class="form-control input-sm input350"  autocapitalize="off" />
                                             <div class="clear-left"><p>where <span id="torrent_client">the torrent client</span> will save downloaded files (blank for client default)
                                                 <span id="path_synology"> <b>note:</b> the destination has to be a shared folder for Synology DS</span></p>
                                             </div>
@@ -596,7 +596,7 @@
                                 <div class="field-pair" id="torrent_seed_time_option">
                                     <label>
                                         <span class="component-title" id="torrent_seed_time_label">Minimum seeding time is</span>
-                                        <span class="component-desc"><input type="number" step="1" name="torrent_seed_time" id="torrent_seed_time" value="${sickbeard.TORRENT_SEED_TIME}" class="form-control input-sm input100" />
+                                        <span class="component-desc"><input type="number" step="1" name="torrent_seed_time" id="torrent_seed_time" value="${sickbeard.TORRENT_SEED_TIME}" class="form-control input-sm input100"  autocapitalize="off" />
                                         <p>hours. (default:'0' passes blank to client and '-1' passes nothing)</p></span>
                                     </label>
                                 </div>
@@ -605,7 +605,7 @@
                                     <label>
                                         <span class="component-title">Start torrent paused</span>
                                         <span class="component-desc">
-                                            <input type="checkbox" name="torrent_paused" class="enabler" id="torrent_paused" ${('', 'checked="checked"')[bool(sickbeard.TORRENT_PAUSED)]}/>
+                                            <input type="checkbox" name="torrent_paused" class="enabler" id="torrent_paused" ${('', 'checked="checked"')[bool(sickbeard.TORRENT_PAUSED)]} autocapitalize="off" />
                                             <p>add .torrent to client but do <b style="font-weight:900">not</b> start downloading</p>
                                         </span>
                                     </label>
@@ -615,15 +615,15 @@
                                     <label>
                                         <span class="component-title">Allow high bandwidth</span>
                                         <span class="component-desc">
-                                            <input type="checkbox" name="torrent_high_bandwidth" class="enabler" id="torrent_high_bandwidth" ${('', 'checked="checked"')[bool(sickbeard.TORRENT_HIGH_BANDWIDTH)]}/>
+                                            <input type="checkbox" name="torrent_high_bandwidth" class="enabler" id="torrent_high_bandwidth" ${('', 'checked="checked"')[bool(sickbeard.TORRENT_HIGH_BANDWIDTH)]} autocapitalize="off" />
                                             <p>use high bandwidth allocation if priority is high</p>
                                         </span>
                                     </label>
                                 </div>
 
                                 <div class="testNotification" id="test_torrent_result">Click below to test</div>
-                                <input class="btn" type="button" value="Test Connection" id="test_torrent" class="btn test-button"/>
-                                <input type="submit" class="btn config_submitter" value="Save Changes" /><br>
+                                <input class="btn" type="button" value="Test Connection" id="test_torrent" class="btn test-button" autocapitalize="off" />
+                                <input type="submit" class="btn config_submitter" value="Save Changes"  autocapitalize="off" /><br>
                                 </div>
                         </div><!-- /content_use_torrents //-->
                     </fieldset>
@@ -631,7 +631,7 @@
 
                 <br>
                 <h6 class="pull-right"><b>All non-absolute folder locations are relative to <span class="path">${sickbeard.DATA_DIR}</span></b> </h6>
-                <input type="submit" class="btn pull-left config_submitter button" value="Save Changes" />
+                <input type="submit" class="btn pull-left config_submitter button" value="Save Changes"  autocapitalize="off" />
 
             </div><!-- /config-components //-->
         </form>

--- a/gui/slick/views/config_subtitles.mako
+++ b/gui/slick/views/config_subtitles.mako
@@ -59,7 +59,7 @@ $('#subtitles_dir').fileBrowser({ title: 'Select Subtitles Download Directory' }
                                 <div class="field-pair">
                                     <label>
                                         <span class="component-title">Subtitle Languages</span>
-                                        <span class="component-desc"><input type="text" id="subtitles_languages" name="subtitles_languages" /></span>
+                                        <span class="component-desc"><input type="text" id="subtitles_languages" name="subtitles_languages"  autocapitalize="off" /></span>
                                     </label>
                                 </div>
                                 <div class="field-pair">
@@ -79,7 +79,7 @@ $('#subtitles_dir').fileBrowser({ title: 'Select Subtitles Download Directory' }
                                 <div class="field-pair">
                                     <label>
                                         <span class="component-title">Subtitle Find Frequency</span>
-                                        <input type="number" name="subtitles_finder_frequency" value="${sickbeard.SUBTITLES_FINDER_FREQUENCY}" hours="1" class="form-control input-sm input75" />
+                                        <input type="number" name="subtitles_finder_frequency" value="${sickbeard.SUBTITLES_FINDER_FREQUENCY}" hours="1" class="form-control input-sm input75"  autocapitalize="off" />
                                         <span class="component-desc">time in hours between scans (default: 1)</span>
                                     </label>
                                 </div>
@@ -87,7 +87,7 @@ $('#subtitles_dir').fileBrowser({ title: 'Select Subtitles Download Directory' }
                                     <label class="clearfix" for="subtitles_history">
                                         <span class="component-title">Subtitles History</span>
                                         <span class="component-desc">
-                                            <input type="checkbox" name="subtitles_history" id="subtitles_history" ${('', 'checked="checked"')[bool(sickbeard.SUBTITLES_HISTORY)]}/>
+                                            <input type="checkbox" name="subtitles_history" id="subtitles_history" ${('', 'checked="checked"')[bool(sickbeard.SUBTITLES_HISTORY)]} autocapitalize="off" />
                                             <p>Log downloaded Subtitle on History page?</p>
                                         </span>
                                     </label>
@@ -96,7 +96,7 @@ $('#subtitles_dir').fileBrowser({ title: 'Select Subtitles Download Directory' }
                                     <label class="clearfix" for="subtitles_multi">
                                         <span class="component-title">Subtitles Multi-Language</span>
                                         <span class="component-desc">
-                                            <input type="checkbox" name="subtitles_multi" id="subtitles_multi" ${('', 'checked="checked"')[bool(sickbeard.SUBTITLES_MULTI)]}/>
+                                            <input type="checkbox" name="subtitles_multi" id="subtitles_multi" ${('', 'checked="checked"')[bool(sickbeard.SUBTITLES_MULTI)]} autocapitalize="off" />
                                             <p>Append language codes to subtitle filenames?</p>
                                         </span>
                                     </label>
@@ -104,7 +104,7 @@ $('#subtitles_dir').fileBrowser({ title: 'Select Subtitles Download Directory' }
                                     <label class="clearfix" for="subtitles_download_in_pp">
                                         <span class="component-title">Subtitles in Post-Process folder</span>
                                         <span class="component-desc">
-                                            <input type="checkbox" name="subtitles_download_in_pp" id="subtitles_download_in_pp" ${('', 'checked="checked"')[bool(sickbeard.SUBTITLES_DOWNLOAD_IN_PP)]}/>
+                                            <input type="checkbox" name="subtitles_download_in_pp" id="subtitles_download_in_pp" ${('', 'checked="checked"')[bool(sickbeard.SUBTITLES_DOWNLOAD_IN_PP)]} autocapitalize="off" />
                                             <p>Download subtitles in post-process folder.</p>
                                             <p>Useful if you only want the episode to be post-processed when it has subtitles associated</p>
                                             <p>You might also want to enable the post-process setting 'Postpone if no subtitle'</p>
@@ -116,7 +116,7 @@ $('#subtitles_dir').fileBrowser({ title: 'Select Subtitles Download Directory' }
                                     <label class="clearfix" for="embedded_subtitles_all">
                                         <span class="component-title">Embedded Subtitles</span>
                                         <span class="component-desc">
-                                            <input type="checkbox" name="embedded_subtitles_all" id="embedded_subtitles_all" ${('', 'checked="checked"')[bool(sickbeard.EMBEDDED_SUBTITLES_ALL)]}/>
+                                            <input type="checkbox" name="embedded_subtitles_all" id="embedded_subtitles_all" ${('', 'checked="checked"')[bool(sickbeard.EMBEDDED_SUBTITLES_ALL)]} autocapitalize="off" />
                                             <p>Ignore subtitles embedded inside video file?</p>
                                             <p><b>Warning: </b>this will ignore <u>all</u> embedded subtitles for every video file!</p>
                                         </span>
@@ -126,7 +126,7 @@ $('#subtitles_dir').fileBrowser({ title: 'Select Subtitles Download Directory' }
                                     <label class="clearfix" for="subtitles_hearing_impaired">
                                         <span class="component-title">Hearing Impaired Subtitles</span>
                                         <span class="component-desc">
-                                            <input type="checkbox" name="subtitles_hearing_impaired" id="subtitles_hearing_impaired" ${('', 'checked="checked"')[bool(sickbeard.SUBTITLES_HEARING_IMPAIRED)]}/>
+                                            <input type="checkbox" name="subtitles_hearing_impaired" id="subtitles_hearing_impaired" ${('', 'checked="checked"')[bool(sickbeard.SUBTITLES_HEARING_IMPAIRED)]} autocapitalize="off" />
                                             <p>Download hearing impaired style subtitles?</p>
                                         </span>
                                     </label>
@@ -134,7 +134,7 @@ $('#subtitles_dir').fileBrowser({ title: 'Select Subtitles Download Directory' }
                                 <div class="field-pair">
                                     <label class="nocheck">
                                         <span class="component-title">Extra Scripts</span>
-                                           <input type="text" name="subtitles_extra_scripts" value="${'|'.join(sickbeard.SUBTITLES_EXTRA_SCRIPTS)}" class="form-control input-sm input350" />
+                                           <input type="text" name="subtitles_extra_scripts" value="${'|'.join(sickbeard.SUBTITLES_EXTRA_SCRIPTS)}" class="form-control input-sm input350"  autocapitalize="off" />
                                     </label>
                                     <label class="nocheck">
                                         <span class="component-title">&nbsp;</span>
@@ -157,7 +157,7 @@ $('#subtitles_dir').fileBrowser({ title: 'Select Subtitles Download Directory' }
                                     </label>
                                 </div>
 
-                        <br><input type="submit" class="btn config_submitter" value="Save Changes" /><br>
+                        <br><input type="submit" class="btn config_submitter" value="Save Changes"  autocapitalize="off" /><br>
                         </div>
                     </fieldset>
                 </div><!-- /component-group1 //-->
@@ -175,7 +175,7 @@ $('#subtitles_dir').fileBrowser({ title: 'Select Subtitles Download Directory' }
                         <ul id="service_order_list">
                         % for curService in sickbeard.subtitles.sortedServiceList():
                             <li class="ui-state-default" id="${curService['name']}">
-                                <input type="checkbox" id="enable_${curService['name']}" class="service_enabler" ${('', 'checked="checked"')[curService['enabled'] is True]}/>
+                                <input type="checkbox" id="enable_${curService['name']}" class="service_enabler" ${('', 'checked="checked"')[curService['enabled'] is True]} autocapitalize="off" />
                                 <a href="${anon_url(curService['url'])}" class="imgLink" target="_new">
                                     <img src="${srRoot}/images/subtitles/${curService['image']}" alt="${curService['url']}" title="${curService['url']}" width="16" height="16" style="vertical-align:middle;"/>
                                 </a>
@@ -184,9 +184,9 @@ $('#subtitles_dir').fileBrowser({ title: 'Select Subtitles Download Directory' }
                           </li>
                         % endfor
                         </ul>
-                        <input type="hidden" name="service_order" id="service_order" value="<%" ".join(['%s:%d' % (x['name'], x['enabled']) for x in sickbeard.subtitles.sortedServiceList()])%>"/>
+                        <input type="hidden" name="service_order" id="service_order" value="<%" ".join(['%s:%d' % (x['name'], x['enabled']) for x in sickbeard.subtitles.sortedServiceList()])%>" autocapitalize="off" />
 
-                        <br><input type="submit" class="btn config_submitter" value="Save Changes" /><br>
+                        <br><input type="submit" class="btn config_submitter" value="Save Changes"  autocapitalize="off" /><br>
                     </fieldset>
                 </div><!-- /component-group2 //-->
                 <div id="core-component-group3" class="component-group">
@@ -211,21 +211,21 @@ $('#subtitles_dir').fileBrowser({ title: 'Select Subtitles Download Directory' }
                                 <label class="nocheck" for="${curService['name']}_user">
                                     <span class="component-title">${curService['name'].capitalize()} User Name</span>
                                     <span class="component-desc">
-                                        <input type="text" name="${curService['name']}_user" id="${curService['name']}_user" value="${providerLoginDict[curService['name']]['user']}" class="form-control input-sm input300" />
+                                        <input type="text" name="${curService['name']}_user" id="${curService['name']}_user" value="${providerLoginDict[curService['name']]['user']}" class="form-control input-sm input300"  autocapitalize="off" />
                                     </span>
                                 </label>
                                 <label class="nocheck" for="${curService['name']}_pass">
                                     <span class="component-title">${curService['name'].capitalize()} Password</span>
                                     <span class="component-desc">
-                                        <input type="password" name="${curService['name']}_pass" id="${curService['name']}_pass" value="${providerLoginDict[curService['name']]['pass']}" class="form-control input-sm input300" />
+                                        <input type="password" name="${curService['name']}_pass" id="${curService['name']}_pass" value="${providerLoginDict[curService['name']]['pass']}" class="form-control input-sm input300"  autocapitalize="off" />
                                     </span>
                                 </label>
                             </div>
                         % endfor
-                        <br><input type="submit" class="btn config_submitter" value="Save Changes" /><br>
+                        <br><input type="submit" class="btn config_submitter" value="Save Changes"  autocapitalize="off" /><br>
                     </fieldset>
                 </div><!-- /component-group3 //-->
-                <br><input type="submit" class="btn config_submitter" value="Save Changes" /><br>
+                <br><input type="submit" class="btn config_submitter" value="Save Changes"  autocapitalize="off" /><br>
             </div><!-- /config-components //-->
 
 </form>

--- a/gui/slick/views/displayShow.mako
+++ b/gui/slick/views/displayShow.mako
@@ -22,7 +22,7 @@
 </%block>
 <%block name="content">
 <%namespace file="/inc_defs.mako" import="renderQualityPill"/>
-<input type="hidden" id="srRoot" value="${srRoot}" />
+<input type="hidden" id="srRoot" value="${srRoot}"  autocapitalize="off" />
     <div class="pull-left form-inline">
         Change Show:
         <div class="navShow"><img id="prevShow" src="${srRoot}/images/prev.png" alt="&lt;&lt;" title="Prev Show" /></div>
@@ -240,20 +240,20 @@
             % endif
         % endfor
         </select>
-        <input type="hidden" id="showID" value="${show.indexerid}" />
-        <input type="hidden" id="indexer" value="${show.indexer}" />
-        <input class="btn btn-inline" type="button" id="changeStatus" value="Go" />
+        <input type="hidden" id="showID" value="${show.indexerid}"  autocapitalize="off" />
+        <input type="hidden" id="indexer" value="${show.indexer}"  autocapitalize="off" />
+        <input class="btn btn-inline" type="button" id="changeStatus" value="Go"  autocapitalize="off" />
     </div>
 
     </br>
 
     <div class="pull-right clearfix" id="checkboxControls">
         <div style="padding-bottom: 5px;">
-            <label for="wanted"><span class="wanted"><input type="checkbox" id="wanted" checked="checked" /> Wanted: <b>${epCounts[Overview.WANTED]}</b></span></label>
-            <label for="qual"><span class="qual"><input type="checkbox" id="qual" checked="checked" /> Low Quality: <b>${epCounts[Overview.QUAL]}</b></span></label>
-            <label for="good"><span class="good"><input type="checkbox" id="good" checked="checked" /> Downloaded: <b>${epCounts[Overview.GOOD]}</b></span></label>
-            <label for="skipped"><span class="skipped"><input type="checkbox" id="skipped" checked="checked" /> Skipped: <b>${epCounts[Overview.SKIPPED]}</b></span></label>
-            <label for="snatched"><span class="snatched"><input type="checkbox" id="snatched" checked="checked" /> Snatched: <b>${epCounts[Overview.SNATCHED]}</b></span></label>
+            <label for="wanted"><span class="wanted"><input type="checkbox" id="wanted" checked="checked"  autocapitalize="off" /> Wanted: <b>${epCounts[Overview.WANTED]}</b></span></label>
+            <label for="qual"><span class="qual"><input type="checkbox" id="qual" checked="checked"  autocapitalize="off" /> Low Quality: <b>${epCounts[Overview.QUAL]}</b></span></label>
+            <label for="good"><span class="good"><input type="checkbox" id="good" checked="checked"  autocapitalize="off" /> Downloaded: <b>${epCounts[Overview.GOOD]}</b></span></label>
+            <label for="skipped"><span class="skipped"><input type="checkbox" id="skipped" checked="checked"  autocapitalize="off" /> Skipped: <b>${epCounts[Overview.SKIPPED]}</b></span></label>
+            <label for="snatched"><span class="snatched"><input type="checkbox" id="snatched" checked="checked"  autocapitalize="off" /> Snatched: <b>${epCounts[Overview.SNATCHED]}</b></span></label>
         </div>
 
         <button id="popover" type="button" class="btn btn-xs">Select Columns <b class="caret"></b></button>
@@ -314,7 +314,7 @@
             % if curSeason == -1:
     <thead>
         <tr class="seasoncols" style="display:none;">
-                <th data-sorter="false" data-priority="critical" class="col-checkbox"><input type="checkbox" class="seasonCheck"/></th>
+                <th data-sorter="false" data-priority="critical" class="col-checkbox"><input type="checkbox" class="seasonCheck" autocapitalize="off" /></th>
                 <th data-sorter="false" class="col-metadata">NFO</th>
                 <th data-sorter="false" class="col-metadata">TBN</th>
                 <th data-sorter="false" class="col-ep">Episode</th>
@@ -353,7 +353,7 @@
     </tbody>
     <tbody class="tablesorter-no-sort">
         <tr id="season-${epResult["season"]}-cols" class="seasoncols">
-            <th class="col-checkbox"><input type="checkbox" class="seasonCheck" id="${epResult["season"]}" /></th>
+            <th class="col-checkbox"><input type="checkbox" class="seasonCheck" id="${epResult["season"]}"  autocapitalize="off" /></th>
             <th class="col-metadata">NFO</th>
             <th class="col-metadata">TBN</th>
             <th class="col-ep">Episode</th>
@@ -393,7 +393,7 @@
     </tbody>
     <tbody class="tablesorter-no-sort">
         <tr id="season-${epResult["season"]}-cols" class="seasoncols">
-            <th class="col-checkbox"><input type="checkbox" class="seasonCheck" id="${epResult["season"]}" /></th>
+            <th class="col-checkbox"><input type="checkbox" class="seasonCheck" id="${epResult["season"]}"  autocapitalize="off" /></th>
             <th class="col-metadata">NFO</th>
             <th class="col-metadata">TBN</th>
             <th class="col-ep">Episode</th>
@@ -421,7 +421,7 @@
         <tr class="${Overview.overviewStrings[epCats[epStr]]} season-${curSeason} seasonstyle" id="${'S' + str(epResult["season"]) + 'E' + str(epResult["episode"])}">
             <td class="col-checkbox">
                 % if int(epResult["status"]) != UNAIRED:
-                    <input type="checkbox" class="epCheck" id="${str(epResult["season"])+'x'+str(epResult["episode"])}" name="${str(epResult["season"]) +"x"+str(epResult["episode"])}" />
+                    <input type="checkbox" class="epCheck" id="${str(epResult["season"])+'x'+str(epResult["episode"])}" name="${str(epResult["season"]) +"x"+str(epResult["episode"])}"  autocapitalize="off" />
                 % endif
             </td>
             <td align="center"><img src="${srRoot}/images/${("nfo-no.gif", "nfo.gif")[epResult["hasnfo"]]}" alt="${("N", "Y")[epResult["hasnfo"]]}" width="23" height="11" /></td>
@@ -445,7 +445,7 @@
                     % else:
                         value="${str(scSeas)}x${str(scEpis)}"
                     % endif
-                        style="padding: 0; text-align: center; max-width: 60px;" />
+                        style="padding: 0; text-align: center; max-width: 60px;"  autocapitalize="off" />
             </td>
             <td align="center">
                 <input type="text" placeholder="${str(dfltAbsolute)}" size="6" maxlength="8"
@@ -457,7 +457,7 @@
                     % else:
                         value="${str(scAbsolute)}"
                     % endif
-                        style="padding: 0; text-align: center; max-width: 60px;" />
+                        style="padding: 0; text-align: center; max-width: 60px;"  autocapitalize="off" />
             </td>
             <td class="col-name">
             % if epResult["description"] != "" and epResult["description"] is not None:

--- a/gui/slick/views/editShow.mako
+++ b/gui/slick/views/editShow.mako
@@ -49,8 +49,8 @@
                             <label for="location">
                                 <span class="component-title">Show Location</span>
                                 <span class="component-desc">
-                                    <input type="hidden" name="show" value="${show.indexerid}" />
-                                    <input type="text" name="location" id="location" value="${show._location}" class="form-control form-control-inline input-sm input350" />
+                                    <input type="hidden" name="show" value="${show.indexerid}"  autocapitalize="off" />
+                                    <input type="text" name="location" id="location" value="${show._location}" class="form-control form-control-inline input-sm input350"  autocapitalize="off" />
                                 </span>
                             </label>
                         </div>
@@ -73,7 +73,7 @@
                             <label for="">
                                 <span class="component-title">Archive on first match</span>
                                 <span class="component-desc">
-                                    <input type="checkbox" id="archive_firstmatch" name="archive_firstmatch" ${('', 'checked="checked"')[show.archive_firstmatch == 1]} /> archive episode after the first best match is found from your archive quality list
+                                    <input type="checkbox" id="archive_firstmatch" name="archive_firstmatch" ${('', 'checked="checked"')[show.archive_firstmatch == 1]}  autocapitalize="off" /> archive episode after the first best match is found from your archive quality list
                                 </span>
                             </label>
                         </div>
@@ -106,7 +106,7 @@
                             <label for="subtitles">
                                 <span class="component-title">Subtitles</span>
                                 <span class="component-desc">
-                                    <input type="checkbox" id="subtitles" name="subtitles" ${('', 'checked="checked"')[show.subtitles == 1 and sickbeard.USE_SUBTITLES is True]} ${('disabled="disabled"', '')[bool(sickbeard.USE_SUBTITLES)]}/> search for subtitles
+                                    <input type="checkbox" id="subtitles" name="subtitles" ${('', 'checked="checked"')[show.subtitles == 1 and sickbeard.USE_SUBTITLES is True]} ${('disabled="disabled"', '')[bool(sickbeard.USE_SUBTITLES)]} autocapitalize="off" /> search for subtitles
                                 </span>
                             </label>
                         </div>
@@ -115,7 +115,7 @@
                             <label for="paused">
                                 <span class="component-title">Paused</span>
                                 <span class="component-desc">
-                                    <input type="checkbox" id="paused" name="paused" ${('', 'checked="checked"')[show.paused == 1]} /> pause this show (SickRage will not download episodes)
+                                    <input type="checkbox" id="paused" name="paused" ${('', 'checked="checked"')[show.paused == 1]}  autocapitalize="off" /> pause this show (SickRage will not download episodes)
                                 </span>
                             </label>
                         </div>
@@ -133,7 +133,7 @@
                             <label for="airbydate">
                                 <span class="component-title">Air by date</span>
                                 <span class="component-desc">
-                                    <input type="checkbox" id="airbydate" name="air_by_date" ${('', 'checked="checked"')[show.air_by_date == 1]} /> check if the show is released as Show.03.02.2010 rather than Show.S02E03.<br>
+                                    <input type="checkbox" id="airbydate" name="air_by_date" ${('', 'checked="checked"')[show.air_by_date == 1]}  autocapitalize="off" /> check if the show is released as Show.03.02.2010 rather than Show.S02E03.<br>
                                     <span style="color:red">In case of an air date conflict between regular and special episodes, the later will be ignored.</span>
                                 </span>
                             </label>
@@ -155,7 +155,7 @@
                             <label for="sports">
                                 <span class="component-title">Sports</span>
                                 <span class="component-desc">
-                                    <input type="checkbox" id="sports" name="sports" ${('', 'checked="checked"')[show.sports == 1]}/> check if the show is a sporting or MMA event released as Show.03.02.2010 rather than Show.S02E03<br>
+                                    <input type="checkbox" id="sports" name="sports" ${('', 'checked="checked"')[show.sports == 1]} autocapitalize="off" /> check if the show is a sporting or MMA event released as Show.03.02.2010 rather than Show.S02E03<br>
                                     <span style="color:red">In case of an air date conflict between regular and special episodes, the later will be ignored.</span>
                                 </span>
                             </label>
@@ -165,7 +165,7 @@
                             <label for="season_folders">
                                 <span class="component-title">Season folders</span>
                                 <span class="component-desc">
-                                    <input type="checkbox" id="season_folders" name="flatten_folders" ${('checked="checked"', '')[show.flatten_folders == 1 and not sickbeard.NAMING_FORCE_FOLDERS]} ${('', 'disabled="disabled"')[bool(sickbeard.NAMING_FORCE_FOLDERS)]}/> group episodes by season folder (uncheck to store in a single folder)
+                                    <input type="checkbox" id="season_folders" name="flatten_folders" ${('checked="checked"', '')[show.flatten_folders == 1 and not sickbeard.NAMING_FORCE_FOLDERS]} ${('', 'disabled="disabled"')[bool(sickbeard.NAMING_FORCE_FOLDERS)]} autocapitalize="off" /> group episodes by season folder (uncheck to store in a single folder)
                                 </span>
                             </label>
                         </div>
@@ -174,7 +174,7 @@
                             <label for="scene">
                                 <span class="component-title">Scene Numbering</span>
                                 <span class="component-desc">
-                                    <input type="checkbox" id="scene" name="scene" ${('', 'checked="checked"')[show.scene == 1]} /> search by scene numbering (uncheck to search by indexer numbering)
+                                    <input type="checkbox" id="scene" name="scene" ${('', 'checked="checked"')[show.scene == 1]}  autocapitalize="off" /> search by scene numbering (uncheck to search by indexer numbering)
                                 </span>
                             </label>
                         </div>
@@ -183,7 +183,7 @@
                             <label for="dvdorder">
                                 <span class="component-title">DVD Order</span>
                                 <span class="component-desc">
-                                    <input type="checkbox" id="dvdorder" name="dvdorder" ${('', 'checked="checked"')[show.dvdorder == 1]} /> use the DVD order instead of the air order<br>
+                                    <input type="checkbox" id="dvdorder" name="dvdorder" ${('', 'checked="checked"')[show.dvdorder == 1]}  autocapitalize="off" /> use the DVD order instead of the air order<br>
                                     <div class="clear-left"><p>A "Force Full Update" is necessary, and if you have existing episodes you need to sort them manually.</p></div>
                                 </span>
                             </label>
@@ -202,7 +202,7 @@
                             <label for="rls_ignore_words">
                                 <span class="component-title">Ignored Words</span>
                                 <span class="component-desc">
-                                    <input type="text" id="rls_ignore_words" name="rls_ignore_words" id="rls_ignore_words" value="${show.rls_ignore_words}" class="form-control form-control-inline input-sm input350" /><br>
+                                    <input type="text" id="rls_ignore_words" name="rls_ignore_words" id="rls_ignore_words" value="${show.rls_ignore_words}" class="form-control form-control-inline input-sm input350"  autocapitalize="off" /><br>
                                     <div class="clear-left">
                                         <p>comma-separated <i>e.g. "word1,word2,word3"</i></>
                                         <p>Search results with one or more words from this list will be ignored.</p>
@@ -215,7 +215,7 @@
                             <label for="rls_require_words">
                                 <span class="component-title">Required Words</span>
                                 <span class="component-desc">
-                                    <input type="text" id="rls_require_words" name="rls_require_words" id="rls_require_words" value="${show.rls_require_words}" class="form-control form-control-inline input-sm input350" /><br>
+                                    <input type="text" id="rls_require_words" name="rls_require_words" id="rls_require_words" value="${show.rls_require_words}" class="form-control form-control-inline input-sm input350"  autocapitalize="off" /><br>
                                     <div class="clear-left">
                                         <p>comma-separated <i>e.g. "word1,word2,word3"</i></p>
                                         <p>Search results with no words from this list will be ignored.</p>
@@ -228,14 +228,14 @@
                             <label for="SceneName">
                                 <span class="component-title">Scene Exception</span>
                                 <span class="component-desc">
-                                    <input type="text" id="SceneName" class="form-control form-control-inline input-sm input200" /><input class="btn btn-inline" type="button" value="Add" id="addSceneName" /><br><br>
+                                    <input type="text" id="SceneName" class="form-control form-control-inline input-sm input200"  autocapitalize="off" /><input class="btn btn-inline" type="button" value="Add" id="addSceneName"  autocapitalize="off" /><br><br>
                                     <div class="pull-left">
                                         <select id="exceptions_list" name="exceptions_list" multiple="multiple" style="min-width:200px;height:99px;">
                                         % for cur_exception in show.exceptions:
                                             <option value="${cur_exception}">${cur_exception}</option>
                                         % endfor
                                         </select>
-                                        <div><input id="removeSceneName" value="Remove" class="btn float-left" type="button" style="margin-top: 10px;"/></div>
+                                        <div><input id="removeSceneName" value="Remove" class="btn float-left" type="button" style="margin-top: 10px;" autocapitalize="off" /></div>
                                     </div>
                                     <div class="clear-left"><p>This will affect episode search on NZB and torrent providers. This list overrides the original name; it doesn't append to it.</p></div>
                                 </span>

--- a/gui/slick/views/home_addExistingShow.mako
+++ b/gui/slick/views/home_addExistingShow.mako
@@ -41,7 +41,7 @@
     <p>SickRage can add existing shows, using the current options, by using locally stored NFO/XML metadata to eliminate user interaction.
     If you would rather have SickRage prompt you to customize each show, then use the checkbox below.</p>
 
-    <p><input type="checkbox" name="promptForSettings" id="promptForSettings" /> <label for="promptForSettings">Prompt me to set settings for each show</label></p>
+    <p><input type="checkbox" name="promptForSettings" id="promptForSettings"  autocapitalize="off" /> <label for="promptForSettings">Prompt me to set settings for each show</label></p>
 
     <hr />
 
@@ -52,7 +52,7 @@
     <div id="tableDiv"></div>
     <br>
     <br>
-    <input class="btn btn-primary" type="button" value="Submit" id="submitShowDirs" />
+    <input class="btn btn-primary" type="button" value="Submit" id="submitShowDirs"  autocapitalize="off" />
 
     </form>
 

--- a/gui/slick/views/home_newShow.mako
+++ b/gui/slick/views/home_newShow.mako
@@ -34,16 +34,16 @@
         <legend class="legendStep">Find a show on theTVDB</legend>
 
         <div class="stepDiv">
-            <input type="hidden" id="indexer_timeout" value="${sickbeard.INDEXER_TIMEOUT}" />
+            <input type="hidden" id="indexer_timeout" value="${sickbeard.INDEXER_TIMEOUT}"  autocapitalize="off" />
 
             % if use_provided_info:
                 Show retrieved from existing metadata: <a href="${anon_url(sickbeard.indexerApi(provided_indexer).config['show_url'], provided_indexer_id)}">${provided_indexer_name}</a>
-                <input type="hidden" id="indexerLang" name="indexerLang" value="en" />
-                <input type="hidden" id="whichSeries" name="whichSeries" value="${provided_indexer_id}" />
-                <input type="hidden" id="providedIndexer" name="providedIndexer" value="${provided_indexer}" />
-                <input type="hidden" id="providedName" value="${provided_indexer_name}" />
+                <input type="hidden" id="indexerLang" name="indexerLang" value="en"  autocapitalize="off" />
+                <input type="hidden" id="whichSeries" name="whichSeries" value="${provided_indexer_id}"  autocapitalize="off" />
+                <input type="hidden" id="providedIndexer" name="providedIndexer" value="${provided_indexer}"  autocapitalize="off" />
+                <input type="hidden" id="providedName" value="${provided_indexer_name}"  autocapitalize="off" />
             % else:
-                <input type="text" id="nameToSearch" value="${default_show_name}" class="form-control form-control-inline input-sm input350" />
+                <input type="text" id="nameToSearch" value="${default_show_name}" class="form-control form-control-inline input-sm input350"  autocapitalize="off" />
                 &nbsp;&nbsp;
                 <select name="indexerLang" id="indexerLangSelect" class="form-control form-control-inline input-sm bfh-languages" data-language="${sickbeard.INDEXER_DEFAULT_LANGUAGE}" data-available="${','.join(sickbeard.indexerApi().config['valid_languages'])}">
                 </select><b>*</b>
@@ -57,7 +57,7 @@
                     % endfor
                 </select>
                 &nbsp;
-                <input class="btn btn-inline" type="button" id="searchName" value="Search" />
+                <input class="btn btn-inline" type="button" id="searchName" value="Search"  autocapitalize="off" />
 
                 <br><br>
                 <b>*</b> This will only affect the language of the retrieved metadata file contents and episode filenames.<br>
@@ -74,7 +74,7 @@
         <div class="stepDiv">
             % if provided_show_dir:
                 Pre-chosen Destination Folder: <b>${provided_show_dir}</b> <br>
-                <input type="hidden" id="fullShowPath" name="fullShowPath" value="${provided_show_dir}" /><br>
+                <input type="hidden" id="fullShowPath" name="fullShowPath" value="${provided_show_dir}"  autocapitalize="off" /><br>
             % else:
                 <%include file="/inc_rootDirs.mako"/>
             % endif
@@ -89,17 +89,17 @@
     </fieldset>
 
     % for curNextDir in other_shows:
-    <input type="hidden" name="other_shows" value="${curNextDir}" />
+    <input type="hidden" name="other_shows" value="${curNextDir}"  autocapitalize="off" />
     % endfor
-    <input type="hidden" name="skipShow" id="skipShow" value="" />
+    <input type="hidden" name="skipShow" id="skipShow" value=""  autocapitalize="off" />
     </form>
 
 <br>
 
 <div style="width: 100%; text-align: center;">
-<input class="btn" type="button" id="addShowButton" value="Add Show" disabled="disabled" />
+<input class="btn" type="button" id="addShowButton" value="Add Show" disabled="disabled"  autocapitalize="off" />
 % if provided_show_dir:
-<input class="btn" type="button" id="skipShowButton" value="Skip Show" />
+<input class="btn" type="button" id="skipShowButton" value="Skip Show"  autocapitalize="off" />
 % endif
 </div>
 </div></div></div></div>

--- a/gui/slick/views/home_postprocess.mako
+++ b/gui/slick/views/home_postprocess.mako
@@ -19,7 +19,7 @@
                 <b>Enter the folder containing the episode:</b>
             </td>
             <td>
-                <input type="text" name="dir" id="episodeDir" class="form-control form-control-inline input-sm input350" />
+                <input type="text" name="dir" id="episodeDir" class="form-control form-control-inline input-sm input350"  autocapitalize="off" />
             </td>
         </tr>
         <tr>
@@ -72,7 +72,7 @@
         </tr>
         % endif
     </table>
-        <input id="submit" class="btn" type="submit" value="Process" />
+        <input id="submit" class="btn" type="submit" value="Process"  autocapitalize="off" />
     </form>
 </div>
 </%block>

--- a/gui/slick/views/inc_addShowOptions.mako
+++ b/gui/slick/views/inc_addShowOptions.mako
@@ -9,7 +9,7 @@
             <label for="subtitles" class="clearfix">
                 <span class="component-title">Subtitles</span>
                 <span class="component-desc">
-                     <input type="checkbox" name="subtitles" id="subtitles" ${('', 'checked="checked"')[bool(sickbeard.SUBTITLES_DEFAULT)]} />
+                     <input type="checkbox" name="subtitles" id="subtitles" ${('', 'checked="checked"')[bool(sickbeard.SUBTITLES_DEFAULT)]}  autocapitalize="off" />
                     <p>Download subtitles for this show?</p>
                 </span>
             </label>
@@ -44,7 +44,7 @@
             <label for="flatten_folders" class="clearfix">
                 <span class="component-title">Flatten Folders</span>
                 <span class="component-desc">
-                    <input class="cb" type="checkbox" name="flatten_folders" id="flatten_folders" ${('', 'checked="checked"')[bool(sickbeard.FLATTEN_FOLDERS_DEFAULT)]}/>
+                    <input class="cb" type="checkbox" name="flatten_folders" id="flatten_folders" ${('', 'checked="checked"')[bool(sickbeard.FLATTEN_FOLDERS_DEFAULT)]} autocapitalize="off" />
                     <p>Disregard sub-folders?</p>
                 </span>
             </label>
@@ -55,7 +55,7 @@
             <label for="anime" class="clearfix">
                 <span class="component-title">Anime</span>
                 <span class="component-desc">
-                    <input type="checkbox" name="anime" id="anime" ${('', 'checked="checked"')[bool(sickbeard.ANIME_DEFAULT)]} />
+                    <input type="checkbox" name="anime" id="anime" ${('', 'checked="checked"')[bool(sickbeard.ANIME_DEFAULT)]}  autocapitalize="off" />
                     <p>Is this show an Anime?<p>
                 </span>
             </label>
@@ -66,7 +66,7 @@
             <label for="scene" class="clearfix">
                 <span class="component-title">Scene Numbering</span>
                 <span class="component-desc">
-                    <input type="checkbox" name="scene" id="scene" ${('', 'checked="checked"')[bool(sickbeard.SCENE_DEFAULT)]} />
+                    <input type="checkbox" name="scene" id="scene" ${('', 'checked="checked"')[bool(sickbeard.SCENE_DEFAULT)]}  autocapitalize="off" />
                     <p>Is this show scene numbered?</p>
                 </span>
             </label>
@@ -76,7 +76,7 @@
             <label for="archive" class="clearfix">
                 <span class="component-title">Archive first match</span>
                 <span class="component-desc">
-                    <input type="checkbox" name="archive" id="archive" ${('', 'checked="checked"')[bool(sickbeard.ARCHIVE_DEFAULT)]} />
+                    <input type="checkbox" name="archive" id="archive" ${('', 'checked="checked"')[bool(sickbeard.ARCHIVE_DEFAULT)]}  autocapitalize="off" />
                     <p>Archive episodes after downloading first match?</p>
                 </span>
             </label>
@@ -90,7 +90,7 @@
         <br>
         <div class="field-pair alt">
             <label for="saveDefaultsButton" class="nocheck clearfix">
-                <span class="component-title"><input class="btn btn-inline" type="button" id="saveDefaultsButton" value="Save Defaults" disabled="disabled" /></span>
+                <span class="component-title"><input class="btn btn-inline" type="button" id="saveDefaultsButton" value="Save Defaults" disabled="disabled"  autocapitalize="off" /></span>
                 <span class="component-desc">
                     <p>Use current values as the defaults</p>
                 </span>
@@ -101,5 +101,5 @@
     <% import sickbeard.blackandwhitelist %>
     <%include file="/inc_blackwhitelist.mako"/>
 % else:
-        <input type="hidden" name="anime" id="anime" value="0" />
+        <input type="hidden" name="anime" id="anime" value="0"  autocapitalize="off" />
 % endif

--- a/gui/slick/views/inc_blackwhitelist.mako
+++ b/gui/slick/views/inc_blackwhitelist.mako
@@ -1,6 +1,6 @@
 <div id="blackwhitelist">
-    <input type="hidden" name="whitelist" id="whitelist"/>
-    <input type="hidden" name="blacklist" id="blacklist"/>
+    <input type="hidden" name="whitelist" id="whitelist" autocapitalize="off" />
+    <input type="hidden" name="blacklist" id="blacklist" autocapitalize="off" />
 
     <b>Fansub Groups:</b>
         <div >
@@ -22,7 +22,7 @@
                         % endfor
                     </select>
                     <br>
-                    <input class="btn" id="removeW" value="Remove" type="button"/>
+                    <input class="btn" id="removeW" value="Remove" type="button" autocapitalize="off" />
                 </div>
                 <div class="blackwhitelist pool">
                     <span><h4>Available Groups</h4></span>
@@ -34,8 +34,8 @@
                     % endfor
                     </select>
                     <br>
-                    <input class="btn" id="addW" value="Add to Whitelist" type="button"/>
-                    <input class="btn" id="addB" value="Add to Blacklist" type="button"/>
+                    <input class="btn" id="addW" value="Add to Whitelist" type="button" autocapitalize="off" />
+                    <input class="btn" id="addB" value="Add to Blacklist" type="button" autocapitalize="off" />
                 </div>
                 <div class="blackwhitelist black">
                     <span><h4>Blacklist</h4></span>
@@ -45,12 +45,12 @@
                         % endfor
                     </select>
                     <br>
-                    <input class="btn" id="removeB" value="Remove" type="button"/>
+                    <input class="btn" id="removeB" value="Remove" type="button" autocapitalize="off" />
                 </div>
             </div>
             <br style="clear:both" />
             <div class="blackwhitelist manual">
-                <input type="text" id="addToPoolText" class="form-control form-control-inline input-sm input250" />
+                <input type="text" id="addToPoolText" class="form-control form-control-inline input-sm input250"  autocapitalize="off" />
                 <input class="btn btn-inline" type="button" value="Add to Whitelist" id="addToWhite">
                 <input class="btn btn-inline" type="button" value="Add to Blacklist" id="addToBlack">
             </div>

--- a/gui/slick/views/inc_rootDirs.mako
+++ b/gui/slick/views/inc_rootDirs.mako
@@ -12,7 +12,7 @@
 
 <span id="sampleRootDir"></span>
 
-<input type="hidden" id="whichDefaultRootDir" value="${backend_default}" />
+<input type="hidden" id="whichDefaultRootDir" value="${backend_default}"  autocapitalize="off" />
 <div class="rootdir-selectbox">
     <select name="rootDir" id="rootDirs" size="6">
     % for cur_dir in backend_dirs:
@@ -21,9 +21,9 @@
     </select>
 </div>
 <div id="rootDirsControls" class="rootdir-controls">
-    <input class="btn" type="button" id="addRootDir" value="New" />
-    <input class="btn" type="button" id="editRootDir" value="Edit" />
-    <input class="btn" type="button" id="deleteRootDir" value="Delete" />
-    <input class="btn" type="button" id="defaultRootDir" value="Set as Default *" />
+    <input class="btn" type="button" id="addRootDir" value="New"  autocapitalize="off" />
+    <input class="btn" type="button" id="editRootDir" value="Edit"  autocapitalize="off" />
+    <input class="btn" type="button" id="deleteRootDir" value="Delete"  autocapitalize="off" />
+    <input class="btn" type="button" id="defaultRootDir" value="Set as Default *"  autocapitalize="off" />
 </div>
-<input type="text" style="display: none" id="rootDirText" />
+<input type="text" style="display: none" id="rootDirText"  autocapitalize="off" />

--- a/gui/slick/views/login.mako
+++ b/gui/slick/views/login.mako
@@ -3,11 +3,11 @@
 <div class="login">
     <form action="" method="post">
         <h1>SickRage</h1>
-        <div class="ctrlHolder"><input class="inlay" name="username" type="text" placeholder="Username" autocomplete="off" /></div>
-        <div class="ctrlHolder"><input class="inlay" name="password" type="password" placeholder="Password" autocomplete="off" /></div>
+        <div class="ctrlHolder"><input class="inlay" name="username" type="text" placeholder="Username" autocomplete="off"  autocapitalize="off" /></div>
+        <div class="ctrlHolder"><input class="inlay" name="password" type="password" placeholder="Password" autocomplete="off"  autocapitalize="off" /></div>
         <div class="ctrlHolder">
-            <label class="remember_me" title="for 30 days"><input class="inlay" id="remember_me" name="remember_me" type="checkbox" value="1"checked="checked" /> Remember me</label>
-            <input class="button" name="submit" type="submit" value="Login" />
+            <label class="remember_me" title="for 30 days"><input class="inlay" id="remember_me" name="remember_me" type="checkbox" value="1"checked="checked"  autocapitalize="off" /> Remember me</label>
+            <input class="button" name="submit" type="submit" value="Login"  autocapitalize="off" />
         </div>
     </form>
 </div>

--- a/gui/slick/views/manage.mako
+++ b/gui/slick/views/manage.mako
@@ -19,7 +19,7 @@
 <table id="massUpdateTable" class="sickbeardTable tablesorter" cellspacing="1" border="0" cellpadding="0">
     <thead>
         <tr>
-            <th class="col-checkbox">Edit<br><input type="checkbox" class="bulkCheck" id="editCheck" /></th>
+            <th class="col-checkbox">Edit<br><input type="checkbox" class="bulkCheck" id="editCheck"  autocapitalize="off" /></th>
             <th class="nowrap" style="text-align: left;">Show Name</th>
             <th class="col-quality">Quality</th>
             <th class="col-legend">Sports</th>
@@ -31,22 +31,22 @@
             <th class="col-legend">Subtitle</th>
             <th class="col-legend">Default Ep<br>Status</th>
             <th class="col-legend">Status</th>
-            <th width="1%">Update<br><input type="checkbox" class="bulkCheck" id="updateCheck" /></th>
-            <th width="1%">Rescan<br><input type="checkbox" class="bulkCheck" id="refreshCheck" /></th>
-            <th width="1%">Rename<br><input type="checkbox" class="bulkCheck" id="renameCheck" /></th>
+            <th width="1%">Update<br><input type="checkbox" class="bulkCheck" id="updateCheck"  autocapitalize="off" /></th>
+            <th width="1%">Rescan<br><input type="checkbox" class="bulkCheck" id="refreshCheck"  autocapitalize="off" /></th>
+            <th width="1%">Rename<br><input type="checkbox" class="bulkCheck" id="renameCheck"  autocapitalize="off" /></th>
         % if sickbeard.USE_SUBTITLES:
-            <th width="1%">Search Subtitle<br><input type="checkbox" class="bulkCheck" id="subtitleCheck" /></th>
+            <th width="1%">Search Subtitle<br><input type="checkbox" class="bulkCheck" id="subtitleCheck"  autocapitalize="off" /></th>
         % endif
-            <!-- <th>Force Metadata Regen <input type="checkbox" class="bulkCheck" id="metadataCheck" /></th>//-->
-            <th width="1%">Delete<br><input type="checkbox" class="bulkCheck" id="deleteCheck" /></th>
-            <th width="1%">Remove<br><input type="checkbox" class="bulkCheck" id="removeCheck" /></th>
+            <!-- <th>Force Metadata Regen <input type="checkbox" class="bulkCheck" id="metadataCheck"  autocapitalize="off" /></th>//-->
+            <th width="1%">Delete<br><input type="checkbox" class="bulkCheck" id="deleteCheck"  autocapitalize="off" /></th>
+            <th width="1%">Remove<br><input type="checkbox" class="bulkCheck" id="removeCheck"  autocapitalize="off" /></th>
         </tr>
     </thead>
 
     <tfoot>
         <tr>
-            <td rowspan="1" colspan="2" class="align-center alt"><input class="btn pull-left" type="button" value="Edit Selected" id="submitMassEdit" /></td>
-            <td rowspan="1" colspan="${(15, 16)[bool(sickbeard.USE_SUBTITLES)]}" class="align-right alt"><input class="btn pull-right" type="button" value="Submit" id="submitMassUpdate" /></td>
+            <td rowspan="1" colspan="2" class="align-center alt"><input class="btn pull-left" type="button" value="Edit Selected" id="submitMassEdit"  autocapitalize="off" /></td>
+            <td rowspan="1" colspan="${(15, 16)[bool(sickbeard.USE_SUBTITLES)]}" class="align-right alt"><input class="btn pull-right" type="button" value="Submit" id="submitMassUpdate"  autocapitalize="off" /></td>
         </tr>
     </tfoot>
 
@@ -67,39 +67,39 @@
             <% curUpdate_disabled = "disabled=\"disabled\" " %>
         % endif
 
-        <% curUpdate = "<input type=\"checkbox\" class=\"updateCheck\" id=\"update-"+str(curShow.indexerid)+"\" "+curUpdate_disabled+"/>" %>
+        <% curUpdate = "<input type=\"checkbox\" class=\"updateCheck\" id=\"update-"+str(curShow.indexerid)+"\" "+curUpdate_disabled+" autocapitalize="off" />" %>
 
         % if sickbeard.showQueueScheduler.action.isBeingRefreshed(curShow) or sickbeard.showQueueScheduler.action.isInRefreshQueue(curShow):
             <% curRefresh_disabled = "disabled=\"disabled\" " %>
         % endif
 
-        <% curRefresh = "<input type=\"checkbox\" class=\"refreshCheck\" id=\"refresh-"+str(curShow.indexerid)+"\" "+curRefresh_disabled+"/>" %>
+        <% curRefresh = "<input type=\"checkbox\" class=\"refreshCheck\" id=\"refresh-"+str(curShow.indexerid)+"\" "+curRefresh_disabled+" autocapitalize="off" />" %>
 
         % if sickbeard.showQueueScheduler.action.isBeingRenamed(curShow) or sickbeard.showQueueScheduler.action.isInRenameQueue(curShow):
             <% curRename = "disabled=\"disabled\" " %>
         % endif
 
-        <% curRename = "<input type=\"checkbox\" class=\"renameCheck\" id=\"rename-"+str(curShow.indexerid)+"\" "+curRename_disabled+"/>" %>
+        <% curRename = "<input type=\"checkbox\" class=\"renameCheck\" id=\"rename-"+str(curShow.indexerid)+"\" "+curRename_disabled+" autocapitalize="off" />" %>
 
         % if not curShow.subtitles or sickbeard.showQueueScheduler.action.isBeingSubtitled(curShow) or sickbeard.showQueueScheduler.action.isInSubtitleQueue(curShow):
             <% curSubtitle_disabled = "disabled=\"disabled\" " %>
         % endif
 
-        <% curSubtitle = "<input type=\"checkbox\" class=\"subtitleCheck\" id=\"subtitle-"+str(curShow.indexerid)+"\" "+curSubtitle_disabled+"/>" %>
+        <% curSubtitle = "<input type=\"checkbox\" class=\"subtitleCheck\" id=\"subtitle-"+str(curShow.indexerid)+"\" "+curSubtitle_disabled+" autocapitalize="off" />" %>
 
         % if sickbeard.showQueueScheduler.action.isBeingRenamed(curShow) or sickbeard.showQueueScheduler.action.isInRenameQueue(curShow) or sickbeard.showQueueScheduler.action.isInRefreshQueue(curShow):
             <% curDelete = "disabled=\"disabled\" " %>
         % endif
 
-        <% curDelete = "<input type=\"checkbox\" class=\"deleteCheck\" id=\"delete-"+str(curShow.indexerid)+"\" "+curDelete_disabled+"/>" %>
+        <% curDelete = "<input type=\"checkbox\" class=\"deleteCheck\" id=\"delete-"+str(curShow.indexerid)+"\" "+curDelete_disabled+" autocapitalize="off" />" %>
 
         % if sickbeard.showQueueScheduler.action.isBeingRenamed(curShow) or sickbeard.showQueueScheduler.action.isInRenameQueue(curShow) or sickbeard.showQueueScheduler.action.isInRefreshQueue(curShow):
             <% curRemove = "disabled=\"disabled\" " %>
         % endif
 
-        <% curRemove = "<input type=\"checkbox\" class=\"removeCheck\" id=\"remove-"+str(curShow.indexerid)+"\" "+curRemove_disabled+"/>" %>
+        <% curRemove = "<input type=\"checkbox\" class=\"removeCheck\" id=\"remove-"+str(curShow.indexerid)+"\" "+curRemove_disabled+" autocapitalize="off" />" %>
         <tr>
-            <td align="center"><input type="checkbox" class="editCheck" id="edit-${curShow.indexerid}" /></td>
+            <td align="center"><input type="checkbox" class="editCheck" id="edit-${curShow.indexerid}"  autocapitalize="off" /></td>
             <td class="tvShow"><a href="${srRoot}/home/displayShow?show=${curShow.indexerid}">${curShow.name}</a></td>
             <td align="center">${renderQualityPill(curShow.quality, showTitle=True)}</td>
             <td align="center"><img src="${srRoot}/images/${('no16.png" alt="N"', 'yes16.png" alt="Y"')[int(curShow.is_sports) == 1]} width="16" height="16" /></td>

--- a/gui/slick/views/manage_episodeStatuses.mako
+++ b/gui/slick/views/manage_episodeStatuses.mako
@@ -31,13 +31,13 @@ Manage episodes with status <select name="whichStatus" class="form-control form-
     %endif
 % endfor
 </select>
-<input class="btn btn-inline" type="submit" value="Manage" />
+<input class="btn btn-inline" type="submit" value="Manage"  autocapitalize="off" />
 </form>
 
 % else:
 
 <form action="${srRoot}/manage/changeEpisodeStatuses" method="post">
-<input type="hidden" id="oldStatus" name="oldStatus" value="${whichStatus}" />
+<input type="hidden" id="oldStatus" name="oldStatus" value="${whichStatus}"  autocapitalize="off" />
 
 <h2>Shows containing ${common.statusStrings[whichStatus]} episodes</h2>
 
@@ -50,7 +50,7 @@ Manage episodes with status <select name="whichStatus" class="form-control form-
         row_class = common.Overview.overviewStrings[int(whichStatus)]
 %>
 
-<input type="hidden" id="row_class" value="${row_class}" />
+<input type="hidden" id="row_class" value="${row_class}"  autocapitalize="off" />
 
 Set checked shows/episodes to <select name="newStatus" class="form-control form-control-inline input-sm">
 <%
@@ -71,7 +71,7 @@ Set checked shows/episodes to <select name="newStatus" class="form-control form-
 
 </select>
 
-<input class="btn btn-inline" type="submit" value="Go" />
+<input class="btn btn-inline" type="submit" value="Go"  autocapitalize="off" />
 
 <div>
     <button type="button" class="btn btn-xs selectAllShows">Select all</a></button>
@@ -82,8 +82,8 @@ Set checked shows/episodes to <select name="newStatus" class="form-control form-
 <table class="sickbeardTable manageTable" cellspacing="1" border="0" cellpadding="0">
     % for cur_indexer_id in sorted_show_ids:
     <tr id="${cur_indexer_id}">
-        <th><input type="checkbox" class="allCheck" id="allCheck-${cur_indexer_id}" name="${cur_indexer_id}-all" checked="checked" /></th>
-        <th colspan="2" style="width: 100%; text-align: left;"><a class="whitelink" href="${srRoot}/home/displayShow?show=${cur_indexer_id}">${show_names[cur_indexer_id]}</a> (${ep_counts[cur_indexer_id]}) <input type="button" class="pull-right get_more_eps btn" id="${cur_indexer_id}" value="Expand" /></th>
+        <th><input type="checkbox" class="allCheck" id="allCheck-${cur_indexer_id}" name="${cur_indexer_id}-all" checked="checked"  autocapitalize="off" /></th>
+        <th colspan="2" style="width: 100%; text-align: left;"><a class="whitelink" href="${srRoot}/home/displayShow?show=${cur_indexer_id}">${show_names[cur_indexer_id]}</a> (${ep_counts[cur_indexer_id]}) <input type="button" class="pull-right get_more_eps btn" id="${cur_indexer_id}" value="Expand"  autocapitalize="off" /></th>
     </tr>
     % endfor
     <tr><td style="padding:0;"></td><td style="padding:0;"></td><td style="padding:0;"></td></tr>

--- a/gui/slick/views/manage_failedDownloads.mako
+++ b/gui/slick/views/manage_failedDownloads.mako
@@ -32,7 +32,7 @@
       <th width="10%">Size</th>
       <th width="14%">Provider</th>
       <th width="1%">Remove<br>
-          <input type="checkbox" class="bulkCheck" id="removeCheck" />
+          <input type="checkbox" class="bulkCheck" id="removeCheck"  autocapitalize="off" />
       </th>
     </tr>
   </thead>
@@ -60,7 +60,7 @@
         <img src="${srRoot}/images/providers/missing.png" width="16" height="16" alt="missing provider" title="missing provider"/>
     % endif
     </td>
-    <td align="center"><input type="checkbox" class="removeCheck" id="remove-${hItem["release"]}" /></td>
+    <td align="center"><input type="checkbox" class="removeCheck" id="remove-${hItem["release"]}"  autocapitalize="off" /></td>
   </tr>
 % endfor
   </tbody>

--- a/gui/slick/views/manage_massEdit.mako
+++ b/gui/slick/views/manage_massEdit.mako
@@ -26,7 +26,7 @@
 
     <div id="config-content">
         <form action="massEditSubmit" method="post">
-            <input type="hidden" name="toEdit" value="${showList}" />
+            <input type="hidden" name="toEdit" value="${showList}"  autocapitalize="off" />
 
             <div id="config-components">
                 <ul>
@@ -74,8 +74,8 @@
                                                 <td>
                                                     <a href="#" class="btn edit_root_dir" class="edit_root_dir" id="edit_root_dir_${cur_index}">Edit</a>
                                                     <a href="#" class="btn delete_root_dir" class="delete_root_dir" id="delete_root_dir_${cur_index}">Delete</a>
-                                                    <input type="hidden" name="orig_root_dir_${cur_index}" value="${cur_dir}" />
-                                                    <input type="text" style="display: none" name="new_root_dir_${cur_index}" id="new_root_dir_${cur_index}" class="new_root_dir" value="${cur_dir}" />
+                                                    <input type="hidden" name="orig_root_dir_${cur_index}" value="${cur_dir}"  autocapitalize="off" />
+                                                    <input type="text" style="display: none" name="new_root_dir_${cur_index}" id="new_root_dir_${cur_index}" class="new_root_dir" value="${cur_dir}"  autocapitalize="off" />
                                                 </td>
                                             </tr>
                                         % endfor

--- a/gui/slick/views/manage_subtitleMissed.mako
+++ b/gui/slick/views/manage_subtitleMissed.mako
@@ -31,16 +31,16 @@ Manage episodes without <select name="whichSubs" class="form-control form-contro
 % endfor
 </select>
 subtitles
-<input class="btn" type="submit" value="Manage" />
+<input class="btn" type="submit" value="Manage"  autocapitalize="off" />
 </form>
 
 % else:
-<input type="hidden" id="selectSubLang" name="selectSubLang" value="${whichSubs}" />
+<input type="hidden" id="selectSubLang" name="selectSubLang" value="${whichSubs}"  autocapitalize="off" />
 
 <form action="${srRoot}/manage/downloadSubtitleMissed" method="post">
 <h2>Episodes without ${subsLanguage} subtitles.</h2>
 <br>
-Download missed subtitles for selected episodes <input class="btn btn-inline" type="submit" value="Go" />
+Download missed subtitles for selected episodes <input class="btn btn-inline" type="submit" value="Go"  autocapitalize="off" />
 <div>
     <button type="button" class="btn btn-xs selectAllShows">Select all</a></button>
     <button type="button" class="btn btn-xs unselectAllShows">Clear all</a></button>
@@ -49,8 +49,8 @@ Download missed subtitles for selected episodes <input class="btn btn-inline" ty
 <table class="sickbeardTable manageTable" cellspacing="1" border="0" cellpadding="0">
 % for cur_indexer_id in sorted_show_ids:
  <tr id="${cur_indexer_id}">
-  <th><input type="checkbox" class="allCheck" id="allCheck-${cur_indexer_id}" name="${cur_indexer_id}-all"checked="checked" /></th>
-  <th colspan="3" style="width: 100%; text-align: left;"><a class="whitelink" href="${srRoot}/home/displayShow?show=${cur_indexer_id}">${show_names[cur_indexer_id]}</a> (${ep_counts[cur_indexer_id]}) <input type="button" class="pull-right get_more_eps btn" id="${cur_indexer_id}" value="Expand" /></th>
+  <th><input type="checkbox" class="allCheck" id="allCheck-${cur_indexer_id}" name="${cur_indexer_id}-all"checked="checked"  autocapitalize="off" /></th>
+  <th colspan="3" style="width: 100%; text-align: left;"><a class="whitelink" href="${srRoot}/home/displayShow?show=${cur_indexer_id}">${show_names[cur_indexer_id]}</a> (${ep_counts[cur_indexer_id]}) <input type="button" class="pull-right get_more_eps btn" id="${cur_indexer_id}" value="Expand"  autocapitalize="off" /></th>
  </tr>
 % endfor
 </table>

--- a/gui/slick/views/schedule.mako
+++ b/gui/slick/views/schedule.mako
@@ -70,7 +70,7 @@
 <!-- start list view //-->
 <% show_div = 'listing-default' %>
 
-<input type="hidden" id="srRoot" value="${srRoot}" />
+<input type="hidden" id="srRoot" value="${srRoot}"  autocapitalize="off" />
 
 <table id="showListTable" class="sickbeardTable tablesorter seasonstyle" cellspacing="1" border="0" cellpadding="0">
 
@@ -355,7 +355,7 @@
 <br>
 <br>
 <div class="calendarWrapper">
-<input type="hidden" id="srRoot" value="${srRoot}" />
+<input type="hidden" id="srRoot" value="${srRoot}"  autocapitalize="off" />
     % for day in dates:
     <% tbl_day += 1 %>
         <table class="sickbeardTable tablesorter calendarTable ${'cal-%s' % (('even', 'odd')[bool(tbl_day % 2)])}" cellspacing="0" border="0" cellpadding="0">

--- a/gui/slick/views/testRename.mako
+++ b/gui/slick/views/testRename.mako
@@ -18,7 +18,7 @@
     <h1 class="title">${title}</h1>
 % endif
 
-<input type="hidden" id="showID" value="${show.indexerid}" />
+<input type="hidden" id="showID" value="${show.indexerid}"  autocapitalize="off" />
 
 <h3>Preview of the proposed name changes</h3>
 <blockquote>
@@ -42,7 +42,7 @@
             </td>
         </tr>
         <tr class="seasoncols" id="selectall">
-            <th class="col-checkbox"><input type="checkbox" class="seriesCheck" id="SelectAll" /></th>
+            <th class="col-checkbox"><input type="checkbox" class="seriesCheck" id="SelectAll"  autocapitalize="off" /></th>
             <th align="left" valign="top" class="nowrap">Select All</th>
             <th width="100%" class="col-name" style="visibility:hidden;"></th>
         </tr>
@@ -69,7 +69,7 @@
             </td>
         </tr>
         <tr class="seasoncols" id="season-${cur_ep_obj.season}-cols">
-            <th class="col-checkbox"><input type="checkbox" class="seasonCheck" id="${cur_ep_obj.season}" /></th>
+            <th class="col-checkbox"><input type="checkbox" class="seasonCheck" id="${cur_ep_obj.season}"  autocapitalize="off" /></th>
             <th class="nowrap">Episode</th>
             <th class="col-name">Old Location</th>
             <th class="col-name">New Location</th>
@@ -88,7 +88,7 @@ if len(epList) > 1:
         <tr class="season-${curSeason} ${('wanted', 'good')[curLoc == newLoc]} seasonstyle">
             <td class="col-checkbox">
             % if curLoc != newLoc:
-                <input type="checkbox" class="epCheck" id="${str(cur_ep_obj.season) + 'x' + str(cur_ep_obj.episode)}" name="${str(cur_ep_obj.season) + "x" + str(cur_ep_obj.episode)}" />
+                <input type="checkbox" class="epCheck" id="${str(cur_ep_obj.season) + 'x' + str(cur_ep_obj.episode)}" name="${str(cur_ep_obj.season) + "x" + str(cur_ep_obj.episode)}"  autocapitalize="off" />
             % endif
             </td>
             <td align="center" valign="top" class="nowrap">${"-".join(map(str, epList))}</td>

--- a/gui/slick/views/viewlogs.mako
+++ b/gui/slick/views/viewlogs.mako
@@ -37,7 +37,7 @@ Filter log by: <select name="logFilter" id="logFilter" class="form-control form-
 % endfor
 </select>
 Search log by:
-<input type="text" name="logSearch" placeholder="clear to reset" id="logSearch" value="${('', logSearch)[bool(logSearch)]}" class="form-control form-control-inline input-sm" />
+<input type="text" name="logSearch" placeholder="clear to reset" id="logSearch" value="${('', logSearch)[bool(logSearch)]}" class="form-control form-control-inline input-sm"  autocapitalize="off" />
 </div>
 <br>
 <div class="align-left"><pre>


### PR DESCRIPTION
Modified GUI templates adding autocapitalize="off" to all inputs to make SickRage easier to use and configure from a mobile device. Adding this tag prevents mobile devices from capitalizing input fields which is frustrating when typing usernames, file paths, API keys, URLs etc.

As suggested in SiCKRAGETV/SickRage#3196 by @justinsg
