### PR TITLE
Fixed beautifullsoup parsing of Danishbits search response

### DIFF
--- a/sickbeard/providers/danishbits.py
+++ b/sickbeard/providers/danishbits.py
@@ -129,7 +129,7 @@ class DanishbitsProvider(TorrentProvider):  # pylint: disable=too-many-instance-
                     continue
 
                 try:
-                    with BS4Parser(data.decode('iso-8859-1'), features=["html5lib", "permissive"]) as html:
+                    with BS4Parser(data,"html5lib") as html:
                         # Collecting entries
                         entries = html.find_all('tr', attrs={'class': 'torrent'})
 


### PR DESCRIPTION
The data.decode was giving errors. Returned html should be in unicode, so don't see any reason to decode. But maybe i'm wrong? For this worked, tested for a limited set of shows.
