### PR TITLE
Fix morethan.tv scraper for search download links

### DIFF
--- a/sickbeard/providers/morethantv.py
+++ b/sickbeard/providers/morethantv.py
@@ -129,7 +129,7 @@ class MoreThanTVProvider(TorrentProvider):
                         # skip colheader
                         for result in torrent_rows[1:]:
                             cells = result.findChildren('td')
-                            link = cells[1].find('a', attrs={'title': 'Download'})
+                            link = cells[1].find('span', attrs={'title': 'Download'}).parent
 
                             # skip if torrent has been nuked due to poor quality
                             if cells[1].find('img', alt='Nuked') is not None:


### PR DESCRIPTION
morethan.tv updated the html returned in search queries to include a nested `<span>` tag with the "Download" `title` attribute. This updates the scraper code to reflect the change.

Before:

```
<a href="torrents.php?action=download&amp;id=..." ... title="Download">&nbsp;</a>
```

After:

```
<a href="torrents.php?action=download&amp;id=..." ...><span ... title="Download">&nbsp;</span></a>
```
