### PR TITLE
Direct tab links

### DIFF
--- a/gui/slick/views/config_anime.mako
+++ b/gui/slick/views/config_anime.mako
@@ -14,11 +14,11 @@
             <div id="config-components">
 
                 <ul>
-                    <li><a href="#core-component-group1">AnimeDB Settings</a></li>
-                    <li><a href="#core-component-group2">Look &amp; Feel</a></li>
+                    <li><a href="#animedb-settings">AnimeDB Settings</a></li>
+                    <li><a href="#anime-look-feel">Look &amp; Feel</a></li>
                 </ul>
 
-                <div id="core-component-group1" class="tab-pane active component-group">
+                <div id="animedb-settings" class="tab-pane active component-group">
                     <div class="component-group-desc">
                         <img class="notifier-icon" src="${srRoot}/images/anidb24.png" alt="AniDB" title="AniDB" width="24" height="24" />
                         <h3><a href="${anon_url('http://anidb.info')}" onclick="window.open(this.href, '_blank'); return false;">AniDB</a></h3>
@@ -69,7 +69,7 @@
 
                 </div><!-- /component-group //-->
 
-                <div id="core-component-group2" class="tab-pane component-group">
+                <div id="anime-look-feel" class="tab-pane component-group">
 
                     <div class="component-group-desc">
                         <h3>Look and Feel</h3>

--- a/gui/slick/views/config_backuprestore.mako
+++ b/gui/slick/views/config_backuprestore.mako
@@ -27,11 +27,11 @@
         <form name="configForm" method="post" action="backuprestore">
             <div id="config-components">
                 <ul>
-                    <li><a href="#core-component-group1">Backup</a></li>
-                    <li><a href="#core-component-group2">Restore</a></li>
+                    <li><a href="#backup">Backup</a></li>
+                    <li><a href="#restore">Restore</a></li>
                 </ul>
 
-                <div id="core-component-group1" class="component-group clearfix">
+                <div id="backup" class="component-group clearfix">
                     <div class="component-group-desc">
                         <h3>Backup</h3>
                         <p><b>Backup your main database file and config.</b></p>
@@ -54,7 +54,7 @@
 
                 </div><!-- /component-group1 //-->
 
-                <div id="core-component-group2" class="component-group clearfix">
+                <div id="restore" class="component-group clearfix">
                     <div class="component-group-desc">
                         <h3>Restore</h3>
                         <p><b>Restore your main database file and config.</b></p>

--- a/gui/slick/views/config_general.mako
+++ b/gui/slick/views/config_general.mako
@@ -33,12 +33,12 @@
             <div id="config-components">
 
                 <ul>
-                    <li><a href="#core-component-group1">Misc</a></li>
-                    <li><a href="#core-component-group2">Interface</a></li>
-                    <li><a href="#core-component-group3">Advanced Settings</a></li>
+                    <li><a href="#misc">Misc</a></li>
+                    <li><a href="#interface">Interface</a></li>
+                    <li><a href="#advanced-settings">Advanced Settings</a></li>
                 </ul>
 
-                <div id="core-component-group1">
+                <div id="misc">
                 <div class="component-group">
 
                     <div class="component-group-desc">
@@ -231,7 +231,7 @@
                 </div><!-- /component-group1 //-->
 
 
-                <div id="core-component-group2">
+                <div id="interface">
                 <div class="component-group">
 
                     <div class="component-group-desc">
@@ -499,7 +499,7 @@
                 </div>
 
 
-                <div id="core-component-group3" class="component-group">
+                <div id="advanced-settings" class="component-group">
 
                 <div class="component-group">
 

--- a/gui/slick/views/config_postProcessing.mako
+++ b/gui/slick/views/config_postProcessing.mako
@@ -23,11 +23,11 @@
         <form id="configForm" action="savePostProcessing" method="post">
             <div id="config-components">
                 <ul>
-                    <li><a href="#core-component-group1">Post-Processing</a></li>
-                    <li><a href="#core-component-group2">Episode Naming</a></li>
-                    <li><a href="#core-component-group3">Metadata</a></li>
+                    <li><a href="#post-processing">Post-Processing</a></li>
+                    <li><a href="#episode-naming">Episode Naming</a></li>
+                    <li><a href="#metadata">Metadata</a></li>
                 </ul>
-                <div id="core-component-group1" class="component-group">
+                <div id="post-processing" class="component-group">
                     <div class="component-group-desc">
                         <h3>Post-Processing</h3>
                         <p>Settings that dictate how SickRage should process completed downloads.</p>
@@ -251,7 +251,7 @@
                         <input type="submit" class="btn config_submitter" value="Save Changes" /><br>
                     </fieldset>
                 </div><!-- /component-group1 //-->
-                <div id="core-component-group2" class="component-group">
+                <div id="episode-naming" class="component-group">
 
                     <div class="component-group-desc">
                         <h3>Episode Naming</h3>
@@ -1090,7 +1090,7 @@
                     </fieldset>
                 </div><!-- /component-group2 //-->
 
-                <div id="core-component-group3" class="component-group">
+                <div id="metadata" class="component-group">
                     <div class="component-group-desc">
                         <h3>Metadata</h3>
                         <p>The data associated to the data. These are files associated to a TV show in the form of images and text that, when supported, will enhance the viewing experience.</p>

--- a/gui/slick/views/config_providers.mako
+++ b/gui/slick/views/config_providers.mako
@@ -36,17 +36,17 @@ $('#config-components').tabs();
 
             <div id="config-components">
                 <ul>
-                    <li><a href="#core-component-group1">Provider Priorities</a></li>
-                    <li><a href="#core-component-group2">Provider Options</a></li>
+                    <li><a href="#provider-priorities">Provider Priorities</a></li>
+                    <li><a href="#provider-options">Provider Options</a></li>
                   % if sickbeard.USE_NZBS:
-                    <li><a href="#core-component-group3">Configure Custom Newznab Providers</a></li>
+                    <li><a href="#custom-newznab">Configure Custom Newznab Providers</a></li>
                   % endif
                   % if sickbeard.USE_TORRENTS:
-                    <li><a href="#core-component-group4">Configure Custom Torrent Providers</a></li>
+                    <li><a href="#custom-torrent">Configure Custom Torrent Providers</a></li>
                   % endif
                 </ul>
 
-                <div id="core-component-group1" class="component-group" style='min-height: 550px;'>
+                <div id="provider-priorities" class="component-group" style='min-height: 550px;'>
 
                     <div class="component-group-desc">
                         <h3>Provider Priorities</h3>
@@ -95,7 +95,7 @@ $('#config-components').tabs();
                     </fieldset>
                 </div><!-- /component-group1 //-->
 
-                <div id="core-component-group2" class="component-group">
+                <div id="provider-options" class="component-group">
 
                     <div class="component-group-desc">
                         <h3>Provider Options</h3>
@@ -611,7 +611,7 @@ $('#config-components').tabs();
                 </div><!-- /component-group2 //-->
 
                 % if sickbeard.USE_NZBS:
-                <div id="core-component-group3" class="component-group">
+                <div id="custom-newznab" class="component-group">
 
                     <div class="component-group-desc">
                         <h3>Configure Custom<br>Newznab Providers</h3>
@@ -687,7 +687,7 @@ $('#config-components').tabs();
 
                 % if sickbeard.USE_TORRENTS:
 
-                <div id="core-component-group4" class="component-group">
+                <div id="custom-torrent" class="component-group">
 
                 <div class="component-group-desc">
                     <h3>Configure Custom Torrent Providers</h3>

--- a/gui/slick/views/config_search.mako
+++ b/gui/slick/views/config_search.mako
@@ -15,12 +15,12 @@
         <form id="configForm" action="saveSearch" method="post">
             <div id="config-components">
                 <ul>
-                    <li><a href="#core-component-group1">Episode Search</a></li>
-                    <li><a href="#core-component-group2">NZB Search</a></li>
-                    <li><a href="#core-component-group3">Torrent Search</a></li>
+                    <li><a href="#episode-search">Episode Search</a></li>
+                    <li><a href="#nzb-search">NZB Search</a></li>
+                    <li><a href="#torrent-search">Torrent Search</a></li>
                 </ul>
 
-                <div id="core-component-group1" class="component-group">
+                <div id="episode-search" class="component-group">
                     <div class="component-group-desc">
                         <h3>Episode Search</h3>
                         <p>How to manage searching with <a href="${srRoot}/config/providers">providers</a>.</p>
@@ -191,7 +191,7 @@
                     </fieldset>
                 </div><!-- /component-group1 //-->
 
-                <div id="core-component-group2" class="component-group">
+                <div id="nzb-search" class="component-group">
 
                     <div class="component-group-desc">
                         <h3>NZB Search</h3>
@@ -440,7 +440,7 @@
                     </fieldset>
                 </div><!-- /component-group2 //-->
 
-                <div id="core-component-group3" class="component-group">
+                <div id="torrent-search" class="component-group">
                     <div class="component-group-desc">
                         <h3>Torrent Search</h3>
                         <p>How to handle Torrent search results.</p>

--- a/gui/slick/views/config_subtitles.mako
+++ b/gui/slick/views/config_subtitles.mako
@@ -34,12 +34,12 @@ $('#subtitles_dir').fileBrowser({ title: 'Select Subtitles Download Directory' }
 
             <div id="config-components">
                 <ul>
-                    <li><a href="#core-component-group1">Subtitles Search</a></li>
-                    <li><a href="#core-component-group2">Subtitles Plugin</a></li>
-                    <li><a href="#core-component-group3">Plugin Settings</a></li>
+                    <li><a href="#subtitles-search">Subtitles Search</a></li>
+                    <li><a href="#subtitles-plugin">Subtitles Plugin</a></li>
+                    <li><a href="#plugin-settings">Plugin Settings</a></li>
                 </ul>
 
-                <div id="core-component-group1" class="component-group">
+                <div id="subtitles-search" class="component-group">
 
                     <div class="component-group-desc">
                         <h3>Subtitles Search</h3>
@@ -156,7 +156,7 @@ $('#subtitles_dir').fileBrowser({ title: 'Select Subtitles Download Directory' }
                     </fieldset>
                 </div><!-- /component-group1 //-->
 
-                <div id="core-component-group2" class="component-group">
+                <div id="subtitles-plugin" class="component-group">
 
                     <div class="component-group-desc">
                         <h3>Subtitle Plugins</h3>
@@ -183,7 +183,7 @@ $('#subtitles_dir').fileBrowser({ title: 'Select Subtitles Download Directory' }
                         <br><input type="submit" class="btn config_submitter" value="Save Changes" /><br>
                     </fieldset>
                 </div><!-- /component-group2 //-->
-                <div id="core-component-group3" class="component-group">
+                <div id="plugin-settings" class="component-group">
                     <div class="component-group-desc">
                         <h3>Subtitle Settings</h3>
                         <p>Set user and password for each provider</p>


### PR DESCRIPTION
@OmgImAlexis like we talked. Need to update JS to always add the #misc / #interface / #advanced-settings to the URL while loading page or switching tabs

@miigotu @neoatomic with this we can add in the wiki or IRC or whatever: 
`please open: /config/providers/#provider-options`

instead of "click the gear, select menu item x. then click tab y"
