### PR TITLE
Fix poster shows '?' when only unaired episodes.

### DIFF
--- a/gui/slick/views/home.mako
+++ b/gui/slick/views/home.mako
@@ -33,7 +33,7 @@
     % if sickbeard.HOME_LAYOUT == 'poster':
     &nbsp;
     <span> Poster Size:
-        <div style="width: 100px; display: inline-block; margin-left: 7px;" id="posterSizeSlider"></div>
+        <div style="width: 100px; display: inline-block;" id="posterSizeSlider"></div>
     </span>
     &nbsp;
     <span>
@@ -122,23 +122,22 @@
         if not cur_total:
             cur_total = 0
 
-    if cur_total != 0:
-        download_stat = str(cur_downloaded)
-        download_stat_tip = "Downloaded: " + str(cur_downloaded)
-        if cur_snatched > 0:
-            download_stat = download_stat
-            download_stat_tip = download_stat_tip + "&#013;" + "Snatched: " + str(cur_snatched)
+    download_stat = str(cur_downloaded)
+    download_stat_tip = "Downloaded: " + str(cur_downloaded)
 
-        download_stat = download_stat + " / " + str(cur_total)
-        download_stat_tip = download_stat_tip + "&#013;" + "Total: " + str(cur_total)
-    else:
-        download_stat = '?'
-        download_stat_tip = "no data"
+    if cur_snatched:
+        download_stat = download_stat + "+" + str(cur_snatched)
+        download_stat_tip = download_stat_tip + "&#013;" + "Snatched: " + str(cur_snatched)
+
+    download_stat = download_stat + " / " + str(cur_total)
+    download_stat_tip = download_stat_tip + "&#013;" + "Total: " + str(cur_total)
 
     nom = cur_downloaded
-    den = cur_total
-    if den == 0:
+    if cur_total:
+        den = cur_total
+    else:
         den = 1
+        download_stat_tip = "Unaired"
 
     progressbar_percent = nom * 100 / den
 
@@ -310,6 +309,7 @@
 
     download_stat = str(cur_downloaded)
     download_stat_tip = "Downloaded: " + str(cur_downloaded)
+
     if cur_snatched:
         download_stat = download_stat + "+" + str(cur_snatched)
         download_stat_tip = download_stat_tip + "&#013;" + "Snatched: " + str(cur_snatched)


### PR DESCRIPTION
Applies same fix as #252 to posters.
