### PR TITLE
Add non-group names to remove list

### DIFF
--- a/sickbeard/helpers.py
+++ b/sickbeard/helpers.py
@@ -127,6 +127,8 @@ def remove_non_release_groups(name):
         r'\.Renc$':          'searchre',
         r'-NZBGEEK$':        'searchre',
         r'-Siklopentan$':    'searchre',
+        r'-Chamele0n$':      'searchre',
+        r'-Obfuscated$':     'searchre',
         r'-\[SpastikusTV\]$':                 'searchre',
         r'-RP$':                             'searchre',
         r'-20-40$':                          'searchre',


### PR DESCRIPTION
Add two non-group names to the remove list as they have become quite common on Usenet releases.
