### PR TITLE
Fix issue #114 IPv6 breaks IPv4 compatibility.

### DIFF
--- a/SickBeard.py
+++ b/SickBeard.py
@@ -318,7 +318,7 @@ class SickRage(object):
             self.webhost = sickbeard.WEB_HOST
         else:
             if sickbeard.WEB_IPV6:
-                self.webhost = '::'
+                self.webhost = ''
             else:
                 self.webhost = '0.0.0.0'
 


### PR DESCRIPTION
To allow IPv6 and IPv4 compatibility simultaneously, leave the host address blank.
