### PR TITLE
Season 0 needs love too

### DIFF
--- a/sickbeard/dailysearcher.py
+++ b/sickbeard/dailysearcher.py
@@ -59,7 +59,7 @@ class DailySearcher(object):
         curTime = datetime.datetime.now(network_timezones.sb_timezone)
 
         myDB = db.DBConnection()
-        sqlResults = myDB.select("SELECT showid, airdate, season, episode FROM tv_episodes WHERE status = ? AND season > 0 AND (airdate <= ? and airdate > 1)",
+        sqlResults = myDB.select("SELECT showid, airdate, season, episode FROM tv_episodes WHERE status = ? AND (airdate <= ? and airdate > 1)",
                                  [common.UNAIRED, curDate])
 
         sql_l = []

--- a/sickbeard/databases/mainDB.py
+++ b/sickbeard/databases/mainDB.py
@@ -210,7 +210,7 @@ class MainSanityCheck(db.DBSanityCheck):
         curDate = datetime.date.today()
 
         sqlResults = self.connection.select(
-            "SELECT episode_id FROM tv_episodes WHERE (airdate > ? or airdate = 1) AND status in (?,?) AND season > 0",
+            "SELECT episode_id FROM tv_episodes WHERE (airdate > ? or airdate = 1) AND status in (?,?)",
             [curDate.toordinal(), common.SKIPPED, common.WANTED])
 
         for cur_unaired in sqlResults:


### PR DESCRIPTION
There are probably several instances in SR in which the code is erroneously checking for "Season > 0"; however, these are the two places that I feel confident it shouldn't happen.

One thing I would like to discuss is this:    the change I made in dailysearcher.py (line 62), actually enables another block of code lower in the method that wasn't previously being called at all:

```
                if ep.season == 0:
                    logger.log(u"New episode " + ep.prettyName() + " airs today, setting status to SKIPPED because is a special season")
                    ep.status = common.SKIPPED
                else:
                    logger.log(u"New episode %s airs today, setting to default episode status for this show: %s" % (ep.prettyName(), common.statusStrings[ep.show.default_ep_status]))
                    ep.status = ep.show.default_ep_status
```

I didn't change it; however, my personal feeling is that all new episodes for a show should follow whatever the user has as settings for default_ep_status.     The way the code right now works, every new episode in season 0 is going to be SKIPPED, regardless of any other settings the user has.

(I should also point out that the backlog search for season 0 isn't really working either.   With this, and the other PRs I submitted today, I still had to run a "daily search" after manually setting the season 0 episode to "wanted".)
