### PR TITLE
rtorrent: add timeout to hash resolution

### DIFF
--- a/sickbeard/clients/rtorrent_client.py
+++ b/sickbeard/clients/rtorrent_client.py
@@ -22,6 +22,7 @@ import traceback
 import sickbeard
 from sickbeard import logger
 from sickbeard.clients.generic import GenericClient
+from sickrage.helper.timeout import exit_after
 from rtorrent import RTorrent
 
 
@@ -52,6 +53,7 @@ class rTorrentAPI(GenericClient):
 
         return self.auth
 
+    @exit_after(60)
     def _add_torrent_uri(self, result):
 
         if not self.auth:

--- a/sickrage/helper/timeout.py
+++ b/sickrage/helper/timeout.py
@@ -1,0 +1,26 @@
+#! /usr/bin/env python
+
+import threading
+from sickbeard import logger
+
+
+def cdquit(fn_name):
+    logger.log(u'% took too long' % fn_name, logger.DEBUG)
+    thread.interrupt_main() # raises KeyboardInterrupt
+
+def exit_after(s):
+    '''
+    use as decorator to exit process if
+    function takes longer than s seconds
+    '''
+    def outer(fn):
+        def inner(*args, **kwargs):
+            timer = threading.Timer(s, cdquit, args=[fn.__name__])
+            timer.start()
+            try:
+                result = fn(*args, **kwargs)
+            finally:
+                timer.cancel()
+            return result
+        return inner
+    return outer


### PR DESCRIPTION
The load_magnet method tends to hang until the magnet is resolved in a torrent. It may need to be added in several places, but it unblocks the searcher at any rate, for rtorrent.

This mechanism is a simple timeout I found on stackoverflow.
