### PR TITLE
Fix providers url encode

### DIFF
--- a/sickbeard/providers/alpharatio.py
+++ b/sickbeard/providers/alpharatio.py
@@ -26,6 +26,7 @@ from sickbeard import tvcache
 from sickbeard.bs4_parser import BS4Parser
 from sickrage.helper.common import convert_size
 from sickrage.providers.torrent.TorrentProvider import TorrentProvider
+from urllib import urlencode
 
 
 class AlphaRatioProvider(TorrentProvider):
@@ -87,7 +88,7 @@ class AlphaRatioProvider(TorrentProvider):
                 if mode != 'RSS':
                     logger.log(u"Search string: %s " % search_string, logger.DEBUG)
 
-                searchURL = self.urls['search'] % (search_string, self.categories)
+                searchURL = self.urls['search'] % (urlencode(search_string), self.categories)
                 logger.log(u"Search URL: %s" % searchURL, logger.DEBUG)
 
                 data = self.get_url(searchURL)

--- a/sickbeard/providers/limetorrents.py
+++ b/sickbeard/providers/limetorrents.py
@@ -23,6 +23,7 @@ from sickbeard import tvcache
 from sickbeard.common import USER_AGENT
 from sickrage.helper.common import try_int, convert_size
 from sickrage.providers.torrent.TorrentProvider import TorrentProvider
+from urllib import urlencode
 
 
 class LimeTorrentsProvider(TorrentProvider): # pylint: disable=too-many-instance-attributes
@@ -60,6 +61,7 @@ class LimeTorrentsProvider(TorrentProvider): # pylint: disable=too-many-instance
 
                 try:
                     url = (self.urls['rss'], self.urls['search'] + search_string)[mode != 'RSS']
+                    url = urlencode(url)
                     logger.log(u"URL: %r " % url, logger.DEBUG)
                     data = self.get_url(url)
                     if not data:


### PR DESCRIPTION
Fix:
`FINDPROPERS :: [AlphaRatio] :: Search URL: http://alpharatio.cc/torrents.php?searchstr=Mike & Molly S06E01 REPACK&filter_cat[1]=1&filter_cat[2]=1&filter_cat[3]=1&filter_cat[4]=1&filter_cat[5]=1`

Like kat.py

https://github.com/SickRage/SickRage/blob/develop/sickbeard/providers/kat.py#L85

isn't already encoded here?
https://github.com/SickRage/SickRage/blob/develop/sickbeard/helpers.py#L1418
