### PR TITLE
Add initial helper.isMediaFile tests

### DIFF
--- a/sickbeard/helpers.py
+++ b/sickbeard/helpers.py
@@ -168,25 +168,29 @@ def isMediaFile(filename):
     """
 
     # ignore samples
-    if re.search(r'(^|[\W_])(?<!shomin.)(sample\d*)[\W_]', filename, re.I):
-        return False
+    try:
+        if re.search(r'(^|[\W_])(?<!shomin.)(sample\d*)[\W_]', filename, re.I):
+            return False
 
-    # ignore RARBG release intro
-    if re.search(r'^RARBG\.\w+\.(mp4|avi|txt)$', filename, re.I):
-        return False
+        # ignore RARBG release intro
+        if re.search(r'^RARBG\.\w+\.(mp4|avi|txt)$', filename, re.I):
+            return False
 
-    # ignore MAC OS's retarded "resource fork" files
-    if filename.startswith('._'):
-        return False
+        # ignore MAC OS's retarded "resource fork" files
+        if filename.startswith('._'):
+            return False
 
-    sepFile = filename.rpartition(".")
+        sepFile = filename.rpartition(".")
 
-    if re.search('extras?$', sepFile[0], re.I):
-        return False
+        if re.search('extras?$', sepFile[0], re.I):
+            return False
 
-    if sepFile[2].lower() in media_extensions:
-        return True
-    else:
+        if sepFile[2].lower() in media_extensions:
+            return True
+        else:
+            return False
+    except TypeError as error:  # Not a string
+        logger.log('Invalid filename. Filename must be a string. %s' % error, logger.DEBUG)  # pylint: disable=no-member
         return False
 
 
@@ -1282,7 +1286,6 @@ def mapIndexersToShow(showObj):
             logger.log(u"Found indexer mapping in cache for show: " + showObj.name, logger.DEBUG)
             mapped[int(curResult['mindexer'])] = int(curResult['mindexer_id'])
             return mapped
-            break
     else:
         sql_l = []
         for indexer in sickbeard.indexerApi().indexers:
@@ -1757,6 +1760,7 @@ def getTVDBFromID(indexer_id, indexer):
         return tvdb_id
     else:
         return tvdb_id
+
 
 def is_ip_private(ip):
     priv_lo = re.compile("^127\.\d{1,3}\.\d{1,3}\.\d{1,3}$")

--- a/tests/helpers_tests.py
+++ b/tests/helpers_tests.py
@@ -21,7 +21,7 @@
 """
 Test sickbeard.helpers
 
-Methods:
+Public Methods:
     fixGlob
     indentXML
     remove_non_release_groups
@@ -60,7 +60,6 @@ Methods:
     encrypt
     decrypt
     full_sanitizeSceneName
-    _check_against_names
     get_show
     is_hidden_folder
     real_path
@@ -72,8 +71,6 @@ Methods:
     restoreConfigZip
     mapIndexersToShow
     touchFile
-    _getTempDir
-    _setUpSession
     getURL
     download_file
     get_size
@@ -84,8 +81,13 @@ Methods:
     pretty_time_delta
     isFileLocked
     getDiskSpaceUsage
+Private Methods:
+    _check_against_names
+    _getTempDir
+    _setUpSession
 """
 
+from __future__ import print_function
 import os.path
 import sys
 import unittest
@@ -93,7 +95,8 @@ import unittest
 sys.path.insert(1, os.path.abspath(os.path.join(os.path.dirname(__file__), '../lib')))
 sys.path.insert(1, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
-from sickbeard.helpers import remove_non_release_groups
+from sickbeard import helpers
+from sickrage.helper.common import media_extensions, subtitle_extensions
 
 TEST_RESULT = 'Show.Name.S01E01.HDTV.x264-RLSGROUP'
 TEST_CASES = {
@@ -163,7 +166,7 @@ def test_generator(test_strings):
         :return: test to run
         """
         for test_string in test_strings:
-            self.assertEqual(remove_non_release_groups(test_string), TEST_RESULT)
+            self.assertEqual(helpers.remove_non_release_groups(test_string), TEST_RESULT)
     return _test
 
 
@@ -258,12 +261,53 @@ class HelpersFileTests(unittest.TestCase):
     """
     Test file helpers
     """
-    @unittest.skip('Not yet implemented')
+
     def test_is_media_file(self):
         """
         Test isMediaFile
         """
-        pass
+        # TODO: Add unicode tests
+        # TODO: Add MAC OS resource fork tests
+        # TODO: Add RARBG release tests
+        # RARBG release intros should be ignored
+        # MAC OS's "resource fork" files should be ignored
+        # Extras should be ignored
+        # and the file extension should be in the list of media extensions
+
+        # Test all valid media extensions
+        temp_name = 'Show.Name.S01E01.HDTV.x264-RLSGROUP'
+        extension_tests = {'.'.join((temp_name, ext)): True for ext in media_extensions}
+        # ...and some invalid ones
+        other_extensions = ['txt', 'sfv', 'srr', 'rar', 'nfo', 'zip']
+        extension_tests.update({'.'.join((temp_name, ext)): False for ext in other_extensions + subtitle_extensions})
+
+        # Samples should be ignored
+        sample_tests = {  # Samples should be ignored, valid samples will return False
+            'Show.Name.S01E01.HDTV.sample.mkv': False,  # default case
+            'Show.Name.S01E01.HDTV.sAmPle.mkv': False,  # Ignore case
+            'Show.Name.S01E01.HDTV.samples.mkv': True,  # sample should not be plural
+            'Show.Name.S01E01.HDTVsample.mkv': True,  # no separation, can't identify as sample
+            'Sample.Show.Name.S01E01.HDTV.mkv': False,  # location doesn't matter
+            'Show.Name.Sample.S01E01.HDTV.sample.mkv': False,  # location doesn't matter
+            'Show.Name.S01E01.HDTV.sample1.mkv': False,  # numbered samples are ok
+            'Show.Name.S01E01.HDTV.sample12.mkv': False,  # numbered samples are ok
+            'Show.Name.S01E01.HDTV.sampleA.mkv': True,  # samples should not be indexed alphabetically
+        }
+
+        edge_cases = {
+            None: False,
+            '': False,
+            0: False,
+            1: False,
+            42: False,
+            123189274981274: False,
+            12.23: False,
+            ('this', 'is', 'a tuple'): False,
+        }
+
+        for cur_test in extension_tests, sample_tests, edge_cases:
+            for cur_name, expected_result in cur_test.items():
+                self.assertEqual(helpers.isMediaFile(cur_name), expected_result, cur_name)
 
     @unittest.skip('Not yet implemented')
     def test_is_file_locked(self):
@@ -640,12 +684,11 @@ class HelpersMiscTests(unittest.TestCase):
         """
         pass
 
-
 if __name__ == '__main__':
-    print "=================="
-    print "STARTING - Helpers TESTS"
-    print "=================="
-    print "######################################################################"
+    print("==================")
+    print("STARTING - Helpers TESTS")
+    print("==================")
+    print("######################################################################")
     for name, test_data in TEST_CASES.items():
         test_name = 'test_%s' % name
         test = test_generator(test_data)


### PR DESCRIPTION
Fix helper.isMediaFile fails for non-string filename arguments
Removed unreachable break statement
