### PR TITLE
Fix logging line to handle NoneType object

### DIFF
--- a/sickbeard/postProcessor.py
+++ b/sickbeard/postProcessor.py
@@ -516,7 +516,8 @@ class PostProcessor(object):
             to_return = (show, season, [], quality, version)
 
             qual_str = common.Quality.qualityStrings[quality] if quality is not None else quality
-            self._log("Found result in history for %s - Season: %s - Quality: %s - Version: %s" % (show.name, season, qual_str, version), logger.DEBUG)
+            self._log("Found result in history for %s - Season: %s - Quality: %s - Version: %s" 
+                % (show.name if show else "UNDEFINED", season, qual_str, version), logger.DEBUG)
 
             return to_return
 


### PR DESCRIPTION
This is intended to address https://github.com/SickRage/sickrage-issues/issues/324     I believe that it should be very rare (odd) for the code to reach this line with the 'show' object as a NoneType, but it must be possible under the right circumstances.
