### PR TITLE
Network timezone adjust, pretty_size fix, _convert_size fixes

### DIFF
--- a/sickbeard/network_timezones.py
+++ b/sickbeard/network_timezones.py
@@ -29,7 +29,7 @@ from sickbeard import logger
 from sickrage.helper.common import try_int
 
 # regex to parse time (12/24 hour format)
-time_regex = re.compile(r'(?P<hour>\d{1,2})(?:[:.](?P<minute>\d{2})) ?(?P<meridiem>[PA]\.? ?M)?\b', flags=re.IGNORECASE)
+time_regex = re.compile(r'(?P<hour>\d{1,2})(?:[:.](?P<minute>\d{2})?)? ?(?P<meridiem>[PA]\.? ?M?)?\b', re.I)
 
 network_dict = None
 sb_timezone = tz.tzwinlocal() if tz.tzwinlocal else tz.tzlocal()
@@ -154,14 +154,10 @@ def parse_date_time(d, t, network):
             hr = 0
             m = 0
 
-    result = datetime.datetime.fromordinal(try_int(d) or 1)
+    result = datetime.datetime.fromordinal(max(try_int(d), 1))
 
     return result.replace(hour=hr, minute=m, tzinfo=network_tz)
 
 
-def test_timeformat(t):
-    mo = time_regex.search(t)
-    if mo is None or len(mo.groups()) < 2:
-        return False
-    else:
-        return True
+def test_timeformat(time_string):
+    return time_regex.search(time_string) is not None

--- a/sickbeard/providers/bitsoup.py
+++ b/sickbeard/providers/bitsoup.py
@@ -162,16 +162,16 @@ class BitSoupProvider(TorrentProvider):
         try:
             size = float(size)
             if modifier in 'KB':
-                size = size * 1024
+                size *= 1024 ** 1
             elif modifier in 'MB':
-                size = size * 1024**2
+                size *= 1024 ** 2
             elif modifier in 'GB':
-                size = size * 1024**3
+                size *= 1024 ** 3
             elif modifier in 'TB':
-                size = size * 1024**4
+                size *= 1024 ** 4
         except Exception:
             size = -1
-        return int(size)
+        return long(size)
 
 
 class BitSoupCache(tvcache.TVCache):

--- a/sickbeard/providers/cpasbien.py
+++ b/sickbeard/providers/cpasbien.py
@@ -132,16 +132,16 @@ class CpasbienProvider(TorrentProvider):
         try:
             size = float(size)
             if modifier in 'KO':
-                size = size * 1024
+                size *= 1024 ** 1
             elif modifier in 'MO':
-                size = size * 1024 ** 2
+                size *= 1024 ** 2
             elif modifier in 'GO':
-                size = size * 1024 ** 3
+                size *= 1024 ** 3
             elif modifier in 'TO':
-                size = size * 1024 ** 4
+                size *= 1024 ** 4
         except Exception:
             size = -1
-        return int(size)
+        return long(size)
 
 
 class CpasbienCache(tvcache.TVCache):

--- a/sickbeard/providers/danishbits.py
+++ b/sickbeard/providers/danishbits.py
@@ -190,14 +190,14 @@ class DanishbitsProvider(TorrentProvider):  # pylint: disable=too-many-instance-
 
         size = float(size)
         if modifier in 'KB':
-            size *= 1024
+            size *= 1024 ** 1
         elif modifier in 'MB':
-            size *= 1024**2
+            size *= 1024 ** 2
         elif modifier in 'GB':
-            size *= 1024**3
+            size *= 1024 ** 3
         elif modifier in 'TB':
-            size *= 1024**4
-        return int(size)
+            size *= 1024 ** 4
+        return long(size)
 
     def seedRatio(self):
         return self.ratio

--- a/sickbeard/providers/gftracker.py
+++ b/sickbeard/providers/gftracker.py
@@ -173,16 +173,16 @@ class GFTrackerProvider(TorrentProvider):
         try:
             size = float(size)
             if modifier in 'KB':
-                size = size * 1024
+                size *= 1024 ** 1
             elif modifier in 'MB':
-                size = size * 1024**2
+                size *= 1024 ** 2
             elif modifier in 'GB':
-                size = size * 1024**3
+                size *= 1024 ** 3
             elif modifier in 'TB':
-                size = size * 1024**4
+                size *= 1024 ** 4
         except Exception:
             size = -1
-        return int(size)
+        return long(size)
 
 
 class GFTrackerCache(tvcache.TVCache):

--- a/sickbeard/providers/hdspace.py
+++ b/sickbeard/providers/hdspace.py
@@ -171,14 +171,14 @@ class HDSpaceProvider(TorrentProvider):
         size, modifier = size.split(' ')
         size = float(size)
         if modifier in 'KB':
-            size = size * 1024
+            size *= 1024 ** 1
         elif modifier in 'MB':
-            size = size * 1024**2
+            size *= 1024 ** 2
         elif modifier in 'GB':
-            size = size * 1024**3
+            size *= 1024 ** 3
         elif modifier in 'TB':
-            size = size * 1024**4
-        return int(size)
+            size *= 1024 ** 4
+        return long(size)
 
 
 class HDSpaceCache(tvcache.TVCache):

--- a/sickbeard/providers/hdtorrents.py
+++ b/sickbeard/providers/hdtorrents.py
@@ -203,14 +203,14 @@ class HDTorrentsProvider(TorrentProvider):
         size, modifier = size.split(' ')
         size = float(size)
         if modifier in 'KB':
-            size = size * 1024
+            size *= 1024 ** 1
         elif modifier in 'MB':
-            size = size * 1024**2
+            size *= 1024 ** 2
         elif modifier in 'GB':
-            size = size * 1024**3
+            size *= 1024 ** 3
         elif modifier in 'TB':
-            size = size * 1024**4
-        return int(size)
+            size *= 1024 ** 4
+        return long(size)
 
 
 class HDTorrentsCache(tvcache.TVCache):

--- a/sickbeard/providers/hounddawgs.py
+++ b/sickbeard/providers/hounddawgs.py
@@ -190,7 +190,7 @@ class HoundDawgsProvider(TorrentProvider):  # pylint: disable=too-many-instance-
         modifier = matches.group(2)
 
         mod = {'K': 1, 'M': 2, 'G': 3, 'T': 4}
-        return int(float(size) * 1024**mod[modifier])
+        return long(float(size) * 1024 ** mod[modifier])
 
 
     def seed_ratio(self):

--- a/sickbeard/providers/iptorrents.py
+++ b/sickbeard/providers/iptorrents.py
@@ -162,14 +162,14 @@ class IPTorrentsProvider(TorrentProvider):
         size, modifier = size.split(' ')
         size = float(size)
         if modifier in 'KB':
-            size = size * 1024
+            size *= 1024 ** 1
         elif modifier in 'MB':
-            size = size * 1024**2
+            size *= 1024 ** 2
         elif modifier in 'GB':
-            size = size * 1024**3
+            size *= 1024 ** 3
         elif modifier in 'TB':
-            size = size * 1024**4
-        return int(size)
+            size *= 1024 ** 4
+        return long(size)
 
 
 class IPTorrentsCache(tvcache.TVCache):

--- a/sickbeard/providers/morethantv.py
+++ b/sickbeard/providers/morethantv.py
@@ -189,16 +189,16 @@ class MoreThanTVProvider(TorrentProvider):
         try:
             size = float(size)
             if modifier in 'KB':
-                size = size * 1024
+                size *= 1024 ** 1
             elif modifier in 'MB':
-                size = size * 1024**2
+                size *= 1024 ** 2
             elif modifier in 'GB':
-                size = size * 1024**3
+                size *= 1024 ** 3
             elif modifier in 'TB':
-                size = size * 1024**4
+                size *= 1024 ** 4
         except Exception:
             size = -1
-        return int(size)
+        return long(size)
 
 
 class MoreThanTVCache(tvcache.TVCache):

--- a/sickbeard/providers/newpct.py
+++ b/sickbeard/providers/newpct.py
@@ -204,14 +204,14 @@ class newpctProvider(TorrentProvider):
         size, modifier = size.split(' ')
         size = float(size)
         if modifier in 'KB':
-            size = size * 1024
+            size *= 1024 ** 1
         elif modifier in 'MB':
-            size = size * 1024**2
+            size *= 1024 ** 2
         elif modifier in 'GB':
-            size = size * 1024**3
+            size *= 1024 ** 3
         elif modifier in 'TB':
-            size = size * 1024**4
-        return int(size)
+            size *= 1024 ** 4
+        return long(size)
 
 
     @staticmethod

--- a/sickbeard/providers/nyaatorrents.py
+++ b/sickbeard/providers/nyaatorrents.py
@@ -110,14 +110,14 @@ class NyaaProvider(TorrentProvider):
         size, modifier = size.split(' ')
         size = float(size)
         if modifier in 'KiB':
-            size = size * 1024
+            size *= 1024 ** 1
         elif modifier in 'MiB':
-            size = size * 1024**2
+            size *= 1024 ** 2
         elif modifier in 'GiB':
-            size = size * 1024**3
+            size *= 1024 ** 3
         elif modifier in 'TiB':
-            size = size * 1024**4
-        return int(size)
+            size *= 1024 ** 4
+        return long(size)
 
     def seed_ratio(self):
         return self.ratio

--- a/sickbeard/providers/pretome.py
+++ b/sickbeard/providers/pretome.py
@@ -174,14 +174,14 @@ class PretomeProvider(TorrentProvider):
         modifier = sizeString[-2:]
         size = float(size)
         if modifier in 'KB':
-            size = size * 1024
+            size *= 1024 ** 1
         elif modifier in 'MB':
-            size = size * 1024**2
+            size *= 1024 ** 2
         elif modifier in 'GB':
-            size = size * 1024**3
+            size *= 1024 ** 3
         elif modifier in 'TB':
-            size = size * 1024**4
-        return int(size)
+            size *= 1024 ** 4
+        return long(size)
 
 
 class PretomeCache(tvcache.TVCache):

--- a/sickbeard/providers/scc.py
+++ b/sickbeard/providers/scc.py
@@ -169,14 +169,14 @@ class SCCProvider(TorrentProvider):  # pylint: disable=too-many-instance-attribu
         size, base = size.split()
         size = float(size)
         if base in 'KB':
-            size = size * 1024
+            size *= 1024 ** 1
         elif base in 'MB':
-            size = size * 1024**2
+            size *= 1024 ** 2
         elif base in 'GB':
-            size = size * 1024**3
+            size *= 1024 ** 3
         elif base in 'TB':
-            size = size * 1024**4
-        return int(size)
+            size *= 1024 ** 4
+        return long(size)
 
 
 class SCCCache(tvcache.TVCache):

--- a/sickbeard/providers/thepiratebay.py
+++ b/sickbeard/providers/thepiratebay.py
@@ -136,7 +136,7 @@ class ThePirateBayProvider(TorrentProvider):
             size *= 1024 ** 3
         elif modifier in 'TiB':
             size *= 1024 ** 4
-        return size
+        return long(size)
 
     def seed_ratio(self):
         return self.ratio

--- a/sickbeard/providers/thepiratebay.py
+++ b/sickbeard/providers/thepiratebay.py
@@ -129,13 +129,13 @@ class ThePirateBayProvider(TorrentProvider):
         size, modifier = size.split('&nbsp;')
         size = float(size)
         if modifier in 'KiB':
-            size = size * 1024
+            size *= 1024 ** 1
         elif modifier in 'MiB':
-            size = size * 1024**2
+            size *= 1024 ** 2
         elif modifier in 'GiB':
-            size = size * 1024**3
+            size *= 1024 ** 3
         elif modifier in 'TiB':
-            size = size * 1024**4
+            size *= 1024 ** 4
         return size
 
     def seed_ratio(self):

--- a/sickbeard/providers/torrentbytes.py
+++ b/sickbeard/providers/torrentbytes.py
@@ -173,14 +173,14 @@ class TorrentBytesProvider(TorrentProvider):
         modifier = sizeString[-2:]
         size = float(size)
         if modifier in 'KB':
-            size = size * 1024
+            size *= 1024 ** 1
         elif modifier in 'MB':
-            size = size * 1024**2
+            size *= 1024 ** 2
         elif modifier in 'GB':
-            size = size * 1024**3
+            size *= 1024 ** 3
         elif modifier in 'TB':
-            size = size * 1024**4
-        return int(size)
+            size *= 1024 ** 4
+        return long(size)
 
 
 class TorrentBytesCache(tvcache.TVCache):

--- a/sickbeard/providers/torrentz.py
+++ b/sickbeard/providers/torrentz.py
@@ -52,7 +52,7 @@ class TORRENTZProvider(TorrentProvider):
     @staticmethod
     def _split_description(description):
         match = re.findall(r'[0-9]+', description)
-        return (int(match[0]) * 1024**2, int(match[1]), int(match[2]))
+        return (int(match[0]) * 1024 ** 2, int(match[1]), int(match[2]))
 
     def search(self, search_strings, age=0, ep_obj=None):
         results = []

--- a/sickbeard/providers/tvchaosuk.py
+++ b/sickbeard/providers/tvchaosuk.py
@@ -210,16 +210,16 @@ class TVChaosUKProvider(TorrentProvider):
         try:
             size = float(size)
             if modifier in 'KB':
-                size = size * 1024
+                size *= 1024 ** 1
             elif modifier in 'MB':
-                size = size * 1024**2
+                size *= 1024 ** 2
             elif modifier in 'GB':
-                size = size * 1024**3
+                size *= 1024 ** 3
             elif modifier in 'TB':
-                size = size * 1024**4
+                size *= 1024 ** 4
         except Exception:
             size = -1
-        return int(size)
+        return long(size)
 
 
 class TVChaosUKCache(tvcache.TVCache):

--- a/sickrage/helper/common.py
+++ b/sickrage/helper/common.py
@@ -162,7 +162,11 @@ def pretty_file_size(size):
     :param size: The size to convert
     :return: The converted size
     """
-    size = float(max(try_int(size), 0))
+    try:
+        size = max(float(size), 0.)
+    except (ValueError, TypeError):
+        size = 0.
+
     remaining_size = size
     for unit in ['B', 'KB', 'MB', 'GB', 'TB', 'PB']:
         if remaining_size < 1024.:

--- a/sickrage/helper/common.py
+++ b/sickrage/helper/common.py
@@ -167,7 +167,7 @@ def pretty_file_size(size):
     for unit in ['B', 'KB', 'MB', 'GB', 'TB', 'PB']:
         if remaining_size < 1024.:
             return '%3.2f %s' % (remaining_size, unit)
-        remaining_size //= 1024.
+        remaining_size /= 1024.
     return size
 
 

--- a/sickrage/helper/common.py
+++ b/sickrage/helper/common.py
@@ -162,19 +162,12 @@ def pretty_file_size(size):
     :param size: The size to convert
     :return: The converted size
     """
-    if isinstance(size, (str, unicode)) and size.isdigit():
-        size = float(size)
-    elif not isinstance(size, (int, long, float)):
-        return ''
-
+    size = float(max(try_int(size), 0))
     remaining_size = size
-
     for unit in ['B', 'KB', 'MB', 'GB', 'TB', 'PB']:
         if remaining_size < 1024.:
             return '%3.2f %s' % (remaining_size, unit)
-
-        remaining_size /= 1024.
-
+        remaining_size //= 1024.
     return size
 
 

--- a/tests/sickrage_tests/helper/common_tests.py
+++ b/tests/sickrage_tests/helper/common_tests.py
@@ -159,12 +159,12 @@ class CommonTests(unittest.TestCase):
         Test pretty file size
         """
         test_cases = {
-            None: '',
-            '': '',
+            None: '0.00 B',
+            '': '0.00 B',
             '1024': '1.00 KB',
-            '1024.5': '',
-            -42.5: '-42.50 B',
-            -42: '-42.00 B',
+            '1024.5': '1.00 KB',
+            -42.5: '0.00 B',
+            -42: '0.00 B',
             0: '0.00 B',
             25: '25.00 B',
             25.5: '25.50 B',
@@ -182,9 +182,9 @@ class CommonTests(unittest.TestCase):
         }
 
         unicode_test_cases = {
-            u'': '',
+            u'': '0.00 B',
             u'1024': '1.00 KB',
-            u'1024.5': '',
+            u'1024.5': '1.00 KB',
         }
 
         for tests in test_cases, unicode_test_cases:


### PR DESCRIPTION
Fix time_regex and test_timeformat for times like '9P'
Fix displayShow showing -1.00 B for shows with missing dir, now shows 0.00 B
pep8ify _convert_size in all providers, and return long instead of int, since sizes can be > maxint on 32 bit python
