### PR TITLE
Move Torrent RSS specific code from sickbeard.providers.__init__ to sickbeard.providers.rsstorrent

### DIFF
--- a/sickbeard/__init__.py
+++ b/sickbeard/__init__.py
@@ -47,17 +47,18 @@ from sickbeard import logger
 from sickbeard import naming
 from sickbeard import dailysearcher
 from sickbeard.indexers import indexer_api
-from sickbeard.indexers.indexer_exceptions import indexer_shownotfound, indexer_showincomplete, indexer_exception, indexer_error, \
-    indexer_episodenotfound, indexer_attributenotfound, indexer_seasonnotfound, indexer_userabort, indexerExcepts
+from sickbeard.indexers.indexer_exceptions import indexer_shownotfound, indexer_showincomplete, indexer_exception, \
+    indexer_error, indexer_episodenotfound, indexer_attributenotfound, indexer_seasonnotfound, indexer_userabort, \
+    indexerExcepts
 from sickbeard.common import SD
 from sickbeard.common import SKIPPED
 from sickbeard.common import WANTED
+from sickbeard.providers.rsstorrent import TorrentRssProvider
 from sickbeard.databases import mainDB, cache_db, failed_db
 
 from sickrage.helper.encoding import ek
 from sickrage.helper.exceptions import ex
 from sickrage.providers.GenericProvider import GenericProvider
-from sickrage.show.Show import Show
 from sickrage.system.Shutdown import Shutdown
 
 from configobj import ConfigObj
@@ -1227,7 +1228,7 @@ def initialize(consoleLogging=True):
         newznabProviderList = providers.getNewznabProviderList(NEWZNAB_DATA)
 
         TORRENTRSS_DATA = check_setting_str(CFG, 'TorrentRss', 'torrentrss_data', '')
-        torrentRssProviderList = providers.getTorrentRssProviderList(TORRENTRSS_DATA)
+        torrentRssProviderList = TorrentRssProvider.get_providers_list(TORRENTRSS_DATA)
 
         # dynamically load provider settings
         for curTorrentProvider in [curProvider for curProvider in providers.sortedProviderList() if

--- a/sickbeard/providers/__init__.py
+++ b/sickbeard/providers/__init__.py
@@ -139,58 +139,6 @@ def makeNewznabProvider(configString):
     return newProvider
 
 
-def getTorrentRssProviderList(data):
-    providerList = [x for x in [makeTorrentRssProvider(x) for x in data.split('!!!')] if x]
-
-    seen_values = set()
-    providerListDeduped = []
-    for d in providerList:
-        value = d.name
-        if value not in seen_values:
-            providerListDeduped.append(d)
-            seen_values.add(value)
-
-    return [x for x in providerList if x]
-
-
-def makeTorrentRssProvider(configString):
-    if not configString:
-        return None
-
-    cookies = None
-    titleTAG = 'title'
-    search_mode = 'eponly'
-    search_fallback = 0
-    enable_daily = 0
-    enable_backlog = 0
-
-    try:
-        values = configString.split('|')
-        if len(values) == 9:
-            name, url, cookies, titleTAG, enabled, search_mode, search_fallback, enable_daily, enable_backlog = values
-        elif len(values) == 8:
-            name, url, cookies, enabled, search_mode, search_fallback, enable_daily, enable_backlog = values
-        else:
-            name = values[0]
-            url = values[1]
-            enabled = values[4]
-    except ValueError:
-        logger.log(u"Skipping RSS Torrent provider string: '" + configString + "', incorrect format",
-                   logger.ERROR)
-        return None
-
-    # try:
-    #     torrentRss = sys.modules['sickbeard.providers.rsstorrent']
-    # except Exception:
-    #     return
-
-    newProvider = rsstorrent.TorrentRssProvider(name, url, cookies, titleTAG, search_mode, search_fallback, enable_daily,
-                                                enable_backlog)
-    newProvider.enabled = enabled == '1'
-
-    return newProvider
-
-
 def getDefaultNewznabProviders():
     # name|url|key|catIDs|enabled|search_mode|search_fallback|enable_daily|enable_backlog
     return 'NZB.Cat|https://nzb.cat/||5030,5040,5010|0|eponly|1|1|1!!!' + \


### PR DESCRIPTION
In `sickbeard.provider.__init__.py`, some code are related to a specific provider/providers type.
This PR move the code dedicated to RSS torrent into the existing provider class (`sickbeard.providers.rsstorrent`).
I will send an other PR for the code dedicated to `NewznabProvider`.
The remaining code is generic enough to stay there (at least until all providers are moved into `sickrage.providers` module).
