### PR TITLE
Add try_int to RARBG

### DIFF
--- a/sickbeard/providers/rarbg.py
+++ b/sickbeard/providers/rarbg.py
@@ -23,7 +23,7 @@ from urllib import urlencode
 
 from sickbeard import logger, tvcache
 from sickbeard.indexers.indexer_config import INDEXER_TVDB
-
+from sickrage.helper.common import try_int
 from sickrage.helper.common import convert_size
 from sickrage.providers.torrent.TorrentProvider import TorrentProvider
 
@@ -77,11 +77,11 @@ class RarbgProvider(TorrentProvider):  # pylint: disable=too-many-instance-attri
         search_params = {
             'app_id': 'sickrage2',
             'categories': 'tv',
-            'seeders': int(self.minseed),
-            'leechers': int(self.minleech),
+            'seeders': try_int(self.minseed),
+            'leechers': try_int(self.minleech),
             'limit': 100,
             'format': 'json_extended',
-            'ranked': int(self.ranked),
+            'ranked': try_int(self.ranked),
             'token': self.token,
         }
 


### PR DESCRIPTION
@miigotu 
fix search_tests

```
======================================================================
ERROR: test_Game_of_Thrones_121361_Rarbg (__main__.SearchTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "search_tests.py", line 120, in do_test
    items = cur_provider.search(search_strings)  # pylint: disable=protected-access
  File "/home/osmc/SickRage/sickbeard/providers/rarbg.py", line 80, in search
    'seeders': int(self.minseed),
TypeError: int() argument must be a string or a number, not 'NoneType'

```
