### PR TITLE
Fixed logging related to TVShow.wantEpisode

### DIFF
--- a/sickbeard/nzbSplitter.py
+++ b/sickbeard/nzbSplitter.py
@@ -205,9 +205,7 @@ def split_result(obj):
         want_ep = True
         for ep_num in parsed_obj.episode_numbers:
             if not obj.extraInfo[0].wantEpisode(season, ep_num, obj.quality):
-                # pylint: disable=no-member
-                logger.log(u"Ignoring result " + new_nzb + " because we don't want an episode that is " +
-                           Quality.qualityStrings[obj.quality], logger.INFO)
+                logger.log(u"Ignoring result: " + new_nzb, logger.DEBUG)
                 want_ep = False
                 break
         if not want_ep:

--- a/sickbeard/tv.py
+++ b/sickbeard/tv.py
@@ -1219,7 +1219,8 @@ class TVShow(object):
                     self.qualitiesToString([quality])), logger.DEBUG)
 
         if quality not in allowed_qualities + preferred_qualities or quality is UNKNOWN:
-            logger.log(u"Don't want this quality, ignoring found episode", logger.DEBUG)
+            logger.log(u"Skipping %s (S%02dE%02d, %s): Don't want this quality, ignoring found episode" %
+                (self.name, season or 0, episode or 0, Quality.qualityStrings[quality]), logger.INFO)
             return False
 
         myDB = db.DBConnection()
@@ -1227,7 +1228,8 @@ class TVShow(object):
                                  [self.indexerid, season, episode])
 
         if not sqlResults or not len(sqlResults):
-            logger.log(u"Unable to find a matching episode in database, ignoring found episode", logger.DEBUG)
+            logger.log(u"Skipping %s (S%02dE%02d, %s): Unable to find a matching episode in database, ignoring found episode" %
+                (self.name, season or 0, episode or 0, Quality.qualityStrings[quality]), logger.INFO)
             return False
 
         epStatus = int(sqlResults[0]["status"])
@@ -1237,14 +1239,15 @@ class TVShow(object):
 
         # if we know we don't want it then just say no
         if epStatus in Quality.ARCHIVED + [UNAIRED, SKIPPED, IGNORED] and not manualSearch:
-            logger.log(u"Existing episode status is unaired/skipped/ignored/archived, ignoring found episode", logger.DEBUG)
+            logger.log(u"Skipping %s (S%02dE%02d, %s): Existing episode status is '%s', ignoring found episode" %
+                (self.name, season or 0, episode or 0, Quality.qualityStrings[quality], epStatus_text), logger.INFO)
             return False
 
         curStatus, curQuality = Quality.splitCompositeStatus(epStatus)
 
         # if it's one of these then we want it as long as it's in our allowed initial qualities
         if epStatus in (WANTED, SKIPPED, UNKNOWN):
-            logger.log(u"Existing episode status is wanted/skipped/unknown, getting found episode", logger.DEBUG)
+            logger.log(u"Existing episode status is '%s', getting found episode" % epStatus_text, logger.DEBUG)
             return True
         elif manualSearch:
             if (downCurQuality and quality >= curQuality) or (not downCurQuality and quality > curQuality):
@@ -1266,7 +1269,8 @@ class TVShow(object):
             logger.log(u"Episode already exists and the found episode has same/lower quality, ignoring found episode",
                        logger.DEBUG)
 
-        logger.log(u"None of the conditions were met, ignoring found episode", logger.DEBUG)
+        logger.log(u"Skipping %s (S%02dE%02d, %s): None of the conditions were met, ignoring found episode" %
+            (self.name, season or 0, episode or 0, Quality.qualityStrings[quality]), logger.INFO)
         return False
 
     def getOverview(self, epStatus):

--- a/sickbeard/tvcache.py
+++ b/sickbeard/tvcache.py
@@ -356,8 +356,7 @@ class TVCache(object):
 
             # if the show says we want that episode then add it to the list
             if not showObj.wantEpisode(curSeason, curEp, curQuality, manualSearch, downCurQuality):
-                logger.log(u"Skipping " + curResult["name"] + " because we don't want an episode that's " +
-                           Quality.qualityStrings[curQuality], logger.INFO)
+                logger.log(u"Skipping " + curResult["name"], logger.DEBUG)
                 continue
 
             epObj = showObj.getEpisode(curSeason, curEp)

--- a/sickrage/providers/GenericProvider.py
+++ b/sickrage/providers/GenericProvider.py
@@ -290,8 +290,7 @@ class GenericProvider(object):  # pylint: disable=too-many-instance-attributes
                     break
 
             if not episode_wanted:
-                logger.log(u'Ignoring result %s because we don\'t want an episode that is %s' % (
-                    title, Quality.qualityStrings[quality]), logger.INFO)
+                logger.log(u'Ignoring result %s.' % (title), logger.DEBUG)
                 continue
 
             logger.log(u'Found result %s at %s' % (title, url), logger.DEBUG)


### PR DESCRIPTION
The wantEpisode method of the TVShow class currently returns false for several reasons; however, in many instances across SR, when the function returned false, a log entry was added indicating that it was because the quality was incorrect.

This commit adjusts wantEpisode so that it creates detailed INFO log messages on a false return. This commit also removes the bogus log information from the calling functions.

So, previously, the log would have looked like this: http://www.hastebin.com/ivebafuyoc.vbs But, with this commit, the log file will look like this: http://hastebin.com/vapapovodo.vbs As you can see, the first one gives the quality as the reason for all of the false returns ...while the second log snippet gives the actual reason for each.   _(Note:  Logging at the DEBUG level would give even more information.)_
