### PR TITLE
Improve output when assertions fail in name parser tests, Adjust normal standard regex

### DIFF
--- a/sickbeard/name_parser/regexes.py
+++ b/sickbeard/name_parser/regexes.py
@@ -193,7 +193,7 @@ normal_regexes = [
      ^((?P<series_name>.+?)(?:[. _-]{2,}|[. _]))?    # Show_Name and separator
      (?P<ep_num>\d{1,3})                             # 02
      (?:-(?P<extra_ep_num>\d{1,3}))*                 # -03-04-05 etc
-     \s?of?\s?\d{1,3}?                               # of joiner (with or without spaces) and series total ep
+     (\s*(?:of)?\s*\d{1,3})?                         # of joiner (with or without spaces) and series total ep
      [. _-]+((?P<extra_info>.+?)                     # Source_Quality_Etc-
      ((?<![. _-])(?<!WEB)                            # Make sure this is really the release group
      -(?P<release_group>[^- ]+([. _-]\[.*\])?))?)?$  # Group

--- a/sickbeard/name_parser/regexes.py
+++ b/sickbeard/name_parser/regexes.py
@@ -58,13 +58,13 @@ normal_regexes = [
      # Show.Name.S01.E02.E03
      r'''
      ^((?P<series_name>.+?)[. _-]+)?             # Show_Name and separator
-     (\()?s(?P<season_num>\d+)[. _-]*            # S01 and optional separator
-     e(?P<ep_num>\d+)(\))?                       # E02 and separator
+     \(?s(?P<season_num>\d+)[. _-]*              # S01 and optional separator
+     e(?P<ep_num>\d+)\)?                         # E02 and separator
      (([. _-]*e|-)                               # linking e/- char
      (?P<extra_ep_num>(?!(1080|720|480)[pi])\d+)(\))?)*   # additional E03/etc
-     [. _-]*((?P<extra_info>.+?)                 # Source_Quality_Etc-
+     ([. _-]+((?P<extra_info>.+?)                 # Source_Quality_Etc-
      ((?<![. _-])(?<!WEB)                        # Make sure this is really the release group
-     -(?P<release_group>[^- ]+([. _-]\[.*\])?))?)?$              # Group
+     -(?P<release_group>[^- ]+([. _-]\[.*\])?))?)?)?$              # Group
      '''),
 
     ('newpct',

--- a/tests/name_parser_tests.py
+++ b/tests/name_parser_tests.py
@@ -489,7 +489,6 @@ class BasicFailedTests(test.SickbeardTestDBCase):
             self.assertEqual(test_result.which_regex, [section], '%s : %s != %s' % (cur_test, test_result.which_regex, [section]))
             self.assertEqual(str(test_result), str(result), '%s : %s != %s' % (cur_test, str(test_result), str(result)))
 
-    @unittest.expectedFailure
     def test_no_s_names(self):
         """
         Test no season names
@@ -497,7 +496,6 @@ class BasicFailedTests(test.SickbeardTestDBCase):
         name_parser = parser.NameParser(False)
         self._test_names(name_parser, 'no_season')
 
-    @unittest.expectedFailure
     def test_no_s_file_names(self):
         """
         Test no season file names

--- a/tests/name_parser_tests.py
+++ b/tests/name_parser_tests.py
@@ -37,7 +37,8 @@ SIMPLE_TEST_CASES = {
         'Show-Name-S06E01-720p': parser.ParseResult(None, 'Show-Name', 6, [1], '720p'),
         'Show-Name-S06E01-1080i': parser.ParseResult(None, 'Show-Name', 6, [1], '1080i'),
         'Show.Name.S06E01.Other.WEB-DL': parser.ParseResult(None, 'Show Name', 6, [1], 'Other.WEB-DL'),
-        'Show.Name.S06E01 Some-Stuff Here': parser.ParseResult(None, 'Show Name', 6, [1], 'Some-Stuff Here')
+        'Show.Name.S06E01 Some-Stuff Here': parser.ParseResult(None, 'Show Name', 6, [1], 'Some-Stuff Here'),
+        'Show Name - S03E14-36! 24! 36! Hut! (1)': parser.ParseResult(None, 'Show Name', 3, [14], '36! 24! 36! Hut! (1)'),
     },
 
     'fov': {
@@ -321,8 +322,8 @@ class BasicTests(test.SickbeardTestDBCase):
                 print 'anime:', test_result.is_anime, 'ab_episode_numbers:', test_result.ab_episode_numbers
                 print test_result
                 print result
-            self.assertEqual(test_result.which_regex, [section])
-            self.assertEqual(str(test_result), str(result))
+            self.assertEqual(test_result.which_regex, [section], '%s : %s != %s' % (cur_test, test_result.which_regex, [section]))
+            self.assertEqual(str(test_result), str(result), '%s : %s != %s' % (cur_test, str(test_result), str(result)))
 
     def test_standard_names(self):
         """
@@ -485,8 +486,8 @@ class BasicFailedTests(test.SickbeardTestDBCase):
                 print 'anime:', test_result.is_anime, 'ab_episode_numbers:', test_result.ab_episode_numbers
                 print test_result
                 print result
-            self.assertEqual(test_result.which_regex, [section])
-            self.assertEqual(str(test_result), str(result))
+            self.assertEqual(test_result.which_regex, [section], '%s : %s != %s' % (cur_test, test_result.which_regex, [section]))
+            self.assertEqual(str(test_result), str(result), '%s : %s != %s' % (cur_test, str(test_result), str(result)))
 
     @unittest.expectedFailure
     def test_no_s_names(self):


### PR DESCRIPTION
Improve output when assertions fail in name parser tests
Adjust normal standard regex
Fixes https://github.com/SickRage/sickrage-issues/issues/233
