### PR TITLE
Fix title parsing in a few providers

### DIFF
--- a/sickbeard/providers/gftracker.py
+++ b/sickbeard/providers/gftracker.py
@@ -118,25 +118,19 @@ class GFTrackerProvider(TorrentProvider):
                             continue
 
                         for result in torrent_rows[1:]:
-                            cells = result.findChildren("td")
-                            title = cells[1].find("a").find_next("a")
-                            link = cells[3].find("a")
-                            shares = cells[8].get_text().split("/", 1)
-                            torrent_size = cells[7].get_text().split("/", 1)[0]
-
                             try:
-                                if 'title' in title:
-                                    title = title['title']
-                                else:
-                                    title = cells[1].find("a")['title']
-
-                                download_url = self.urls['download'] % (link['href'])
+                                cells = result.findChildren("td")
+                                title = cells[1].find("a").find_next("a").get('title', '') or cells[1].find("a").get('title')
+                                download_url = self.urls['download'] % cells[3].find("a").get('href')
+                                shares = cells[8].get_text().split("/", 1)
                                 seeders = int(shares[0])
                                 leechers = int(shares[1])
 
-                                size = -1
+                                torrent_size = cells[7].get_text().split("/", 1)[0]
                                 if re.match(r"\d+([,\.]\d+)?\s*[KkMmGgTt]?[Bb]", torrent_size):
-                                    size = self._convertSize(torrent_size.rstrip())
+                                    size = self._convertSize(torrent_size.strip())
+                                else:
+                                    size = -1
 
                             except (AttributeError, TypeError):
                                 continue

--- a/sickbeard/providers/morethantv.py
+++ b/sickbeard/providers/morethantv.py
@@ -138,7 +138,7 @@ class MoreThanTVProvider(TorrentProvider):
                             torrent_id_long = link['href'].replace('torrents.php?action=download&id=', '')
 
                             try:
-                                if 'title' in link:
+                                if link.get('title', ''):
                                     title = cells[1].find('a', {'title': 'View torrent'}).contents[0].strip()
                                 else:
                                     title = link.contents[0]

--- a/sickbeard/providers/pretome.py
+++ b/sickbeard/providers/pretome.py
@@ -123,7 +123,7 @@ class PretomeProvider(TorrentProvider):
                             torrent_id = link['href'].replace('details.php?id=', '')
 
                             try:
-                                if 'title' in link:
+                                if link.get('title', ''):
                                     title = link['title']
                                 else:
                                     title = link.contents[0]

--- a/sickbeard/providers/torrentbytes.py
+++ b/sickbeard/providers/torrentbytes.py
@@ -123,7 +123,7 @@ class TorrentBytesProvider(TorrentProvider):
                                 continue
 
                             try:
-                                if 'title' in link:
+                                if link.get('title', ''):
                                     title = cells[1].find('a', {'class': 'index'})['title']
                                 else:
                                     title = link.contents[0]


### PR DESCRIPTION
These are using some poor logic, and the logic replacement of the deprecated 'has_key' caused some issues becuase they might just be a string. `has_key` would have returned false because it was not a dict, but `in` might return `True` if the word is literally `in` the string.
