### PR TITLE
Update showUpdater to use theTVDB update files

### DIFF
--- a/sickbeard/showUpdater.py
+++ b/sickbeard/showUpdater.py
@@ -16,6 +16,9 @@
 # You should have received a copy of the GNU General Public License
 # along with SickRage.  If not, see <http://www.gnu.org/licenses/>.
 
+import xml.etree.ElementTree as ET
+import requests
+import time
 import datetime
 import threading
 import sickbeard
@@ -25,20 +28,34 @@ from sickbeard import ui
 from sickbeard import db
 from sickbeard import network_timezones
 from sickbeard import failed_history
+from sickbeard import helpers
 from sickrage.helper.exceptions import CantRefreshShowException, CantUpdateShowException, ex
-
+from sickbeard.indexers.indexer_config import INDEXER_TVRAGE
+from sickbeard.indexers.indexer_config import INDEXER_TVDB
 
 class ShowUpdater:
     def __init__(self):
         self.lock = threading.Lock()
         self.amActive = False
 
-    def run(self, force=False):
+        self.session = requests.Session()
+
+    def run(self):
 
         self.amActive = True
 
+        bad_indexer = [INDEXER_TVRAGE]
         update_datetime = datetime.datetime.now()
         update_date = update_datetime.date()
+
+        # update_timestamp = calendar.timegm(update_datetime.timetuple())
+        update_timestamp = time.mktime(update_datetime.timetuple())
+        my_db = db.DBConnection('cache.db')
+        result = my_db.select("SELECT `time` FROM lastUpdate WHERE provider = 'theTVDB'")
+        if result:
+            last_update = int(result[0]['time'])
+        else:
+            my_db.action("INSERT INTO lastUpdate (provider,`time`) VALUES (?, ?)", ['theTVDB', update_timestamp - 86400])
 
         # refresh network timezones
         network_timezones.update_network_dict()
@@ -47,45 +64,63 @@ class ShowUpdater:
         if sickbeard.USE_FAILED_DOWNLOADS:
             failed_history.trimHistory()
 
+        update_delta = update_timestamp - last_update
+
+        if update_delta >= 691200:      # 8 days ( 7 days + 1 day of buffer time)
+            update_file = 'updates_month.xml'
+        elif update_delta >= 90000:     # 25 hours ( 1 day + 1 hour of buffer time)
+            update_file = 'updates_week.xml'
+        else:
+            update_file = 'updates_day.xml'
+
+        # url = 'http://thetvdb.com/api/Updates.php?type=series&time=%s' % last_update
+        url = 'http://thetvdb.com/api/%s/updates/%s' % (sickbeard.indexerApi(INDEXER_TVDB).api_params['apikey'], update_file)
+        data = helpers.getURL(url, session=self.session)
+
+        updated_shows = []
+        try:
+            tree = ET.fromstring(data)
+            for show in tree.findall("Series"):
+                updated_shows.append(int(show.find('id').text))
+
+        except SyntaxError:
+            pass
+
         logger.log(u"Doing full update on all shows")
 
-        # select 10 'Ended' tv_shows updated more than 90 days ago to include in this update
-        stale_should_update = []
-        stale_update_date = (update_date - datetime.timedelta(days=90)).toordinal()
+        pi_list = []
+        for cur_show in sickbeard.showList:
 
-        # last_update_date <= 90 days, sorted ASC because dates are ordinal
-        myDB = db.DBConnection()
-        sql_result = myDB.select(
-            "SELECT indexer_id FROM tv_shows WHERE status = 'Ended' AND last_update_indexer <= ? ORDER BY last_update_indexer ASC LIMIT 10;",
-            [stale_update_date])
-
-        for cur_result in sql_result:
-            stale_should_update.append(int(cur_result['indexer_id']))
-
-        # start update process
-        piList = []
-        for curShow in sickbeard.showList:
+            if cur_show.indexer in bad_indexer:
+                logger.log(u"Indexer is no longer available for show [ %s ] " % cur_show.name, logger.WARNING)
+            else:
+                indexer_name = sickbeard.indexerApi(cur_show.indexer).name
 
             try:
-                # get next episode airdate
-                curShow.nextEpisode()
-
-                # if should_update returns True (not 'Ended') or show is selected stale 'Ended' then update, otherwise just refresh
-                if curShow.should_update(update_date=update_date) or curShow.indexerid in stale_should_update:
-                    try:
-                        piList.append(sickbeard.showQueueScheduler.action.updateShow(curShow, True))  # @UndefinedVariable
-                    except CantUpdateShowException as e:
-                        logger.log(u"Unable to update show: {0}".format(str(e)),logger.DEBUG)
+                if indexer_name == 'theTVDB':
+                    if cur_show.indexerid in updated_shows:
+                        pi_list.append(sickbeard.showQueueScheduler.action.updateShow(cur_show, True))
+                    # else:
+                    #     pi_list.append(sickbeard.showQueueScheduler.action.refreshShow(cur_show, True))
                 else:
-                    logger.log(
-                        u"Not updating episodes for show " + curShow.name + " because it's marked as ended and last/next episode is not within the grace period.",
-                        logger.DEBUG)
-                    piList.append(sickbeard.showQueueScheduler.action.refreshShow(curShow, True))  # @UndefinedVariable
+                    cur_show.nextEpisode()
 
+                    if cur_show.should_update(update_date=update_date):
+                        try:
+                            pi_list.append(sickbeard.showQueueScheduler.action.updateShow(cur_show, True))
+                        except CantUpdateShowException as e:
+                            logger.log(u"Unable to update show: {0}".format(str(e)), logger.DEBUG)
+                    else:
+                        logger.log(
+                            u"Not updating episodes for show " + cur_show.name + " because it's last/next episode is not within the grace period.",
+                            logger.DEBUG)
+                        # pi_list.append(sickbeard.showQueueScheduler.action.refreshShow(cur_show, True))
             except (CantUpdateShowException, CantRefreshShowException), e:
                 logger.log(u"Automatic update failed: " + ex(e), logger.ERROR)
 
-        ui.ProgressIndicators.setIndicator('dailyUpdate', ui.QueueProgressIndicator("Daily Update", piList))
+        ui.ProgressIndicators.setIndicator('dailyUpdate', ui.QueueProgressIndicator("Daily Update", pi_list))
+
+        my_db.action("UPDATE lastUpdate SET `time` = ? WHERE provider=?", [update_timestamp, 'theTVDB'])
 
         logger.log(u"Completed full update on all shows")
 


### PR DESCRIPTION
- Stores last_update time in cache.db lastUpdate table
- If value is not there it inserts it with a value of current time -
  86400 seconds
- Compares update time to last update time to select which update XML
  file to call from the TVDB
  - Less than 25 hours will pull the updates_day.xml
  - Over 25 hours but less than 8 days will pull the updates_week.xml
  - Anything over 8 days will pull the update_month.xml
- Basic support for multiple indexers is in place
- Array for bad indexers (aka tvRage) included to post warning messages
  in the log for shows when an indexer is removed
- Will update any show regardless of status (Ended / Continuing)
