### PR TITLE
Only set torrent label if label is set and replace space for safety

### DIFF
--- a/sickbeard/clients/qbittorrent_client.py
+++ b/sickbeard/clients/qbittorrent_client.py
@@ -82,9 +82,9 @@ class qbittorrentAPI(GenericClient):
         if result.show.is_anime:
             label = sickbeard.TORRENT_LABEL_ANIME
 
-        if self.api > 6:
+        if self.api > 6 and label:
             self.url = self.host + 'command/setLabel'
-            data = {'hashes': result.hash.lower(), 'label': label}
+            data = {'hashes': result.hash.lower(), 'label': label.replace(' ','_')}
             return self._request(method='post', data=data, cookies=self.session.cookies)
         return None
 


### PR DESCRIPTION
Change space for "_" as space is not allowed (only qbittorrent doesn't allow space)

Fixe https://github.com/SickRage/sickrage-issues/issues/440

Thanks to @NeoMod
