### PR TITLE
Fix API show.addnew not finding results for non-English shows.

### DIFF
--- a/gui/slick/views/apiBuilder.mako
+++ b/gui/slick/views/apiBuilder.mako
@@ -261,13 +261,7 @@ var episodes = ${episodes};
         </select>
         % endif
     % elif parameter == 'tvdbid':
-        <select class="form-control" name="${parameter}" data-command="${command}">
-            <option>${parameter}</option>
-
-            % for show in shows:
-            <option value="${show.indexerid}">${show.name}</option>
-            % endfor
-        </select>
+        <input class="form-control" name="${parameter}" placeholder="${parameter}" type="number" data-command="${command}" />
     % elif type == 'int':
         % if parameter not in ('episode', 'season'):
         <input class="form-control" name="${parameter}" placeholder="${parameter}" type="number" data-command="${command}" />

--- a/sickbeard/webapi.py
+++ b/sickbeard/webapi.py
@@ -2146,7 +2146,7 @@ class CMD_ShowAddNew(ApiCall):
             default_ep_status_after = self.future_status
 
         indexer_name = None
-        indexer_result = CMD_SickBeardSearchIndexers([], {indexer_ids[self.indexer]: self.indexerid}).run()
+        indexer_result = CMD_SickBeardSearchIndexers([], {indexer_ids[self.indexer]: self.indexerid, 'lang': self.lang}).run()
 
         if indexer_result['result'] == result_type_map[RESULT_SUCCESS]:
             if not indexer_result['data']['results']:


### PR DESCRIPTION
Fix apiBuilder TVDBID only accepts shows in show list
- API was not passing optional lang parameter to sb.searchindexers, so no results were returned for shows without an English TVDB listing.
- TVDB ID parameter in API Builder only allowed shows from show list.  Changed input type to int so any value can be entered.
