### PR TITLE
Change all pylint disables to use short-name instead of code

### DIFF
--- a/SickBeard.py
+++ b/SickBeard.py
@@ -20,7 +20,7 @@
 
 # Check needed software dependencies to nudge users to fix their setup
 
-# pylint: disable=W0703
+# pylint: disable=broad-except
 # Catching too general exception
 
 import codecs
@@ -48,7 +48,7 @@ if sys.version_info < (2, 7):
 # https://mail.python.org/pipermail/python-dev/2014-September/136300.html
 if sys.version_info >= (2, 7, 9):
     import ssl
-    # pylint: disable=W0212
+    # pylint: disable=protected-access
     # Access to a protected member of a client class
     ssl._create_default_https_context = ssl._create_unverified_context
 
@@ -80,7 +80,7 @@ signal.signal(signal.SIGTERM, sickbeard.sig_handler)
 
 
 class SickRage(object):
-    # pylint: disable=R0902
+    # pylint: disable=too-many-instance-attributes
     # Too many instance attributes
     def __init__(self):
         # system event callback for shutdown/restart
@@ -135,7 +135,7 @@ class SickRage(object):
 
         return help_msg
 
-    # pylint: disable=R0912,R0915
+    # pylint: disable=too-many-branches,too-many-statements
     # Too many branches
     # Too many statements
     def start(self):
@@ -152,7 +152,7 @@ class SickRage(object):
         except (locale.Error, IOError):
             sickbeard.SYS_ENCODING = 'UTF-8'
 
-        # pylint: disable=E1101
+        # pylint: disable=no-member
         if not sickbeard.SYS_ENCODING or sickbeard.SYS_ENCODING.lower() in ('ansi_x3.4-1968', 'us-ascii', 'ascii', 'charmap') or \
             (sys.platform.startswith('win') and sys.getwindowsversion()[0] >= 6 and str(getattr(sys.stdout, 'device', sys.stdout).encoding).lower() in ('cp65001', 'charmap')):
             sickbeard.SYS_ENCODING = 'UTF-8'
@@ -162,7 +162,7 @@ class SickRage(object):
             reload(sys)
 
         try:
-            # pylint: disable=E1101
+            # pylint: disable=no-member
             # On non-unicode builds this will raise an AttributeError, if encoding type is not valid it throws a LookupError
             sys.setdefaultencoding(sickbeard.SYS_ENCODING)
         except Exception:
@@ -382,7 +382,7 @@ class SickRage(object):
         """
         Fork off as a daemon
         """
-        # pylint: disable=E1101,W0212
+        # pylint: disable=no-member,protected-access
         # An object is accessed for a non-existent member.
         # Access to a protected member of a client class
         # Make a non-session-leader child process
@@ -527,7 +527,7 @@ class SickRage(object):
 
         # system exit
         logger.shutdown()  # Make sure the logger has stopped, just in case
-        # pylint: disable=W0212
+        # pylint: disable=protected-access
         # Access to a protected member of a client class
         os._exit(0)
 

--- a/sickbeard/helpers.py
+++ b/sickbeard/helpers.py
@@ -67,7 +67,7 @@ import json
 
 shutil.copyfile = shutil_custom.copyfile_custom
 
-# pylint: disable=W0212
+# pylint: disable=protected-access
 # Access to a protected member of a client class
 urllib._urlopener = classes.SickBeardURLopener()
 
@@ -859,7 +859,7 @@ def create_https_certificates(ssl_cert, ssl_key):
 
     # Save the key and certificate to disk
     try:
-        # pylint: disable=E1101
+        # pylint: disable=no-member
         # Module has no member
         io.open(ssl_key, 'wb').write(crypto.dump_privatekey(crypto.FILETYPE_PEM, pkey))
         io.open(ssl_cert, 'wb').write(crypto.dump_certificate(crypto.FILETYPE_PEM, cert))
@@ -1420,7 +1420,7 @@ def _setUpSession(session, headers):
     session = CacheControl(sess=session, cache=caches.FileCache(ek(os.path.join, cache_dir, 'sessions'), use_dir_lock=True), cache_etags=False)
 
     # request session clear residual referer
-    # pylint: disable=C0325
+    # pylint: disable=superfluous-parens
     # These extra parens are necessary!
     if 'Referer' in session.headers and 'Referer' not in (headers or {}):
         session.headers.pop('Referer')

--- a/sickbeard/logger.py
+++ b/sickbeard/logger.py
@@ -177,7 +177,7 @@ class Logger(object):
         else:
             sys.exit(1)
 
-    def submit_errors(self): # Too many local variables, too many branches, pylint: disable=R0912,R0914
+    def submit_errors(self): # Too many local variables, too many branches, pylint: disable=too-many-branches,too-many-locals
 
         submitter_result = u''
         issue_id = None
@@ -326,7 +326,7 @@ class Logger(object):
 
         return submitter_result, issue_id
 
-# pylint: disable=R0903
+# pylint: disable=too-few-public-methods
 class Wrapper(object):
     instance = Logger()
 

--- a/sickbeard/metadata/generic.py
+++ b/sickbeard/metadata/generic.py
@@ -231,7 +231,7 @@ class GenericMetadata(object):
     def get_season_all_banner_path(self, show_obj):
         return ek(os.path.join, show_obj.location, self.season_all_banner_name)
 
-    # pylint: disable=W0613,R0201
+    # pylint: disable=unused-argument,no-self-use
     def _show_data(self, show_obj):
         """
         This should be overridden by the implementing class. It should
@@ -239,7 +239,7 @@ class GenericMetadata(object):
         """
         return None
 
-    # pylint: disable=W0613,R0201
+    # pylint: disable=unused-argument,no-self-use
     def _ep_data(self, ep_obj):
         """
         This should be overridden by the implementing class. It should

--- a/sickbeard/network_timezones.py
+++ b/sickbeard/network_timezones.py
@@ -94,7 +94,7 @@ def load_network_dict():
         d = dict(cur_network_list)
     except Exception:
         d = {}
-    # pylint: disable=W0603
+    # pylint: disable=global-statement
     global network_dict
     network_dict = d
 

--- a/sickbeard/notifiers/pushover.py
+++ b/sickbeard/notifiers/pushover.py
@@ -30,8 +30,11 @@ from sickrage.helper.exceptions import ex
 
 API_URL = "https://api.pushover.net/1/messages.json"
 
-# pylint: disable=W0232
+
 class PushoverNotifier(object):
+    def __init__(self):
+        pass
+
     def test_notify(self, userKey=None, apiKey=None):
         return self._notifyPushover("This is a test notification from SickRage", 'Test', userKey=userKey, apiKey=apiKey, force=True)
 

--- a/sickbeard/providers/bitsnoop.py
+++ b/sickbeard/providers/bitsnoop.py
@@ -26,7 +26,7 @@ from sickbeard.providers import generic
 from sickrage.helper.common import try_int
 
 
-class BitSnoopProvider(generic.TorrentProvider): # pylint: disable=R0902,R0913
+class BitSnoopProvider(generic.TorrentProvider): # pylint: disable=too-many-instance-attributes,too-many-arguments
     def __init__(self):
         generic.TorrentProvider.__init__(self, "BitSnoop")
 
@@ -47,7 +47,7 @@ class BitSnoopProvider(generic.TorrentProvider): # pylint: disable=R0902,R0913
 
         self.cache = BitSnoopCache(self)
 
-    def _doSearch(self, search_strings, search_mode='eponly', epcount=0, age=0, epObj=None): # pylint: disable=R0912,R0913,R0914
+    def _doSearch(self, search_strings, search_mode='eponly', epcount=0, age=0, epObj=None): # pylint: disable=too-many-branches,too-many-arguments,too-many-locals
 
         results = []
         items = {'Season': [], 'Episode': [], 'RSS': []}

--- a/sickbeard/providers/generic.py
+++ b/sickbeard/providers/generic.py
@@ -98,7 +98,7 @@ class GenericProvider(object):
     def imageName(self):
         return self.getID() + '.png'
 
-    # pylint: disable=R0201,W0612
+    # pylint: disable=no-self-use,unused-variable
     # Method could be a function, Unused variable
     def _checkAuth(self):
         return True
@@ -219,7 +219,7 @@ class GenericProvider(object):
             try:
                 parser = createParser(file_name)
                 if parser:
-                    # pylint: disable=W0212
+                    # pylint: disable=protected-access
                     # Access to a protected member of a client class
                     mime_type = parser._getMimeType()
                     try:
@@ -251,8 +251,7 @@ class GenericProvider(object):
         quality = Quality.sceneQuality(title, anime)
         return quality
 
-    # pylint: disable=R0201,W0613
-    # Method could be a function, Unused argument
+    # pylint: disable=no-self-use,unused-argument
     def _doSearch(self, search_params, search_mode='eponly', epcount=0, age=0, epObj=None):
         return []
 
@@ -447,7 +446,7 @@ class GenericProvider(object):
             # add parsed result to cache for usage later on
             if addCacheEntry:
                 logger.log(u"Adding item from search to cache: " + title, logger.DEBUG)
-                # pylint: disable=W0212
+                # pylint: disable=protected-access
                 # Access to a protected member of a client class
                 ci = self.cache._addCacheEntry(title, url, parse_result=parse_result)
                 if ci is not None:
@@ -504,7 +503,7 @@ class GenericProvider(object):
 
         # check if we have items to add to cache
         if len(cl) > 0:
-            # pylint: disable=W0212
+            # pylint: disable=protected-access
             # Access to a protected member of a client class
             myDB = self.cache._getDB()
             myDB.mass_action(cl)

--- a/sickbeard/providers/newznab.py
+++ b/sickbeard/providers/newznab.py
@@ -19,7 +19,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with SickRage.  If not, see <http://www.gnu.org/licenses/>.
-# pylint: disable=R0902,R0913
+# pylint: disable=too-many-instance-attributes,too-many-arguments
 
 import os
 import re
@@ -234,7 +234,7 @@ class NewznabProvider(generic.NZBProvider):
 
         return False
 
-    def _doSearch(self, search_params, search_mode='eponly', epcount=0, age=0, epObj=None): # pylint: disable=R0913,R0914
+    def _doSearch(self, search_params, search_mode='eponly', epcount=0, age=0, epObj=None): # pylint: disable=too-many-arguments,too-many-locals
         """
         Searches indexer using the params in search_params, either for latest releases, or a string/id search
         Returns: list of results in dict form

--- a/sickbeard/providers/rsstorrent.py
+++ b/sickbeard/providers/rsstorrent.py
@@ -101,7 +101,7 @@ class TorrentRssProvider(generic.TorrentProvider):
                 if not cookie_validator.match(self.cookies):
                     return (False, 'Cookie is not correctly formatted: ' + self.cookies)
 
-            # pylint: disable=W0212
+            # pylint: disable=protected-access
             # Access to a protected member of a client class
             data = self.cache._getRSSData()['entries']
             if not data:

--- a/sickbeard/subtitles.py
+++ b/sickbeard/subtitles.py
@@ -58,7 +58,7 @@ ENTRY_POINTS = {
     ]
 }
 
-# pylint: disable=W0212
+# pylint: disable=protected-access
 # Access to a protected member of a client class
 DISTRIBUTION._ep_map = pkg_resources.EntryPoint.parse_map(ENTRY_POINTS, DISTRIBUTION)
 pkg_resources.working_set.add(DISTRIBUTION)
@@ -310,7 +310,7 @@ class SubtitlesFinder(object):
         self.amActive = False
 
     @staticmethod
-    def subtitles_download_in_pp():  # pylint: disable=R0914
+    def subtitles_download_in_pp():  # pylint: disable=too-many-locals
         logger.log(u'Checking for needed subtitles in Post-Process folder', logger.INFO)
 
         providers = enabled_service_list()

--- a/sickbeard/webapi.py
+++ b/sickbeard/webapi.py
@@ -19,8 +19,8 @@
 # along with SickRage.  If not, see <http://www.gnu.org/licenses/>.
 
 # TODO: break this up into separate files
-# pylint: disable=C0301,C0302
-# pylint: disable=E1101,E0202,C0111,C0103
+# pylint: disable=line-too-long,too-many-lines,abstract-method
+# pylint: disable=no-member,method-hidden,missing-docstring,invalid-name
 
 import io
 import os
@@ -68,10 +68,10 @@ from sickbeard.common import statusStrings
 try:
     import json
 except ImportError:
-    # pylint: disable=F0401
+    # pylint: disable=import-error
     import simplejson as json
 
-# pylint: disable=F0401
+# pylint: disable=import-error
 from tornado.web import RequestHandler
 
 indexer_ids = ["indexerid", "tvdbid"]
@@ -1708,7 +1708,7 @@ class CMD_SickBeardSearchTVRAGE(CMD_SickBeardSearchIndexers):
 
     def __init__(self, args, kwargs):
         # Leave this one as APICall so it doesnt try and search anything
-        # pylint: disable=W0233,W0231
+        # pylint: disable=non-parent-init-called,super-init-not-called
         ApiCall.__init__(self, args, kwargs)
 
     def run(self):

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -16,6 +16,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with SickRage.  If not, see <http://www.gnu.org/licenses/>.
+# pylint: disable=abstract-method,too-many-lines
 
 import io
 import os
@@ -94,9 +95,9 @@ mako_path = None
 
 
 def get_lookup():
-    global mako_lookup  # pylint: disable=W0603
-    global mako_cache  # pylint: disable=W0603
-    global mako_path  # pylint: disable=W0603
+    global mako_lookup  # pylint: disable=global-statement
+    global mako_cache  # pylint: disable=global-statement
+    global mako_path  # pylint: disable=global-statement
 
     if mako_path is None:
         mako_path = ek(os.path.join, sickbeard.PROG_DIR, "gui/" + sickbeard.GUI_NAME + "/views/")
@@ -843,12 +844,12 @@ class Home(WebRoot):
 
     @staticmethod
     def twitterStep1():
-        return notifiers.twitter_notifier._get_authorization()
+        return notifiers.twitter_notifier._get_authorization()  # pylint: disable=protected-access
 
     @staticmethod
     def twitterStep2(key):
 
-        result = notifiers.twitter_notifier._get_credentials(key)
+        result = notifiers.twitter_notifier._get_credentials(key)  # pylint: disable=protected-access
         logger.log(u"result: " + str(result))
         if result:
             return "Key verification successful"
@@ -1010,7 +1011,7 @@ class Home(WebRoot):
                 else:
                     NotifyList = dict(ast.literal_eval(r['notify_list']))
 
-            data[r['show_id']] = {'id': r['show_id'],'name': r['show_name'],
+            data[r['show_id']] = {'id': r['show_id'], 'name': r['show_name'],
                                   'list': NotifyList['emails'],
                                   'prowl_notify_list': NotifyList['prowlAPIs']
                                  }
@@ -1026,19 +1027,19 @@ class Home(WebRoot):
 
         # Get current data
         for subs in myDB.select("SELECT notify_list FROM tv_shows WHERE show_id = ?", [show]):
-            if (subs['notify_list'] and len(subs['notify_list']) > 0):
+            if subs['notify_list'] and len(subs['notify_list']) > 0:
                 # First, handle legacy format (emails only)
                 if not subs['notify_list'][0] == '{':
                     entries['emails'] = subs['notify_list']
                 else:
                     entries = dict(ast.literal_eval(subs['notify_list']))
 
-        if (emails is not None):
+        if emails is not None:
             entries['emails'] = emails
             if not myDB.action("UPDATE tv_shows SET notify_list = ? WHERE show_id = ?", [str(entries), show]):
                 return 'ERROR'
 
-        if (prowlAPIs is not None):
+        if prowlAPIs is not None:
             entries['prowlAPIs'] = prowlAPIs
             if not myDB.action("UPDATE tv_shows SET notify_list = ? WHERE show_id = ?", [str(entries), show]):
                 return 'ERROR'
@@ -1105,8 +1106,9 @@ class Home(WebRoot):
                 rootDir[subject] = helpers.getDiskSpaceUsage(subject)
 
         t = PageTemplate(rh=self, filename="status.mako")
-        return t.render(title='Status', header='Status', topmenu='system', tvdirFree=tvdirFree, rootDir=rootDir,
-                controller="home", action="status")
+        return t.render(title='Status', header='Status', topmenu='system',
+                        tvdirFree=tvdirFree, rootDir=rootDir,
+                        controller="home", action="status")
 
     def shutdown(self, pid=None):
         if not Shutdown.stop(pid):
@@ -1140,7 +1142,7 @@ class Home(WebRoot):
             return self.redirect('/home/')
 
         checkversion = CheckVersion()
-        backup = checkversion.updater and checkversion._runbackup()
+        backup = checkversion.updater and checkversion._runbackup()  # pylint: disable=protected-access
 
         if backup is True:
             if branch:
@@ -1214,7 +1216,7 @@ class Home(WebRoot):
         try:
             showLoc = (showObj.location, True)
         except ShowDirectoryNotFoundException:
-            showLoc = (showObj._location, False)
+            showLoc = (showObj._location, False)  # pylint: disable=protected-access
 
         show_message = ''
 
@@ -1496,8 +1498,8 @@ class Home(WebRoot):
 
             location = location.decode('UTF-8')
             # if we change location clear the db of episodes, change it, write to db, and rescan
-            if ek(os.path.normpath, showObj._location) != ek(os.path.normpath, location):
-                logger.log(ek(os.path.normpath, showObj._location) + " != " + ek(os.path.normpath, location), logger.DEBUG)
+            if ek(os.path.normpath, showObj._location) != ek(os.path.normpath, location):  # pylint: disable=protected-access
+                logger.log(ek(os.path.normpath, showObj._location) + " != " + ek(os.path.normpath, location), logger.DEBUG)  # pylint: disable=protected-access
                 if not ek(os.path.isdir, location) and not sickbeard.CREATE_MISSING_SHOW_DIRS:
                     errors.append("New location <tt>%s</tt> does not exist" % location)
 
@@ -2220,7 +2222,7 @@ class HomePostProcess(Home):
         return t.render(title='Post Processing', header='Post Processing', topmenu='home', controller="home", action="postProcess")
 
     # TODO: PR to NZBtoMedia so that we can rename dir to proc_dir, and type to proc_type. Using names of builtins as var names is bad
-    # pylint: disable=W0622
+    # pylint: disable=redefined-builtin
     def processEpisode(self, dir=None, nzbName=None, jobName=None, quiet=None, process_method=None, force=None,
                        is_priority=None, delete_on="0", failed="0", type="auto", *args, **kwargs):
 
@@ -2459,8 +2461,9 @@ class HomeAddShows(Home):
         posts them to addNewShow
         """
         t = PageTemplate(rh=self, filename="addShows_recommendedShows.mako")
-        return t.render(title="Recommended Shows", header="Recommended Shows", enable_anime_options=False,
-                controller="addShows", action="recommendedShows")
+        return t.render(title="Recommended Shows", header="Recommended Shows",
+                        enable_anime_options=False,
+                        controller="addShows", action="recommendedShows")
 
     def getRecommendedShows(self):
         t = PageTemplate(rh=self, filename="trendingShows.mako")
@@ -2510,8 +2513,9 @@ class HomeAddShows(Home):
         posts them to addNewShow
         """
         t = PageTemplate(rh=self, filename="addShows_trendingShows.mako")
-        return t.render(title="Trending Shows", header="Trending Shows", enable_anime_options=False,
-                controller="addShows", action="trendingShows")
+        return t.render(title="Trending Shows", header="Trending Shows",
+                        enable_anime_options=False,
+                        controller="addShows", action="trendingShows")
 
     def getTrendingShows(self):
         """
@@ -2572,8 +2576,10 @@ class HomeAddShows(Home):
             # print traceback.format_exc()
             popular_shows = None
 
-        return t.render(title="Popular Shows", header="Popular Shows", popular_shows=popular_shows, imdb_exception=e, topmenu="home",
-                controller="addShows", action="popularShows")
+        return t.render(title="Popular Shows", header="Popular Shows",
+                        popular_shows=popular_shows, imdb_exception=e,
+                        topmenu="home",
+                        controller="addShows", action="popularShows")
 
     def addShowToBlacklist(self, indexer_id):
         # URL parameters
@@ -2590,8 +2596,9 @@ class HomeAddShows(Home):
         Prints out the page to add existing shows from a root dir
         """
         t = PageTemplate(rh=self, filename="addShows_addExistingShow.mako")
-        return t.render(enable_anime_options=False, title='Existing Show', header='Existing Show', topmenu="home",
-                controller="addShows", action="addExistingShow")
+        return t.render(enable_anime_options=False, title='Existing Show',
+                        header='Existing Show', topmenu="home",
+                        controller="addShows", action="addExistingShow")
 
     def addShowByID(self, indexer_id, showName, indexer="TVDB"):
 
@@ -3147,7 +3154,7 @@ class Manage(Home, WebRoot):
 
         for curShow in showList:
 
-            cur_root_dir = ek(os.path.dirname, curShow._location)
+            cur_root_dir = ek(os.path.dirname, curShow._location)  # pylint: disable=protected-access
             if cur_root_dir not in root_dir_list:
                 root_dir_list.append(cur_root_dir)
 
@@ -3252,14 +3259,14 @@ class Manage(Home, WebRoot):
             if not showObj:
                 continue
 
-            cur_root_dir = ek(os.path.dirname, showObj._location)
-            cur_show_dir = ek(os.path.basename, showObj._location)
+            cur_root_dir = ek(os.path.dirname, showObj._location)  # pylint: disable=protected-access
+            cur_show_dir = ek(os.path.basename, showObj._location)  # pylint: disable=protected-access
             if cur_root_dir in dir_map and cur_root_dir != dir_map[cur_root_dir]:
                 new_show_dir = ek(os.path.join, dir_map[cur_root_dir], cur_show_dir)
                 logger.log(
-                    u"For show " + showObj.name + " changing dir from " + showObj._location + " to " + new_show_dir)
+                    u"For show " + showObj.name + " changing dir from " + showObj._location + " to " + new_show_dir)  # pylint: disable=protected-access
             else:
-                new_show_dir = showObj._location
+                new_show_dir = showObj._location  # pylint: disable=protected-access
 
             if archive_firstmatch == 'keep':
                 new_archive_firstmatch = showObj.archive_firstmatch
@@ -3507,8 +3514,10 @@ class Manage(Home, WebRoot):
 
         t = PageTemplate(rh=self, filename="manage_failedDownloads.mako")
 
-        return t.render(limit=limit, failedResults=sqlResults, title='Failed Downloads', header='Failed Downloads', topmenu='manage',
-                controller="manage", action="failedDownloads")
+        return t.render(limit=limit, failedResults=sqlResults,
+                        title='Failed Downloads', header='Failed Downloads',
+                        topmenu='manage', controller="manage",
+                        action="failedDownloads")
 
 
 @route('/manage/manageSearches(/?.*)')
@@ -3636,8 +3645,9 @@ class History(WebRoot):
             {'title': 'Trim History', 'path': 'history/trimHistory', 'icon': 'ui-icon ui-icon-trash', 'class': 'trimhistory', 'confirm': True},
         ]
 
-        return t.render(historyResults=data, compactResults=compact, limit=limit, submenu=submenu, title='History', header='History', topmenu="history",
-                controller="history", action="index")
+        return t.render(historyResults=data, compactResults=compact, limit=limit,
+                        submenu=submenu, title='History', header='History',
+                        topmenu="history", controller="history", action="index")
 
     def clearHistory(self):
         self.history.clear()
@@ -3714,7 +3724,7 @@ class ConfigGeneral(Config):
         else:
             bestQualities = []
 
-        newQuality = Quality.combineQualities(map(int, anyQualities), map(int, bestQualities))
+        newQuality = Quality.combineQualities([int(quality) for quality in anyQualities], [int(quality) for quality in bestQualities])
 
         sickbeard.STATUS_DEFAULT = int(defaultStatus)
         sickbeard.STATUS_DEFAULT_AFTER = int(defaultStatusAfter)
@@ -4022,8 +4032,9 @@ class ConfigPostProcessing(Config):
     def index(self):
         t = PageTemplate(rh=self, filename="config_postProcessing.mako")
 
-        return t.render(submenu=self.ConfigMenu(), title='Config - Post Processing', header='Post Processing', topmenu='config',
-                controller="config", action="postProcessing")
+        return t.render(submenu=self.ConfigMenu(), title='Config - Post Processing',
+                        header='Post Processing', topmenu='config',
+                        controller="config", action="postProcessing")
 
     def savePostProcessing(self, naming_pattern=None, naming_multi_ep=None,
                            kodi_data=None, kodi_12plus_data=None,
@@ -4590,7 +4601,7 @@ class ConfigProviders(Config):
                 try:
                     curTorrentProvider.onlyspasearch = config.checkbox_to_value(
                         kwargs[curTorrentProvider.getID() + '_onlyspasearch'])
-                except:
+                except Exception:
                     curTorrentProvider.onlyspasearch = 0
 
             if hasattr(curTorrentProvider, 'sorting'):
@@ -4712,8 +4723,9 @@ class ConfigNotifications(Config):
     def index(self):
         t = PageTemplate(rh=self, filename="config_notifications.mako")
 
-        return t.render(submenu=self.ConfigMenu(), title='Config - Notifications', header='Notifications', topmenu='config',
-                controller="config", action="notifications")
+        return t.render(submenu=self.ConfigMenu(), title='Config - Notifications',
+                        header='Notifications', topmenu='config',
+                        controller="config", action="notifications")
 
     def saveNotifications(self, use_kodi=None, kodi_always_on=None, kodi_notify_onsnatch=None,
                           kodi_notify_ondownload=None,

--- a/sickrage/helper/common.py
+++ b/sickrage/helper/common.py
@@ -187,8 +187,7 @@ def remove_extension(filename):
     """
 
     if isinstance(filename, (str, unicode)) and '.' in filename:
-        # pylint: disable=W0612
-        basename, separator, extension = filename.rpartition('.')  # @UnusedVariable
+        basename, _, extension = filename.rpartition('.')
 
         if basename and extension.lower() in ['nzb', 'torrent'] + media_extensions:
             return basename
@@ -205,8 +204,7 @@ def replace_extension(filename, new_extension):
     """
 
     if isinstance(filename, (str, unicode)) and '.' in filename:
-        # pylint: disable=W0612
-        basename, separator, extension = filename.rpartition('.')  # @UnusedVariable
+        basename, _, _ = filename.rpartition('.')
 
         if basename:
             return '%s.%s' % (basename, new_extension)

--- a/tests/test_lib.py
+++ b/tests/test_lib.py
@@ -18,8 +18,7 @@
 # You should have received a copy of the GNU General Public License
 # along with SickRage.  If not, see <http://www.gnu.org/licenses/>.
 
-# pylint: disable=C0301
-# Line too long
+# pylint: disable=line-too-long
 
 """
 Create a test database for testing.
@@ -55,9 +54,7 @@ from sickbeard.tv import TVEpisode
 import shutil_custom  # pylint: disable=import-error
 import sickbeard
 
-# pylint: disable=F0401
-# Unable to import
-
+# pylint: disable=import-error
 
 shutil.copyfile = shutil_custom.copyfile_custom
 
@@ -134,8 +131,7 @@ create_test_log_folder()
 sickbeard.CACHE_DIR = os.path.join(TEST_DIR, 'cache')
 create_test_cache_folder()
 
-# pylint: disable=E1103
-# Has no member
+# pylint: disable=no-member
 sickbeard.logger.initLogging(False, True)
 
 
@@ -164,7 +160,7 @@ def _fake_specify_ep(self, season, episode):
     :param episode: Episode to search for  ...not used
     """
     _ = self, season, episode  # throw away unused variables
-    pass
+
 
 # the real one tries to contact TVDB just stop it from getting more info on the ep
 TVEpisode.specifyEpisode = _fake_specify_ep
@@ -208,8 +204,7 @@ class TestCacheDBConnection(TestDBConnection, object):
     Test connecting to the cache database.
     """
     def __init__(self, provider_name):
-        # pylint: disable=W0233
-        # Init method from non-direct base class
+        # pylint: disable=non-parent-init-called
         db.DBConnection.__init__(self, os.path.join(TEST_DIR, TEST_CACHE_DB_NAME))
 
         # Create the table if it's not already there
@@ -218,7 +213,7 @@ class TestCacheDBConnection(TestDBConnection, object):
                 sql = "CREATE TABLE [" + provider_name + "] (name TEXT, season NUMERIC, episodes TEXT, indexerid NUMERIC, url TEXT, time NUMERIC, quality TEXT, release_group TEXT)"
                 self.connection.execute(sql)
                 self.connection.commit()
-        # pylint: disable=W0703
+        # pylint: disable=broad-except
         # Catching too general exception
         except Exception as error:
             if str(error) != "table [" + provider_name + "] already exists":
@@ -233,7 +228,7 @@ class TestCacheDBConnection(TestDBConnection, object):
             sql = "CREATE TABLE lastUpdate (provider TEXT, time NUMERIC);"
             self.connection.execute(sql)
             self.connection.commit()
-        # pylint: disable=W0703
+        # pylint: disable=broad-except
         # Catching too general exception
         except Exception as error:
             if str(error) != "table lastUpdate already exists":
@@ -295,7 +290,7 @@ def setup_test_episode_file():
         with open(FILE_PATH, 'wb') as ep_file:
             ep_file.write("foo bar")
             ep_file.flush()
-    # pylint: disable=W0703
+    # pylint: disable=broad-except
     # Catching too general exception
     except Exception:
         print "Unable to set up test episode"


### PR DESCRIPTION
To find the short-name of an error us `pylint --help-msg=<code>`
Some linting in webserve and webapi
