### PR TITLE
Change tpb url to the new official domain .ms

### DIFF
--- a/sickbeard/providers/thepiratebay.py
+++ b/sickbeard/providers/thepiratebay.py
@@ -41,9 +41,9 @@ class ThePirateBayProvider(TorrentProvider):
         self.cache = ThePirateBayCache(self)
 
         self.urls = {
-            'base_url': 'https://thepiratebay.se/',
-            'search': 'https://thepiratebay.se/s/',
-            'rss': 'https://thepiratebay.se/tv/latest'
+            'base_url': 'https://thepiratebay.ms/',
+            'search': 'https://thepiratebay.ms/s/',
+            'rss': 'https://thepiratebay.ms/tv/latest'
         }
 
         self.url = self.urls['base_url']


### PR DESCRIPTION
https://torrentfreak.com/the-pirate-bay-switches-on-new-ms-domain-160107/
The .se tld its more likely to be blocked than the .md
