### PR TITLE
Fix backup/restore dialog title issue (Issue #41)

### DIFF
--- a/gui/slick/js/browser.js
+++ b/gui/slick/js/browser.js
@@ -90,7 +90,11 @@
                 autoOpen:    false
             });
         }
-
+        else {
+            // The title may change, even if fileBrowserDialog already exists
+            fileBrowserDialog.dialog('option', 'title', options.title);   
+        }
+        
         fileBrowserDialog.dialog('option', 'buttons', [
             {
                 text: 'Ok',


### PR DESCRIPTION
This commit fixes https://github.com/SickRage/sickrage-issues/issues/41    

Basically, the current file browser code doesn't allow for the title changing if the dialog already exists.
