### PR TITLE
Remove ! from the notes since it was removed for some reason Oo

### DIFF
--- a/gui/slick/views/config_providers.mako
+++ b/gui/slick/views/config_providers.mako
@@ -61,7 +61,6 @@ $('#config-components').tabs();
 
                         <div>
                             <p class="note">* Provider does not support backlog searches at this time.</p>
-                            <p class="note">! Provider is <b>NOT WORKING</b>.</p>
                         </div>
                     </div>
 


### PR DESCRIPTION
@SickRage/collaborators & @SickRage/moderators  
Should we add back the support for this option? Would be good for when a site is in maintance for example ,or like when TPB has issues ie)
OR remove it with this PR
