### PR TITLE
Update "Help & Info" section

### DIFF
--- a/gui/slick/views/config.mako
+++ b/gui/slick/views/config.mako
@@ -3,7 +3,8 @@
     import sickbeard
     from sickbeard import db
     from sickbeard.helpers import anon_url
-    import sys, os
+    from sickbeard.versionChecker import CheckVersion
+    import sys
 %>
 <%block name="content">
 % if not header is UNDEFINED:
@@ -25,9 +26,22 @@
 ##disk_percent_used = ${disk.percent}
 <div id="config-content">
 <table class="infoTable" cellspacing="1" border="0" cellpadding="0" width="100%">
-    <tr><td class="infoTableHeader">SR Version: </td><td class="infoTableCell">
+    <tr><td class="infoTableHeader" style="vertical-align: top;">Version:</td><td class="infoTableCell">
 % if sickbeard.VERSION_NOTIFY:
-        BRANCH: (${sickbeard.BRANCH}) / COMMIT: (${sickbeard.CUR_COMMIT_HASH}) <!-- &ndash; build.date //--><br>
+        Branch: <a href="${anon_url('https://github.com/SickRage/SickRage/tree/%s' % sickbeard.BRANCH)}">${sickbeard.BRANCH}</a><br>
+        Commit: <a href="${anon_url('https://github.com/SickRage/SickRage/commit/%s' % sickbeard.CUR_COMMIT_HASH)}">${sickbeard.CUR_COMMIT_HASH}</a><br>
+        <%
+        updater = CheckVersion().updater
+        %>
+
+        % if updater is not None:
+            <%
+            updater.need_update()
+            %>
+
+            Version: <a href="${anon_url('https://github.com/SickRage/SickRage/releases/tag/%s' % updater.get_cur_version())}">${updater.get_cur_version()}</a>
+        % endif
+        <!-- &ndash; build.date //-->
 % else:
         You don't have version checking turned on. Please turn on "Check for Update" in Config > General.<br>
 % endif
@@ -36,37 +50,40 @@
 <%
     sr_user = None
     try:
-        import pwd
+        import os, pwd
         sr_user = pwd.getpwuid(os.getuid()).pw_name
     except ImportError:
         import getpass
         sr_user = getpass.getuser()
 %>
 % if sr_user:
-    <tr><td class="infoTableHeader">SR User:</td><td class="infoTableCell">${sr_user}</td></tr>
+    <tr><td class="infoTableHeader">User:</td><td class="infoTableCell">${sr_user}</td></tr>
 % endif
 
 % try:
     <% import locale %>
     <% sr_locale = locale.getdefaultlocale() %>
-    <tr><td class="infoTableHeader">SR Locale:</td><td class="infoTableCell">${sr_locale}</td></tr>
+    <tr><td class="infoTableHeader" style="vertical-align: top;">Locale:</td><td class="infoTableCell">
+        Language: ${sr_locale[0]}<br>
+        Encoding: ${sr_locale[1]}
+    </td></tr>
 % except:
     ""
 % endtry
 
-    <tr><td class="infoTableHeader">SR Config:</td><td class="infoTableCell">${sickbeard.CONFIG_FILE}</td></tr>
-    <tr><td class="infoTableHeader">SR Database:</td><td class="infoTableCell">${db.dbFilename()}</td></tr>
-    <tr><td class="infoTableHeader">SR Cache Dir:</td><td class="infoTableCell">${sickbeard.CACHE_DIR}</td></tr>
-    <tr><td class="infoTableHeader">SR Log Dir:</td><td class="infoTableCell">${sickbeard.LOG_DIR}</td></tr>
-    <tr><td class="infoTableHeader">SR Arguments:</td><td class="infoTableCell">${sickbeard.MY_ARGS}</td></tr>
+    <tr><td class="infoTableHeader">Configuration File:</td><td class="infoTableCell">${sickbeard.CONFIG_FILE}</td></tr>
+    <tr><td class="infoTableHeader">Database:</td><td class="infoTableCell">${db.dbFilename()}</td></tr>
+    <tr><td class="infoTableHeader">Cache Directory:</td><td class="infoTableCell">${sickbeard.CACHE_DIR}</td></tr>
+    <tr><td class="infoTableHeader">Log Directory:</td><td class="infoTableCell">${sickbeard.LOG_DIR}</td></tr>
+    <tr><td class="infoTableHeader">Arguments:</td><td class="infoTableCell">${sickbeard.MY_ARGS}</td></tr>
 % if sickbeard.WEB_ROOT:
-    <tr><td class="infoTableHeader">SR Web Root:</td><td class="infoTableCell">${sickbeard.WEB_ROOT}</td></tr>
+    <tr><td class="infoTableHeader">Web Root:</td><td class="infoTableCell">${sickbeard.WEB_ROOT}</td></tr>
 % endif
     <tr><td class="infoTableHeader">Python Version:</td><td class="infoTableCell">${sys.version[:120]}</td></tr>
-    <tr class="infoTableSeperator"><td class="infoTableHeader"><i class="icon16-sb"></i> Website</td><td class="infoTableCell"><a href="${anon_url('http://sickrage.github.io/')}" rel="noreferrer" onclick="window.open(this.href, '_blank'); return false;">http://sickrage.github.io/</a></td></tr>
-    <tr><td class="infoTableHeader"><i class="icon16-WiKi"></i> WiKi</td><td class="infoTableCell"><a href="${anon_url('https://github.com/SickRage/sickrage-issues/wiki')}" rel="noreferrer" onclick="window.open(this.href, '_blank'); return false;">https://github.com/SickRage/sickrage-issues/wiki</a></td></tr>
-    <tr><td class="infoTableHeader"><i class="icon16-github"></i> Source</td><td class="infoTableCell"><a href="${anon_url('https://github.com/SickRage/SickRage/')}" rel="noreferrer" onclick="window.open(this.href, '_blank'); return false;">https://github.com/SickRage/SickRage/</a></td></tr>
-    <tr><td class="infoTableHeader"><i class="icon16-mirc"></i> IRChat</td><td class="infoTableCell"><a href="irc://irc.freenode.net/#sickrage-issues" rel="noreferrer"><i>#sickrage-issues</i> on <i>irc.freenode.net</i></a></td></tr>
+    <tr class="infoTableSeperator"><td class="infoTableHeader"><i class="icon16-sb"></i> Website:</td><td class="infoTableCell"><a href="${anon_url('http://sickrage.github.io/')}" rel="noreferrer" onclick="window.open(this.href, '_blank'); return false;">http://sickrage.github.io/</a></td></tr>
+    <tr><td class="infoTableHeader"><i class="icon16-WiKi"></i> Wiki:</td><td class="infoTableCell"><a href="${anon_url('https://github.com/SickRage/sickrage-issues/wiki')}" rel="noreferrer" onclick="window.open(this.href, '_blank'); return false;">https://github.com/SickRage/sickrage-issues/wiki</a></td></tr>
+    <tr><td class="infoTableHeader"><i class="icon16-github"></i> Source:</td><td class="infoTableCell"><a href="${anon_url('https://github.com/SickRage/SickRage/')}" rel="noreferrer" onclick="window.open(this.href, '_blank'); return false;">https://github.com/SickRage/SickRage/</a></td></tr>
+    <tr><td class="infoTableHeader"><i class="icon16-mirc"></i> IRChat:</td><td class="infoTableCell"><a href="irc://irc.freenode.net/#sickrage-issues" rel="noreferrer"><i>#sickrage-issues</i> on <i>irc.freenode.net</i></a></td></tr>
 </table>
 </div>
 </%block>

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -3694,7 +3694,7 @@ class Config(WebRoot):
     def index(self):
         t = PageTemplate(rh=self, filename="config.mako")
 
-        return t.render(submenu=self.ConfigMenu(), title='Configuration', header='Configuration', topmenu="config")
+        return t.render(submenu=self.ConfigMenu(), title='SickRage Configuration', header='SickRage Configuration', topmenu="config")
 
 
 @route('/config/general(/?.*)')


### PR DESCRIPTION
A small update to the "Help & Info" section that I wanted to do for a while now.
- Add SickRage's version if it is available
- Add links to the current branch/commit/version
- Remove all "SR" prefixes and rename the page "SickRage configuration"
