### PR TITLE
Add more tests to sickrage module

### DIFF
--- a/sickrage/media/GenericMedia.py
+++ b/sickrage/media/GenericMedia.py
@@ -21,6 +21,7 @@ import sickbeard
 from abc import abstractmethod
 from mimetypes import guess_type
 from os.path import isfile, join, normpath
+from sickrage.helper.common import try_int
 from sickrage.helper.encoding import ek
 from sickrage.helper.exceptions import MultipleShowObjectsException
 from sickrage.show.Show import Show
@@ -33,15 +34,12 @@ class GenericMedia:
         :param media_format: The format of the media to get. Must be either 'normal' or 'thumb'
         """
 
+        self.indexer_id = try_int(indexer_id, 0)
+
         if media_format in ('normal', 'thumb'):
             self.media_format = media_format
         else:
             self.media_format = 'normal'
-
-        try:
-            self.indexer_id = int(indexer_id)
-        except ValueError:
-            self.indexer_id = 0
 
     @abstractmethod
     def get_default_media_name(self):

--- a/tests/sickrage_tests/helper/__init__.py
+++ b/tests/sickrage_tests/helper/__init__.py
@@ -2,3 +2,20 @@
 """
 Tests for SickRage helpers
 """
+
+import unittest
+
+from common_tests import CommonTests
+from quality_tests import QualityTests
+
+if __name__ == '__main__':
+    print('=====> Running all test in "sickrage_tests.helper" <=====')
+
+    TEST_CLASSES = [
+        CommonTests,
+        QualityTests,
+    ]
+
+    for test_class in TEST_CLASSES:
+        SUITE = unittest.TestLoader().loadTestsFromTestCase(test_class)
+        unittest.TextTestRunner(verbosity=2).run(SUITE)

--- a/tests/sickrage_tests/helper/common_tests.py
+++ b/tests/sickrage_tests/helper/common_tests.py
@@ -46,6 +46,10 @@ class CommonTests(unittest.TestCase):
         test_cases = {
             None: None,
             '': None,
+            '123': None,
+            '12.3': None,
+            '-123': None,
+            '-12.3': None,
             '300': None,
             0: None,
             123: None,
@@ -61,6 +65,10 @@ class CommonTests(unittest.TestCase):
 
         unicode_test_cases = {
             u'': None,
+            u'123': None,
+            u'12.3': None,
+            u'-123': None,
+            u'-12.3': None,
             u'300': None,
         }
 

--- a/tests/sickrage_tests/media/__init__.py
+++ b/tests/sickrage_tests/media/__init__.py
@@ -1,0 +1,27 @@
+# coding=utf-8
+"""
+Tests for SickRage media
+"""
+
+import unittest
+
+from generic_media_tests import GenericMediaTests
+from show_banner_tests import ShowBannerTests
+from show_fan_art_tests import ShowFanArtTests
+from show_network_logo_tests import ShowNetworkLogoTests
+from show_poster_tests import ShowPosterTests
+
+if __name__ == '__main__':
+    print('=====> Running all test in "sickrage_tests.media" <=====')
+
+    TEST_CLASSES = [
+        GenericMediaTests,
+        ShowBannerTests,
+        ShowFanArtTests,
+        ShowNetworkLogoTests,
+        ShowPosterTests,
+    ]
+
+    for test_class in TEST_CLASSES:
+        SUITE = unittest.TestLoader().loadTestsFromTestCase(test_class)
+        unittest.TextTestRunner(verbosity=2).run(SUITE)

--- a/tests/sickrage_tests/media/generic_media_tests.py
+++ b/tests/sickrage_tests/media/generic_media_tests.py
@@ -1,0 +1,145 @@
+# coding=utf-8
+# This file is part of SickRage.
+#
+# URL: https://SickRage.GitHub.io
+# Git: https://github.com/SickRage/SickRage.git
+#
+# SickRage is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# SickRage is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with SickRage.  If not, see <http://www.gnu.org/licenses/>.
+
+"""
+Test GenericMedia
+"""
+
+from __future__ import print_function
+
+import os
+import sys
+import unittest
+
+sys.path.insert(1, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../../lib')))
+sys.path.insert(1, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../..')))
+
+import sickbeard
+
+from sickrage.media.GenericMedia import GenericMedia
+
+
+class GenericMediaTests(unittest.TestCase):
+    """
+    Test GenericMedia
+    """
+
+    def test___init__(self):
+        """
+        Test __init__
+        """
+        test_cases = {
+            (None, None): (0, 'normal'),
+            ('', None): (0, 'normal'),
+            ('123', None): (123, 'normal'),
+            ('12.3', None): (0, 'normal'),
+            (123, None): (123, 'normal'),
+            (12.3, None): (12, 'normal'),
+            (None, ''): (0, 'normal'),
+            ('', ''): (0, 'normal'),
+            ('123', ''): (123, 'normal'),
+            ('12.3', ''): (0, 'normal'),
+            (123, ''): (123, 'normal'),
+            (12.3, ''): (12, 'normal'),
+            (None, 'normal'): (0, 'normal'),
+            ('', 'normal'): (0, 'normal'),
+            ('123', 'normal'): (123, 'normal'),
+            ('12.3', 'normal'): (0, 'normal'),
+            (123, 'normal'): (123, 'normal'),
+            (12.3, 'normal'): (12, 'normal'),
+            (None, 'thumb'): (0, 'thumb'),
+            ('', 'thumb'): (0, 'thumb'),
+            ('123', 'thumb'): (123, 'thumb'),
+            ('12.3', 'thumb'): (0, 'thumb'),
+            (123, 'thumb'): (123, 'thumb'),
+            (12.3, 'thumb'): (12, 'thumb'),
+            (None, 'foo'): (0, 'normal'),
+            ('', 'foo'): (0, 'normal'),
+            ('123', 'foo'): (123, 'normal'),
+            ('12.3', 'foo'): (0, 'normal'),
+            (123, 'foo'): (123, 'normal'),
+            (12.3, 'foo'): (12, 'normal'),
+        }
+
+        unicode_test_cases = {
+            (u'', None): (0, 'normal'),
+            (u'123', None): (123, 'normal'),
+            (u'12.3', None): (0, 'normal'),
+            (None, u''): (0, 'normal'),
+            (u'', u''): (0, 'normal'),
+            (u'123', u''): (123, 'normal'),
+            (u'12.3', u''): (0, 'normal'),
+            (123, u''): (123, 'normal'),
+            (12.3, u''): (12, 'normal'),
+            (None, u'normal'): (0, 'normal'),
+            (u'', u'normal'): (0, 'normal'),
+            (u'123', u'normal'): (123, 'normal'),
+            (u'12.3', u'normal'): (0, 'normal'),
+            (123, u'normal'): (123, 'normal'),
+            (12.3, u'normal'): (12, 'normal'),
+            (None, u'thumb'): (0, 'thumb'),
+            (u'', u'thumb'): (0, 'thumb'),
+            (u'123', u'thumb'): (123, 'thumb'),
+            (u'12.3', u'thumb'): (0, 'thumb'),
+            (123, u'thumb'): (123, 'thumb'),
+            (12.3, u'thumb'): (12, 'thumb'),
+            (None, u'foo'): (0, 'normal'),
+            (u'', u'foo'): (0, 'normal'),
+            (u'123', u'foo'): (123, 'normal'),
+            (u'12.3', u'foo'): (0, 'normal'),
+            (123, u'foo'): (123, 'normal'),
+            (12.3, u'foo'): (12, 'normal'),
+        }
+
+        for test in test_cases, unicode_test_cases:
+            for ((indexer_id, media_format), (expected_indexer_id, expected_media_format)) in test.iteritems():
+                generic_media = GenericMedia(indexer_id, media_format)
+
+                self.assertEqual(generic_media.indexer_id, expected_indexer_id)
+                self.assertEqual(generic_media.media_format, expected_media_format)
+
+    def test_get_default_media_name(self):
+        """
+        Test get_default_media_name
+        """
+
+        self.assertEqual(GenericMedia(0, '').get_default_media_name(), '')
+
+    def test_get_media_path(self):
+        """
+        Test get_media_path
+        """
+
+        self.assertEqual(GenericMedia(0, '').get_media_path(), '')
+
+    def test_get_media_root(self):
+        """
+        Test get_media_root
+        """
+
+        sickbeard.PROG_DIR = '/home/SickRage/'
+
+        self.assertEqual(GenericMedia.get_media_root(), '/home/SickRage/gui/slick')
+
+
+if __name__ == '__main__':
+    print('=====> Testing %s' % __file__)
+
+    SUITE = unittest.TestLoader().loadTestsFromTestCase(GenericMediaTests)
+    unittest.TextTestRunner(verbosity=2).run(SUITE)

--- a/tests/sickrage_tests/media/show_banner_tests.py
+++ b/tests/sickrage_tests/media/show_banner_tests.py
@@ -18,27 +18,36 @@
 # along with SickRage.  If not, see <http://www.gnu.org/licenses/>.
 
 """
-Tests for SickRage
+Test ShowBanner
 """
 
-from __future__ import print_function
+from generic_media_tests import GenericMediaTests
 
-import helper
-import media
-import show
-import system
+import os
+import sys
 import unittest
 
+sys.path.insert(1, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../../lib')))
+sys.path.insert(1, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../..')))
+
+from sickrage.media.ShowBanner import ShowBanner
+
+
+class ShowBannerTests(GenericMediaTests):
+    """
+    Test ShowBanner
+    """
+
+    def test_get_default_media_name(self):
+        """
+        Test get_default_media_name
+        """
+
+        self.assertEqual(ShowBanner(0, '').get_default_media_name(), 'banner.png')
+
+
 if __name__ == '__main__':
-    print('=====> Running all test in "sickrage_tests" <=====')
+    print('=====> Testing %s' % __file__)
 
-    TEST_MODULES = [
-        helper,
-        media,
-        show,
-        system,
-    ]
-
-    for test_module in TEST_MODULES:
-        SUITE = unittest.TestLoader().loadTestsFromModule(test_module)
-        unittest.TextTestRunner(verbosity=2).run(SUITE)
+    SUITE = unittest.TestLoader().loadTestsFromTestCase(ShowBannerTests)
+    unittest.TextTestRunner(verbosity=2).run(SUITE)

--- a/tests/sickrage_tests/media/show_fan_art_tests.py
+++ b/tests/sickrage_tests/media/show_fan_art_tests.py
@@ -18,27 +18,36 @@
 # along with SickRage.  If not, see <http://www.gnu.org/licenses/>.
 
 """
-Tests for SickRage
+Test ShowFanArt
 """
 
-from __future__ import print_function
+from generic_media_tests import GenericMediaTests
 
-import helper
-import media
-import show
-import system
+import os
+import sys
 import unittest
 
+sys.path.insert(1, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../../lib')))
+sys.path.insert(1, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../..')))
+
+from sickrage.media.ShowFanArt import ShowFanArt
+
+
+class ShowFanArtTests(GenericMediaTests):
+    """
+    Test ShowFanArt
+    """
+
+    def test_get_default_media_name(self):
+        """
+        Test get_default_media_name
+        """
+
+        self.assertEqual(ShowFanArt(0, '').get_default_media_name(), 'fanart.png')
+
+
 if __name__ == '__main__':
-    print('=====> Running all test in "sickrage_tests" <=====')
+    print('=====> Testing %s' % __file__)
 
-    TEST_MODULES = [
-        helper,
-        media,
-        show,
-        system,
-    ]
-
-    for test_module in TEST_MODULES:
-        SUITE = unittest.TestLoader().loadTestsFromModule(test_module)
-        unittest.TextTestRunner(verbosity=2).run(SUITE)
+    SUITE = unittest.TestLoader().loadTestsFromTestCase(ShowFanArtTests)
+    unittest.TextTestRunner(verbosity=2).run(SUITE)

--- a/tests/sickrage_tests/media/show_network_logo_tests.py
+++ b/tests/sickrage_tests/media/show_network_logo_tests.py
@@ -18,27 +18,36 @@
 # along with SickRage.  If not, see <http://www.gnu.org/licenses/>.
 
 """
-Tests for SickRage
+Test ShowNetworkLogo
 """
 
-from __future__ import print_function
+from generic_media_tests import GenericMediaTests
 
-import helper
-import media
-import show
-import system
+import os
+import sys
 import unittest
 
+sys.path.insert(1, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../../lib')))
+sys.path.insert(1, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../..')))
+
+from sickrage.media.ShowNetworkLogo import ShowNetworkLogo
+
+
+class ShowNetworkLogoTests(GenericMediaTests):
+    """
+    Test ShowNetworkLogo
+    """
+
+    def test_get_default_media_name(self):
+        """
+        Test get_default_media_name
+        """
+
+        self.assertEqual(ShowNetworkLogo(0, '').get_default_media_name(), 'network/nonetwork.png')
+
+
 if __name__ == '__main__':
-    print('=====> Running all test in "sickrage_tests" <=====')
+    print('=====> Testing %s' % __file__)
 
-    TEST_MODULES = [
-        helper,
-        media,
-        show,
-        system,
-    ]
-
-    for test_module in TEST_MODULES:
-        SUITE = unittest.TestLoader().loadTestsFromModule(test_module)
-        unittest.TextTestRunner(verbosity=2).run(SUITE)
+    SUITE = unittest.TestLoader().loadTestsFromTestCase(ShowNetworkLogoTests)
+    unittest.TextTestRunner(verbosity=2).run(SUITE)

--- a/tests/sickrage_tests/media/show_poster_tests.py
+++ b/tests/sickrage_tests/media/show_poster_tests.py
@@ -18,27 +18,36 @@
 # along with SickRage.  If not, see <http://www.gnu.org/licenses/>.
 
 """
-Tests for SickRage
+Test ShowPoster
 """
 
-from __future__ import print_function
+from generic_media_tests import GenericMediaTests
 
-import helper
-import media
-import show
-import system
+import os
+import sys
 import unittest
 
+sys.path.insert(1, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../../lib')))
+sys.path.insert(1, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../..')))
+
+from sickrage.media.ShowPoster import ShowPoster
+
+
+class ShowPosterTests(GenericMediaTests):
+    """
+    Test ShowPoster
+    """
+
+    def test_get_default_media_name(self):
+        """
+        Test get_default_media_name
+        """
+
+        self.assertEqual(ShowPoster(0, '').get_default_media_name(), 'poster.png')
+
+
 if __name__ == '__main__':
-    print('=====> Running all test in "sickrage_tests" <=====')
+    print('=====> Testing %s' % __file__)
 
-    TEST_MODULES = [
-        helper,
-        media,
-        show,
-        system,
-    ]
-
-    for test_module in TEST_MODULES:
-        SUITE = unittest.TestLoader().loadTestsFromModule(test_module)
-        unittest.TextTestRunner(verbosity=2).run(SUITE)
+    SUITE = unittest.TestLoader().loadTestsFromTestCase(ShowPosterTests)
+    unittest.TextTestRunner(verbosity=2).run(SUITE)

--- a/tests/sickrage_tests/show/__init__.py
+++ b/tests/sickrage_tests/show/__init__.py
@@ -2,3 +2,22 @@
 """
 Tests for SickRage show
 """
+
+import unittest
+
+from coming_episodes_tests import ComingEpisodesTests
+from history_tests import HistoryTests
+from show_tests import ShowTests
+
+if __name__ == '__main__':
+    print('=====> Running all test in "sickrage_tests.show" <=====')
+
+    TEST_CLASSES = [
+        ComingEpisodesTests,
+        HistoryTests,
+        ShowTests,
+    ]
+
+    for test_class in TEST_CLASSES:
+        SUITE = unittest.TestLoader().loadTestsFromTestCase(test_class)
+        unittest.TextTestRunner(verbosity=2).run(SUITE)

--- a/tests/sickrage_tests/system/__init__.py
+++ b/tests/sickrage_tests/system/__init__.py
@@ -2,3 +2,20 @@
 """
 Tests for SickRage system
 """
+
+import unittest
+
+from restart_tests import RestartTests
+from shutdown_tests import ShutdownTests
+
+if __name__ == '__main__':
+    print('=====> Running all test in "sickrage_tests.system" <=====')
+
+    TEST_CLASSES = [
+        RestartTests,
+        ShutdownTests,
+    ]
+
+    for test_class in TEST_CLASSES:
+        SUITE = unittest.TestLoader().loadTestsFromTestCase(test_class)
+        unittest.TextTestRunner(verbosity=2).run(SUITE)


### PR DESCRIPTION
- More tests have been added to the `sickrage` module
- Tests in each test module can be ran at once:
  - Call `python2 tests/sickrage_tests/{module_name}/__init__.py` with `module_name` in:
    - `helper`
    - `media`
    - `show`
    - `system`
  - Or `python2 tests/sickrage_tests/__init__.py` for all tests in the `sickrage` module
