### PR TITLE
Hotfix-Issue 90: Fix API to match SB API

### DIFF
--- a/sickbeard/webapi.py
+++ b/sickbeard/webapi.py
@@ -2775,7 +2775,7 @@ class CMD_Shows(ApiCall):
         "desc": "Get all shows in SickRage",
         "optionalParameters": {
             "sort": {"desc": "The sorting strategy to apply to the list of shows"},
-            "paused": {"desc": "True to include paused shows, False otherwise"},
+            "paused": {"desc": "True: show paused, False: show un-paused, otherwise show all"},
         },
     }
 
@@ -2791,9 +2791,9 @@ class CMD_Shows(ApiCall):
         """ Get all shows in SickRage """
         shows = {}
         for curShow in sickbeard.showList:
-
-            if not self.paused and curShow.paused:  # If we're not including paused shows, and the current show is paused
-                continue  # continue with the next show
+            # If self.paused is None: show all, 0: show un-paused, 1: show paused
+            if self.paused is not None and self.paused != curShow.paused:
+                    continue
 
             indexer_show = helpers.mapIndexersToShow(curShow)
 


### PR DESCRIPTION
API Shows description of pause parameter was incorrect.  Corrected API Builder description to match expected functionality.  Hotfixed API to match SB API.

Paused Parameter:
- 0 - show only non paused
- 1 - show only paused
- if not set then both paused and non paused are shown

http://sickbeard.com/api/#shows
