### PR TITLE
Changed move associated files to delete associated files, adds possib…

### DIFF
--- a/gui/slick/views/config_postProcessing.mako
+++ b/gui/slick/views/config_postProcessing.mako
@@ -41,7 +41,7 @@
                             </label>
                             <label class="nocheck" for="process_automatically">
                                 <span class="component-title">&nbsp;</span>
-                                <span class="component-desc"><b>NOTE:</b> Do not use if you use an external PostProcessing script</span>
+                                <span class="component-desc"><b>NOTE:</b> Do not use if you use an external Post Processing script</span>
                             </label>
                         </div>
                         <div class="field-pair">
@@ -138,18 +138,18 @@
                         <div class="field-pair">
                             <input type="checkbox" name="move_associated_files" id="move_associated_files" ${('', 'checked="checked"')[bool(sickbeard.MOVE_ASSOCIATED_FILES)]}/>
                             <label for="move_associated_files">
-                                <span class="component-title">Move Associated Files</span>
-                                <span class="component-desc">Move srr/sfv/etc files with the episode when processed?</span>
+                                <span class="component-title">Delete associated files</span>
+                                <span class="component-desc">Delete srt/srr/sfv/etc files while post processing?</span>
                             </label>
                         </div>
                         <div class="field-pair">
                             <label class="nocheck">
-                                <span class="component-title">Allowed associated file extensions</span>
+                                <span class="component-title">Keep associated file extensions</span>
                                 <input type="text" name="allowed_extensions" id="allowed_extensions" value="${sickbeard.ALLOWED_EXTENSIONS}" class="form-control input-sm input350" autocapitalize="off" />
                             </label>
                             <label class="nocheck">
                                 <span class="component-title">&nbsp;</span>
-                                <span class="component-desc">Comma seperated list of associated file extensions SickRage should move while Post Processing. Leaving it empty means all extensions will be allowed</span>
+                                <span class="component-desc">Comma seperated list of associated file extensions SickRage should keep while post processing. Leaving it empty means all associated files will be deleted</span>
                             </label>
                         </div>
                         <div class="field-pair">

--- a/sickbeard/__init__.py
+++ b/sickbeard/__init__.py
@@ -283,7 +283,7 @@ NFO_RENAME = True
 TV_DOWNLOAD_DIR = None
 UNPACK = False
 SKIP_REMOVED_FILES = False
-ALLOWED_EXTENSIONS = "nfo,srr,sfv"
+ALLOWED_EXTENSIONS = "srt,nfo,srr,sfv"
 
 NZBS = False
 NZBS_UID = None

--- a/sickbeard/postProcessor.py
+++ b/sickbeard/postProcessor.py
@@ -186,13 +186,18 @@ class PostProcessor(object):
         if not base_name:
             return []
 
-        if subfolders: # subfolders are only checked in show folder, so names will always be exactly alike
-            filelist = recursive_glob(ek(os.path.dirname, globbable_file_path), base_name + '*') # just create the list of all files starting with the basename
-        else: # this is called when PP, so we need to do the filename check case-insensitive
+        # subfolders are only checked in show folder, so names will always be exactly alike
+        if subfolders:
+            # just create the list of all files starting with the basename
+            filelist = recursive_glob(ek(os.path.dirname, globbable_file_path), base_name + '*')
+        # this is called when PP, so we need to do the filename check case-insensitive
+        else:
             filelist = []
 
-            checklist = glob.glob(ek(os.path.join, ek(os.path.dirname, globbable_file_path), '*')) # get a list of all the files in the folder
-            for filefound in checklist: # loop through all the files in the folder, and check if they are the same name even when the cases don't match
+            # get a list of all the files in the folder
+            checklist = glob.glob(ek(os.path.join, ek(os.path.dirname, globbable_file_path), '*'))
+            # loop through all the files in the folder, and check if they are the same name even when the cases don't match
+            for filefound in checklist:
 
                 file_name = filefound.rpartition('.')[0]
                 file_extension = filefound.rpartition('.')[2]
@@ -214,26 +219,27 @@ class PostProcessor(object):
                         filelist.append(filefound)
                     elif file_name.lower().endswith('pt-br') and len(filefound.rsplit('.', 2)[1]) == 5:
                         filelist.append(filefound)
-                elif new_file_name.lower() == base_name.lower().replace('[[]', '[').replace('[]]', ']'): # if there's no difference in the filename add it to the filelist
+                # if there's no difference in the filename add it to the filelist
+                elif new_file_name.lower() == base_name.lower().replace('[[]', '[').replace('[]]', ']'):
                     filelist.append(filefound)
 
         for associated_file_path in filelist:
-            # only add associated to list
+            # Exclude the video file we are post-processing
             if associated_file_path == file_path:
                 continue
 
-            # only list it if the only non-shared part is the extension or if it is a subtitle
-            if subtitles_only and not associated_file_path[len(associated_file_path) - 3:] in subtitle_extensions:
-                continue
+            # Exlude non-subtitle files with the 'only subtitles' option (not implemented yet)
+            # if subtitles_only and not associated_file_path[-3:] in subtitle_extensions:
+            #     continue
 
             # Exclude .rar files from associated list
             if re.search(r'(^.+\.(rar|r\d+)$)', associated_file_path):
                 continue
 
             # Add the extensions that the user doesn't allow to the 'extensions_to_delete' list
-            if sickbeard.MOVE_ASSOCIATED_FILES and sickbeard.ALLOWED_EXTENSIONS:
+            if sickbeard.MOVE_ASSOCIATED_FILES:
                 allowed_extensions = sickbeard.ALLOWED_EXTENSIONS.split(",")
-                if not associated_file_path[-3:] in allowed_extensions and not associated_file_path[-3:] in subtitle_extensions:
+                if not associated_file_path[-3:] in allowed_extensions:
                     if ek(os.path.isfile, associated_file_path):
                         extensions_to_delete.append(associated_file_path)
 
@@ -413,7 +419,6 @@ class PostProcessor(object):
 
         self._combined_file_operation(file_path, new_path, new_base_name, associated_files, action=_int_copy,
                                       subtitles=subtitles)
-
 
     def _hardlink(self, file_path, new_path, new_base_name, associated_files=False, subtitles=False):
         """
@@ -789,7 +794,7 @@ class PostProcessor(object):
                 return ep_quality
 
         # Try getting quality from the episode (snatched) status
-        if ep_obj.status in common.Quality.SNATCHED + common.Quality.SNATCHED_PROPER  + common.Quality.SNATCHED_BEST:
+        if ep_obj.status in common.Quality.SNATCHED + common.Quality.SNATCHED_PROPER + common.Quality.SNATCHED_BEST:
             _, ep_quality = common.Quality.splitCompositeStatus(ep_obj.status)  # @UnusedVariable
             if ep_quality != common.Quality.UNKNOWN:
                 self._log(
@@ -987,7 +992,6 @@ class PostProcessor(object):
                 return False
         else:
             self._log("Unable to determine needed filespace as the source file is locked for access")
-
 
         # delete the existing file (and company)
         for cur_ep in [ep_obj] + ep_obj.relatedEps:


### PR DESCRIPTION
…ilty to discard srt files.

_What is this change about?_
SickRage's default behavior is to move all associated files. That's why the option "move associated files" didn't really make any sense, since it would already do it by default.
Now the option is called "delete associated files". It allows, in combination with the "Keep associated file extensions" option, to let the users actually choose which associated files to keep. E.g. by adding "srt,nfo" to the input field, srt and nfo files will be moved during post-processing. The empty input field would mean that all associated files should be deleted. This also adds the ability to move only the video file, which previously wasn't possible (subtitles were always moved). 
