### PR TITLE
Dont update cache for all providers at the same time, causes huge cpu…

### DIFF
--- a/sickbeard/__init__.py
+++ b/sickbeard/__init__.py
@@ -1149,7 +1149,7 @@ def initialize(consoleLogging=True):
                                       if x]
         SUBTITLES_DEFAULT = bool(check_setting_int(CFG, 'Subtitles', 'subtitles_default', 0))
         SUBTITLES_HISTORY = bool(check_setting_int(CFG, 'Subtitles', 'subtitles_history', 0))
-        SUBTITLES_PERFECT_MATCH = bool(check_setting_int(CFG, 'Subtitles', 'subtitles_perfect_match', 1)) 
+        SUBTITLES_PERFECT_MATCH = bool(check_setting_int(CFG, 'Subtitles', 'subtitles_perfect_match', 1))
         EMBEDDED_SUBTITLES_ALL = bool(check_setting_int(CFG, 'Subtitles', 'embedded_subtitles_all', 0))
         SUBTITLES_HEARING_IMPAIRED = bool(check_setting_int(CFG, 'Subtitles', 'subtitles_hearing_impaired', 0))
         SUBTITLES_FINDER_FREQUENCY = check_setting_int(CFG, 'Subtitles', 'subtitles_finder_frequency', 1)

--- a/sickbeard/providers/__init__.py
+++ b/sickbeard/providers/__init__.py
@@ -23,7 +23,7 @@ from random import shuffle
 
 import sickbeard
 from sickbeard import logger
-from sickbeard.providers import btn, newznab, womble, thepiratebay, torrentleech, kat, iptorrents, torrentz, \
+from sickbeard.providers import btn, newznab, rsstorrent, womble, thepiratebay, torrentleech, kat, iptorrents, torrentz, \
     omgwtfnzbs, scc, hdtorrents, torrentday, hdbits, hounddawgs, speedcd, nyaatorrents, animenzb, bluetigers, cpasbien, fnt, xthor, torrentbytes, \
     freshontv, titansoftv, morethantv, bitsoup, t411, tokyotoshokan, shazbat, rarbg, alpharatio, tntvillage, binsearch, torrentproject, extratorrent, \
     scenetime, btdigg, strike, transmitthenet, tvchaosuk, bitcannon, pretome, gftracker, hdspace, newpct, elitetorrent, bitsnoop, danishbits
@@ -73,7 +73,7 @@ def makeProviderList():
 
 def getNewznabProviderList(data):
     defaultList = [makeNewznabProvider(x) for x in getDefaultNewznabProviders().split('!!!')]
-    providerList = filter(lambda x: x, [makeNewznabProvider(x) for x in data.split('!!!')])
+    providerList = [x for x in [makeNewznabProvider(x) for x in data.split('!!!')] if x]
 
     seen_values = set()
     providerListDeduped = []
@@ -103,7 +103,7 @@ def getNewznabProviderList(data):
             providerDict[curDefault.name].enable_daily = curDefault.enable_daily
             providerDict[curDefault.name].enable_backlog = curDefault.enable_backlog
 
-    return filter(lambda x: x, providerList)
+    return [x for x in providerList if x]
 
 
 def makeNewznabProvider(configString):
@@ -129,7 +129,7 @@ def makeNewznabProvider(configString):
         logger.log(u"Skipping Newznab provider string: '" + configString + "', incorrect format", logger.ERROR)
         return None
 
-    newznab = sys.modules['sickbeard.providers.newznab']
+    # newznab = sys.modules['sickbeard.providers.newznab']
 
     newProvider = newznab.NewznabProvider(name, url, key=key, catIDs=catIDs, search_mode=search_mode,
                                           search_fallback=search_fallback, enable_daily=enable_daily,
@@ -140,7 +140,7 @@ def makeNewznabProvider(configString):
 
 
 def getTorrentRssProviderList(data):
-    providerList = filter(lambda x: x, [makeTorrentRssProvider(x) for x in data.split('!!!')])
+    providerList = [x for x in [makeTorrentRssProvider(x) for x in data.split('!!!')] if x]
 
     seen_values = set()
     providerListDeduped = []
@@ -150,7 +150,7 @@ def getTorrentRssProviderList(data):
             providerListDeduped.append(d)
             seen_values.add(value)
 
-    return filter(lambda x: x, providerList)
+    return [x for x in providerList if x]
 
 
 def makeTorrentRssProvider(configString):
@@ -179,12 +179,12 @@ def makeTorrentRssProvider(configString):
                    logger.ERROR)
         return None
 
-    try:
-        torrentRss = sys.modules['sickbeard.providers.rsstorrent']
-    except Exception:
-        return
+    # try:
+    #     torrentRss = sys.modules['sickbeard.providers.rsstorrent']
+    # except Exception:
+    #     return
 
-    newProvider = torrentRss.TorrentRssProvider(name, url, cookies, titleTAG, search_mode, search_fallback, enable_daily,
+    newProvider = rsstorrent.TorrentRssProvider(name, url, cookies, titleTAG, search_mode, search_fallback, enable_daily,
                                                 enable_backlog)
     newProvider.enabled = enabled == '1'
 


### PR DESCRIPTION
…/memory spike on low resource devices

Also it mixes logs up and thrashes a bit
Lint sickbeard.providers.**init** and remove filter calls, and redefinition of newznab
