### PR TITLE
Remove duplicate function definition

### DIFF
--- a/sickbeard/config.py
+++ b/sickbeard/config.py
@@ -28,6 +28,7 @@ from sickbeard import logger
 from sickbeard import naming
 from sickbeard import db
 
+from sickrage.helper.common import try_int
 from sickrage.helper.encoding import ek
 
 # Address poor support for scgi over unix domain sockets
@@ -198,7 +199,7 @@ def change_AUTOPOSTPROCESSER_FREQUENCY(freq):
 
     :param freq: New frequency
     """
-    sickbeard.AUTOPOSTPROCESSER_FREQUENCY = to_int(freq, default=sickbeard.DEFAULT_AUTOPOSTPROCESSER_FREQUENCY)
+    sickbeard.AUTOPOSTPROCESSER_FREQUENCY = try_int(freq, sickbeard.DEFAULT_AUTOPOSTPROCESSER_FREQUENCY)
 
     if sickbeard.AUTOPOSTPROCESSER_FREQUENCY < sickbeard.MIN_AUTOPOSTPROCESSER_FREQUENCY:
         sickbeard.AUTOPOSTPROCESSER_FREQUENCY = sickbeard.MIN_AUTOPOSTPROCESSER_FREQUENCY
@@ -212,7 +213,7 @@ def change_DAILYSEARCH_FREQUENCY(freq):
 
     :param freq: New frequency
     """
-    sickbeard.DAILYSEARCH_FREQUENCY = to_int(freq, default=sickbeard.DEFAULT_DAILYSEARCH_FREQUENCY)
+    sickbeard.DAILYSEARCH_FREQUENCY = try_int(freq, sickbeard.DEFAULT_DAILYSEARCH_FREQUENCY)
 
     if sickbeard.DAILYSEARCH_FREQUENCY < sickbeard.MIN_DAILYSEARCH_FREQUENCY:
         sickbeard.DAILYSEARCH_FREQUENCY = sickbeard.MIN_DAILYSEARCH_FREQUENCY
@@ -226,7 +227,7 @@ def change_BACKLOG_FREQUENCY(freq):
 
     :param freq: New frequency
     """
-    sickbeard.BACKLOG_FREQUENCY = to_int(freq, default=sickbeard.DEFAULT_BACKLOG_FREQUENCY)
+    sickbeard.BACKLOG_FREQUENCY = try_int(freq, sickbeard.DEFAULT_BACKLOG_FREQUENCY)
 
     sickbeard.MIN_BACKLOG_FREQUENCY = sickbeard.get_backlog_cycle_time()
     if sickbeard.BACKLOG_FREQUENCY < sickbeard.MIN_BACKLOG_FREQUENCY:
@@ -241,7 +242,7 @@ def change_UPDATE_FREQUENCY(freq):
 
     :param freq: New frequency
     """
-    sickbeard.UPDATE_FREQUENCY = to_int(freq, default=sickbeard.DEFAULT_UPDATE_FREQUENCY)
+    sickbeard.UPDATE_FREQUENCY = try_int(freq, sickbeard.DEFAULT_UPDATE_FREQUENCY)
 
     if sickbeard.UPDATE_FREQUENCY < sickbeard.MIN_UPDATE_FREQUENCY:
         sickbeard.UPDATE_FREQUENCY = sickbeard.MIN_UPDATE_FREQUENCY
@@ -255,7 +256,7 @@ def change_SHOWUPDATE_HOUR(freq):
 
     :param freq: New frequency
     """
-    sickbeard.SHOWUPDATE_HOUR = to_int(freq, default=sickbeard.DEFAULT_SHOWUPDATE_HOUR)
+    sickbeard.SHOWUPDATE_HOUR = try_int(freq, sickbeard.DEFAULT_SHOWUPDATE_HOUR)
 
     if sickbeard.SHOWUPDATE_HOUR > 23:
         sickbeard.SHOWUPDATE_HOUR = 0
@@ -274,7 +275,7 @@ def change_SUBTITLES_FINDER_FREQUENCY(subtitles_finder_frequency):
     if subtitles_finder_frequency == '' or subtitles_finder_frequency is None:
         subtitles_finder_frequency = 1
 
-    sickbeard.SUBTITLES_FINDER_FREQUENCY = to_int(subtitles_finder_frequency, 1)
+    sickbeard.SUBTITLES_FINDER_FREQUENCY = try_int(subtitles_finder_frequency, 1)
 
 
 def change_VERSION_NOTIFY(version_notify):
@@ -506,24 +507,13 @@ def clean_url(url):
     return cleaned_url
 
 
-def to_int(val, default=0):
-    """ Return int value of val or default on error """
-
-    try:
-        val = int(val)
-    except Exception:
-        val = default
-
-    return val
-
-
 ################################################################################
 # Check_setting_int                                                            #
 ################################################################################
 def minimax(val, default, low, high):
     """ Return value forced within range """
 
-    val = to_int(val, default=default)
+    val = try_int(val, default)
 
     if val < low:
         return low

--- a/sickbeard/indexers/indexer_api.py
+++ b/sickbeard/indexers/indexer_api.py
@@ -17,16 +17,19 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with SickRage.  If not, see <http://www.gnu.org/licenses/>.
+
 import os
 import sickbeard
+from sickrage.helper.common import try_int
 from sickrage.helper.encoding import ek
 
 from indexer_config import initConfig
 from indexer_config import indexerConfig
 
+
 class indexerApi(object):
     def __init__(self, indexerID=None):
-        self.indexerID = int(indexerID) if indexerID else None
+        self.indexerID = try_int(indexerID, None)
 
     def __del__(self):
         pass

--- a/sickbeard/providers/omgwtfnzbs.py
+++ b/sickbeard/providers/omgwtfnzbs.py
@@ -25,6 +25,7 @@ from sickbeard import classes
 from sickbeard import logger
 from sickbeard import show_name_helpers
 from sickbeard.providers import generic
+from sickrage.helper.common import try_int
 
 
 class OmgwtfnzbsProvider(generic.NZBProvider):
@@ -82,12 +83,7 @@ class OmgwtfnzbsProvider(generic.NZBProvider):
         return (item['release'], item['getnzb'])
 
     def _get_size(self, item):
-        try:
-            size = int(item['sizebytes'])
-        except (ValueError, TypeError, AttributeError, KeyError):
-            return -1
-
-        return size
+        return try_int(item['sizebytes'], -1)
 
     def _doSearch(self, search, search_mode='eponly', epcount=0, retention=0, epObj=None):
 

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -3767,10 +3767,10 @@ class ConfigGeneral(Config):
         sickbeard.DEBUG = config.checkbox_to_value(debug)
         sickbeard.SSL_VERIFY = config.checkbox_to_value(ssl_verify)
         # sickbeard.LOG_DIR is set in config.change_LOG_DIR()
-        sickbeard.COMING_EPS_MISSED_RANGE = config.to_int(coming_eps_missed_range, default=7)
+        sickbeard.COMING_EPS_MISSED_RANGE = try_int(coming_eps_missed_range, 7)
         sickbeard.DISPLAY_ALL_SEASONS = config.checkbox_to_value(display_all_seasons)
 
-        sickbeard.WEB_PORT = config.to_int(web_port)
+        sickbeard.WEB_PORT = try_int(web_port)
         sickbeard.WEB_IPV6 = config.checkbox_to_value(web_ipv6)
         # sickbeard.WEB_LOG is set in config.change_LOG_DIR()
         if config.checkbox_to_value(encryption_version) == 1:
@@ -3787,10 +3787,10 @@ class ConfigGeneral(Config):
             sickbeard.DATE_PRESET = date_preset
 
         if indexer_default:
-            sickbeard.INDEXER_DEFAULT = config.to_int(indexer_default)
+            sickbeard.INDEXER_DEFAULT = try_int(indexer_default)
 
         if indexer_timeout:
-            sickbeard.INDEXER_TIMEOUT = config.to_int(indexer_timeout)
+            sickbeard.INDEXER_TIMEOUT = try_int(indexer_timeout)
 
         if time_preset:
             sickbeard.TIME_PRESET_W_SECONDS = time_preset
@@ -3930,14 +3930,14 @@ class ConfigSearch(Config):
         config.change_DAILYSEARCH_FREQUENCY(dailysearch_frequency)
 
         config.change_BACKLOG_FREQUENCY(backlog_frequency)
-        sickbeard.BACKLOG_DAYS = config.to_int(backlog_days, default=7)
+        sickbeard.BACKLOG_DAYS = try_int(backlog_days, 7)
 
         sickbeard.USE_NZBS = config.checkbox_to_value(use_nzbs)
         sickbeard.USE_TORRENTS = config.checkbox_to_value(use_torrents)
 
         sickbeard.NZB_METHOD = nzb_method
         sickbeard.TORRENT_METHOD = torrent_method
-        sickbeard.USENET_RETENTION = config.to_int(usenet_retention, default=500)
+        sickbeard.USENET_RETENTION = try_int(usenet_retention, 500)
 
         sickbeard.IGNORE_WORDS = ignore_words if ignore_words else ""
         sickbeard.TRACKERS_LIST = trackers_list if trackers_list else ""
@@ -3973,7 +3973,7 @@ class ConfigSearch(Config):
         sickbeard.NZBGET_CATEGORY_ANIME_BACKLOG = nzbget_category_anime_backlog
         sickbeard.NZBGET_HOST = config.clean_host(nzbget_host)
         sickbeard.NZBGET_USE_HTTPS = config.checkbox_to_value(nzbget_use_https)
-        sickbeard.NZBGET_PRIORITY = config.to_int(nzbget_priority, default=100)
+        sickbeard.NZBGET_PRIORITY = try_int(nzbget_priority, 100)
 
         sickbeard.TORRENT_USERNAME = torrent_username
         sickbeard.TORRENT_PASSWORD = torrent_password
@@ -4463,7 +4463,7 @@ class ConfigProviders(Config):
         # do the enable/disable
         for curProviderStr in provider_str_list:
             curProvider, curEnabled = curProviderStr.split(':')
-            curEnabled = config.to_int(curEnabled)
+            curEnabled = try_int(curEnabled)
 
             curProvObj = [x for x in sickbeard.providers.sortedProviderList() if
                           x.getID() == curProvider and hasattr(x, 'enabled')]
@@ -4869,7 +4869,7 @@ class ConfigNotifications(Config):
         sickbeard.EMAIL_NOTIFY_ONDOWNLOAD = config.checkbox_to_value(email_notify_ondownload)
         sickbeard.EMAIL_NOTIFY_ONSUBTITLEDOWNLOAD = config.checkbox_to_value(email_notify_onsubtitledownload)
         sickbeard.EMAIL_HOST = config.clean_host(email_host)
-        sickbeard.EMAIL_PORT = config.to_int(email_port, default=25)
+        sickbeard.EMAIL_PORT = try_int(email_port, 25)
         sickbeard.EMAIL_FROM = email_from
         sickbeard.EMAIL_TLS = config.checkbox_to_value(email_tls)
         sickbeard.EMAIL_USER = email_user

--- a/sickrage/show/History.py
+++ b/sickrage/show/History.py
@@ -20,6 +20,7 @@ from datetime import datetime
 from datetime import timedelta
 from sickbeard.common import Quality
 from sickbeard.db import DBConnection
+from sickrage.helper.common import try_int
 
 
 class History:
@@ -108,12 +109,6 @@ class History:
 
     @staticmethod
     def _get_limit(limit):
-        try:
-            limit = int(limit)
-        except (TypeError, ValueError):
-            return 0
+        limit = try_int(limit, 0)
 
-        if limit < 0:
-            return 0
-
-        return int(limit)
+        return max(limit, 0)

--- a/sickrage/show/Show.py
+++ b/sickrage/show/Show.py
@@ -181,7 +181,7 @@ class Show:
             return 'Invalid show ID', None
 
         try:
-            show = Show.find(sickbeard.showList, int(indexer_id))
+            show = Show.find(sickbeard.showList, indexer_id)
         except MultipleShowObjectsException:
             return 'Unable to find the specified show', None
 

--- a/tests/config_tests.py
+++ b/tests/config_tests.py
@@ -37,7 +37,6 @@ Methods
     clean_host
     clean_hosts
     clean_url
-    to_int
     minimax
     check_setting_int
     check_setting_float
@@ -123,13 +122,6 @@ class ConfigTestBasic(unittest.TestCase):
                 self.assertNotEqual(config.clean_url(test_url.dirty), test_url.clean)
             else:
                 log.error('Test not defined for %s', test_url)
-
-    @unittest.skip('Test not implemented')
-    def test_to_int(self):
-        """
-        Test to_int
-        """
-        pass
 
     @unittest.skip('Test not implemented')
     def test_mini_max(self):


### PR DESCRIPTION
The `to_int` function is redundant, as we have a `try_int` function, which is tested.
I also used the `try_int` function in a couple more places.
