### PR TITLE
Change A > Z to Ascending and Descenting

### DIFF
--- a/gui/slick/views/home.mako
+++ b/gui/slick/views/home.mako
@@ -55,8 +55,8 @@
 
                     <span class="show-option"> Direction:
                         <select id="postersortdirection" class="form-control form-control-inline input-sm">
-                            <option value="true" data-sort="${srRoot}/setPosterSortDir/?direction=1" ${('', 'selected="selected"')[sickbeard.POSTER_SORTDIR == 1]}>A &#10140; Z</option>
-                            <option value="false" data-sort="${srRoot}/setPosterSortDir/?direction=0" ${('', 'selected="selected"')[sickbeard.POSTER_SORTDIR == 0]}>Z &#10140; A</option>
+                            <option value="true" data-sort="${srRoot}/setPosterSortDir/?direction=1" ${('', 'selected="selected"')[sickbeard.POSTER_SORTDIR == 1]}>Ascending </option>
+                            <option value="false" data-sort="${srRoot}/setPosterSortDir/?direction=0" ${('', 'selected="selected"')[sickbeard.POSTER_SORTDIR == 0]}>Descending</option>
                         </select>
                     </span>
                 % endif


### PR DESCRIPTION
if I have sort by next episode for example it still says direction a-> or z->a even though its sorting based on next aired date
