### PR TITLE
Temporary add number of seeders to log message to help debug

### DIFF
--- a/sickbeard/providers/kat.py
+++ b/sickbeard/providers/kat.py
@@ -139,7 +139,7 @@ class KatProvider(TorrentProvider):  # pylint: disable=too-many-instance-attribu
 
                         item = title, download_url, size, seeders, leechers, info_hash
                         if mode != 'RSS':
-                            logger.log(u"Found result: %s " % title, logger.DEBUG)
+                            logger.log(u"Found result: %s with %s seeders and %s leechers" % (title, seeders, leechers), logger.DEBUG)
 
                         items.append(item)
 


### PR DESCRIPTION
kat not always parsing correct seeders from website - @dbmandrake

if you want, we can make this default log for all providers.
