### PR TITLE
Add video file name to log to compare with subtitles filaname + score

### DIFF
--- a/sickbeard/subtitles.py
+++ b/sickbeard/subtitles.py
@@ -357,6 +357,7 @@ class SubtitlesFinder(object):
                                            % ek(os.path.join, root, video_filename), logger.DEBUG)
                                 continue
 
+                            logger.log(u'Found subtitle(s) canditate(s) for %s' % video_filename, logger.INFO)
                             hearing_impaired = sickbeard.SUBTITLES_HEARING_IMPAIRED
                             user_score = 132 if sickbeard.SUBTITLES_PERFECT_MATCH else 111
                             found_subtitles = pool.download_best_subtitles(subtitles_list, video, languages=languages,
@@ -414,7 +415,7 @@ class SubtitlesFinder(object):
         if sickbeard.SUBTITLES_DOWNLOAD_IN_PP:
             self.subtitles_download_in_pp()
 
-        logger.log(u'Checking for subtitles', logger.INFO)
+        logger.log(u'Checking for missed subtitles', logger.INFO)
 
         # get episodes on which we want subtitles
         # criteria is:

--- a/sickbeard/subtitles.py
+++ b/sickbeard/subtitles.py
@@ -32,8 +32,8 @@ from sickbeard import logger
 from sickbeard import history
 from sickbeard import db
 from sickbeard import processTV
-from sickbeard.helpers import remove_non_release_groups
-from sickrage.helper.common import media_extensions, dateTimeFormat
+from sickbeard.helpers import remove_non_release_groups, isMediaFile
+from sickrage.helper.common import dateTimeFormat
 from sickrage.helper.encoding import ek
 from sickrage.helper.exceptions import ex
 from sickrage.show.Show import Show
@@ -223,8 +223,7 @@ def download_subtitles(subtitles_info):  # pylint: disable=too-many-locals
         sickbeard.helpers.chmodAsParent(subtitle_path)
         sickbeard.helpers.fixSetGroupID(subtitle_path)
 
-    if (not sickbeard.EMBEDDED_SUBTITLES_ALL and sickbeard.SUBTITLES_EXTRA_SCRIPTS and
-            video_path.rsplit(".", 1)[1] in media_extensions):
+    if sickbeard.SUBTITLES_EXTRA_SCRIPTS and isMediaFile(video_path) and not sickbeard.EMBEDDED_SUBTITLES_ALL:
         run_subs_extra_scripts(subtitles_info, found_subtitles, video, single=not sickbeard.SUBTITLES_MULTI)
 
     current_subtitles = [subtitle.language.opensubtitles for subtitle in found_subtitles]
@@ -346,7 +345,7 @@ class SubtitlesFinder(object):
                     except Exception as error:
                         logger.log(u'Could not remove non release groups from video file. Error: %r'
                                    % ex(error), logger.DEBUG)
-                    if video_filename.rsplit(".", 1)[1] in media_extensions:
+                    if isMediaFile(video_filename):
                         try:
                             video = subliminal.scan_video(os.path.join(root, video_filename),
                                                           subtitles=False, embedded_subtitles=False)

--- a/sickbeard/tv.py
+++ b/sickbeard/tv.py
@@ -1435,8 +1435,8 @@ class TVEpisode(object):
                          % (self.season or 0,  self.episode or 0, self.show.name), logger.DEBUG)
             return
 
-        logger.log(u"%s: Downloading subtitles for %s S%02dE%02d"
-                   % (self.show.indexerid, self.show.name, self.season or 0, self.episode or 0), logger.DEBUG)
+        logger.log(u"Checking subtitle candidates for %s S%02dE%02d"
+                   % (self.show.name, self.season or 0, self.episode or 0), logger.DEBUG)
 
         subtitles_info = {'location': self.location, 'subtitles': self.subtitles, 'season': self.season,
                           'episode': self.episode, 'name': self.name, 'show_name': self.show.name,


### PR DESCRIPTION
We don't show video filename anywhere while searching for subs

@medariox  what was @Labrys suggestion? Where should I add "candidates" to log and changed downloading>verifying

update: found!
