### PR TITLE
Fixes AA with query in log

### DIFF
--- a/sickbeard/subtitles.py
+++ b/sickbeard/subtitles.py
@@ -439,15 +439,13 @@ class SubtitlesFinder(object):
 
         database = db.DBConnection()
         sql_results = database.select(
-            """
-            SELECT s.show_name, e.showid, e.season, e.episode,
-            e.status, e.subtitles, e.subtitles_searchcount AS searchcount,
-            e.subtitles_lastsearch AS lastsearch, e.location, (? - e.airdate) as age
-            FROM tv_episodes AS e INNER JOIN tv_shows AS s
-            ON (e.showid = s.indexer_id)
-            WHERE s.subtitles = 1 AND e.subtitles NOT LIKE ?
-            AND e.location != '' AND e.status IN (?) ORDER BY age ASC
-            """,
+            "SELECT s.show_name, e.showid, e.season, e.episode, "
+            "e.status, e.subtitles, e.subtitles_searchcount AS searchcount, "
+            "e.subtitles_lastsearch AS lastsearch, e.location, (? - e.airdate) as age "
+            "FROM tv_episodes AS e INNER JOIN tv_shows AS s "
+            "ON (e.showid = s.indexer_id) "
+            "WHERE s.subtitles = 1 AND e.subtitles NOT LIKE ? "
+            "AND e.location != '' AND e.status IN (?) ORDER BY age ASC",
             [datetime.datetime.now().toordinal(), wanted_languages(True),
              ','.join({str(status) for status in Quality.DOWNLOADED + Quality.ARCHIVED})]
         )


### PR DESCRIPTION
```
AA             with args [735950, '%pob%', '3276806,3276804,406,404,4,6,204,206,12806,12804,106,104,3206,3204,6406,6404,1604,1606,25606,25604,806,804']
AA            AND e.location != '' AND e.status IN (?) ORDER BY age ASC
AA            WHERE s.subtitles = 1 AND e.subtitles NOT LIKE ?
AA            ON (e.showid = s.indexer_id)
AA            FROM tv_episodes AS e INNER JOIN tv_shows AS s
AA            e.subtitles_lastsearch AS lastsearch, e.location, (? - e.airdate) as age
AA            e.status, e.subtitles, e.subtitles_searchcount AS searchcount,
AA            SELECT s.show_name, e.showid, e.season, e.episode,
2015-12-18 09:03:24 INFO     FINDSUBTITLES :: Checking for missed subtitles
```
