### PR TITLE
Add missing import to BTDigg

### DIFF
--- a/sickbeard/providers/btdigg.py
+++ b/sickbeard/providers/btdigg.py
@@ -18,6 +18,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with SickRage.  If not, see <http://www.gnu.org/licenses/>.
+import traceback
 
 from urllib import urlencode
 from sickbeard import logger


### PR DESCRIPTION
`[BTDigg] :: Error while searching BTDigg, skipping: NameError("global name 'traceback' is not defined",)`
