### PR TITLE
Fix BTDigg

### DIFF
--- a/sickbeard/providers/btdigg.py
+++ b/sickbeard/providers/btdigg.py
@@ -92,6 +92,7 @@ class BTDIGGProvider(TorrentProvider):
                         # Provider doesn't provide seeders/leechers
                         seeders = 1
                         leechers = 0
+                        title = torrent['name']
                         torrent_size = torrent['size']
                         size = convert_size(torrent_size) or -1
         


### PR DESCRIPTION
@labrys 

```
2016-01-08 01:12:10 SEARCHQUEUE-MANUAL-71663 :: [BTDigg] :: Failed parsing provider. Traceback: Traceback (most recent call last):
  File "/home/home/SickRage/sickbeard/providers/btdigg.py", line 98, in search
    if not all([title, download_url]):
NameError: global name 'title' is not defined
 [0c94fba]
```
