### PR TITLE
allowed extensions fail safe (adds srt) if POSTPONE_IF_NO_SUBS enabled

### DIFF
--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -4091,9 +4091,12 @@ class ConfigPostProcessing(Config):
         sickbeard.FILE_TIMESTAMP_TIMEZONE = file_timestamp_timezone
         sickbeard.MOVE_ASSOCIATED_FILES = config.checkbox_to_value(move_associated_files)
         sickbeard.SYNC_FILES = sync_files
-        sickbeard.ALLOWED_EXTENSIONS = allowed_extensions
         sickbeard.POSTPONE_IF_SYNC_FILES = config.checkbox_to_value(postpone_if_sync_files)
         sickbeard.POSTPONE_IF_NO_SUBS = config.checkbox_to_value(postpone_if_no_subs)
+        # If 'postpone if no subs' is enabled, we must have SRT in allowed extensions list
+        if sickbeard.POSTPONE_IF_NO_SUBS:
+            allowed_extensions += ',srt'
+        sickbeard.ALLOWED_EXTENSIONS = ','.join({x.strip() for x in allowed_extensions.split(',') if x.strip()})
         sickbeard.NAMING_CUSTOM_ABD = config.checkbox_to_value(naming_custom_abd)
         sickbeard.NAMING_CUSTOM_SPORTS = config.checkbox_to_value(naming_custom_sports)
         sickbeard.NAMING_CUSTOM_ANIME = config.checkbox_to_value(naming_custom_anime)


### PR DESCRIPTION
@miigotu like this?

it outputs the string with single quotes

```
>>> allowed_extensions="nfo,sft"
>>> allowed_extensions += ',srt'
>>> allowed_extensions = {x.strip() for x in allowed_extensions.split(',') if x.strip()}
>>> print allowed_extensions
set(['nfo', 'sft', 'srt'])
>>> ','.join(allowed_extensions)
'nfo,sft,srt'
```
