### PR TITLE
Add "Total Disk Usage" to main page footer

### DIFF
--- a/gui/slick/views/layouts/main.mako
+++ b/gui/slick/views/layouts/main.mako
@@ -284,6 +284,7 @@
                 ep_downloaded = stats['episodes']['downloaded']
                 ep_snatched = stats['episodes']['snatched']
                 ep_total = stats['episodes']['total']
+                ep_total_size = stats['episodes']['total_size']
                 ep_percentage = '' if ep_total == 0 else '(<span class="footerhighlight">%s%%</span>)' % re.sub(r'(\d+)(\.\d)\d+', r'\1\2', str((float(ep_downloaded)/float(ep_total))*100))
             %>
                 <span class="footerhighlight">${stats['shows']['total']}</span> Shows (<span class="footerhighlight">${stats['shows']['active']}</span> Active)
@@ -302,6 +303,7 @@
                     Memory used: <span class="footerhighlight">${pretty_file_size(resource.getrusage(resource.RUSAGE_SELF).ru_maxrss)}</span> |
                     % endif
                     Load time: <span class="footerhighlight">${"%.4f" % (time() - sbStartTime)}s</span> / Mako: <span class="footerhighlight">${"%.4f" % (time() - makoStartTime)}s</span> |
+                    Total Disk Usage: <span class="footerhighlight">${pretty_file_size(ep_total_size)}</span> |
                     Branch: <span class="footerhighlight">${sickbeard.BRANCH}</span> |
                     Now: <span class="footerhighlight">${datetime.datetime.now(network_timezones.sb_timezone).strftime(sickbeard.DATE_PRESET+" "+sickbeard.TIME_PRESET)}</span>
                 </div>

--- a/sickrage/show/Show.py
+++ b/sickrage/show/Show.py
@@ -89,7 +89,7 @@ class Show(object):
         total_status = [SKIPPED, WANTED]
 
         results = db.select(
-            'SELECT airdate, status '
+            'SELECT airdate, status, file_size '
             'FROM tv_episodes '
             'WHERE season > 0 '
             'AND episode > 0 '
@@ -101,6 +101,7 @@ class Show(object):
                 'downloaded': 0,
                 'snatched': 0,
                 'total': 0,
+                'total_size': 0,
             },
             'shows': {
                 'active': len([show for show in shows if show.paused == 0 and show.status == 'Continuing']),
@@ -112,6 +113,7 @@ class Show(object):
             if result['status'] in downloaded_status:
                 stats['episodes']['downloaded'] += 1
                 stats['episodes']['total'] += 1
+                stats['episodes']['total_size'] += result['file_size']
             elif result['status'] in snatched_status:
                 stats['episodes']['snatched'] += 1
                 stats['episodes']['total'] += 1


### PR DESCRIPTION
I found myself wondering the total disk usage by SR, and thought it would be a nice feature to have included in the webUI "footer".    It turns out that it was a VERY easy thing to add (and I think the additional data added to Show.overall_stats() might be useful in the future anyway.)

Here is a screenshot of how it looks:  http://bit.ly/1ZtcSuy

I'm happy to change the label from "Total Disk Usage" to something else, but I couldn't think of anything better to use.
