### PR TITLE
Update speedcd to point to new login location

### DIFF
--- a/sickbeard/providers/speedcd.py
+++ b/sickbeard/providers/speedcd.py
@@ -38,7 +38,7 @@ class SpeedCDProvider(generic.TorrentProvider):
         self.minleech = None
 
         self.urls = {'base_url': 'http://speed.cd/',
-                     'login': 'http://speed.cd/take_login.php',
+                     'login': 'http://speed.cd/take.login.php',
                      'detail': 'http://speed.cd/t/%s',
                      'search': 'http://speed.cd/V3/API/API.php',
                      'download': 'http://speed.cd/download.php?torrent=%s'}


### PR DESCRIPTION
This fixes the issue for speed.cd that I referenced in the comments of SickRage/sickrage-issues#119

It doesn't however fix the TorrentDay issue that was originally referenced.
