### PR TITLE
Fix subs download button not showing for subs without language

### DIFF
--- a/gui/slick/views/displayShow.mako
+++ b/gui/slick/views/displayShow.mako
@@ -519,7 +519,7 @@
                         <a class="epSearch" id="${str(show.indexerid)}x${str(epResult["season"])}x${str(epResult["episode"])}" name="${str(show.indexerid)}x${str(epResult["season"])}x${str(epResult["episode"])}" href="searchEpisode?show=${show.indexerid}&amp;season=${epResult["season"]}&amp;episode=${epResult["episode"]}"><img src="${srRoot}/images/search16.png" width="16" height="16" alt="search" title="Manual Search" /></a>
                     % endif
                 % endif
-                % if sickbeard.USE_SUBTITLES and show.subtitles and epResult["location"] and subtitles.needs_subtitles(epResult['subtitles']):
+                % if sickbeard.USE_SUBTITLES and show.subtitles and epResult["location"] and (len(epResult["subtitles"]) == 0 or subtitles.needs_subtitles(epResult['subtitles'])):
                     <a class="epSubtitlesSearch" href="searchEpisodeSubtitles?show=${show.indexerid}&amp;season=${epResult["season"]}&amp;episode=${epResult["episode"]}"><img src="${srRoot}/images/closed_captioning.png" height="16" alt="search subtitles" title="Search Subtitles" /></a>
                 % endif
             </td>


### PR DESCRIPTION
@miigotu There could be a better way to do this, but it works fine in my tests so far.

Related issue: Missed subtitle management does not work for subtitles without language. We should either count 'und' as a valid sub or remove the feature if MULTI SUBS is unchecked.

Other pseudo-related issues (also keeping this as a tracker for me):
- srRoot needs to be added here: https://github.com/SickRage/SickRage/blob/81aa99c0b4bd39fbf333decd6e4f6c155d9401ef/gui/slick/js/core.js#L2388 or flags won't show in subtitleManagement.
- Some html problems in missed subtitle management (not related to the missing flags):
  ![issue](https://snapr.pw/i/28650fd329.png)
