### PR TITLE
Enable strict_undefined for mako

### DIFF
--- a/gui/slick/views/config_postProcessing.mako
+++ b/gui/slick/views/config_postProcessing.mako
@@ -699,7 +699,7 @@
                                                 % if cur_preset == sickbeard.NAMING_SPORTS_PATTERN:
                                                     <% is_sports_custom = False %>
                                                 % endif
-                                                <option id="${cur_preset}" ${('', 'selected="selected"')[NAMING_SPORTS_PATTERN == cur_preset]}>${ek(os.path.join, tmp['dir'], tmp['name'])}</option>
+                                                <option id="${cur_preset}" ${('', 'selected="selected"')[sickbeard.NAMING_SPORTS_PATTERN == cur_preset]}>${ek(os.path.join, tmp['dir'], tmp['name'])}</option>
                                             % endfor
                                             <option id="${sickbeard.NAMING_SPORTS_PATTERN}" ${('', 'selected="selected"')[bool(is_sports_custom)]}>Custom...</option>
                                         </select>

--- a/gui/slick/views/displayShow.mako
+++ b/gui/slick/views/displayShow.mako
@@ -7,7 +7,7 @@
     from sickbeard import subtitles, sbdatetime, network_timezones
     import sickbeard.helpers
 
-    from sickbeard.common import SKIPPED, WANTED, UNAIRED, ARCHIVED, IGNORED, FAILED
+    from sickbeard.common import SKIPPED, WANTED, UNAIRED, ARCHIVED, IGNORED, FAILED, DOWNLOADED
     from sickbeard.common import Quality, qualityPresets, statusStrings, Overview
     from sickbeard.helpers import anon_url
     from sickrage.helper.common import pretty_file_size
@@ -234,7 +234,7 @@
         % if not sickbeard.USE_FAILED_DOWNLOADS:
         <% availableStatus.remove(FAILED) %>
         % endif
-        % for curStatus in availableStatus + sorted(Quality.DOWNLOADED) + sorted(Quality.ARCHIVED):
+        % for curStatus in availableStatus + Quality.DOWNLOADED + Quality.ARCHIVED:
             % if curStatus not in [DOWNLOADED, ARCHIVED]:
             <option value="${curStatus}">${statusStrings[curStatus]}</option>
             % endif

--- a/gui/slick/views/manage_episodeStatuses.mako
+++ b/gui/slick/views/manage_episodeStatuses.mako
@@ -26,7 +26,7 @@
 <form action="${srRoot}/manage/episodeStatuses" method="get">
 Manage episodes with status <select name="whichStatus" class="form-control form-control-inline input-sm">
 % for curStatus in [common.SKIPPED, common.SNATCHED, common.WANTED, common.IGNORED] + common.Quality.DOWNLOADED + common.Quality.ARCHIVED:
-    %if surStatus not in [common.ARCHIVED, common.DOWNLOADED]:
+    %if curStatus not in [common.ARCHIVED, common.DOWNLOADED]:
         <option value="${curStatus}">${common.statusStrings[curStatus]}</option>
     %endif
 % endfor

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -102,7 +102,7 @@ def get_lookup():
     if mako_cache is None:
         mako_cache = ek(os.path.join, sickbeard.CACHE_DIR, 'mako')
     if mako_lookup is None:
-        mako_lookup = TemplateLookup(directories=[mako_path], module_directory=mako_cache, format_exceptions=True)
+        mako_lookup = TemplateLookup(directories=[mako_path], module_directory=mako_cache, format_exceptions=True, strict_undefined=True)
     return mako_lookup
 
 
@@ -2877,7 +2877,9 @@ class Manage(Home, WebRoot):
         if not status_list:
             return t.render(
                 title="Episode Overview", header="Episode Overview",
-                topmenu="manage", whichStatus=whichStatus, controller="manage", action="episodeStatuses")
+                topmenu="manage", show_names=None, whichStatus=whichStatus,
+                ep_counts=None, sorted_show_ids=None,
+                controller="manage", action="episodeStatuses")
 
         myDB = db.DBConnection()
         status_results = myDB.select(
@@ -2978,6 +2980,7 @@ class Manage(Home, WebRoot):
         if not whichSubs:
             return t.render(whichSubs=whichSubs, title='Episode Overview',
                             header='Episode Overview', topmenu='manage',
+                            show_names=None, ep_counts=None, sorted_show_ids=None,
                             controller="manage", action="subtitleMissed")
 
         myDB = db.DBConnection()


### PR DESCRIPTION
Fix a typo in a mako variable name
Fix a few missed imports and arguments that were not passed
