### PR TITLE
Provider optimization

### DIFF
--- a/sickbeard/providers/__init__.py
+++ b/sickbeard/providers/__init__.py
@@ -1,7 +1,7 @@
 # coding=utf-8
-
 # Author: Nic Wolfe <nic@wolfeden.ca>
-# URL: http://code.google.com/p/sickbeard/
+#
+# URL: https://sickrage.github.io
 #
 # This file is part of SickRage.
 #

--- a/sickbeard/providers/alpharatio.py
+++ b/sickbeard/providers/alpharatio.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 # Author: Dustyn Gibson <miigotu@gmail.com>
+#
 # URL: https://sickrage.github.io
 #
 # This file is part of SickRage.
@@ -18,13 +19,13 @@
 # along with SickRage. If not, see <http://www.gnu.org/licenses/>.
 
 import re
-from urllib import urlencode
 from requests.utils import dict_from_cookiejar
+from urllib import urlencode
 
-from sickbeard import logger
-from sickbeard import tvcache
+from sickbeard import logger, tvcache
 from sickbeard.bs4_parser import BS4Parser
-from sickrage.helper.common import try_int, convert_size
+
+from sickrage.helper.common import convert_size, try_int
 from sickrage.providers.torrent.TorrentProvider import TorrentProvider
 
 

--- a/sickbeard/providers/alpharatio.py
+++ b/sickbeard/providers/alpharatio.py
@@ -49,7 +49,7 @@ class AlphaRatioProvider(TorrentProvider):  # pylint: disable=too-many-instance-
 
         self.proper_strings = ['PROPER', 'REPACK']
 
-        self.cache = AlphaRatioCache(self, min_time=20)  # only poll AlphaRatio every 20 minutes max
+        self.cache = tvcache.TVCache(self)
 
     def login(self):
         if any(dict_from_cookiejar(self.session.cookies).values()):
@@ -162,11 +162,5 @@ class AlphaRatioProvider(TorrentProvider):  # pylint: disable=too-many-instance-
 
     def seed_ratio(self):
         return self.ratio
-
-
-class AlphaRatioCache(tvcache.TVCache):
-    def _getRSSData(self):
-        search_strings = {'RSS': ['']}
-        return {'entries': self.provider.search(search_strings)}
 
 provider = AlphaRatioProvider()

--- a/sickbeard/providers/alpharatio.py
+++ b/sickbeard/providers/alpharatio.py
@@ -48,7 +48,7 @@ class AlphaRatioProvider(TorrentProvider):  # pylint: disable=too-many-instance-
 
         self.proper_strings = ['PROPER', 'REPACK']
 
-        self.cache = AlphaRatioCache(self)
+        self.cache = AlphaRatioCache(self, min_time=20)  # only poll AlphaRatio every 20 minutes max
 
     def login(self):
         if any(dict_from_cookiejar(self.session.cookies).values()):
@@ -164,14 +164,6 @@ class AlphaRatioProvider(TorrentProvider):  # pylint: disable=too-many-instance-
 
 
 class AlphaRatioCache(tvcache.TVCache):
-
-    def __init__(self, provider_obj):
-
-        tvcache.TVCache.__init__(self, provider_obj)
-
-        # only poll AlphaRatio every 20 minutes max
-        self.minTime = 20
-
     def _getRSSData(self):
         search_strings = {'RSS': ['']}
         return {'entries': self.provider.search(search_strings)}

--- a/sickbeard/providers/binsearch.py
+++ b/sickbeard/providers/binsearch.py
@@ -41,7 +41,9 @@ class BinSearchProvider(NZBProvider):
 
 class BinSearchCache(tvcache.TVCache):
     def __init__(self, provider_obj, **kwargs):
-        tvcache.TVCache.__init__(self, provider_obj, **kwargs)
+        kwargs.pop(u'search_params', None)  # does not use _getRSSData so strip param from kwargs...
+        search_params = None  # ...and pass None instead
+        tvcache.TVCache.__init__(self, provider_obj, search_params=search_params, **kwargs)
 
         # compile and save our regular expressions
 

--- a/sickbeard/providers/binsearch.py
+++ b/sickbeard/providers/binsearch.py
@@ -1,31 +1,35 @@
 # coding=utf-8
 # Author: moparisthebest <admin@moparisthebest.com>
 #
-# This file is part of Sick Beard.
+# URL: https://sickrage.github.io
 #
-# Sick Beard is free software: you can redistribute it and/or modify
+# This file is part of SickRage.
+#
+# SickRage is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# Sick Beard is distributed in the hope that it will be useful,
+# SickRage is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with Sick Beard.  If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
 
-import urllib
 import re
+from urllib import urlencode
 
-from sickbeard import logger
-from sickbeard import tvcache
+from sickbeard import logger, tvcache
+
 from sickrage.providers.nzb.NZBProvider import NZBProvider
 
 
 class BinSearchProvider(NZBProvider):
+
     def __init__(self):
+
         NZBProvider.__init__(self, "BinSearch")
 
         self.public = True
@@ -33,7 +37,6 @@ class BinSearchProvider(NZBProvider):
         self.urls = {'base_url': 'https://www.binsearch.info/'}
         self.url = self.urls['base_url']
         self.supports_backlog = False
-
 
 
 class BinSearchCache(tvcache.TVCache):
@@ -97,7 +100,7 @@ class BinSearchCache(tvcache.TVCache):
             url = self.provider.url + 'rss.php?'
             urlArgs = {'max': 50, 'g': group}
 
-            url += urllib.urlencode(urlArgs)
+            url += urlencode(urlArgs)
 
             logger.log(u"Cache update URL: %s " % url, logger.DEBUG)
 

--- a/sickbeard/providers/binsearch.py
+++ b/sickbeard/providers/binsearch.py
@@ -29,17 +29,16 @@ class BinSearchProvider(NZBProvider):
         NZBProvider.__init__(self, "BinSearch")
 
         self.public = True
-        self.cache = BinSearchCache(self)
+        self.cache = BinSearchCache(self, min_time=30)  # only poll Binsearch every 30 minutes max
         self.urls = {'base_url': 'https://www.binsearch.info/'}
         self.url = self.urls['base_url']
         self.supports_backlog = False
 
 
+
 class BinSearchCache(tvcache.TVCache):
-    def __init__(self, provider_obj):
-        tvcache.TVCache.__init__(self, provider_obj)
-        # only poll Binsearch every 30 minutes max
-        self.minTime = 30
+    def __init__(self, provider_obj, **kwargs):
+        tvcache.TVCache.__init__(self, provider_obj, **kwargs)
 
         # compile and save our regular expressions
 

--- a/sickbeard/providers/bitcannon.py
+++ b/sickbeard/providers/bitcannon.py
@@ -41,7 +41,7 @@ class BitCannonProvider(TorrentProvider):  # pylint: disable=too-many-instance-a
         self.custom_url = None
         self.api_key = None
 
-        self.cache = BitCannonCache(self, min_time=20)  # only poll BitCannon every 20 minutes max
+        self.cache = tvcache.TVCache(self, search_params={'RSS': ['tv', 'anime']})
 
         self.search_params = {
             'q': '',
@@ -139,11 +139,5 @@ class BitCannonProvider(TorrentProvider):  # pylint: disable=too-many-instance-a
                 return False
 
         return True
-
-
-class BitCannonCache(tvcache.TVCache):
-    def _getRSSData(self):
-        search_params = {'RSS': ['tv', 'anime']}
-        return {'entries': self.provider.search(search_params)}
 
 provider = BitCannonProvider()

--- a/sickbeard/providers/bitcannon.py
+++ b/sickbeard/providers/bitcannon.py
@@ -1,6 +1,7 @@
 # coding=utf-8
-# Author: miigotu <miigotu@gmail.com>
-# URL: http://github.com/SickRage/SickRage
+# Author: Dustyn Gibson <miigotu@gmail.com>
+#
+# URL: https://sickrage.github.io
 #
 # This file is part of SickRage.
 #
@@ -20,13 +21,14 @@
 import traceback
 from urllib import urlencode
 
-from sickbeard import logger
-from sickbeard import tvcache
+from sickbeard import logger, tvcache
+
 from sickrage.helper.common import convert_size
 from sickrage.providers.torrent.TorrentProvider import TorrentProvider
 
 
 class BitCannonProvider(TorrentProvider):  # pylint: disable=too-many-instance-attributes
+
     def __init__(self):
 
         TorrentProvider.__init__(self, "BitCannon")

--- a/sickbeard/providers/bitcannon.py
+++ b/sickbeard/providers/bitcannon.py
@@ -39,7 +39,7 @@ class BitCannonProvider(TorrentProvider):  # pylint: disable=too-many-instance-a
         self.custom_url = None
         self.api_key = None
 
-        self.cache = BitCannonCache(self)
+        self.cache = BitCannonCache(self, min_time=20)  # only poll BitCannon every 20 minutes max
 
         self.search_params = {
             'q': '',
@@ -140,13 +140,6 @@ class BitCannonProvider(TorrentProvider):  # pylint: disable=too-many-instance-a
 
 
 class BitCannonCache(tvcache.TVCache):
-    def __init__(self, provider_obj):
-
-        tvcache.TVCache.__init__(self, provider_obj)
-
-        # only poll bitcannon every 20 minutes max
-        self.minTime = 20
-
     def _getRSSData(self):
         search_params = {'RSS': ['tv', 'anime']}
         return {'entries': self.provider.search(search_params)}

--- a/sickbeard/providers/bitsnoop.py
+++ b/sickbeard/providers/bitsnoop.py
@@ -49,7 +49,7 @@ class BitSnoopProvider(TorrentProvider):  # pylint: disable=too-many-instance-at
 
         self.proper_strings = ['PROPER', 'REPACK']
 
-        self.cache = BitSnoopCache(self, min_time=20)  # only poll BitSnoop every 20 minutes max
+        self.cache = tvcache.TVCache(self, search_params={'RSS': ['rss']})
 
     def search(self, search_strings, age=0, ep_obj=None):  # pylint: disable=too-many-branches,too-many-locals
         results = []
@@ -124,11 +124,5 @@ class BitSnoopProvider(TorrentProvider):  # pylint: disable=too-many-instance-at
 
     def seed_ratio(self):
         return self.ratio
-
-
-class BitSnoopCache(tvcache.TVCache):
-    def _getRSSData(self):
-        search_strings = {'RSS': ['rss']}
-        return {'entries': self.provider.search(search_strings)}
 
 provider = BitSnoopProvider()

--- a/sickbeard/providers/bitsnoop.py
+++ b/sickbeard/providers/bitsnoop.py
@@ -1,6 +1,8 @@
 # coding=utf-8
-# Author: Gonçalo (aka duramato) <matigonkas@outlook.com>
-# URL: https://github.com/SickRage/sickrage
+# Author: Gonçalo M. (aka duramato/supergonkas) <supergonkas@gmail.com>
+#
+# URL: https://sickrage.github.io
+#
 # This file is part of SickRage.
 #
 # SickRage is free software: you can redistribute it and/or modify
@@ -20,14 +22,16 @@ import traceback
 from bs4 import BeautifulSoup
 
 import sickbeard
-from sickbeard import logger
-from sickbeard import tvcache
-from sickrage.helper.common import try_int, convert_size
+from sickbeard import logger, tvcache
+
+from sickrage.helper.common import convert_size, try_int
 from sickrage.providers.torrent.TorrentProvider import TorrentProvider
 
 
 class BitSnoopProvider(TorrentProvider):  # pylint: disable=too-many-instance-attributes
+
     def __init__(self):
+
         TorrentProvider.__init__(self, "BitSnoop")
 
         self.urls = {
@@ -126,6 +130,5 @@ class BitSnoopCache(tvcache.TVCache):
     def _getRSSData(self):
         search_strings = {'RSS': ['rss']}
         return {'entries': self.provider.search(search_strings)}
-
 
 provider = BitSnoopProvider()

--- a/sickbeard/providers/bitsnoop.py
+++ b/sickbeard/providers/bitsnoop.py
@@ -45,7 +45,7 @@ class BitSnoopProvider(TorrentProvider):  # pylint: disable=too-many-instance-at
 
         self.proper_strings = ['PROPER', 'REPACK']
 
-        self.cache = BitSnoopCache(self)
+        self.cache = BitSnoopCache(self, min_time=20)  # only poll BitSnoop every 20 minutes max
 
     def search(self, search_strings, age=0, ep_obj=None):  # pylint: disable=too-many-branches,too-many-locals
         results = []
@@ -123,12 +123,6 @@ class BitSnoopProvider(TorrentProvider):  # pylint: disable=too-many-instance-at
 
 
 class BitSnoopCache(tvcache.TVCache):
-    def __init__(self, provider_obj):
-
-        tvcache.TVCache.__init__(self, provider_obj)
-
-        self.minTime = 20
-
     def _getRSSData(self):
         search_strings = {'RSS': ['rss']}
         return {'entries': self.provider.search(search_strings)}

--- a/sickbeard/providers/bitsoup.py
+++ b/sickbeard/providers/bitsoup.py
@@ -47,7 +47,7 @@ class BitSoupProvider(TorrentProvider):  # pylint: disable=too-many-instance-att
         self.minseed = None
         self.minleech = None
 
-        self.cache = BitSoupCache(self)
+        self.cache = BitSoupCache(self, min_time=20)  # only poll TorrentBytes every 20 minutes max
 
         self.search_params = {
             "c42": 1, "c45": 1, "c49": 1, "c7": 1
@@ -154,13 +154,6 @@ class BitSoupProvider(TorrentProvider):  # pylint: disable=too-many-instance-att
 
 
 class BitSoupCache(tvcache.TVCache):
-    def __init__(self, provider_obj):
-
-        tvcache.TVCache.__init__(self, provider_obj)
-
-        # only poll TorrentBytes every 20 minutes max
-        self.minTime = 20
-
     def _getRSSData(self):
         search_strings = {'RSS': ['']}
         return {'entries': self.provider.search(search_strings)}

--- a/sickbeard/providers/bitsoup.py
+++ b/sickbeard/providers/bitsoup.py
@@ -50,7 +50,7 @@ class BitSoupProvider(TorrentProvider):  # pylint: disable=too-many-instance-att
         self.minseed = None
         self.minleech = None
 
-        self.cache = BitSoupCache(self, min_time=20)  # only poll TorrentBytes every 20 minutes max
+        self.cache = tvcache.TVCache(self)
 
         self.search_params = {
             "c42": 1, "c45": 1, "c49": 1, "c7": 1
@@ -154,11 +154,5 @@ class BitSoupProvider(TorrentProvider):  # pylint: disable=too-many-instance-att
 
     def seed_ratio(self):
         return self.ratio
-
-
-class BitSoupCache(tvcache.TVCache):
-    def _getRSSData(self):
-        search_strings = {'RSS': ['']}
-        return {'entries': self.provider.search(search_strings)}
 
 provider = BitSoupProvider()

--- a/sickbeard/providers/bitsoup.py
+++ b/sickbeard/providers/bitsoup.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 # Author: Idan Gutman
-# URL: http://code.google.com/p/sickbeard/
+#
+# URL: https://sickrage.github.io
 #
 # This file is part of SickRage.
 #
@@ -20,15 +21,17 @@
 import re
 import traceback
 
-from sickbeard import logger
-from sickbeard import tvcache
+from sickbeard import logger, tvcache
 from sickbeard.bs4_parser import BS4Parser
+
 from sickrage.helper.common import convert_size
 from sickrage.providers.torrent.TorrentProvider import TorrentProvider
 
 
 class BitSoupProvider(TorrentProvider):  # pylint: disable=too-many-instance-attributes
+
     def __init__(self):
+
         TorrentProvider.__init__(self, "BitSoup")
 
         self.urls = {
@@ -157,6 +160,5 @@ class BitSoupCache(tvcache.TVCache):
     def _getRSSData(self):
         search_strings = {'RSS': ['']}
         return {'entries': self.provider.search(search_strings)}
-
 
 provider = BitSoupProvider()

--- a/sickbeard/providers/bluetigers.py
+++ b/sickbeard/providers/bluetigers.py
@@ -37,7 +37,7 @@ class BlueTigersProvider(TorrentProvider):  # pylint: disable=too-many-instance-
         self.ratio = None
         self.token = None
 
-        self.cache = BlueTigersCache(self)
+        self.cache = BlueTigersCache(self, min_time=10)  # Only poll BLUETIGERS every 10 minutes max
 
         self.urls = {
             'base_url': 'https://www.bluetigers.ca/',
@@ -145,12 +145,6 @@ class BlueTigersProvider(TorrentProvider):  # pylint: disable=too-many-instance-
 
 
 class BlueTigersCache(tvcache.TVCache):
-    def __init__(self, provider_obj):
-        tvcache.TVCache.__init__(self, provider_obj)
-
-        # Only poll BLUETIGERS every 10 minutes max
-        self.minTime = 10
-
     def _getRSSData(self):
         search_strings = {'RSS': ['']}
         return {'entries': self.provider.search(search_strings)}

--- a/sickbeard/providers/bluetigers.py
+++ b/sickbeard/providers/bluetigers.py
@@ -39,7 +39,7 @@ class BlueTigersProvider(TorrentProvider):  # pylint: disable=too-many-instance-
         self.ratio = None
         self.token = None
 
-        self.cache = BlueTigersCache(self, min_time=10)  # Only poll BLUETIGERS every 10 minutes max
+        self.cache = tvcache.TVCache(self, min_time=10)  # Only poll BLUETIGERS every 10 minutes max
 
         self.urls = {
             'base_url': 'https://www.bluetigers.ca/',
@@ -144,11 +144,5 @@ class BlueTigersProvider(TorrentProvider):  # pylint: disable=too-many-instance-
 
     def seed_ratio(self):
         return self.ratio
-
-
-class BlueTigersCache(tvcache.TVCache):
-    def _getRSSData(self):
-        search_strings = {'RSS': ['']}
-        return {'entries': self.provider.search(search_strings)}
 
 provider = BlueTigersProvider()

--- a/sickbeard/providers/bluetigers.py
+++ b/sickbeard/providers/bluetigers.py
@@ -1,35 +1,37 @@
 # coding=utf-8
 # Author: raver2046 <raver2046@gmail.com>
-# URL: http://code.google.com/p/sickbeard/
+#
+# URL: https://sickrage.github.io
 #
 # This file is part of SickRage.
 #
-# Sick Beard is free software: you can redistribute it and/or modify
+# SickRage is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# Sick Beard is distributed in the hope that it will be useful,
+# SickRage is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with Sick Beard.  If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
 
-import traceback
-import requests
 import re
+from requests.utils import dict_from_cookiejar
+import traceback
 
+from sickbeard import logger, tvcache
 from sickbeard.bs4_parser import BS4Parser
 
-from sickbeard import logger
-from sickbeard import tvcache
 from sickrage.providers.torrent.TorrentProvider import TorrentProvider
 
 
 class BlueTigersProvider(TorrentProvider):  # pylint: disable=too-many-instance-attributes
+
     def __init__(self):
+
         TorrentProvider.__init__(self, "BLUETIGERS")
 
         self.username = None
@@ -53,7 +55,7 @@ class BlueTigersProvider(TorrentProvider):  # pylint: disable=too-many-instance-
         self.url = self.urls['base_url']
 
     def login(self):
-        if any(requests.utils.dict_from_cookiejar(self.session.cookies).values()):
+        if any(dict_from_cookiejar(self.session.cookies).values()):
             return True
 
         login_params = {
@@ -148,6 +150,5 @@ class BlueTigersCache(tvcache.TVCache):
     def _getRSSData(self):
         search_strings = {'RSS': ['']}
         return {'entries': self.provider.search(search_strings)}
-
 
 provider = BlueTigersProvider()

--- a/sickbeard/providers/btdigg.py
+++ b/sickbeard/providers/btdigg.py
@@ -1,8 +1,7 @@
 # coding=utf-8
 # Author: Jodi Jones <venom@gen-x.co.nz>
-# URL: http://code.google.com/p/sickbeard/
 # Rewrite: Gonçalo <matigonkas@outlook.com>
-# URL: https://github.com/SickRage/SickRage
+# URL: https://sickrage.github.io
 #
 # This file is part of SickRage.
 #
@@ -18,11 +17,12 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with SickRage. If not, see <http://www.gnu.org/licenses/>.
-import traceback
 
+import traceback
 from urllib import urlencode
-from sickbeard import logger
-from sickbeard import tvcache
+
+from sickbeard import logger, tvcache
+
 from sickrage.helper.common import convert_size
 from sickrage.providers.torrent.TorrentProvider import TorrentProvider
 
@@ -30,6 +30,7 @@ from sickrage.providers.torrent.TorrentProvider import TorrentProvider
 class BTDiggProvider(TorrentProvider):
 
     def __init__(self):
+
         TorrentProvider.__init__(self, "BTDigg")
 
         self.public = True
@@ -126,9 +127,7 @@ class BTDiggProvider(TorrentProvider):
 
 class BTDiggCache(tvcache.TVCache):
     def _getRSSData(self):
-
-        # Use this hacky way for RSS search since most results will use this codecs
-        search_params = {'RSS': ['x264', 'x264.HDTV', '720.HDTV.x264']}
+        search_params = {'RSS': ['x264', 'x264.HDTV', '720.HDTV.x264']}  # Use this hacky way for RSS search since most results will use this codecs
         return {'entries': self.provider.search(search_params)}
 
 provider = BTDiggProvider()

--- a/sickbeard/providers/btdigg.py
+++ b/sickbeard/providers/btdigg.py
@@ -45,7 +45,7 @@ class BTDiggProvider(TorrentProvider):
         # self.minseed = 1
         # self.minleech = 0
 
-        self.cache = BTDiggCache(self)
+        self.cache = BTDiggCache(self, min_time=30)  # Only poll BTDigg every 30 minutes max, since BTDigg takes some time to crawl
 
     def search(self, search_strings, age=0, ep_obj=None):  # pylint: disable=too-many-locals
         results = []
@@ -125,13 +125,6 @@ class BTDiggProvider(TorrentProvider):
 
 
 class BTDiggCache(tvcache.TVCache):
-    def __init__(self, provider_obj):
-
-        tvcache.TVCache.__init__(self, provider_obj)
-
-        # Cache results for a 30min, since BTDigg takes some time to crawl
-        self.minTime = 30
-
     def _getRSSData(self):
 
         # Use this hacky way for RSS search since most results will use this codecs

--- a/sickbeard/providers/btdigg.py
+++ b/sickbeard/providers/btdigg.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 # Author: Jodi Jones <venom@gen-x.co.nz>
-# Rewrite: Gonçalo <matigonkas@outlook.com>
+# Rewrite: Gonçalo M. (aka duramato/supergonkas) <supergonkas@gmail.com>
 # URL: https://sickrage.github.io
 #
 # This file is part of SickRage.
@@ -46,7 +46,10 @@ class BTDiggProvider(TorrentProvider):
         # self.minseed = 1
         # self.minleech = 0
 
-        self.cache = BTDiggCache(self, min_time=30)  # Only poll BTDigg every 30 minutes max, since BTDigg takes some time to crawl
+        # Use this hacky way for RSS search since most results will use this codecs
+        params = {'RSS': ['x264', 'x264.HDTV', '720.HDTV.x264']}
+        # Only poll BTDigg every 30 minutes max, since BTDigg takes some time to crawl
+        self.cache = tvcache.TVCache(self, min_time=30, search_params=params)
 
     def search(self, search_strings, age=0, ep_obj=None):  # pylint: disable=too-many-locals
         results = []
@@ -123,11 +126,5 @@ class BTDiggProvider(TorrentProvider):
 
     def seed_ratio(self):
         return self.ratio
-
-
-class BTDiggCache(tvcache.TVCache):
-    def _getRSSData(self):
-        search_params = {'RSS': ['x264', 'x264.HDTV', '720.HDTV.x264']}  # Use this hacky way for RSS search since most results will use this codecs
-        return {'entries': self.provider.search(search_params)}
 
 provider = BTDiggProvider()

--- a/sickbeard/providers/btn.py
+++ b/sickbeard/providers/btn.py
@@ -301,6 +301,7 @@ class BTNCache(tvcache.TVCache):
                 logger.DEBUG)
             seconds_since_last_update = 86400
 
-        return {'entries': self.provider.search(search_params=None, age=seconds_since_last_update)}
+        self.search_params = None  # BTN cache does not use search params
+        return {'entries': self.provider.search(search_params=self.search_params, age=seconds_since_last_update)}
 
 provider = BTNProvider()

--- a/sickbeard/providers/btn.py
+++ b/sickbeard/providers/btn.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 # Author: Daniel Heimans
-# URL: http://code.google.com/p/sickbeard
+#
+# URL: https://sickrage.github.io
 #
 # This file is part of SickRage.
 #
@@ -17,25 +18,25 @@
 # You should have received a copy of the GNU General Public License
 # along with SickRage. If not, see <http://www.gnu.org/licenses/>.
 
-import time
-import socket
-import math
-import jsonrpclib
 from datetime import datetime
+import jsonrpclib
+import math
+import socket
+import time
 
 import sickbeard
-from sickbeard import logger
-from sickbeard import classes
-from sickbeard import tvcache
-from sickbeard import scene_exceptions
-from sickbeard.helpers import sanitizeSceneName
+from sickbeard import classes, logger, scene_exceptions, tvcache
 from sickbeard.common import cpu_presets
+from sickbeard.helpers import sanitizeSceneName
+
 from sickrage.helper.exceptions import AuthException, ex
 from sickrage.providers.torrent.TorrentProvider import TorrentProvider
 
 
 class BTNProvider(TorrentProvider):
+
     def __init__(self):
+
         TorrentProvider.__init__(self, "BTN")
 
         self.supports_absolute_numbering = True
@@ -301,6 +302,5 @@ class BTNCache(tvcache.TVCache):
             seconds_since_last_update = 86400
 
         return {'entries': self.provider.search(search_params=None, age=seconds_since_last_update)}
-
 
 provider = BTNProvider()

--- a/sickbeard/providers/btn.py
+++ b/sickbeard/providers/btn.py
@@ -43,7 +43,7 @@ class BTNProvider(TorrentProvider):
         self.api_key = None
         self.ratio = None
 
-        self.cache = BTNCache(self)
+        self.cache = BTNCache(self, min_time=15)  # Only poll BTN every 15 minutes max
 
         self.urls = {'base_url': u'http://api.btnapps.net',
                      'website': u'http://broadcasthe.net/', }
@@ -284,12 +284,6 @@ class BTNProvider(TorrentProvider):
 
 
 class BTNCache(tvcache.TVCache):
-    def __init__(self, provider_obj):
-        tvcache.TVCache.__init__(self, provider_obj)
-
-        # At least 15 minutes between queries
-        self.minTime = 15
-
     def _getRSSData(self):
         # Get the torrents uploaded since last check.
         seconds_since_last_update = math.ceil(time.time() - time.mktime(self._getLastUpdate().timetuple()))

--- a/sickbeard/providers/cpasbien.py
+++ b/sickbeard/providers/cpasbien.py
@@ -40,7 +40,7 @@ class CpasbienProvider(TorrentProvider):
         self.url = "http://www.cpasbien.io"
 
         self.proper_strings = ['PROPER', 'REPACK']
-        self.cache = CpasbienCache(self, min_time=20)  # Only poll Cpasbien every 20 minutes max
+        self.cache = tvcache.TVCache(self)
 
     def search(self, search_strings, age=0, ep_obj=None):  # pylint: disable=too-many-locals
         results = []
@@ -98,11 +98,5 @@ class CpasbienProvider(TorrentProvider):
 
     def seed_ratio(self):
         return self.ratio
-
-
-class CpasbienCache(tvcache.TVCache):
-    def _getRSSData(self):
-        search_strings = {'RSS': ['']}
-        return {'entries': self.provider.search(search_strings)}
 
 provider = CpasbienProvider()

--- a/sickbeard/providers/cpasbien.py
+++ b/sickbeard/providers/cpasbien.py
@@ -1,27 +1,29 @@
-# -*- coding: latin-1 -*-
+# coding=utf-8
 # Author: Guillaume Serre <guillaume.serre@gmail.com>
-# URL: http://code.google.com/p/sickbeard/
+#
+# URL: https://sickrage.github.io
 #
 # This file is part of SickRage.
 #
-# Sick Beard is free software: you can redistribute it and/or modify
+# SickRage is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# Sick Beard is distributed in the hope that it will be useful,
+# SickRage is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with Sick Beard.  If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+
 import re
 
-from sickbeard import logger
-from sickbeard import tvcache
-from sickrage.helper.common import try_int, convert_size
+from sickbeard import logger, tvcache
 from sickbeard.bs4_parser import BS4Parser
+
+from sickrage.helper.common import convert_size, try_int
 from sickrage.providers.torrent.TorrentProvider import TorrentProvider
 
 

--- a/sickbeard/providers/cpasbien.py
+++ b/sickbeard/providers/cpasbien.py
@@ -38,7 +38,7 @@ class CpasbienProvider(TorrentProvider):
         self.url = "http://www.cpasbien.io"
 
         self.proper_strings = ['PROPER', 'REPACK']
-        self.cache = CpasbienCache(self)
+        self.cache = CpasbienCache(self, min_time=20)  # Only poll Cpasbien every 20 minutes max
 
     def search(self, search_strings, age=0, ep_obj=None):  # pylint: disable=too-many-locals
         results = []
@@ -99,12 +99,6 @@ class CpasbienProvider(TorrentProvider):
 
 
 class CpasbienCache(tvcache.TVCache):
-    def __init__(self, provider_obj):
-
-        tvcache.TVCache.__init__(self, provider_obj)
-
-        self.minTime = 20
-
     def _getRSSData(self):
         search_strings = {'RSS': ['']}
         return {'entries': self.provider.search(search_strings)}

--- a/sickbeard/providers/danishbits.py
+++ b/sickbeard/providers/danishbits.py
@@ -38,7 +38,7 @@ class DanishbitsProvider(TorrentProvider):  # pylint: disable=too-many-instance-
         self.password = None
         self.ratio = None
 
-        self.cache = DanishbitsCache(self, min_time=10)  # Only poll Danishbits every 10 minutes max
+        self.cache = tvcache.TVCache(self, min_time=10)  # Only poll Danishbits every 10 minutes max
 
         self.url = 'https://danishbits.org/'
         self.urls = {
@@ -165,11 +165,5 @@ class DanishbitsProvider(TorrentProvider):  # pylint: disable=too-many-instance-
 
     def seedRatio(self):
         return self.ratio
-
-
-class DanishbitsCache(tvcache.TVCache):
-    def _getRSSData(self):
-        search_strings = {'RSS': ['']}
-        return {'entries': self.provider.search(search_strings)}
 
 provider = DanishbitsProvider()

--- a/sickbeard/providers/danishbits.py
+++ b/sickbeard/providers/danishbits.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 # Author: Dustyn Gibson <miigotu@gmail.com>
+#
 # URL: https://sickrage.github.io
 #
 # This file is part of SickRage.
@@ -17,15 +18,14 @@
 # You should have received a copy of the GNU General Public License
 # along with SickRage. If not, see <http://www.gnu.org/licenses/>.
 
-from urllib import urlencode
 from requests.utils import dict_from_cookiejar
+from urllib import urlencode
 
-from sickbeard import logger
-from sickbeard import tvcache
-from sickrage.helper.common import try_int, convert_size
-from sickrage.providers.torrent.TorrentProvider import TorrentProvider
-
+from sickbeard import logger, tvcache
 from sickbeard.bs4_parser import BS4Parser
+
+from sickrage.helper.common import convert_size, try_int
+from sickrage.providers.torrent.TorrentProvider import TorrentProvider
 
 
 class DanishbitsProvider(TorrentProvider):  # pylint: disable=too-many-instance-attributes
@@ -171,6 +171,5 @@ class DanishbitsCache(tvcache.TVCache):
     def _getRSSData(self):
         search_strings = {'RSS': ['']}
         return {'entries': self.provider.search(search_strings)}
-
 
 provider = DanishbitsProvider()

--- a/sickbeard/providers/danishbits.py
+++ b/sickbeard/providers/danishbits.py
@@ -38,7 +38,7 @@ class DanishbitsProvider(TorrentProvider):  # pylint: disable=too-many-instance-
         self.password = None
         self.ratio = None
 
-        self.cache = DanishbitsCache(self)
+        self.cache = DanishbitsCache(self, min_time=10)  # Only poll Danishbits every 10 minutes max
 
         self.url = 'https://danishbits.org/'
         self.urls = {
@@ -168,13 +168,6 @@ class DanishbitsProvider(TorrentProvider):  # pylint: disable=too-many-instance-
 
 
 class DanishbitsCache(tvcache.TVCache):
-    def __init__(self, provider_obj):
-
-        tvcache.TVCache.__init__(self, provider_obj)
-
-        # Only poll Danishbits every 10 minutes max
-        self.minTime = 10
-
     def _getRSSData(self):
         search_strings = {'RSS': ['']}
         return {'entries': self.provider.search(search_strings)}

--- a/sickbeard/providers/elitetorrent.py
+++ b/sickbeard/providers/elitetorrent.py
@@ -38,7 +38,7 @@ class elitetorrentProvider(TorrentProvider):
         self.onlyspasearch = None
         self.minseed = None
         self.minleech = None
-        self.cache = elitetorrentCache(self, min_time=20)  # Only poll EliteTorrent every 20 minutes max
+        self.cache = tvcache.TVCache(self)  # Only poll EliteTorrent every 20 minutes max
 
         self.urls = {
             'base_url': 'http://www.elitetorrent.net',
@@ -162,11 +162,5 @@ class elitetorrentProvider(TorrentProvider):
         title += '-ELITETORRENT'
 
         return title.strip()
-
-
-class elitetorrentCache(tvcache.TVCache):
-    def _getRSSData(self):
-        search_params = {'RSS': ['']}
-        return {'entries': self.provider.search(search_params)}
 
 provider = elitetorrentProvider()

--- a/sickbeard/providers/elitetorrent.py
+++ b/sickbeard/providers/elitetorrent.py
@@ -38,7 +38,7 @@ class elitetorrentProvider(TorrentProvider):
         self.onlyspasearch = None
         self.minseed = None
         self.minleech = None
-        self.cache = elitetorrentCache(self)
+        self.cache = elitetorrentCache(self, min_time=20)  # Only poll EliteTorrent every 20 minutes max
 
         self.urls = {
             'base_url': 'http://www.elitetorrent.net',
@@ -165,12 +165,6 @@ class elitetorrentProvider(TorrentProvider):
 
 
 class elitetorrentCache(tvcache.TVCache):
-    def __init__(self, provider_obj):
-
-        tvcache.TVCache.__init__(self, provider_obj)
-
-        self.minTime = 20
-
     def _getRSSData(self):
         search_params = {'RSS': ['']}
         return {'entries': self.provider.search(search_params)}

--- a/sickbeard/providers/elitetorrent.py
+++ b/sickbeard/providers/elitetorrent.py
@@ -1,7 +1,7 @@
 # coding=utf-8
 # Author: CristianBB
 #
-# URL: http://code.google.com/p/sickbeard/
+# URL: https://sickrage.github.io
 #
 # This file is part of SickRage.
 #
@@ -18,19 +18,19 @@
 # You should have received a copy of the GNU General Public License
 # along with SickRage. If not, see <http://www.gnu.org/licenses/>.
 
-import traceback
 import re
 from six.moves import urllib
+import traceback
 
-from sickbeard import logger
-from sickbeard import tvcache
+from sickbeard import logger, tvcache
 from sickbeard.bs4_parser import BS4Parser
-from sickrage.providers.torrent.TorrentProvider import TorrentProvider
 
 from sickrage.helper.common import try_int
+from sickrage.providers.torrent.TorrentProvider import TorrentProvider
 
 
 class elitetorrentProvider(TorrentProvider):
+
     def __init__(self):
 
         TorrentProvider.__init__(self, "EliteTorrent")
@@ -168,6 +168,5 @@ class elitetorrentCache(tvcache.TVCache):
     def _getRSSData(self):
         search_params = {'RSS': ['']}
         return {'entries': self.provider.search(search_params)}
-
 
 provider = elitetorrentProvider()

--- a/sickbeard/providers/extratorrent.py
+++ b/sickbeard/providers/extratorrent.py
@@ -44,7 +44,7 @@ class ExtraTorrentProvider(TorrentProvider):  # pylint: disable=too-many-instanc
         self.minleech = None
         self.custom_url = None
 
-        self.cache = ExtraTorrentCache(self)
+        self.cache = ExtraTorrentCache(self, min_time=30)  # Only poll ExtraTorrent every 30 minutes max
         self.headers.update({'User-Agent': USER_AGENT})
         self.search_params = {'cid': 8}
 
@@ -114,12 +114,6 @@ class ExtraTorrentProvider(TorrentProvider):  # pylint: disable=too-many-instanc
 
 
 class ExtraTorrentCache(tvcache.TVCache):
-    def __init__(self, provider_obj):
-
-        tvcache.TVCache.__init__(self, provider_obj)
-
-        self.minTime = 30
-
     def _getRSSData(self):
         search_strings = {'RSS': ['']}
         return {'entries': self.provider.search(search_strings)}

--- a/sickbeard/providers/extratorrent.py
+++ b/sickbeard/providers/extratorrent.py
@@ -49,7 +49,7 @@ class ExtraTorrentProvider(TorrentProvider):  # pylint: disable=too-many-instanc
         self.minleech = None
         self.custom_url = None
 
-        self.cache = ExtraTorrentCache(self, min_time=30)  # Only poll ExtraTorrent every 30 minutes max
+        self.cache = tvcache.TVCache(self, min_time=30)  # Only poll ExtraTorrent every 30 minutes max
         self.headers.update({'User-Agent': USER_AGENT})
         self.search_params = {'cid': 8}
 
@@ -116,11 +116,5 @@ class ExtraTorrentProvider(TorrentProvider):  # pylint: disable=too-many-instanc
 
     def seed_ratio(self):
         return self.ratio
-
-
-class ExtraTorrentCache(tvcache.TVCache):
-    def _getRSSData(self):
-        search_strings = {'RSS': ['']}
-        return {'entries': self.provider.search(search_strings)}
 
 provider = ExtraTorrentProvider()

--- a/sickbeard/providers/extratorrent.py
+++ b/sickbeard/providers/extratorrent.py
@@ -1,7 +1,9 @@
 # coding=utf-8
-# Author: duramato <matigonkas@outlook.com>
-# Author: miigotu
-# URL: https://github.com/SickRage/sickrage
+# Author: Gonçalo M. (aka duramato/supergonkas) <supergonkas@gmail.com>
+# Author: Dustyn Gibson <miigotu@gmail.com>
+#
+# URL: https://sickrage.github.io
+#
 # This file is part of SickRage.
 #
 # SickRage is free software: you can redistribute it and/or modify
@@ -18,17 +20,20 @@
 # along with SickRage. If not, see <http://www.gnu.org/licenses/>.
 
 import re
+
 import sickbeard
-from sickbeard import logger
-from sickbeard import tvcache
-from sickbeard.common import USER_AGENT
-from sickrage.helper.common import try_int, convert_size
+from sickbeard import logger, tvcache
 from sickbeard.bs4_parser import BS4Parser
+from sickbeard.common import USER_AGENT
+
+from sickrage.helper.common import convert_size, try_int
 from sickrage.providers.torrent.TorrentProvider import TorrentProvider
 
 
 class ExtraTorrentProvider(TorrentProvider):  # pylint: disable=too-many-instance-attributes
+
     def __init__(self):
+
         TorrentProvider.__init__(self, "ExtraTorrent")
 
         self.urls = {
@@ -117,6 +122,5 @@ class ExtraTorrentCache(tvcache.TVCache):
     def _getRSSData(self):
         search_strings = {'RSS': ['']}
         return {'entries': self.provider.search(search_strings)}
-
 
 provider = ExtraTorrentProvider()

--- a/sickbeard/providers/fnt.py
+++ b/sickbeard/providers/fnt.py
@@ -37,7 +37,7 @@ class FNTProvider(TorrentProvider):  # pylint: disable=too-many-instance-attribu
         self.minseed = None
         self.minleech = None
 
-        self.cache = FNTCache(self)
+        self.cache = FNTCache(self, min_time=10)  # Only poll FNT every 10 minutes max
 
         self.urls = {
             'base_url': 'https://fnt.nu',
@@ -154,12 +154,6 @@ class FNTProvider(TorrentProvider):  # pylint: disable=too-many-instance-attribu
 
 
 class FNTCache(tvcache.TVCache):
-    def __init__(self, provider_obj):
-        tvcache.TVCache.__init__(self, provider_obj)
-
-        # Only poll FNT every 10 minutes max
-        self.minTime = 10
-
     def _getRSSData(self):
         search_strings = {'RSS': ['']}
         return {'entries': self.provider.search(search_strings)}

--- a/sickbeard/providers/fnt.py
+++ b/sickbeard/providers/fnt.py
@@ -40,7 +40,7 @@ class FNTProvider(TorrentProvider):  # pylint: disable=too-many-instance-attribu
         self.minseed = None
         self.minleech = None
 
-        self.cache = FNTCache(self, min_time=10)  # Only poll FNT every 10 minutes max
+        self.cache = tvcache.TVCache(self, min_time=10)  # Only poll FNT every 10 minutes max
 
         self.urls = {
             'base_url': 'https://fnt.nu',
@@ -154,11 +154,5 @@ class FNTProvider(TorrentProvider):  # pylint: disable=too-many-instance-attribu
 
     def seed_ratio(self):
         return self.ratio
-
-
-class FNTCache(tvcache.TVCache):
-    def _getRSSData(self):
-        search_strings = {'RSS': ['']}
-        return {'entries': self.provider.search(search_strings)}
 
 provider = FNTProvider()

--- a/sickbeard/providers/fnt.py
+++ b/sickbeard/providers/fnt.py
@@ -1,34 +1,37 @@
-# -*- coding: latin-1 -*-
+# coding=utf-8
 # Author: raver2046 <raver2046@gmail.com> from djoole <bobby.djoole@gmail.com>
-# URL: http://code.google.com/p/sickbeard/
+#
+# URL: https://sickrage.github.io
 #
 # This file is part of SickRage.
 #
-# Sick Beard is free software: you can redistribute it and/or modify
+# SickRage is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# Sick Beard is distributed in the hope that it will be useful,
+# SickRage is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with Sick Beard.  If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
 
-import traceback
 import re
-import requests
+from requests.utils import dict_from_cookiejar
+import traceback
 
-from sickbeard import logger
-from sickbeard import tvcache
+from sickbeard import logger, tvcache
 from sickbeard.bs4_parser import BS4Parser
+
 from sickrage.providers.torrent.TorrentProvider import TorrentProvider
 
 
 class FNTProvider(TorrentProvider):  # pylint: disable=too-many-instance-attributes
+
     def __init__(self):
+
         TorrentProvider.__init__(self, "FNT")
 
         self.username = None
@@ -55,7 +58,7 @@ class FNTProvider(TorrentProvider):  # pylint: disable=too-many-instance-attribu
 
     def login(self):
 
-        if any(requests.utils.dict_from_cookiejar(self.session.cookies).values()):
+        if any(dict_from_cookiejar(self.session.cookies).values()):
             return True
 
         login_params = {
@@ -157,6 +160,5 @@ class FNTCache(tvcache.TVCache):
     def _getRSSData(self):
         search_strings = {'RSS': ['']}
         return {'entries': self.provider.search(search_strings)}
-
 
 provider = FNTProvider()

--- a/sickbeard/providers/freshontv.py
+++ b/sickbeard/providers/freshontv.py
@@ -45,7 +45,7 @@ class FreshOnTVProvider(TorrentProvider):  # pylint: disable=too-many-instance-a
         self.minleech = None
         self.freeleech = False
 
-        self.cache = FreshOnTVCache(self, min_time=20)  # Only poll FreshOnTV every 20 minutes max
+        self.cache = tvcache.TVCache(self)
 
         self.urls = {'base_url': 'https://freshon.tv/',
                      'login': 'https://freshon.tv/login.php?action=makelogin',
@@ -233,11 +233,5 @@ class FreshOnTVProvider(TorrentProvider):  # pylint: disable=too-many-instance-a
 
     def seed_ratio(self):
         return self.ratio
-
-
-class FreshOnTVCache(tvcache.TVCache):
-    def _getRSSData(self):
-        search_params = {'RSS': ['']}
-        return {'entries': self.provider.search(search_params)}
 
 provider = FreshOnTVProvider()

--- a/sickbeard/providers/freshontv.py
+++ b/sickbeard/providers/freshontv.py
@@ -43,7 +43,7 @@ class FreshOnTVProvider(TorrentProvider):  # pylint: disable=too-many-instance-a
         self.minleech = None
         self.freeleech = False
 
-        self.cache = FreshOnTVCache(self)
+        self.cache = FreshOnTVCache(self, min_time=20)  # Only poll FreshOnTV every 20 minutes max
 
         self.urls = {'base_url': 'https://freshon.tv/',
                      'login': 'https://freshon.tv/login.php?action=makelogin',
@@ -234,13 +234,6 @@ class FreshOnTVProvider(TorrentProvider):  # pylint: disable=too-many-instance-a
 
 
 class FreshOnTVCache(tvcache.TVCache):
-    def __init__(self, provider_obj):
-
-        tvcache.TVCache.__init__(self, provider_obj)
-
-        # poll delay in minutes
-        self.minTime = 20
-
     def _getRSSData(self):
         search_params = {'RSS': ['']}
         return {'entries': self.provider.search(search_params)}

--- a/sickbeard/providers/freshontv.py
+++ b/sickbeard/providers/freshontv.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 # Author: Idan Gutman
-# URL: http://code.google.com/p/sickbeard/
+#
+# URL: https://sickrage.github.io
 #
 # This file is part of SickRage.
 #
@@ -18,18 +19,19 @@
 # along with SickRage. If not, see <http://www.gnu.org/licenses/>.
 
 import re
+from requests.utils import add_dict_to_cookiejar, dict_from_cookiejar
 import time
-import requests
 import traceback
 
-from sickbeard import logger
-from sickbeard import tvcache
+from sickbeard import logger, tvcache
 from sickbeard.bs4_parser import BS4Parser
-from sickrage.helper.common import try_int, convert_size
+
+from sickrage.helper.common import convert_size, try_int
 from sickrage.providers.torrent.TorrentProvider import TorrentProvider
 
 
 class FreshOnTVProvider(TorrentProvider):  # pylint: disable=too-many-instance-attributes
+
     def __init__(self):
 
         TorrentProvider.__init__(self, "FreshOnTV")
@@ -63,11 +65,11 @@ class FreshOnTVProvider(TorrentProvider):  # pylint: disable=too-many-instance-a
         return True
 
     def login(self):
-        if any(requests.utils.dict_from_cookiejar(self.session.cookies).values()):
+        if any(dict_from_cookiejar(self.session.cookies).values()):
             return True
 
         if self._uid and self._hash:
-            requests.utils.add_dict_to_cookiejar(self.session.cookies, self.cookies)
+            add_dict_to_cookiejar(self.session.cookies, self.cookies)
         else:
             login_params = {'username': self.username,
                             'password': self.password,
@@ -81,9 +83,9 @@ class FreshOnTVProvider(TorrentProvider):  # pylint: disable=too-many-instance-a
             if re.search('/logout.php', response):
 
                 try:
-                    if requests.utils.dict_from_cookiejar(self.session.cookies)['uid'] and requests.utils.dict_from_cookiejar(self.session.cookies)['pass']:
-                        self._uid = requests.utils.dict_from_cookiejar(self.session.cookies)['uid']
-                        self._hash = requests.utils.dict_from_cookiejar(self.session.cookies)['pass']
+                    if dict_from_cookiejar(self.session.cookies)['uid'] and dict_from_cookiejar(self.session.cookies)['pass']:
+                        self._uid = dict_from_cookiejar(self.session.cookies)['uid']
+                        self._hash = dict_from_cookiejar(self.session.cookies)['pass']
 
                         self.cookies = {'uid': self._uid,
                                         'pass': self._hash}

--- a/sickbeard/providers/gftracker.py
+++ b/sickbeard/providers/gftracker.py
@@ -50,7 +50,7 @@ class GFTrackerProvider(TorrentProvider):  # pylint: disable=too-many-instance-a
 
         self.proper_strings = ['PROPER', 'REPACK', 'REAL']
 
-        self.cache = GFTrackerCache(self, min_time=20)  # Only poll GFTracker every 20 minutes max
+        self.cache = tvcache.TVCache(self)
 
     def _check_auth(self):
 
@@ -173,11 +173,5 @@ class GFTrackerProvider(TorrentProvider):  # pylint: disable=too-many-instance-a
 
     def seed_ratio(self):
         return self.ratio
-
-
-class GFTrackerCache(tvcache.TVCache):
-    def _getRSSData(self):
-        search_strings = {'RSS': ['']}
-        return {'entries': self.provider.search(search_strings)}
 
 provider = GFTrackerProvider()

--- a/sickbeard/providers/gftracker.py
+++ b/sickbeard/providers/gftracker.py
@@ -50,7 +50,7 @@ class GFTrackerProvider(TorrentProvider):  # pylint: disable=too-many-instance-a
 
         self.proper_strings = ['PROPER', 'REPACK', 'REAL']
 
-        self.cache = GFTrackerCache(self)
+        self.cache = GFTrackerCache(self, min_time=20)  # Only poll GFTracker every 20 minutes max
 
     def _check_auth(self):
 
@@ -176,13 +176,6 @@ class GFTrackerProvider(TorrentProvider):  # pylint: disable=too-many-instance-a
 
 
 class GFTrackerCache(tvcache.TVCache):
-    def __init__(self, provider_obj):
-
-        tvcache.TVCache.__init__(self, provider_obj)
-
-        # Poll delay in minutes
-        self.minTime = 20
-
     def _getRSSData(self):
         search_strings = {'RSS': ['']}
         return {'entries': self.provider.search(search_strings)}

--- a/sickbeard/providers/gftracker.py
+++ b/sickbeard/providers/gftracker.py
@@ -22,10 +22,10 @@ import re
 from requests.utils import dict_from_cookiejar
 from urllib import urlencode
 
-from sickbeard import logger
-from sickbeard import tvcache
+from sickbeard import logger, tvcache
 from sickbeard.bs4_parser import BS4Parser
-from sickrage.helper.common import try_int, convert_size
+
+from sickrage.helper.common import convert_size, try_int
 from sickrage.helper.exceptions import AuthException
 from sickrage.providers.torrent.TorrentProvider import TorrentProvider
 

--- a/sickbeard/providers/hd4free.py
+++ b/sickbeard/providers/hd4free.py
@@ -1,6 +1,7 @@
 # coding=utf-8
-# Author: Gonçalo (aka duramato) <matigonkas@outlook.com>
-# URL: https://github.com/SickRage/SickRage
+# Author: Gonçalo M. (aka duramato/supergonkas) <supergonkas@gmail.com>
+#
+# URL: https://sickrage.github.io
 #
 # This file is part of SickRage.
 #
@@ -18,8 +19,9 @@
 # along with SickRage. If not, see <http://www.gnu.org/licenses/>.
 
 from urllib import urlencode
-from sickbeard import logger
-from sickbeard import tvcache
+
+from sickbeard import logger, tvcache
+
 from sickrage.helper.common import convert_size
 from sickrage.providers.torrent.TorrentProvider import TorrentProvider
 
@@ -27,6 +29,7 @@ from sickrage.providers.torrent.TorrentProvider import TorrentProvider
 class HD4FreeProvider(TorrentProvider):  # pylint: disable=too-many-instance-attributes
 
     def __init__(self):
+
         TorrentProvider.__init__(self, "HD4Free")
 
         self.url = 'https://hd4free.xyz'
@@ -127,7 +130,6 @@ class HD4FreeProvider(TorrentProvider):  # pylint: disable=too-many-instance-att
 
 class HD4FreeCache(tvcache.TVCache):
     def _getRSSData(self):
-
         search_params = {'RSS': ['']}
         return {'entries': self.provider.search(search_params)}
 

--- a/sickbeard/providers/hd4free.py
+++ b/sickbeard/providers/hd4free.py
@@ -39,7 +39,7 @@ class HD4FreeProvider(TorrentProvider):  # pylint: disable=too-many-instance-att
         self.minleech = None
         self.ratio = 0
 
-        self.cache = HD4FreeCache(self)
+        self.cache = HD4FreeCache(self, min_time=10)  # Only poll HD4Free every 10 minutes max
 
     def _check_auth(self):
         if self.username and self.api_key:
@@ -126,13 +126,6 @@ class HD4FreeProvider(TorrentProvider):  # pylint: disable=too-many-instance-att
 
 
 class HD4FreeCache(tvcache.TVCache):
-    def __init__(self, provider_obj):
-
-        tvcache.TVCache.__init__(self, provider_obj)
-
-        # Cache results for 10 min
-        self.minTime = 10
-
     def _getRSSData(self):
 
         search_params = {'RSS': ['']}

--- a/sickbeard/providers/hd4free.py
+++ b/sickbeard/providers/hd4free.py
@@ -42,7 +42,7 @@ class HD4FreeProvider(TorrentProvider):  # pylint: disable=too-many-instance-att
         self.minleech = None
         self.ratio = 0
 
-        self.cache = HD4FreeCache(self, min_time=10)  # Only poll HD4Free every 10 minutes max
+        self.cache = tvcache.TVCache(self, min_time=10)  # Only poll HD4Free every 10 minutes max
 
     def _check_auth(self):
         if self.username and self.api_key:
@@ -126,11 +126,5 @@ class HD4FreeProvider(TorrentProvider):  # pylint: disable=too-many-instance-att
 
     def seed_ratio(self):
         return self.ratio
-
-
-class HD4FreeCache(tvcache.TVCache):
-    def _getRSSData(self):
-        search_params = {'RSS': ['']}
-        return {'entries': self.provider.search(search_params)}
 
 provider = HD4FreeProvider()

--- a/sickbeard/providers/hdbits.py
+++ b/sickbeard/providers/hdbits.py
@@ -37,7 +37,7 @@ class HDBitsProvider(TorrentProvider):
         self.passkey = None
         self.ratio = None
 
-        self.cache = HDBitsCache(self)
+        self.cache = HDBitsCache(self, min_time=15)  # only poll HDBits every 15 minutes max
 
         self.urls = {'base_url': 'https://hdbits.org',
                      'search': 'https://hdbits.org/api/torrents',
@@ -179,13 +179,6 @@ class HDBitsProvider(TorrentProvider):
 
 
 class HDBitsCache(tvcache.TVCache):
-    def __init__(self, provider_obj):
-
-        tvcache.TVCache.__init__(self, provider_obj)
-
-        # only poll HDBits every 15 minutes max
-        self.minTime = 15
-
     def _getRSSData(self):
         results = []
 

--- a/sickbeard/providers/hdbits.py
+++ b/sickbeard/providers/hdbits.py
@@ -30,6 +30,7 @@ try:
 except ImportError:
     import simplejson as json
 
+
 class HDBitsProvider(TorrentProvider):
 
     def __init__(self):
@@ -183,6 +184,7 @@ class HDBitsProvider(TorrentProvider):
 
 class HDBitsCache(tvcache.TVCache):
     def _getRSSData(self):
+        self.search_params = None  # HDBits cache does not use search_params so set it to None
         results = []
 
         try:

--- a/sickbeard/providers/hdbits.py
+++ b/sickbeard/providers/hdbits.py
@@ -1,4 +1,7 @@
 # coding=utf-8
+#
+# URL: https://sickrage.github.io
+#
 # This file is part of SickRage.
 #
 # SickRage is free software: you can redistribute it and/or modify
@@ -15,10 +18,10 @@
 # along with SickRage. If not, see <http://www.gnu.org/licenses/>.
 
 import datetime
-import urllib
+from urllib import urlencode
 
-from sickbeard import classes
-from sickbeard import logger, tvcache
+from sickbeard import classes, logger, tvcache
+
 from sickrage.helper.exceptions import AuthException
 from sickrage.providers.torrent.TorrentProvider import TorrentProvider
 
@@ -27,8 +30,8 @@ try:
 except ImportError:
     import simplejson as json
 
-
 class HDBitsProvider(TorrentProvider):
+
     def __init__(self):
 
         TorrentProvider.__init__(self, "HDBits")
@@ -71,7 +74,7 @@ class HDBitsProvider(TorrentProvider):
 
     def _get_title_and_url(self, item):
         title = item.get('name', '').replace(' ', '.')
-        url = self.urls['download'] + urllib.urlencode({'id': item['id'], 'passkey': self.passkey})
+        url = self.urls['download'] + urlencode({'id': item['id'], 'passkey': self.passkey})
 
         return title, url
 
@@ -191,6 +194,5 @@ class HDBitsCache(tvcache.TVCache):
             pass
 
         return {'entries': results}
-
 
 provider = HDBitsProvider()

--- a/sickbeard/providers/hdspace.py
+++ b/sickbeard/providers/hdspace.py
@@ -40,7 +40,7 @@ class HDSpaceProvider(TorrentProvider):  # pylint: disable=too-many-instance-att
         self.minseed = None
         self.minleech = None
 
-        self.cache = HDSpaceCache(self)
+        self.cache = HDSpaceCache(self, min_time=10)  # only poll HDSpace every 10 minutes max
 
         self.urls = {'base_url': u'https://hd-space.org/',
                      'login': u'https://hd-space.org/index.php?page=login',
@@ -168,13 +168,6 @@ class HDSpaceProvider(TorrentProvider):  # pylint: disable=too-many-instance-att
 
 
 class HDSpaceCache(tvcache.TVCache):
-    def __init__(self, provider_obj):
-
-        tvcache.TVCache.__init__(self, provider_obj)
-
-        # only poll HDSpace every 10 minutes max
-        self.minTime = 10
-
     def _getRSSData(self):
         search_strings = {'RSS': ['']}
         return {'entries': self.provider.search(search_strings)}

--- a/sickbeard/providers/hdspace.py
+++ b/sickbeard/providers/hdspace.py
@@ -2,7 +2,7 @@
 # Author: Idan Gutman
 # Modified by jkaberg, https://github.com/jkaberg for SceneAccess
 # Modified by 7ca for HDSpace
-# URL: http://code.google.com/p/sickbeard/
+# URL: https://sickrage.github.io
 #
 # This file is part of SickRage.
 #
@@ -20,18 +20,20 @@
 # along with SickRage. If not, see <http://www.gnu.org/licenses/>.
 
 import re
-import urllib
-import requests
+from requests.utils import dict_from_cookiejar
+from urllib import quote_plus
 from bs4 import BeautifulSoup
 
-from sickbeard import logger
-from sickbeard import tvcache
+from sickbeard import logger, tvcache
+
 from sickrage.helper.common import convert_size
 from sickrage.providers.torrent.TorrentProvider import TorrentProvider
 
 
 class HDSpaceProvider(TorrentProvider):  # pylint: disable=too-many-instance-attributes
+
     def __init__(self):
+
         TorrentProvider.__init__(self, "HDSpace")
 
         self.username = None
@@ -65,7 +67,7 @@ class HDSpaceProvider(TorrentProvider):  # pylint: disable=too-many-instance-att
 
     def login(self):
 
-        if 'pass' in requests.utils.dict_from_cookiejar(self.session.cookies):
+        if 'pass' in dict_from_cookiejar(self.session.cookies):
             return True
 
         login_params = {'uid': self.username,
@@ -92,7 +94,7 @@ class HDSpaceProvider(TorrentProvider):  # pylint: disable=too-many-instance-att
             logger.log(u"Search Mode: %s" % mode, logger.DEBUG)
             for search_string in search_strings[mode]:
                 if mode != 'RSS':
-                    search_url = self.urls['search'] % (urllib.quote_plus(search_string.replace('.', ' ')),)
+                    search_url = self.urls['search'] % (quote_plus(search_string.replace('.', ' ')),)
                 else:
                     search_url = self.urls['search'] % ''
 

--- a/sickbeard/providers/hdspace.py
+++ b/sickbeard/providers/hdspace.py
@@ -42,7 +42,7 @@ class HDSpaceProvider(TorrentProvider):  # pylint: disable=too-many-instance-att
         self.minseed = None
         self.minleech = None
 
-        self.cache = HDSpaceCache(self, min_time=10)  # only poll HDSpace every 10 minutes max
+        self.cache = tvcache.TVCache(self, min_time=10)  # only poll HDSpace every 10 minutes max
 
         self.urls = {'base_url': u'https://hd-space.org/',
                      'login': u'https://hd-space.org/index.php?page=login',
@@ -167,11 +167,5 @@ class HDSpaceProvider(TorrentProvider):  # pylint: disable=too-many-instance-att
 
     def seed_ratio(self):
         return self.ratio
-
-
-class HDSpaceCache(tvcache.TVCache):
-    def _getRSSData(self):
-        search_strings = {'RSS': ['']}
-        return {'entries': self.provider.search(search_strings)}
 
 provider = HDSpaceProvider()

--- a/sickbeard/providers/hdtorrents.py
+++ b/sickbeard/providers/hdtorrents.py
@@ -52,7 +52,7 @@ class HDTorrentsProvider(TorrentProvider):  # pylint: disable=too-many-instance-
         self.categories = "&category[]=59&category[]=60&category[]=30&category[]=38"
         self.proper_strings = ['PROPER', 'REPACK']
 
-        self.cache = HDTorrentsCache(self)
+        self.cache = HDTorrentsCache(self, min_time=30)  # only poll HDTorrents every 30 minutes max
 
     def _check_auth(self):
 
@@ -184,13 +184,6 @@ class HDTorrentsProvider(TorrentProvider):  # pylint: disable=too-many-instance-
 
 
 class HDTorrentsCache(tvcache.TVCache):
-    def __init__(self, provider_obj):
-
-        tvcache.TVCache.__init__(self, provider_obj)
-
-        # only poll HDTorrents every 30 minutes max
-        self.minTime = 30
-
     def _getRSSData(self):
         search_strings = {'RSS': ['']}
         return {'entries': self.provider.search(search_strings)}

--- a/sickbeard/providers/hdtorrents.py
+++ b/sickbeard/providers/hdtorrents.py
@@ -1,5 +1,6 @@
 # coding=utf-8
-# Author: miigotu (Dustyn Gibson) <miigotu@gmail.com>
+# Author: Dustyn Gibson <miigotu@gmail.com>
+#
 # URL: https://sickrage.github.io
 #
 # This file is part of SickRage.
@@ -18,18 +19,18 @@
 # along with SickRage. If not, see <http://www.gnu.org/licenses/>.
 
 import re
-import urllib
-import requests
+from requests.utils import dict_from_cookiejar
+from urllib import quote_plus
 
-from sickbeard import logger
-from sickbeard import tvcache
+from sickbeard import logger, tvcache
 from sickbeard.bs4_parser import BS4Parser
 
-from sickrage.helper.common import try_int, convert_size
+from sickrage.helper.common import convert_size, try_int
 from sickrage.providers.torrent.TorrentProvider import TorrentProvider
 
 
 class HDTorrentsProvider(TorrentProvider):  # pylint: disable=too-many-instance-attributes
+
     def __init__(self):
 
         TorrentProvider.__init__(self, "HDTorrents")
@@ -62,8 +63,7 @@ class HDTorrentsProvider(TorrentProvider):  # pylint: disable=too-many-instance-
         return True
 
     def login(self):
-
-        if any(requests.utils.dict_from_cookiejar(self.session.cookies).values()):
+        if any(dict_from_cookiejar(self.session.cookies).values()):
             return True
 
         login_params = {'uid': self.username,
@@ -92,7 +92,7 @@ class HDTorrentsProvider(TorrentProvider):  # pylint: disable=too-many-instance-
             for search_string in search_strings[mode]:
 
                 if mode != 'RSS':
-                    search_url = self.urls['search'] % (urllib.quote_plus(search_string), self.categories)
+                    search_url = self.urls['search'] % (quote_plus(search_string), self.categories)
                     logger.log(u"Search string: %s" % search_string, logger.DEBUG)
                 else:
                     search_url = self.urls['rss'] % self.categories

--- a/sickbeard/providers/hdtorrents.py
+++ b/sickbeard/providers/hdtorrents.py
@@ -53,7 +53,7 @@ class HDTorrentsProvider(TorrentProvider):  # pylint: disable=too-many-instance-
         self.categories = "&category[]=59&category[]=60&category[]=30&category[]=38"
         self.proper_strings = ['PROPER', 'REPACK']
 
-        self.cache = HDTorrentsCache(self, min_time=30)  # only poll HDTorrents every 30 minutes max
+        self.cache = tvcache.TVCache(self, min_time=30)  # only poll HDTorrents every 30 minutes max
 
     def _check_auth(self):
 
@@ -181,11 +181,5 @@ class HDTorrentsProvider(TorrentProvider):  # pylint: disable=too-many-instance-
 
     def seed_ratio(self):
         return self.ratio
-
-
-class HDTorrentsCache(tvcache.TVCache):
-    def _getRSSData(self):
-        search_strings = {'RSS': ['']}
-        return {'entries': self.provider.search(search_strings)}
 
 provider = HDTorrentsProvider()

--- a/sickbeard/providers/hounddawgs.py
+++ b/sickbeard/providers/hounddawgs.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 # Author: Idan Gutman
-# URL: http://code.google.com/p/sickbeard/
+#
+# URL: https://sickrage.github.io
 #
 # This file is part of SickRage.
 #
@@ -19,10 +20,11 @@
 
 import re
 import traceback
-from sickbeard import logger
-from sickbeard import tvcache
+
+from sickbeard import logger, tvcache
 from sickbeard.bs4_parser import BS4Parser
-from sickrage.helper.common import try_int, convert_size
+
+from sickrage.helper.common import convert_size, try_int
 from sickrage.providers.torrent.TorrentProvider import TorrentProvider
 
 
@@ -187,6 +189,5 @@ class HoundDawgsCache(tvcache.TVCache):
     def _getRSSData(self):
         search_strings = {'RSS': ['']}
         return {'entries': self.provider.search(search_strings)}
-
 
 provider = HoundDawgsProvider()

--- a/sickbeard/providers/hounddawgs.py
+++ b/sickbeard/providers/hounddawgs.py
@@ -66,7 +66,7 @@ class HoundDawgsProvider(TorrentProvider):  # pylint: disable=too-many-instance-
             "searchtags": ''
         }
 
-        self.cache = HoundDawgsCache(self, min_time=20)  # only poll HoundDawgs every 20 minutes max
+        self.cache = tvcache.TVCache(self)
 
     def login(self):
 
@@ -183,11 +183,5 @@ class HoundDawgsProvider(TorrentProvider):  # pylint: disable=too-many-instance-
 
     def seed_ratio(self):
         return self.ratio
-
-
-class HoundDawgsCache(tvcache.TVCache):
-    def _getRSSData(self):
-        search_strings = {'RSS': ['']}
-        return {'entries': self.provider.search(search_strings)}
 
 provider = HoundDawgsProvider()

--- a/sickbeard/providers/hounddawgs.py
+++ b/sickbeard/providers/hounddawgs.py
@@ -64,7 +64,7 @@ class HoundDawgsProvider(TorrentProvider):  # pylint: disable=too-many-instance-
             "searchtags": ''
         }
 
-        self.cache = HoundDawgsCache(self)
+        self.cache = HoundDawgsCache(self, min_time=20)  # only poll HoundDawgs every 20 minutes max
 
     def login(self):
 
@@ -184,13 +184,6 @@ class HoundDawgsProvider(TorrentProvider):  # pylint: disable=too-many-instance-
 
 
 class HoundDawgsCache(tvcache.TVCache):
-    def __init__(self, provider_obj):
-
-        tvcache.TVCache.__init__(self, provider_obj)
-
-        # only poll HoundDawgs every 20 minutes max
-        self.minTime = 20
-
     def _getRSSData(self):
         search_strings = {'RSS': ['']}
         return {'entries': self.provider.search(search_strings)}

--- a/sickbeard/providers/iptorrents.py
+++ b/sickbeard/providers/iptorrents.py
@@ -41,7 +41,7 @@ class IPTorrentsProvider(TorrentProvider):  # pylint: disable=too-many-instance-
         self.minseed = None
         self.minleech = None
 
-        self.cache = IPTorrentsCache(self, min_time=10)  # Only poll IPTorrents every 10 minutes max
+        self.cache = tvcache.TVCache(self, min_time=10)  # Only poll IPTorrents every 10 minutes max
 
         self.urls = {'base_url': 'https://iptorrents.eu',
                      'login': 'https://iptorrents.eu/torrents/',
@@ -163,11 +163,5 @@ class IPTorrentsProvider(TorrentProvider):  # pylint: disable=too-many-instance-
 
     def seed_ratio(self):
         return self.ratio
-
-
-class IPTorrentsCache(tvcache.TVCache):
-    def _getRSSData(self):
-        search_params = {'RSS': ['']}
-        return {'entries': self.provider.search(search_params)}
 
 provider = IPTorrentsProvider()

--- a/sickbeard/providers/iptorrents.py
+++ b/sickbeard/providers/iptorrents.py
@@ -38,7 +38,7 @@ class IPTorrentsProvider(TorrentProvider):  # pylint: disable=too-many-instance-
         self.minseed = None
         self.minleech = None
 
-        self.cache = IPTorrentsCache(self)
+        self.cache = IPTorrentsCache(self, min_time=10)  # Only poll IPTorrents every 10 minutes max
 
         self.urls = {'base_url': 'https://iptorrents.eu',
                      'login': 'https://iptorrents.eu/torrents/',
@@ -163,13 +163,6 @@ class IPTorrentsProvider(TorrentProvider):  # pylint: disable=too-many-instance-
 
 
 class IPTorrentsCache(tvcache.TVCache):
-    def __init__(self, provider_obj):
-
-        tvcache.TVCache.__init__(self, provider_obj)
-
-        # Only poll IPTorrents every 10 minutes max
-        self.minTime = 10
-
     def _getRSSData(self):
         search_params = {'RSS': ['']}
         return {'entries': self.provider.search(search_params)}

--- a/sickbeard/providers/iptorrents.py
+++ b/sickbeard/providers/iptorrents.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 # Author: seedboy
-# URL: https://github.com/seedboy
+#
+# URL: https://sickrage.github.io
 #
 # This file is part of SickRage.
 #
@@ -18,15 +19,17 @@
 # along with SickRage. If not, see <http://www.gnu.org/licenses/>.
 
 import re
-from sickbeard import logger
-from sickbeard import tvcache
+
+from sickbeard import logger, tvcache
 from sickbeard.bs4_parser import BS4Parser
-from sickrage.helper.common import convert_size
+
 from sickrage.helper.exceptions import AuthException, ex
+from sickrage.helper.common import convert_size
 from sickrage.providers.torrent.TorrentProvider import TorrentProvider
 
 
 class IPTorrentsProvider(TorrentProvider):  # pylint: disable=too-many-instance-attributes
+
     def __init__(self):
 
         TorrentProvider.__init__(self, "IPTorrents")
@@ -166,6 +169,5 @@ class IPTorrentsCache(tvcache.TVCache):
     def _getRSSData(self):
         search_params = {'RSS': ['']}
         return {'entries': self.provider.search(search_params)}
-
 
 provider = IPTorrentsProvider()

--- a/sickbeard/providers/kat.py
+++ b/sickbeard/providers/kat.py
@@ -60,7 +60,7 @@ class KatProvider(TorrentProvider):  # pylint: disable=too-many-instance-attribu
             'category': 'tv'
         }
 
-        self.cache = KatCache(self)
+        self.cache = KatCache(self, min_time=20)  # only poll KickAss every 20 minutes max
 
     def search(self, search_strings, age=0, ep_obj=None):  # pylint: disable=too-many-branches, too-many-locals, too-many-statements
         results = []
@@ -158,13 +158,6 @@ class KatProvider(TorrentProvider):  # pylint: disable=too-many-instance-attribu
 
 
 class KatCache(tvcache.TVCache):
-    def __init__(self, provider_obj):
-
-        tvcache.TVCache.__init__(self, provider_obj)
-
-        # only poll KickAss every 10 minutes max
-        self.minTime = 20
-
     def _getRSSData(self):
         search_params = {'RSS': ['tv', 'anime']}
         return {'entries': self.provider.search(search_params)}

--- a/sickbeard/providers/kat.py
+++ b/sickbeard/providers/kat.py
@@ -23,14 +23,15 @@ from urllib import urlencode
 from bs4 import BeautifulSoup
 
 import sickbeard
-from sickbeard import logger
-from sickbeard import tvcache
+from sickbeard import logger, tvcache
 from sickbeard.common import USER_AGENT
-from sickrage.helper.common import try_int, convert_size
+
+from sickrage.helper.common import convert_size, try_int
 from sickrage.providers.torrent.TorrentProvider import TorrentProvider
 
 
 class KatProvider(TorrentProvider):  # pylint: disable=too-many-instance-attributes
+
     def __init__(self):
 
         TorrentProvider.__init__(self, "KickAssTorrents")

--- a/sickbeard/providers/kat.py
+++ b/sickbeard/providers/kat.py
@@ -61,7 +61,7 @@ class KatProvider(TorrentProvider):  # pylint: disable=too-many-instance-attribu
             'category': 'tv'
         }
 
-        self.cache = KatCache(self, min_time=20)  # only poll KickAss every 20 minutes max
+        self.cache = tvcache.TVCache(self, search_params={'RSS': ['tv', 'anime']})
 
     def search(self, search_strings, age=0, ep_obj=None):  # pylint: disable=too-many-branches, too-many-locals, too-many-statements
         results = []
@@ -156,11 +156,5 @@ class KatProvider(TorrentProvider):  # pylint: disable=too-many-instance-attribu
 
     def seed_ratio(self):
         return self.ratio
-
-
-class KatCache(tvcache.TVCache):
-    def _getRSSData(self):
-        search_params = {'RSS': ['tv', 'anime']}
-        return {'entries': self.provider.search(search_params)}
 
 provider = KatProvider()

--- a/sickbeard/providers/limetorrents.py
+++ b/sickbeard/providers/limetorrents.py
@@ -49,7 +49,7 @@ class LimeTorrentsProvider(TorrentProvider):  # pylint: disable=too-many-instanc
         self.headers.update({'User-Agent': USER_AGENT})
         self.proper_strings = ['PROPER', 'REPACK', 'REAL']
 
-        self.cache = LimeTorrentsCache(self, min_time=20)  # only poll LimeTorrents every 20 minutes max
+        self.cache = tvcache.TVCache(self, search_params={'RSS': ['rss']})
 
     def search(self, search_strings, age=0, ep_obj=None):  # pylint: disable=too-many-branches,too-many-locals
         results = []
@@ -132,11 +132,5 @@ class LimeTorrentsProvider(TorrentProvider):  # pylint: disable=too-many-instanc
 
     def seed_ratio(self):
         return self.ratio
-
-
-class LimeTorrentsCache(tvcache.TVCache):
-    def _getRSSData(self):
-        search_strings = {'RSS': ['rss']}
-        return {'entries': self.provider.search(search_strings)}
 
 provider = LimeTorrentsProvider()

--- a/sickbeard/providers/limetorrents.py
+++ b/sickbeard/providers/limetorrents.py
@@ -44,9 +44,9 @@ class LimeTorrentsProvider(TorrentProvider): # pylint: disable=too-many-instance
         self.headers.update({'User-Agent': USER_AGENT})
         self.proper_strings = ['PROPER', 'REPACK', 'REAL']
 
-        self.cache = LimeTorrentsCache(self)
+        self.cache = LimeTorrentsCache(self, min_time=20)  # only poll LimeTorrents every 20 minutes max
 
-    def search(self, search_strings, age=0, ep_obj=None): # pylint: disable=too-many-branches,too-many-locals
+    def search(self, search_strings, age=0, ep_obj=None):  # pylint: disable=too-many-branches,too-many-locals
         results = []
         for mode in search_strings:
             items = []
@@ -130,12 +130,6 @@ class LimeTorrentsProvider(TorrentProvider): # pylint: disable=too-many-instance
 
 
 class LimeTorrentsCache(tvcache.TVCache):
-    def __init__(self, provider_obj):
-
-        tvcache.TVCache.__init__(self, provider_obj)
-
-        self.minTime = 20
-
     def _getRSSData(self):
         search_strings = {'RSS': ['rss']}
         return {'entries': self.provider.search(search_strings)}

--- a/sickbeard/providers/limetorrents.py
+++ b/sickbeard/providers/limetorrents.py
@@ -1,6 +1,8 @@
 # coding=utf-8
-# Author: Gonçalo (aka duramato/supergonkas) <matigonkas@outlook.com>
-# URL: https://github.com/SickRage/sickrage
+# Author: Gonçalo M. (aka duramato/supergonkas) <supergonkas@gmail.com>
+#
+# URL: https://sickrage.github.io
+#
 # This file is part of SickRage.
 #
 # SickRage is free software: you can redistribute it and/or modify
@@ -18,15 +20,18 @@
 
 import traceback
 from bs4 import BeautifulSoup
-from sickbeard import logger
-from sickbeard import tvcache
+
+from sickbeard import logger, tvcache
 from sickbeard.common import USER_AGENT
-from sickrage.helper.common import try_int, convert_size
+
+from sickrage.helper.common import convert_size, try_int
 from sickrage.providers.torrent.TorrentProvider import TorrentProvider
 
 
-class LimeTorrentsProvider(TorrentProvider): # pylint: disable=too-many-instance-attributes
+class LimeTorrentsProvider(TorrentProvider):  # pylint: disable=too-many-instance-attributes
+
     def __init__(self):
+
         TorrentProvider.__init__(self, "LimeTorrents")
 
         self.urls = {
@@ -133,6 +138,5 @@ class LimeTorrentsCache(tvcache.TVCache):
     def _getRSSData(self):
         search_strings = {'RSS': ['rss']}
         return {'entries': self.provider.search(search_strings)}
-
 
 provider = LimeTorrentsProvider()

--- a/sickbeard/providers/morethantv.py
+++ b/sickbeard/providers/morethantv.py
@@ -21,11 +21,11 @@ import re
 from requests.utils import dict_from_cookiejar
 from urllib import urlencode
 
-from sickbeard import logger
-from sickbeard import tvcache
+from sickbeard import logger, tvcache
 from sickbeard.bs4_parser import BS4Parser
-from sickrage.helper.common import try_int, convert_size
+
 from sickrage.helper.exceptions import AuthException
+from sickrage.helper.common import convert_size, try_int
 from sickrage.providers.torrent.TorrentProvider import TorrentProvider
 
 

--- a/sickbeard/providers/morethantv.py
+++ b/sickbeard/providers/morethantv.py
@@ -51,7 +51,7 @@ class MoreThanTVProvider(TorrentProvider):  # pylint: disable=too-many-instance-
 
         self.proper_strings = ['PROPER', 'REPACK']
 
-        self.cache = MoreThanTVCache(self)
+        self.cache = MoreThanTVCache(self, min_time=20)  # only poll MoreThanTV every 20 minutes max
 
     def _check_auth(self):
 
@@ -175,13 +175,6 @@ class MoreThanTVProvider(TorrentProvider):  # pylint: disable=too-many-instance-
 
 
 class MoreThanTVCache(tvcache.TVCache):
-    def __init__(self, provider_obj):
-
-        tvcache.TVCache.__init__(self, provider_obj)
-
-        # poll delay in minutes
-        self.minTime = 20
-
     def _getRSSData(self):
         search_strings = {'RSS': ['']}
         return {'entries': self.provider.search(search_strings)}

--- a/sickbeard/providers/morethantv.py
+++ b/sickbeard/providers/morethantv.py
@@ -51,7 +51,7 @@ class MoreThanTVProvider(TorrentProvider):  # pylint: disable=too-many-instance-
 
         self.proper_strings = ['PROPER', 'REPACK']
 
-        self.cache = MoreThanTVCache(self, min_time=20)  # only poll MoreThanTV every 20 minutes max
+        self.cache = tvcache.TVCache(self)
 
     def _check_auth(self):
 
@@ -172,11 +172,5 @@ class MoreThanTVProvider(TorrentProvider):  # pylint: disable=too-many-instance-
 
     def seed_ratio(self):
         return self.ratio
-
-
-class MoreThanTVCache(tvcache.TVCache):
-    def _getRSSData(self):
-        search_strings = {'RSS': ['']}
-        return {'entries': self.provider.search(search_strings)}
 
 provider = MoreThanTVProvider()

--- a/sickbeard/providers/newpct.py
+++ b/sickbeard/providers/newpct.py
@@ -37,7 +37,7 @@ class newpctProvider(TorrentProvider):
         TorrentProvider.__init__(self, "Newpct")
 
         self.onlyspasearch = None
-        self.cache = newpctCache(self, min_time=10)
+        self.cache = tvcache.TVCache(self, min_time=10)
 
         # Unsupported
         # self.minseed = None
@@ -229,11 +229,5 @@ class newpctProvider(TorrentProvider):
         title += '-NEWPCT'
 
         return title.strip()
-
-
-class newpctCache(tvcache.TVCache):
-    def _getRSSData(self):
-        search_params = {'RSS': ['']}
-        return {'entries': self.provider.search(search_params)}
 
 provider = newpctProvider()

--- a/sickbeard/providers/newpct.py
+++ b/sickbeard/providers/newpct.py
@@ -37,7 +37,7 @@ class newpctProvider(TorrentProvider):
         TorrentProvider.__init__(self, "Newpct")
 
         self.onlyspasearch = None
-        self.cache = newpctCache(self)
+        self.cache = newpctCache(self, min_time=10)
 
         # Unsupported
         # self.minseed = None
@@ -232,13 +232,6 @@ class newpctProvider(TorrentProvider):
 
 
 class newpctCache(tvcache.TVCache):
-    def __init__(self, provider_obj):
-
-        tvcache.TVCache.__init__(self, provider_obj)
-
-        # set this 0 to suppress log line, since we aren't updating it anyways
-        self.minTime = 20
-
     def _getRSSData(self):
         search_params = {'RSS': ['']}
         return {'entries': self.provider.search(search_params)}

--- a/sickbeard/providers/newpct.py
+++ b/sickbeard/providers/newpct.py
@@ -1,8 +1,7 @@
 # coding=utf-8
 # Author: CristianBB
 # Greetings to Mr. Pine-apple
-#
-# URL: http://code.google.com/p/sickbeard/
+# URL: https://sickrage.github.io
 #
 # This file is part of SickRage.
 #
@@ -19,19 +18,20 @@
 # You should have received a copy of the GNU General Public License
 # along with SickRage. If not, see <http://www.gnu.org/licenses/>.
 
-import traceback
 import re
 from six.moves import urllib
+import traceback
 
 from sickbeard import helpers
-from sickbeard import logger
-from sickbeard import tvcache
+from sickbeard import logger, tvcache
 from sickbeard.bs4_parser import BS4Parser
+
 from sickrage.helper.common import convert_size
 from sickrage.providers.torrent.TorrentProvider import TorrentProvider
 
 
 class newpctProvider(TorrentProvider):
+
     def __init__(self):
 
         TorrentProvider.__init__(self, "Newpct")
@@ -235,6 +235,5 @@ class newpctCache(tvcache.TVCache):
     def _getRSSData(self):
         search_params = {'RSS': ['']}
         return {'entries': self.provider.search(search_params)}
-
 
 provider = newpctProvider()

--- a/sickbeard/providers/newznab.py
+++ b/sickbeard/providers/newznab.py
@@ -1,9 +1,7 @@
 # coding=utf-8
 # Author: Nic Wolfe <nic@wolfeden.ca>
-# URL: http://code.google.com/p/sickbeard/
-#
 # Rewrite: Dustyn Gibson (miigotu) <miigotu@gmail.com>
-# URL: http://sickrage.github.io
+# URL: https://sickrage.github.io
 #
 # This file is part of SickRage.
 #
@@ -20,20 +18,20 @@
 # You should have received a copy of the GNU General Public License
 # along with SickRage. If not, see <http://www.gnu.org/licenses/>.
 
-import os
-import time
 import datetime
+import os
 import posixpath  # Must use posixpath
+import time
 from urllib import urlencode
 
 import sickbeard
-from sickbeard import logger
-from sickbeard import tvcache
-from sickrage.helper.encoding import ek, ss
+from sickbeard import logger, tvcache
 from sickbeard.bs4_parser import BS4Parser
-from sickrage.helper.common import try_int, convert_size
-from sickrage.providers.nzb.NZBProvider import NZBProvider
 from sickbeard.common import cpu_presets
+
+from sickrage.helper.common import convert_size, try_int
+from sickrage.helper.encoding import ek, ss
+from sickrage.providers.nzb.NZBProvider import NZBProvider
 
 
 class NewznabProvider(NZBProvider):  # pylint: disable=too-many-instance-attributes, too-many-arguments
@@ -43,6 +41,7 @@ class NewznabProvider(NZBProvider):  # pylint: disable=too-many-instance-attribu
     Tested with: newznab, nzedb, spotweb, torznab
     """
     # pylint: disable=too-many-arguments
+
     def __init__(self, name, url, key='0', catIDs='5030,5040', search_mode='eponly',
                  search_fallback=False, enable_daily=True, enable_backlog=False):
 

--- a/sickbeard/providers/newznab.py
+++ b/sickbeard/providers/newznab.py
@@ -66,7 +66,7 @@ class NewznabProvider(NZBProvider):  # pylint: disable=too-many-instance-attribu
 
         self.default = False
 
-        self.cache = NewznabCache(self)
+        self.cache = NewznabCache(self, min_time=30)  # only poll newznab providers every 30 minutes max
 
     def configStr(self):
         """
@@ -342,13 +342,6 @@ class NewznabProvider(NZBProvider):  # pylint: disable=too-many-instance-attribu
 
 
 class NewznabCache(tvcache.TVCache):
-    def __init__(self, provider_obj):
-
-        tvcache.TVCache.__init__(self, provider_obj)
-
-        # only poll newznab providers every 30 minutes
-        self.minTime = 30
-
     def _getRSSData(self):
         search_strings = {'RSS': ['']}
         return {'entries': self.provider.search(search_strings)}

--- a/sickbeard/providers/newznab.py
+++ b/sickbeard/providers/newznab.py
@@ -65,7 +65,7 @@ class NewznabProvider(NZBProvider):  # pylint: disable=too-many-instance-attribu
 
         self.default = False
 
-        self.cache = NewznabCache(self, min_time=30)  # only poll newznab providers every 30 minutes max
+        self.cache = tvcache.TVCache(self, min_time=30)  # only poll newznab providers every 30 minutes max
 
     def configStr(self):
         """
@@ -338,9 +338,3 @@ class NewznabProvider(NZBProvider):  # pylint: disable=too-many-instance-attribu
         Returns int size or -1
         """
         return try_int(item.get('size', -1), -1)
-
-
-class NewznabCache(tvcache.TVCache):
-    def _getRSSData(self):
-        search_strings = {'RSS': ['']}
-        return {'entries': self.provider.search(search_strings)}

--- a/sickbeard/providers/nyaatorrents.py
+++ b/sickbeard/providers/nyaatorrents.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 # Author: Mr_Orange
-# URL: http://code.google.com/p/sickbeard/
+#
+# URL: https://sickrage.github.io
 #
 # This file is part of SickRage.
 #
@@ -17,16 +18,17 @@
 # You should have received a copy of the GNU General Public License
 # along with SickRage. If not, see <http://www.gnu.org/licenses/>.
 
-import urllib
 import re
+from urllib import urlencode
 
-from sickbeard import logger
-from sickbeard import tvcache
+from sickbeard import logger, tvcache
+
 from sickrage.helper.common import convert_size
 from sickrage.providers.torrent.TorrentProvider import TorrentProvider
 
 
 class NyaaProvider(TorrentProvider):  # pylint: disable=too-many-instance-attributes
+
     def __init__(self):
 
         TorrentProvider.__init__(self, "NyaaTorrents")
@@ -67,7 +69,7 @@ class NyaaProvider(TorrentProvider):  # pylint: disable=too-many-instance-attrib
                 if mode != 'RSS':
                     params["term"] = search_string.encode('utf-8')
 
-                search_url = self.url + '?' + urllib.urlencode(params)
+                search_url = self.url + '?' + urlencode(params)
                 logger.log(u"Search URL: %s" % search_url, logger.DEBUG)
 
                 summary_regex = ur"(\d+) seeder\(s\), (\d+) leecher\(s\), \d+ download\(s\) - (\d+.?\d* [KMGT]iB)(.*)"

--- a/sickbeard/providers/nyaatorrents.py
+++ b/sickbeard/providers/nyaatorrents.py
@@ -38,7 +38,7 @@ class NyaaProvider(TorrentProvider):  # pylint: disable=too-many-instance-attrib
         self.anime_only = True
         self.ratio = None
 
-        self.cache = NyaaCache(self, min_time=15)  # only poll NyaaTorrents every 15 minutes max
+        self.cache = tvcache.TVCache(self, min_time=15)  # only poll NyaaTorrents every 15 minutes max
 
         self.urls = {'base_url': 'http://www.nyaa.se/'}
 
@@ -109,11 +109,5 @@ class NyaaProvider(TorrentProvider):  # pylint: disable=too-many-instance-attrib
 
     def seed_ratio(self):
         return self.ratio
-
-
-class NyaaCache(tvcache.TVCache):
-    def _getRSSData(self):
-        search_params = {'RSS': ['']}
-        return {'entries': self.provider.search(search_params)}
 
 provider = NyaaProvider()

--- a/sickbeard/providers/nyaatorrents.py
+++ b/sickbeard/providers/nyaatorrents.py
@@ -36,7 +36,7 @@ class NyaaProvider(TorrentProvider):  # pylint: disable=too-many-instance-attrib
         self.anime_only = True
         self.ratio = None
 
-        self.cache = NyaaCache(self)
+        self.cache = NyaaCache(self, min_time=15)  # only poll NyaaTorrents every 15 minutes max
 
         self.urls = {'base_url': 'http://www.nyaa.se/'}
 
@@ -110,12 +110,6 @@ class NyaaProvider(TorrentProvider):  # pylint: disable=too-many-instance-attrib
 
 
 class NyaaCache(tvcache.TVCache):
-    def __init__(self, provider_obj):
-        tvcache.TVCache.__init__(self, provider_obj)
-
-        # only poll NyaaTorrents every 15 minutes max
-        self.minTime = 15
-
     def _getRSSData(self):
         search_params = {'RSS': ['']}
         return {'entries': self.provider.search(search_params)}

--- a/sickbeard/providers/omgwtfnzbs.py
+++ b/sickbeard/providers/omgwtfnzbs.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 # Author: Jordon Smith <smith@jordon.me.uk>
-# URL: http://code.google.com/p/sickbeard/
+#
+# URL: https://sickrage.github.io
 #
 # This file is part of SickRage.
 #
@@ -17,11 +18,12 @@
 # You should have received a copy of the GNU General Public License
 # along with SickRage. If not, see <http://www.gnu.org/licenses/>.
 
-import urllib
+from datetime import datetime
+from urllib import urlencode
 
 import sickbeard
-from sickbeard import tvcache
-from sickbeard import logger
+from sickbeard import classes, logger, tvcache
+
 from sickrage.helper.common import try_int
 from sickrage.providers.nzb.NZBProvider import NZBProvider
 
@@ -105,7 +107,7 @@ class OmgwtfnzbsProvider(NZBProvider):
                 if mode != 'RSS':
                     logger.log(u"Search string: %s " % search_string, logger.DEBUG)
 
-                logger.log(u"Search URL: %s" % self.urls['api'] + '?' + urllib.urlencode(search_params), logger.DEBUG)
+                logger.log(u"Search URL: %s" % self.urls['api'] + '?' + urlencode(search_params), logger.DEBUG)
 
                 data = self.get_url(self.urls['api'], params=search_params, json=True)
                 if not data:
@@ -153,7 +155,7 @@ class OmgwtfnzbsCache(tvcache.TVCache):
             'catid': '19,20'  # SD,HD
         }
 
-        rss_url = self.provider.urls['rss'] + '?' + urllib.urlencode(search_params)
+        rss_url = self.provider.urls['rss'] + '?' + urlencode(search_params)
 
         logger.log(u"Cache update URL: %s" % rss_url, logger.DEBUG)
 

--- a/sickbeard/providers/omgwtfnzbs.py
+++ b/sickbeard/providers/omgwtfnzbs.py
@@ -32,7 +32,7 @@ class OmgwtfnzbsProvider(NZBProvider):
 
         self.username = None
         self.api_key = None
-        self.cache = OmgwtfnzbsCache(self)
+        self.cache = OmgwtfnzbsCache(self, min_time=20)  # only poll Omgwtfnzbs every 15 minutes max
 
         self.url = 'https://omgwtfnzbs.org/'
         self.urls = {
@@ -125,10 +125,6 @@ class OmgwtfnzbsProvider(NZBProvider):
 
 
 class OmgwtfnzbsCache(tvcache.TVCache):
-    def __init__(self, provider_obj):
-        tvcache.TVCache.__init__(self, provider_obj)
-        self.minTime = 20
-
     def _get_title_and_url(self, item):
         """
         Retrieves the title and URL data from the item XML node

--- a/sickbeard/providers/omgwtfnzbs.py
+++ b/sickbeard/providers/omgwtfnzbs.py
@@ -34,7 +34,8 @@ class OmgwtfnzbsProvider(NZBProvider):
 
         self.username = None
         self.api_key = None
-        self.cache = OmgwtfnzbsCache(self, min_time=20)  # only poll Omgwtfnzbs every 15 minutes max
+
+        self.cache = OmgwtfnzbsCache(self)
 
         self.url = 'https://omgwtfnzbs.org/'
         self.urls = {
@@ -156,9 +157,7 @@ class OmgwtfnzbsCache(tvcache.TVCache):
         }
 
         rss_url = self.provider.urls['rss'] + '?' + urlencode(search_params)
-
         logger.log(u"Cache update URL: %s" % rss_url, logger.DEBUG)
-
         return self.getRSSFeed(rss_url)
 
 provider = OmgwtfnzbsProvider()

--- a/sickbeard/providers/pretome.py
+++ b/sickbeard/providers/pretome.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 # Author: Nick Sologoub
-# URL: http://code.google.com/p/sickbeard/
+#
+# URL: https://sickrage.github.io
 #
 # This file is part of SickRage.
 #
@@ -18,17 +19,18 @@
 # along with SickRage. If not, see <http://www.gnu.org/licenses/>.
 
 import re
-import urllib
 import traceback
+from urllib import quote
 
-from sickbeard import logger
-from sickbeard import tvcache
+from sickbeard import logger, tvcache
 from sickbeard.bs4_parser import BS4Parser
+
 from sickrage.helper.common import convert_size
 from sickrage.providers.torrent.TorrentProvider import TorrentProvider
 
 
 class PretomeProvider(TorrentProvider):  # pylint: disable=too-many-instance-attributes
+
     def __init__(self):
 
         TorrentProvider.__init__(self, "Pretome")
@@ -91,7 +93,7 @@ class PretomeProvider(TorrentProvider):  # pylint: disable=too-many-instance-att
                 if mode != 'RSS':
                     logger.log(u"Search string: %s " % search_string, logger.DEBUG)
 
-                search_url = self.urls['search'] % (urllib.quote(search_string.encode('utf-8')), self.categories)
+                search_url = self.urls['search'] % (quote(search_string.encode('utf-8')), self.categories)
                 logger.log(u"Search URL: %s" % search_url, logger.DEBUG)
 
                 data = self.get_url(search_url)
@@ -171,6 +173,5 @@ class PretomeCache(tvcache.TVCache):
     def _getRSSData(self):
         search_params = {'RSS': ['']}
         return {'entries': self.provider.search(search_params)}
-
 
 provider = PretomeProvider()

--- a/sickbeard/providers/pretome.py
+++ b/sickbeard/providers/pretome.py
@@ -52,7 +52,7 @@ class PretomeProvider(TorrentProvider):  # pylint: disable=too-many-instance-att
 
         self.proper_strings = ['PROPER', 'REPACK']
 
-        self.cache = PretomeCache(self)
+        self.cache = PretomeCache(self, min_time=20)  # only poll Pretome every 20 minutes max
 
     def _check_auth(self):
 
@@ -168,13 +168,6 @@ class PretomeProvider(TorrentProvider):  # pylint: disable=too-many-instance-att
 
 
 class PretomeCache(tvcache.TVCache):
-    def __init__(self, provider_obj):
-
-        tvcache.TVCache.__init__(self, provider_obj)
-
-        # only poll Pretome every 20 minutes max
-        self.minTime = 20
-
     def _getRSSData(self):
         search_params = {'RSS': ['']}
         return {'entries': self.provider.search(search_params)}

--- a/sickbeard/providers/pretome.py
+++ b/sickbeard/providers/pretome.py
@@ -54,7 +54,7 @@ class PretomeProvider(TorrentProvider):  # pylint: disable=too-many-instance-att
 
         self.proper_strings = ['PROPER', 'REPACK']
 
-        self.cache = PretomeCache(self, min_time=20)  # only poll Pretome every 20 minutes max
+        self.cache = tvcache.TVCache(self)
 
     def _check_auth(self):
 
@@ -167,11 +167,5 @@ class PretomeProvider(TorrentProvider):  # pylint: disable=too-many-instance-att
 
     def seed_ratio(self):
         return self.ratio
-
-
-class PretomeCache(tvcache.TVCache):
-    def _getRSSData(self):
-        search_params = {'RSS': ['']}
-        return {'entries': self.provider.search(search_params)}
 
 provider = PretomeProvider()

--- a/sickbeard/providers/rarbg.py
+++ b/sickbeard/providers/rarbg.py
@@ -48,7 +48,7 @@ class RarbgProvider(TorrentProvider):  # pylint: disable=too-many-instance-attri
 
         self.proper_strings = ['{{PROPER|REPACK}}']
 
-        self.cache = RarbgCache(self)
+        self.cache = RarbgCache(self, min_time=10)  # only poll RARBG every 10 minutes max
 
     def login(self):
         if self.token and self.token_expires and datetime.datetime.now() < self.token_expires:
@@ -153,13 +153,6 @@ class RarbgProvider(TorrentProvider):  # pylint: disable=too-many-instance-attri
 
 
 class RarbgCache(tvcache.TVCache):
-    def __init__(self, provider_obj):
-
-        tvcache.TVCache.__init__(self, provider_obj)
-
-        # only poll RARBG every 10 minutes max
-        self.minTime = 10
-
     def _getRSSData(self):
         search_strings = {'RSS': ['']}
         return {'entries': self.provider.search(search_strings)}

--- a/sickbeard/providers/rarbg.py
+++ b/sickbeard/providers/rarbg.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 # Author: Dustyn Gibson <miigotu@gmail.com>
+#
 # URL: https://sickrage.github.io
 #
 # This file is part of SickRage.
@@ -17,20 +18,21 @@
 # You should have received a copy of the GNU General Public License
 # along with SickRage. If not, see <http://www.gnu.org/licenses/>.
 
-import time
 import datetime
+import time
 from urllib import urlencode
 
 from sickbeard import logger, tvcache
 from sickbeard.indexers.indexer_config import INDEXER_TVDB
-from sickrage.helper.common import try_int
-from sickrage.helper.common import convert_size
+
+from sickrage.helper.common import convert_size, try_int
 from sickrage.providers.torrent.TorrentProvider import TorrentProvider
 
 
 class RarbgProvider(TorrentProvider):  # pylint: disable=too-many-instance-attributes
 
     def __init__(self):
+
         TorrentProvider.__init__(self, "Rarbg")
 
         self.public = True

--- a/sickbeard/providers/rarbg.py
+++ b/sickbeard/providers/rarbg.py
@@ -50,7 +50,7 @@ class RarbgProvider(TorrentProvider):  # pylint: disable=too-many-instance-attri
 
         self.proper_strings = ['{{PROPER|REPACK}}']
 
-        self.cache = RarbgCache(self, min_time=10)  # only poll RARBG every 10 minutes max
+        self.cache = tvcache.TVCache(self, min_time=10)  # only poll RARBG every 10 minutes max
 
     def login(self):
         if self.token and self.token_expires and datetime.datetime.now() < self.token_expires:
@@ -152,12 +152,5 @@ class RarbgProvider(TorrentProvider):  # pylint: disable=too-many-instance-attri
 
     def seed_ratio(self):
         return self.ratio
-
-
-class RarbgCache(tvcache.TVCache):
-    def _getRSSData(self):
-        search_strings = {'RSS': ['']}
-        return {'entries': self.provider.search(search_strings)}
-
 
 provider = RarbgProvider()

--- a/sickbeard/providers/rsstorrent.py
+++ b/sickbeard/providers/rsstorrent.py
@@ -1,5 +1,7 @@
 # coding=utf-8
-# Author: Mr_Orange
+# # Author: Mr_Orange
+#
+# URL: https://sickrage.github.io
 #
 # This file is part of SickRage.
 #
@@ -19,13 +21,11 @@
 import io
 import os
 import re
-import requests
+from requests.utils import add_dict_to_cookiejar
 from bencode import bdecode
 
 import sickbeard
-from sickbeard import helpers
-from sickbeard import logger
-from sickbeard import tvcache
+from sickbeard import helpers, logger, tvcache
 
 from sickrage.helper.encoding import ek
 from sickrage.helper.exceptions import ex
@@ -33,15 +33,15 @@ from sickrage.providers.torrent.TorrentProvider import TorrentProvider
 
 
 class TorrentRssProvider(TorrentProvider):
+
     def __init__(self, name, url, cookies='', titleTAG='title', search_mode='eponly', search_fallback=False, enable_daily=False,
                  enable_backlog=False):
+
         TorrentProvider.__init__(self, name)
+
         self.cache = TorrentRssCache(self, min_time=15)
-
         self.urls = {'base_url': re.sub(r'/$', '', url)}
-
         self.url = self.urls['base_url']
-
         self.ratio = None
         self.supports_backlog = False
 
@@ -168,7 +168,7 @@ class TorrentRssProvider(TorrentProvider):
                 return True, 'RSS feed Parsed correctly'
             else:
                 if self.cookies:
-                    requests.utils.add_dict_to_cookiejar(self.session.cookies,
+                    add_dict_to_cookiejar(self.session.cookies,
                                                          dict(x.rsplit('=', 1) for x in self.cookies.split(';')))
                 torrent_file = self.get_url(url, need_bytes=True)
                 try:

--- a/sickbeard/providers/rsstorrent.py
+++ b/sickbeard/providers/rsstorrent.py
@@ -36,9 +36,9 @@ class TorrentRssProvider(TorrentProvider):
     def __init__(self, name, url, cookies='', titleTAG='title', search_mode='eponly', search_fallback=False, enable_daily=False,
                  enable_backlog=False):
         TorrentProvider.__init__(self, name)
-        self.cache = TorrentRssCache(self)
+        self.cache = TorrentRssCache(self, min_time=15)
 
-        self.urls = {'base_url': re.sub(r'\/$', '', url)}
+        self.urls = {'base_url': re.sub(r'/$', '', url)}
 
         self.url = self.urls['base_url']
 
@@ -202,10 +202,6 @@ class TorrentRssProvider(TorrentProvider):
 
 
 class TorrentRssCache(tvcache.TVCache):
-    def __init__(self, provider_obj):
-        tvcache.TVCache.__init__(self, provider_obj)
-        self.minTime = 15
-
     def _getRSSData(self):
         logger.log(u"Cache update URL: %s" % self.provider.url, logger.DEBUG)
 

--- a/sickbeard/providers/scc.py
+++ b/sickbeard/providers/scc.py
@@ -43,7 +43,7 @@ class SCCProvider(TorrentProvider):  # pylint: disable=too-many-instance-attribu
         self.minseed = None
         self.minleech = None
 
-        self.cache = SCCCache(self, min_time=20)  # only poll SCC every 20 minutes max
+        self.cache = tvcache.TVCache(self)  # only poll SCC every 20 minutes max
 
         self.urls = {
             'base_url': 'https://sceneaccess.eu',
@@ -165,11 +165,5 @@ class SCCProvider(TorrentProvider):  # pylint: disable=too-many-instance-attribu
 
     def seed_ratio(self):
         return self.ratio
-
-
-class SCCCache(tvcache.TVCache):
-    def _getRSSData(self):
-        search_strings = {'RSS': ['']}
-        return {'entries': self.provider.search(search_strings)}
 
 provider = SCCProvider()

--- a/sickbeard/providers/scc.py
+++ b/sickbeard/providers/scc.py
@@ -43,7 +43,7 @@ class SCCProvider(TorrentProvider):  # pylint: disable=too-many-instance-attribu
         self.minseed = None
         self.minleech = None
 
-        self.cache = SCCCache(self)
+        self.cache = SCCCache(self, min_time=20)  # only poll SCC every 20 minutes max
 
         self.urls = {
             'base_url': 'https://sceneaccess.eu',
@@ -168,13 +168,6 @@ class SCCProvider(TorrentProvider):  # pylint: disable=too-many-instance-attribu
 
 
 class SCCCache(tvcache.TVCache):
-    def __init__(self, provider_obj):
-
-        tvcache.TVCache.__init__(self, provider_obj)
-
-        # only poll SCC every 20 minutes max
-        self.minTime = 20
-
     def _getRSSData(self):
         search_strings = {'RSS': ['']}
         return {'entries': self.provider.search(search_strings)}

--- a/sickbeard/providers/scc.py
+++ b/sickbeard/providers/scc.py
@@ -1,7 +1,7 @@
 # coding=utf-8
 # Author: Idan Gutman
 # Modified by jkaberg, https://github.com/jkaberg for SceneAccess
-# URL: http://code.google.com/p/sickbeard/
+# URL: https://sickrage.github.io
 #
 # This file is part of SickRage.
 #
@@ -20,14 +20,14 @@
 
 import re
 import time
-import urllib
+from urllib import quote
 
 import sickbeard
-from sickbeard.common import cpu_presets
-from sickbeard import logger
-from sickbeard import tvcache
-from sickrage.helper.common import convert_size
+from sickbeard import logger, tvcache
 from sickbeard.bs4_parser import BS4Parser
+from sickbeard.common import cpu_presets
+
+from sickrage.helper.common import convert_size
 from sickrage.providers.torrent.TorrentProvider import TorrentProvider
 
 
@@ -99,7 +99,7 @@ class SCCProvider(TorrentProvider):  # pylint: disable=too-many-instance-attribu
                 if mode != 'RSS':
                     logger.log(u"Search string: %s " % search_string, logger.DEBUG)
 
-                search_url = self.urls['search'] % (urllib.quote(search_string), self.categories[mode])
+                search_url = self.urls['search'] % (quote(search_string), self.categories[mode])
 
                 try:
                     logger.log(u"Search URL: %s" % search_url, logger.DEBUG)

--- a/sickbeard/providers/scenetime.py
+++ b/sickbeard/providers/scenetime.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 # Author: Idan Gutman
-# URL: http://code.google.com/p/sickbeard/
+#
+# URL: https://sickrage.github.io
 #
 # This file is part of SickRage.
 #
@@ -18,15 +19,13 @@
 # along with SickRage. If not, see <http://www.gnu.org/licenses/>.
 
 import re
-import urllib
+from urllib import quote
 
-from sickbeard import logger
-from sickbeard import tvcache
+from sickbeard import logger, tvcache
 from sickbeard.bs4_parser import BS4Parser
-from sickrage.helper.common import convert_size
-from sickrage.providers.torrent.TorrentProvider import TorrentProvider
 
-from sickrage.helper.common import try_int
+from sickrage.helper.common import convert_size, try_int
+from sickrage.providers.torrent.TorrentProvider import TorrentProvider
 
 
 class SceneTimeProvider(TorrentProvider):  # pylint: disable=too-many-instance-attributes
@@ -82,7 +81,7 @@ class SceneTimeProvider(TorrentProvider):  # pylint: disable=too-many-instance-a
                 if mode != 'RSS':
                     logger.log(u"Search string: %s " % search_string, logger.DEBUG)
 
-                search_url = self.urls['search'] % (urllib.quote(search_string), self.categories)
+                search_url = self.urls['search'] % (quote(search_string), self.categories)
                 logger.log(u"Search URL: %s" % search_url, logger.DEBUG)
 
                 data = self.get_url(search_url)
@@ -154,6 +153,5 @@ class SceneTimeCache(tvcache.TVCache):
     def _getRSSData(self):
         search_params = {'RSS': ['']}
         return {'entries': self.provider.search(search_params)}
-
 
 provider = SceneTimeProvider()

--- a/sickbeard/providers/scenetime.py
+++ b/sickbeard/providers/scenetime.py
@@ -40,7 +40,7 @@ class SceneTimeProvider(TorrentProvider):  # pylint: disable=too-many-instance-a
         self.minseed = None
         self.minleech = None
 
-        self.cache = SceneTimeCache(self, min_time=20)  # only poll SceneTime every 20 minutes max
+        self.cache = tvcache.TVCache(self)  # only poll SceneTime every 20 minutes max
 
         self.urls = {'base_url': 'https://www.scenetime.com',
                      'login': 'https://www.scenetime.com/takelogin.php',
@@ -147,11 +147,5 @@ class SceneTimeProvider(TorrentProvider):  # pylint: disable=too-many-instance-a
 
     def seed_ratio(self):
         return self.ratio
-
-
-class SceneTimeCache(tvcache.TVCache):
-    def _getRSSData(self):
-        search_params = {'RSS': ['']}
-        return {'entries': self.provider.search(search_params)}
 
 provider = SceneTimeProvider()

--- a/sickbeard/providers/scenetime.py
+++ b/sickbeard/providers/scenetime.py
@@ -41,7 +41,7 @@ class SceneTimeProvider(TorrentProvider):  # pylint: disable=too-many-instance-a
         self.minseed = None
         self.minleech = None
 
-        self.cache = SceneTimeCache(self)
+        self.cache = SceneTimeCache(self, min_time=20)  # only poll SceneTime every 20 minutes max
 
         self.urls = {'base_url': 'https://www.scenetime.com',
                      'login': 'https://www.scenetime.com/takelogin.php',
@@ -151,13 +151,6 @@ class SceneTimeProvider(TorrentProvider):  # pylint: disable=too-many-instance-a
 
 
 class SceneTimeCache(tvcache.TVCache):
-    def __init__(self, provider_obj):
-
-        tvcache.TVCache.__init__(self, provider_obj)
-
-        # only poll SceneTime every 20 minutes max
-        self.minTime = 20
-
     def _getRSSData(self):
         search_params = {'RSS': ['']}
         return {'entries': self.provider.search(search_params)}

--- a/sickbeard/providers/shazbat.py
+++ b/sickbeard/providers/shazbat.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 # Author: Nic Wolfe <nic@wolfeden.ca>
-# URL: http://code.google.com/p/sickbeard/
+#
+# URL: https://sickrage.github.io
 #
 # This file is part of SickRage.
 #
@@ -17,13 +18,13 @@
 # You should have received a copy of the GNU General Public License
 # along with SickRage. If not, see <http://www.gnu.org/licenses/>.
 
-from sickbeard import logger
-from sickbeard import tvcache
+from sickbeard import logger, tvcache
 from sickrage.helper.exceptions import AuthException
 from sickrage.providers.torrent.TorrentProvider import TorrentProvider
 
 
 class ShazbatProvider(TorrentProvider):
+
     def __init__(self):
 
         TorrentProvider.__init__(self, "Shazbat.tv")
@@ -60,7 +61,6 @@ class ShazbatProvider(TorrentProvider):
 
 class ShazbatCache(tvcache.TVCache):
     def _getRSSData(self):
-
         rss_url = self.provider.urls['base_url'] + 'rss/recent?passkey=' + provider.passkey + '&fname=true'
         logger.log(u"Cache update URL: %s" % rss_url, logger.DEBUG)
 

--- a/sickbeard/providers/shazbat.py
+++ b/sickbeard/providers/shazbat.py
@@ -34,7 +34,7 @@ class ShazbatProvider(TorrentProvider):
         self.ratio = None
         self.options = None
 
-        self.cache = ShazbatCache(self)
+        self.cache = ShazbatCache(self, min_time=15)  # only poll Shazbat feed every 15 minutes max
 
         self.urls = {'base_url': u'http://www.shazbat.tv/',
                      'website': u'http://www.shazbat.tv/login', }
@@ -59,12 +59,6 @@ class ShazbatProvider(TorrentProvider):
 
 
 class ShazbatCache(tvcache.TVCache):
-    def __init__(self, provider_obj):
-        tvcache.TVCache.__init__(self, provider_obj)
-
-        # only poll Shazbat feed every 15 minutes max
-        self.minTime = 15
-
     def _getRSSData(self):
 
         rss_url = self.provider.urls['base_url'] + 'rss/recent?passkey=' + provider.passkey + '&fname=true'

--- a/sickbeard/providers/speedcd.py
+++ b/sickbeard/providers/speedcd.py
@@ -50,7 +50,7 @@ class SpeedCDProvider(TorrentProvider):  # pylint: disable=too-many-instance-att
 
         self.proper_strings = ['PROPER', 'REPACK']
 
-        self.cache = SpeedCDCache(self, min_time=20)  # only poll SpeedCD every 20 minutes max
+        self.cache = tvcache.TVCache(self)
 
     def login(self):
         if any(dict_from_cookiejar(self.session.cookies).values()):
@@ -167,11 +167,5 @@ class SpeedCDProvider(TorrentProvider):  # pylint: disable=too-many-instance-att
 
     def seed_ratio(self):
         return self.ratio
-
-
-class SpeedCDCache(tvcache.TVCache):
-    def _getRSSData(self):
-        search_strings = {'RSS': ['']}
-        return {'entries': self.provider.search(search_strings)}
 
 provider = SpeedCDProvider()

--- a/sickbeard/providers/speedcd.py
+++ b/sickbeard/providers/speedcd.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 # Author: Dustyn Gibson <miigotu@gmail.com>
+#
 # URL: https://sickrage.github.io
 #
 # This file is part of SickRage.
@@ -18,13 +19,13 @@
 # along with SickRage. If not, see <http://www.gnu.org/licenses/>.
 
 import re
-from urllib import urlencode
 from requests.utils import dict_from_cookiejar
+from urllib import urlencode
 
-from sickbeard import logger
-from sickbeard import tvcache
+from sickbeard import logger, tvcache
 from sickbeard.bs4_parser import BS4Parser
-from sickrage.helper.common import try_int, convert_size
+
+from sickrage.helper.common import convert_size, try_int
 from sickrage.providers.torrent.TorrentProvider import TorrentProvider
 
 
@@ -172,6 +173,5 @@ class SpeedCDCache(tvcache.TVCache):
     def _getRSSData(self):
         search_strings = {'RSS': ['']}
         return {'entries': self.provider.search(search_strings)}
-
 
 provider = SpeedCDProvider()

--- a/sickbeard/providers/speedcd.py
+++ b/sickbeard/providers/speedcd.py
@@ -49,7 +49,7 @@ class SpeedCDProvider(TorrentProvider):  # pylint: disable=too-many-instance-att
 
         self.proper_strings = ['PROPER', 'REPACK']
 
-        self.cache = SpeedCDCache(self)
+        self.cache = SpeedCDCache(self, min_time=20)  # only poll SpeedCD every 20 minutes max
 
     def login(self):
         if any(dict_from_cookiejar(self.session.cookies).values()):
@@ -169,13 +169,6 @@ class SpeedCDProvider(TorrentProvider):  # pylint: disable=too-many-instance-att
 
 
 class SpeedCDCache(tvcache.TVCache):
-    def __init__(self, provider_obj):
-
-        tvcache.TVCache.__init__(self, provider_obj)
-
-        # only poll Speedcd every 20 minutes max
-        self.minTime = 20
-
     def _getRSSData(self):
         search_strings = {'RSS': ['']}
         return {'entries': self.provider.search(search_strings)}

--- a/sickbeard/providers/strike.py
+++ b/sickbeard/providers/strike.py
@@ -33,7 +33,8 @@ class StrikeProvider(TorrentProvider):
         self.public = True
         self.url = 'https://getstrike.net/'
         self.ratio = 0
-        self.cache = StrikeCache(self, min_time=10)
+        params = {'RSS': ['x264']}  # Use this hack for RSS search since most results will use this codec
+        self.cache = tvcache.TVCache(self, min_time=10, search_params=params)
         self.minseed, self.minleech = 2 * [None]
 
     def search(self, search_strings, age=0, ep_obj=None):
@@ -87,11 +88,5 @@ class StrikeProvider(TorrentProvider):
 
     def seed_ratio(self):
         return self.ratio
-
-
-class StrikeCache(tvcache.TVCache):
-    def _getRSSData(self):
-        search_params = {'RSS': ['x264']}  # Use this hacky way for RSS search since most results will use this codec
-        return {'entries': self.provider.search(search_params)}
 
 provider = StrikeProvider()

--- a/sickbeard/providers/strike.py
+++ b/sickbeard/providers/strike.py
@@ -31,7 +31,7 @@ class StrikeProvider(TorrentProvider):
         self.public = True
         self.url = 'https://getstrike.net/'
         self.ratio = 0
-        self.cache = StrikeCache(self)
+        self.cache = StrikeCache(self, min_time=10)
         self.minseed, self.minleech = 2 * [None]
 
     def search(self, search_strings, age=0, ep_obj=None):
@@ -88,13 +88,6 @@ class StrikeProvider(TorrentProvider):
 
 
 class StrikeCache(tvcache.TVCache):
-    def __init__(self, provider_obj):
-
-        tvcache.TVCache.__init__(self, provider_obj)
-
-        # Cache results for 10 min
-        self.minTime = 10
-
     def _getRSSData(self):
 
         # Use this hacky way for RSS search since most results will use this codec

--- a/sickbeard/providers/strike.py
+++ b/sickbeard/providers/strike.py
@@ -1,6 +1,7 @@
 # coding=utf-8
-# Author: Gonçalo (aka duramato) <matigonkas@outlook.com>
-# URL: https://github.com/SickRage/SickRage
+# Author: Gonçalo M. (aka duramato/supergonkas) <supergonkas@gmail.com>
+#
+# URL: https://sickrage.github.io
 #
 # This file is part of SickRage.
 #
@@ -17,8 +18,8 @@
 # You should have received a copy of the GNU General Public License
 # along with SickRage. If not, see <http://www.gnu.org/licenses/>.
 
-from sickbeard import logger
-from sickbeard import tvcache
+from sickbeard import logger, tvcache
+
 from sickrage.helper.common import convert_size
 from sickrage.providers.torrent.TorrentProvider import TorrentProvider
 
@@ -26,6 +27,7 @@ from sickrage.providers.torrent.TorrentProvider import TorrentProvider
 class StrikeProvider(TorrentProvider):
 
     def __init__(self):
+
         TorrentProvider.__init__(self, "Strike")
 
         self.public = True
@@ -89,9 +91,7 @@ class StrikeProvider(TorrentProvider):
 
 class StrikeCache(tvcache.TVCache):
     def _getRSSData(self):
-
-        # Use this hacky way for RSS search since most results will use this codec
-        search_params = {'RSS': ['x264']}
+        search_params = {'RSS': ['x264']}  # Use this hacky way for RSS search since most results will use this codec
         return {'entries': self.provider.search(search_params)}
 
 provider = StrikeProvider()

--- a/sickbeard/providers/t411.py
+++ b/sickbeard/providers/t411.py
@@ -1,35 +1,38 @@
-# -*- coding: latin-1 -*-
+# coding=utf-8
 # Author: djoole <bobby.djoole@gmail.com>
-# URL: http://code.google.com/p/sickbeard/
+#
+# URL: https://sickrage.github.io
 #
 # This file is part of SickRage.
 #
-# Sick Beard is free software: you can redistribute it and/or modify
+# SickRage is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# Sick Beard is distributed in the hope that it will be useful,
+# SickRage is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with Sick Beard.  If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
 
+from requests.auth import AuthBase
 import time
 import traceback
-from requests.auth import AuthBase
 
-from sickbeard import logger
-from sickbeard import tvcache
+from sickbeard import logger, tvcache
 from sickbeard.common import USER_AGENT
+
 from sickrage.helper.common import convert_size
 from sickrage.providers.torrent.TorrentProvider import TorrentProvider
 
 
 class T411Provider(TorrentProvider):  # pylint: disable=too-many-instance-attributes
+
     def __init__(self):
+
         TorrentProvider.__init__(self, "T411")
 
         self.username = None
@@ -177,6 +180,5 @@ class T411Cache(tvcache.TVCache):
     def _getRSSData(self):
         search_params = {'RSS': ['']}
         return {'entries': self.provider.search(search_params)}
-
 
 provider = T411Provider()

--- a/sickbeard/providers/t411.py
+++ b/sickbeard/providers/t411.py
@@ -41,7 +41,7 @@ class T411Provider(TorrentProvider):  # pylint: disable=too-many-instance-attrib
         self.token = None
         self.tokenLastUpdate = None
 
-        self.cache = T411Cache(self, min_time=10)  # Only poll T411 every 10 minutes max
+        self.cache = tvcache.TVCache(self, min_time=10)  # Only poll T411 every 10 minutes max
 
         self.urls = {'base_url': 'http://www.t411.in/',
                      'search': 'https://api.t411.in/torrents/search/%s?cid=%s&limit=100',
@@ -174,11 +174,5 @@ class T411Auth(AuthBase):  # pylint: disable=too-few-public-methods
     def __call__(self, r):
         r.headers['Authorization'] = self.token
         return r
-
-
-class T411Cache(tvcache.TVCache):
-    def _getRSSData(self):
-        search_params = {'RSS': ['']}
-        return {'entries': self.provider.search(search_params)}
 
 provider = T411Provider()

--- a/sickbeard/providers/t411.py
+++ b/sickbeard/providers/t411.py
@@ -38,7 +38,7 @@ class T411Provider(TorrentProvider):  # pylint: disable=too-many-instance-attrib
         self.token = None
         self.tokenLastUpdate = None
 
-        self.cache = T411Cache(self)
+        self.cache = T411Cache(self, min_time=10)  # Only poll T411 every 10 minutes max
 
         self.urls = {'base_url': 'http://www.t411.in/',
                      'search': 'https://api.t411.in/torrents/search/%s?cid=%s&limit=100',
@@ -174,12 +174,6 @@ class T411Auth(AuthBase):  # pylint: disable=too-few-public-methods
 
 
 class T411Cache(tvcache.TVCache):
-    def __init__(self, provider_obj):
-        tvcache.TVCache.__init__(self, provider_obj)
-
-        # Only poll T411 every 10 minutes max
-        self.minTime = 10
-
     def _getRSSData(self):
         search_params = {'RSS': ['']}
         return {'entries': self.provider.search(search_params)}

--- a/sickbeard/providers/thepiratebay.py
+++ b/sickbeard/providers/thepiratebay.py
@@ -39,7 +39,7 @@ class ThePirateBayProvider(TorrentProvider):  # pylint: disable=too-many-instanc
         self.minseed = None
         self.minleech = None
 
-        self.cache = ThePirateBayCache(self)
+        self.cache = ThePirateBayCache(self, min_time=30)  # only poll ThePirateBay every 30 minutes max
 
         self.url = 'https://thepiratebay.se/'
         self.urls = {
@@ -148,13 +148,6 @@ class ThePirateBayProvider(TorrentProvider):  # pylint: disable=too-many-instanc
 
 
 class ThePirateBayCache(tvcache.TVCache):
-    def __init__(self, provider_obj):
-
-        tvcache.TVCache.__init__(self, provider_obj)
-
-        # only poll ThePirateBay every 30 minutes max
-        self.minTime = 30
-
     def _getRSSData(self):
         search_strings = {'RSS': ['']}
         return {'entries': self.provider.search(search_strings)}

--- a/sickbeard/providers/thepiratebay.py
+++ b/sickbeard/providers/thepiratebay.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 # Author: Dustyn Gibson <miigotu@gmail.com>
+#
 # URL: https://sickrage.github.io
 #
 # This file is part of SickRage.
@@ -17,17 +18,19 @@
 # You should have received a copy of the GNU General Public License
 # along with SickRage. If not, see <http://www.gnu.org/licenses/>.
 
-import re
 import posixpath  # Must use posixpath
+import re
 from urllib import urlencode
-from sickbeard import logger
-from sickbeard import tvcache
+
+from sickbeard import logger, tvcache
 from sickbeard.bs4_parser import BS4Parser
-from sickrage.helper.common import try_int, convert_size
+
+from sickrage.helper.common import convert_size, try_int
 from sickrage.providers.torrent.TorrentProvider import TorrentProvider
 
 
 class ThePirateBayProvider(TorrentProvider):  # pylint: disable=too-many-instance-attributes
+
     def __init__(self):
 
         TorrentProvider.__init__(self, "ThePirateBay")

--- a/sickbeard/providers/thepiratebay.py
+++ b/sickbeard/providers/thepiratebay.py
@@ -42,7 +42,7 @@ class ThePirateBayProvider(TorrentProvider):  # pylint: disable=too-many-instanc
         self.minseed = None
         self.minleech = None
 
-        self.cache = ThePirateBayCache(self, min_time=30)  # only poll ThePirateBay every 30 minutes max
+        self.cache = tvcache.TVCache(self, min_time=30)  # only poll ThePirateBay every 30 minutes max
 
         self.url = 'https://thepiratebay.se/'
         self.urls = {
@@ -148,11 +148,5 @@ class ThePirateBayProvider(TorrentProvider):  # pylint: disable=too-many-instanc
 
     def seed_ratio(self):
         return self.ratio
-
-
-class ThePirateBayCache(tvcache.TVCache):
-    def _getRSSData(self):
-        search_strings = {'RSS': ['']}
-        return {'entries': self.provider.search(search_strings)}
 
 provider = ThePirateBayProvider()

--- a/sickbeard/providers/tntvillage.py
+++ b/sickbeard/providers/tntvillage.py
@@ -110,7 +110,7 @@ class TNTVillageProvider(TorrentProvider):  # pylint: disable=too-many-instance-
 
         self.categories = "cat=29"
 
-        self.cache = TNTVillageCache(self)
+        self.cache = TNTVillageCache(self, min_time=30)  # only poll TNTVillage every 30 minutes max
 
     def _check_auth(self):
 
@@ -405,13 +405,6 @@ class TNTVillageProvider(TorrentProvider):  # pylint: disable=too-many-instance-
 
 
 class TNTVillageCache(tvcache.TVCache):
-    def __init__(self, provider_obj):
-
-        tvcache.TVCache.__init__(self, provider_obj)
-
-        # only poll TNTVillage every 30 minutes max
-        self.minTime = 30
-
     def _getRSSData(self):
         search_params = {'RSS': []}
         return {'entries': self.provider.search(search_params)}

--- a/sickbeard/providers/tntvillage.py
+++ b/sickbeard/providers/tntvillage.py
@@ -112,7 +112,7 @@ class TNTVillageProvider(TorrentProvider):  # pylint: disable=too-many-instance-
 
         self.categories = "cat=29"
 
-        self.cache = TNTVillageCache(self, min_time=30)  # only poll TNTVillage every 30 minutes max
+        self.cache = tvcache.TVCache(self, min_time=30)  # only poll TNTVillage every 30 minutes max
 
     def _check_auth(self):
 
@@ -404,11 +404,5 @@ class TNTVillageProvider(TorrentProvider):  # pylint: disable=too-many-instance-
 
     def seed_ratio(self):
         return self.ratio
-
-
-class TNTVillageCache(tvcache.TVCache):
-    def _getRSSData(self):
-        search_params = {'RSS': []}
-        return {'entries': self.provider.search(search_params)}
 
 provider = TNTVillageProvider()

--- a/sickbeard/providers/tntvillage.py
+++ b/sickbeard/providers/tntvillage.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 # Author: Giovanni Borri
 # Modified by gborri, https://github.com/gborri for TNTVillage
+# URL: https://sickrage.github.io
 #
 # This file is part of SickRage.
 #
@@ -19,13 +20,12 @@
 
 import re
 import traceback
-from sickbeard.common import Quality
-from sickbeard import logger
-from sickbeard import tvcache
-from sickbeard import db
 
+from sickbeard import db, logger, tvcache
 from sickbeard.bs4_parser import BS4Parser
+from sickbeard.common import Quality
 from sickbeard.name_parser.parser import NameParser, InvalidNameException, InvalidShowException
+
 from sickrage.helper.common import convert_size
 from sickrage.helper.exceptions import AuthException
 from sickrage.providers.torrent.TorrentProvider import TorrentProvider
@@ -58,7 +58,9 @@ category_excluded = {'Sport': 22,
 
 
 class TNTVillageProvider(TorrentProvider):  # pylint: disable=too-many-instance-attributes
+
     def __init__(self):
+
         TorrentProvider.__init__(self, "TNTVillage")
 
         self._uid = None
@@ -408,6 +410,5 @@ class TNTVillageCache(tvcache.TVCache):
     def _getRSSData(self):
         search_params = {'RSS': []}
         return {'entries': self.provider.search(search_params)}
-
 
 provider = TNTVillageProvider()

--- a/sickbeard/providers/tokyotoshokan.py
+++ b/sickbeard/providers/tokyotoshokan.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 # Author: Mr_Orange
-# URL: http://code.google.com/p/sickbeard/
+#
+# URL: https://sickrage.github.io
 #
 # This file is part of SickRage.
 #
@@ -18,17 +19,17 @@
 # along with SickRage. If not, see <http://www.gnu.org/licenses/>.
 
 import re
-import urllib
+from urllib import urlencode
 
-from sickbeard import logger
-from sickbeard import tvcache
+from sickbeard import logger, tvcache
 from sickbeard.bs4_parser import BS4Parser
 
-from sickrage.helper.common import try_int, convert_size
+from sickrage.helper.common import convert_size, try_int
 from sickrage.providers.torrent.TorrentProvider import TorrentProvider
 
 
 class TokyoToshokanProvider(TorrentProvider):  # pylint: disable=too-many-instance-attributes
+
     def __init__(self):
 
         TorrentProvider.__init__(self, "TokyoToshokan")
@@ -68,7 +69,7 @@ class TokyoToshokanProvider(TorrentProvider):  # pylint: disable=too-many-instan
                     "type": 1,  # get anime types
                 }
 
-                logger.log(u"Search URL: %s" % self.urls['search'] + '?' + urllib.urlencode(search_params), logger.DEBUG)
+                logger.log(u"Search URL: %s" % self.urls['search'] + '?' + urlencode(search_params), logger.DEBUG)
                 data = self.get_url(self.urls['search'], params=search_params)
                 if not data:
                     continue

--- a/sickbeard/providers/tokyotoshokan.py
+++ b/sickbeard/providers/tokyotoshokan.py
@@ -47,7 +47,7 @@ class TokyoToshokanProvider(TorrentProvider):  # pylint: disable=too-many-instan
             'search': self.url + 'search.php',
             'rss': self.url + 'rss.php'
         }
-        self.cache = TokyoToshokanCache(self, min_time=15)  # only poll TokyoToshokan every 15 minutes max
+        self.cache = tvcache.TVCache(self, min_time=15)  # only poll TokyoToshokan every 15 minutes max
 
     def seed_ratio(self):
         return self.ratio
@@ -121,22 +121,5 @@ class TokyoToshokanProvider(TorrentProvider):  # pylint: disable=too-many-instan
             results += items
 
         return results
-
-
-class TokyoToshokanCache(tvcache.TVCache):
-    # def _getRSSData(self):
-    #     params = {
-    #         "filter": '1',
-    #     }
-    #
-    #     url = self.provider.urls['rss'] + '?' + urllib.urlencode(params)
-    #
-    #     logger.log(u"Cache update URL: %s" % url, logger.DEBUG)
-    #
-    #     return self.getRSSFeed(url)
-
-    def _getRSSData(self):
-        search_strings = {'RSS': ['']}
-        return {'entries': self.provider.search(search_strings)}
 
 provider = TokyoToshokanProvider()

--- a/sickbeard/providers/tokyotoshokan.py
+++ b/sickbeard/providers/tokyotoshokan.py
@@ -46,7 +46,7 @@ class TokyoToshokanProvider(TorrentProvider):  # pylint: disable=too-many-instan
             'search': self.url + 'search.php',
             'rss': self.url + 'rss.php'
         }
-        self.cache = TokyoToshokanCache(self)
+        self.cache = TokyoToshokanCache(self, min_time=15)  # only poll TokyoToshokan every 15 minutes max
 
     def seed_ratio(self):
         return self.ratio
@@ -123,12 +123,6 @@ class TokyoToshokanProvider(TorrentProvider):  # pylint: disable=too-many-instan
 
 
 class TokyoToshokanCache(tvcache.TVCache):
-    def __init__(self, provider_obj):
-        tvcache.TVCache.__init__(self, provider_obj)
-
-        # only poll TokyoToshokan every 15 minutes max
-        self.minTime = 15
-
     # def _getRSSData(self):
     #     params = {
     #         "filter": '1',

--- a/sickbeard/providers/torrentbytes.py
+++ b/sickbeard/providers/torrentbytes.py
@@ -56,7 +56,7 @@ class TorrentBytesProvider(TorrentProvider):  # pylint: disable=too-many-instanc
 
         self.proper_strings = ['PROPER', 'REPACK']
 
-        self.cache = TorrentBytesCache(self, min_time=20)  # only poll TorrentBytes every 20 minutes max
+        self.cache = tvcache.TVCache(self)
 
     def login(self):
 
@@ -168,11 +168,5 @@ class TorrentBytesProvider(TorrentProvider):  # pylint: disable=too-many-instanc
 
     def seed_ratio(self):
         return self.ratio
-
-
-class TorrentBytesCache(tvcache.TVCache):
-    def _getRSSData(self):
-        search_params = {'RSS': ['']}
-        return {'entries': self.provider.search(search_params)}
 
 provider = TorrentBytesProvider()

--- a/sickbeard/providers/torrentbytes.py
+++ b/sickbeard/providers/torrentbytes.py
@@ -1,6 +1,7 @@
 ﻿# coding=utf-8
 # Author: Idan Gutman
-# URL: http://code.google.com/p/sickbeard/
+#
+# URL: https://sickrage.github.io
 #
 # This file is part of SickRage.
 #
@@ -18,12 +19,12 @@
 # along with SickRage. If not, see <http://www.gnu.org/licenses/>.
 
 import re
-import urllib
 import traceback
+from urllib import quote
 
-from sickbeard import logger
-from sickbeard import tvcache
+from sickbeard import logger, tvcache
 from sickbeard.bs4_parser import BS4Parser
+
 from sickrage.helper.common import convert_size
 from sickrage.providers.torrent.TorrentProvider import TorrentProvider
 
@@ -87,7 +88,7 @@ class TorrentBytesProvider(TorrentProvider):  # pylint: disable=too-many-instanc
                 if mode != 'RSS':
                     logger.log(u"Search string: %s " % search_string, logger.DEBUG)
 
-                search_url = self.urls['search'] % (urllib.quote(search_string.encode('utf-8')), self.categories)
+                search_url = self.urls['search'] % (quote(search_string.encode('utf-8')), self.categories)
                 logger.log(u"Search URL: %s" % search_url, logger.DEBUG)
 
                 data = self.get_url(search_url)
@@ -173,6 +174,5 @@ class TorrentBytesCache(tvcache.TVCache):
     def _getRSSData(self):
         search_params = {'RSS': ['']}
         return {'entries': self.provider.search(search_params)}
-
 
 provider = TorrentBytesProvider()

--- a/sickbeard/providers/torrentbytes.py
+++ b/sickbeard/providers/torrentbytes.py
@@ -55,7 +55,7 @@ class TorrentBytesProvider(TorrentProvider):  # pylint: disable=too-many-instanc
 
         self.proper_strings = ['PROPER', 'REPACK']
 
-        self.cache = TorrentBytesCache(self)
+        self.cache = TorrentBytesCache(self, min_time=20)  # only poll TorrentBytes every 20 minutes max
 
     def login(self):
 
@@ -170,13 +170,6 @@ class TorrentBytesProvider(TorrentProvider):  # pylint: disable=too-many-instanc
 
 
 class TorrentBytesCache(tvcache.TVCache):
-    def __init__(self, provider_obj):
-
-        tvcache.TVCache.__init__(self, provider_obj)
-
-        # only poll TorrentBytes every 20 minutes max
-        self.minTime = 20
-
     def _getRSSData(self):
         search_params = {'RSS': ['']}
         return {'entries': self.provider.search(search_params)}

--- a/sickbeard/providers/torrentday.py
+++ b/sickbeard/providers/torrentday.py
@@ -42,7 +42,7 @@ class TorrentDayProvider(TorrentProvider):  # pylint: disable=too-many-instance-
         self.minseed = None
         self.minleech = None
 
-        self.cache = TorrentDayCache(self, min_time=10)  # Only poll IPTorrents every 10 minutes max
+        self.cache = tvcache.TVCache(self, min_time=10)  # Only poll IPTorrents every 10 minutes max
 
         self.urls = {
             'base_url': 'https://classic.torrentday.com',
@@ -162,11 +162,5 @@ class TorrentDayProvider(TorrentProvider):  # pylint: disable=too-many-instance-
 
     def seed_ratio(self):
         return self.ratio
-
-
-class TorrentDayCache(tvcache.TVCache):
-    def _getRSSData(self):
-        search_params = {'RSS': ['']}
-        return {'entries': self.provider.search(search_params)}
 
 provider = TorrentDayProvider()

--- a/sickbeard/providers/torrentday.py
+++ b/sickbeard/providers/torrentday.py
@@ -1,7 +1,9 @@
 # coding=utf-8
 # Author: Mr_Orange <mr_orange@hotmail.it>
 #
-# This file is part of SickRage.
+# URL: https://sickrage.github.io
+#
+#  This file is part of SickRage.
 #
 # SickRage is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -17,9 +19,10 @@
 # along with SickRage. If not, see <http://www.gnu.org/licenses/>.
 
 import re
-import requests
-from sickbeard import logger
-from sickbeard import tvcache
+from requests.utils import add_dict_to_cookiejar, dict_from_cookiejar
+
+from sickbeard import logger, tvcache
+
 from sickrage.helper.common import convert_size
 from sickrage.providers.torrent.TorrentProvider import TorrentProvider
 
@@ -57,11 +60,11 @@ class TorrentDayProvider(TorrentProvider):  # pylint: disable=too-many-instance-
 
     def login(self):
 
-        if any(requests.utils.dict_from_cookiejar(self.session.cookies).values()):
+        if any(dict_from_cookiejar(self.session.cookies).values()):
             return True
 
         if self._uid and self._hash:
-            requests.utils.add_dict_to_cookiejar(self.session.cookies, self.cookies)
+            add_dict_to_cookiejar(self.session.cookies, self.cookies)
         else:
 
             login_params = {
@@ -81,9 +84,9 @@ class TorrentDayProvider(TorrentProvider):  # pylint: disable=too-many-instance-
                 return False
 
             try:
-                if requests.utils.dict_from_cookiejar(self.session.cookies)['uid'] and requests.utils.dict_from_cookiejar(self.session.cookies)['pass']:
-                    self._uid = requests.utils.dict_from_cookiejar(self.session.cookies)['uid']
-                    self._hash = requests.utils.dict_from_cookiejar(self.session.cookies)['pass']
+                if dict_from_cookiejar(self.session.cookies)['uid'] and dict_from_cookiejar(self.session.cookies)['pass']:
+                    self._uid = dict_from_cookiejar(self.session.cookies)['uid']
+                    self._hash = dict_from_cookiejar(self.session.cookies)['pass']
 
                     self.cookies = {'uid': self._uid,
                                     'pass': self._hash}

--- a/sickbeard/providers/torrentday.py
+++ b/sickbeard/providers/torrentday.py
@@ -39,7 +39,7 @@ class TorrentDayProvider(TorrentProvider):  # pylint: disable=too-many-instance-
         self.minseed = None
         self.minleech = None
 
-        self.cache = TorrentDayCache(self)
+        self.cache = TorrentDayCache(self, min_time=10)  # Only poll IPTorrents every 10 minutes max
 
         self.urls = {
             'base_url': 'https://classic.torrentday.com',
@@ -162,13 +162,6 @@ class TorrentDayProvider(TorrentProvider):  # pylint: disable=too-many-instance-
 
 
 class TorrentDayCache(tvcache.TVCache):
-    def __init__(self, provider_obj):
-
-        tvcache.TVCache.__init__(self, provider_obj)
-
-        # Only poll IPTorrents every 10 minutes max
-        self.minTime = 10
-
     def _getRSSData(self):
         search_params = {'RSS': ['']}
         return {'entries': self.provider.search(search_params)}

--- a/sickbeard/providers/torrentleech.py
+++ b/sickbeard/providers/torrentleech.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 # Author: Dustyn Gibson <miigotu@gmail.com>
+#
 # URL: https://sickrage.github.io
 #
 # This file is part of SickRage.
@@ -18,13 +19,13 @@
 # along with SickRage. If not, see <http://www.gnu.org/licenses/>.
 
 import re
-from urllib import urlencode
 from requests.utils import dict_from_cookiejar
+from urllib import urlencode
 
-from sickbeard import logger
-from sickbeard import tvcache
+from sickbeard import logger, tvcache
 from sickbeard.bs4_parser import BS4Parser
-from sickrage.helper.common import try_int, convert_size
+
+from sickrage.helper.common import convert_size, try_int
 from sickrage.providers.torrent.TorrentProvider import TorrentProvider
 
 
@@ -166,6 +167,5 @@ class TorrentLeechCache(tvcache.TVCache):
     def _getRSSData(self):
         search_strings = {'RSS': ['']}
         return {'entries': self.provider.search(search_strings)}
-
 
 provider = TorrentLeechProvider()

--- a/sickbeard/providers/torrentleech.py
+++ b/sickbeard/providers/torrentleech.py
@@ -48,7 +48,7 @@ class TorrentLeechProvider(TorrentProvider):  # pylint: disable=too-many-instanc
 
         self.proper_strings = ['PROPER', 'REPACK']
 
-        self.cache = TorrentLeechCache(self)
+        self.cache = TorrentLeechCache(self, min_time=20)  # only poll TorrentLeech every 20 minutes max
 
     def login(self):
         if any(dict_from_cookiejar(self.session.cookies).values()):
@@ -163,13 +163,6 @@ class TorrentLeechProvider(TorrentProvider):  # pylint: disable=too-many-instanc
 
 
 class TorrentLeechCache(tvcache.TVCache):
-    def __init__(self, provider_obj):
-
-        tvcache.TVCache.__init__(self, provider_obj)
-
-        # only poll TorrentLeech every 20 minutes max
-        self.minTime = 20
-
     def _getRSSData(self):
         search_strings = {'RSS': ['']}
         return {'entries': self.provider.search(search_strings)}

--- a/sickbeard/providers/torrentleech.py
+++ b/sickbeard/providers/torrentleech.py
@@ -49,7 +49,7 @@ class TorrentLeechProvider(TorrentProvider):  # pylint: disable=too-many-instanc
 
         self.proper_strings = ['PROPER', 'REPACK']
 
-        self.cache = TorrentLeechCache(self, min_time=20)  # only poll TorrentLeech every 20 minutes max
+        self.cache = tvcache.TVCache(self)
 
     def login(self):
         if any(dict_from_cookiejar(self.session.cookies).values()):
@@ -161,11 +161,5 @@ class TorrentLeechProvider(TorrentProvider):  # pylint: disable=too-many-instanc
 
     def seed_ratio(self):
         return self.ratio
-
-
-class TorrentLeechCache(tvcache.TVCache):
-    def _getRSSData(self):
-        search_strings = {'RSS': ['']}
-        return {'entries': self.provider.search(search_strings)}
 
 provider = TorrentLeechProvider()

--- a/sickbeard/providers/torrentproject.py
+++ b/sickbeard/providers/torrentproject.py
@@ -1,6 +1,7 @@
 # coding=utf-8
-# Author: duramato <matigonkas@outlook.com>
-# URL: https://github.com/SickRage/sickrage
+# Author: Gonçalo M. (aka duramato/supergonkas) <supergonkas@gmail.com>
+#
+# URL: https://sickrage.github.io
 #
 # This file is part of SickRage.
 #
@@ -17,17 +18,20 @@
 # You should have received a copy of the GNU General Public License
 # along with SickRage. If not, see <http://www.gnu.org/licenses/>.
 
-import posixpath # Must use posixpath
+import posixpath  # Must use posixpath
 from urllib import quote_plus
-from sickbeard import logger
-from sickbeard import tvcache
+
+from sickbeard import logger, tvcache
 from sickbeard.common import USER_AGENT
-from sickrage.helper.common import try_int, convert_size
+
+from sickrage.helper.common import convert_size, try_int
 from sickrage.providers.torrent.TorrentProvider import TorrentProvider
 
 
 class TorrentProjectProvider(TorrentProvider):
+
     def __init__(self):
+
         TorrentProvider.__init__(self, "TorrentProject")
 
         self.public = True
@@ -111,7 +115,6 @@ class TorrentProjectProvider(TorrentProvider):
 
 class TorrentProjectCache(tvcache.TVCache):
     def _getRSSData(self):
-
         search_params = {'RSS': ['0day']}
         return {'entries': self.provider.search(search_params)}
 

--- a/sickbeard/providers/torrentproject.py
+++ b/sickbeard/providers/torrentproject.py
@@ -42,7 +42,7 @@ class TorrentProjectProvider(TorrentProvider):
         self.headers.update({'User-Agent': USER_AGENT})
         self.minseed = None
         self.minleech = None
-        self.cache = TorrentProjectCache(self, min_time=20)  # only poll TorrentProject every 20 minutes max
+        self.cache = tvcache.TVCache(self, search_params={'RSS': ['0day']})
 
     def search(self, search_strings, age=0, ep_obj=None):
         results = []
@@ -111,11 +111,5 @@ class TorrentProjectProvider(TorrentProvider):
 
     def seed_ratio(self):
         return self.ratio
-
-
-class TorrentProjectCache(tvcache.TVCache):
-    def _getRSSData(self):
-        search_params = {'RSS': ['0day']}
-        return {'entries': self.provider.search(search_params)}
 
 provider = TorrentProjectProvider()

--- a/sickbeard/providers/torrentproject.py
+++ b/sickbeard/providers/torrentproject.py
@@ -38,7 +38,7 @@ class TorrentProjectProvider(TorrentProvider):
         self.headers.update({'User-Agent': USER_AGENT})
         self.minseed = None
         self.minleech = None
-        self.cache = TorrentProjectCache(self)
+        self.cache = TorrentProjectCache(self, min_time=20)  # only poll TorrentProject every 20 minutes max
 
     def search(self, search_strings, age=0, ep_obj=None):
         results = []
@@ -110,12 +110,6 @@ class TorrentProjectProvider(TorrentProvider):
 
 
 class TorrentProjectCache(tvcache.TVCache):
-    def __init__(self, provider_obj):
-
-        tvcache.TVCache.__init__(self, provider_obj)
-
-        self.minTime = 20
-
     def _getRSSData(self):
 
         search_params = {'RSS': ['0day']}

--- a/sickbeard/providers/torrentz.py
+++ b/sickbeard/providers/torrentz.py
@@ -38,7 +38,7 @@ class TorrentzProvider(TorrentProvider):  # pylint: disable=too-many-instance-at
         self.ratio = None
         self.minseed = None
         self.minleech = None
-        self.cache = TorrentzCache(self)
+        self.cache = TorrentzCache(self, min_time=15)  # only poll Torrentz every 15 minutes max
         self.headers.update({'User-Agent': USER_AGENT})
         self.urls = {'verified': 'https://torrentz.eu/feed_verified',
                      'feed': 'https://torrentz.eu/feed',
@@ -107,14 +107,6 @@ class TorrentzProvider(TorrentProvider):  # pylint: disable=too-many-instance-at
 
 
 class TorrentzCache(tvcache.TVCache):
-
-    def __init__(self, provider_obj):
-
-        tvcache.TVCache.__init__(self, provider_obj)
-
-        # only poll every 15 minutes max
-        self.minTime = 15
-
     def _getRSSData(self):
         return {'entries': self.provider.search({'RSS': ['']})}
 

--- a/sickbeard/providers/torrentz.py
+++ b/sickbeard/providers/torrentz.py
@@ -41,7 +41,7 @@ class TorrentzProvider(TorrentProvider):  # pylint: disable=too-many-instance-at
         self.ratio = None
         self.minseed = None
         self.minleech = None
-        self.cache = TorrentzCache(self, min_time=15)  # only poll Torrentz every 15 minutes max
+        self.cache = tvcache.TVCache(self, min_time=15)  # only poll Torrentz every 15 minutes max
         self.headers.update({'User-Agent': USER_AGENT})
         self.urls = {'verified': 'https://torrentz.eu/feed_verified',
                      'feed': 'https://torrentz.eu/feed',
@@ -107,11 +107,5 @@ class TorrentzProvider(TorrentProvider):  # pylint: disable=too-many-instance-at
             results += items
 
         return results
-
-
-class TorrentzCache(tvcache.TVCache):
-    def _getRSSData(self):
-        search_strings = {'RSS': ['']}
-        return {'entries': self.provider.search(search_strings)}
 
 provider = TorrentzProvider()

--- a/sickbeard/providers/torrentz.py
+++ b/sickbeard/providers/torrentz.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 # Author: Dustyn Gibson <miigotu@gmail.com>
-# URL: https://github.com/SickRage/SickRage
+#
+# URL: https://sickrage.github.io
 #
 # This file is part of SickRage.
 #
@@ -18,12 +19,13 @@
 # along with SickRage. If not, see <http://www.gnu.org/licenses/>.
 
 import re
-import traceback
 from six.moves import urllib
-from sickbeard import logger
-from sickbeard import tvcache
-from sickbeard.common import USER_AGENT
+import traceback
+
+from sickbeard import logger, tvcache
 from sickbeard.bs4_parser import BS4Parser
+from sickbeard.common import USER_AGENT
+
 from sickrage.helper.common import convert_size
 from sickrage.providers.torrent.TorrentProvider import TorrentProvider
 
@@ -33,6 +35,7 @@ class TorrentzProvider(TorrentProvider):  # pylint: disable=too-many-instance-at
     def __init__(self):
 
         TorrentProvider.__init__(self, "Torrentz")
+
         self.public = True
         self.confirmed = True
         self.ratio = None
@@ -108,6 +111,7 @@ class TorrentzProvider(TorrentProvider):  # pylint: disable=too-many-instance-at
 
 class TorrentzCache(tvcache.TVCache):
     def _getRSSData(self):
-        return {'entries': self.provider.search({'RSS': ['']})}
+        search_strings = {'RSS': ['']}
+        return {'entries': self.provider.search(search_strings)}
 
 provider = TorrentzProvider()

--- a/sickbeard/providers/transmitthenet.py
+++ b/sickbeard/providers/transmitthenet.py
@@ -50,7 +50,7 @@ class TransmitTheNetProvider(TorrentProvider):  # pylint: disable=too-many-insta
         self.minleech = None
         self.freeleech = None
 
-        self.cache = TransmitTheNetCache(self, min_time=20)  # Only poll TransmitTheNet every 20 minutes max
+        self.cache = tvcache.TVCache(self)
 
     def _check_auth(self):
 
@@ -173,11 +173,5 @@ class TransmitTheNetProvider(TorrentProvider):  # pylint: disable=too-many-insta
 
     def seed_ratio(self):
         return self.ratio
-
-
-class TransmitTheNetCache(tvcache.TVCache):
-    def _getRSSData(self):
-        search_strings = {'RSS': ['']}
-        return {'entries': self.provider.search(search_strings)}
 
 provider = TransmitTheNetProvider()

--- a/sickbeard/providers/transmitthenet.py
+++ b/sickbeard/providers/transmitthenet.py
@@ -1,4 +1,7 @@
 # coding=utf-8
+#
+# URL: https://sickrage.github.io
+#
 # This file is part of SickRage.
 #
 # SickRage is free software: you can redistribute it and/or modify
@@ -18,15 +21,16 @@ import re
 import traceback
 from urllib import urlencode
 
-from sickbeard import logger
-from sickbeard import tvcache
+from sickbeard import logger, tvcache
 from sickbeard.bs4_parser import BS4Parser
+
+from sickrage.helper.common import convert_size, try_int
 from sickrage.helper.exceptions import AuthException
-from sickrage.helper.common import try_int, convert_size
 from sickrage.providers.torrent.TorrentProvider import TorrentProvider
 
 
 class TransmitTheNetProvider(TorrentProvider):  # pylint: disable=too-many-instance-attributes
+
     def __init__(self):
 
         TorrentProvider.__init__(self, "TransmitTheNet")
@@ -175,6 +179,5 @@ class TransmitTheNetCache(tvcache.TVCache):
     def _getRSSData(self):
         search_strings = {'RSS': ['']}
         return {'entries': self.provider.search(search_strings)}
-
 
 provider = TransmitTheNetProvider()

--- a/sickbeard/providers/transmitthenet.py
+++ b/sickbeard/providers/transmitthenet.py
@@ -46,7 +46,7 @@ class TransmitTheNetProvider(TorrentProvider):  # pylint: disable=too-many-insta
         self.minleech = None
         self.freeleech = None
 
-        self.cache = TransmitTheNetCache(self)
+        self.cache = TransmitTheNetCache(self, min_time=20)  # Only poll TransmitTheNet every 20 minutes max
 
     def _check_auth(self):
 
@@ -172,12 +172,6 @@ class TransmitTheNetProvider(TorrentProvider):  # pylint: disable=too-many-insta
 
 
 class TransmitTheNetCache(tvcache.TVCache):
-    def __init__(self, provider_obj):
-        tvcache.TVCache.__init__(self, provider_obj)
-
-        # Only poll TransmitTheNet every 20 minutes max
-        self.minTime = 20
-
     def _getRSSData(self):
         search_strings = {'RSS': ['']}
         return {'entries': self.provider.search(search_strings)}

--- a/sickbeard/providers/tvchaosuk.py
+++ b/sickbeard/providers/tvchaosuk.py
@@ -15,14 +15,12 @@
 # along with SickRage. If not, see <http://www.gnu.org/licenses/>.
 
 import re
-# from urllib import urlencode
 
 import sickbeard
-from sickbeard import logger
-from sickbeard import tvcache
-from sickbeard import show_name_helpers
-from sickbeard.helpers import sanitizeSceneName
+from sickbeard import logger, show_name_helpers, tvcache
 from sickbeard.bs4_parser import BS4Parser
+from sickbeard.helpers import sanitizeSceneName
+
 from sickrage.helper.common import convert_size
 from sickrage.helper.exceptions import AuthException
 from sickrage.providers.torrent.TorrentProvider import TorrentProvider
@@ -205,6 +203,5 @@ class TVChaosUKCache(tvcache.TVCache):
     def _getRSSData(self):
         search_strings = {'RSS': ['']}
         return {'entries': self.provider.search(search_strings)}
-
 
 provider = TVChaosUKProvider()

--- a/sickbeard/providers/tvchaosuk.py
+++ b/sickbeard/providers/tvchaosuk.py
@@ -44,7 +44,7 @@ class TVChaosUKProvider(TorrentProvider):  # pylint: disable=too-many-instance-a
         self.minleech = None
         self.freeleech = None
 
-        self.cache = TVChaosUKCache(self, min_time=20)  # only poll TVChaosUK every 20 minutes max
+        self.cache = tvcache.TVCache(self)
 
         self.search_params = {
             'do': 'search',
@@ -197,11 +197,5 @@ class TVChaosUKProvider(TorrentProvider):  # pylint: disable=too-many-instance-a
 
     def seed_ratio(self):
         return self.ratio
-
-
-class TVChaosUKCache(tvcache.TVCache):
-    def _getRSSData(self):
-        search_strings = {'RSS': ['']}
-        return {'entries': self.provider.search(search_strings)}
 
 provider = TVChaosUKProvider()

--- a/sickbeard/providers/tvchaosuk.py
+++ b/sickbeard/providers/tvchaosuk.py
@@ -46,7 +46,7 @@ class TVChaosUKProvider(TorrentProvider):  # pylint: disable=too-many-instance-a
         self.minleech = None
         self.freeleech = None
 
-        self.cache = TVChaosUKCache(self)
+        self.cache = TVChaosUKCache(self, min_time=20)  # only poll TVChaosUK every 20 minutes max
 
         self.search_params = {
             'do': 'search',
@@ -202,13 +202,6 @@ class TVChaosUKProvider(TorrentProvider):  # pylint: disable=too-many-instance-a
 
 
 class TVChaosUKCache(tvcache.TVCache):
-    def __init__(self, provider_obj):
-
-        tvcache.TVCache.__init__(self, provider_obj)
-
-        # only poll TVChaosUK every 20 minutes max
-        self.minTime = 20
-
     def _getRSSData(self):
         search_strings = {'RSS': ['']}
         return {'entries': self.provider.search(search_strings)}

--- a/sickbeard/providers/womble.py
+++ b/sickbeard/providers/womble.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 # Author: Nic Wolfe <nic@wolfeden.ca>
-# URL: http://code.google.com/p/sickbeard/
+#
+# URL: https://sickrage.github.io
 #
 # This file is part of SickRage.
 #
@@ -17,14 +18,17 @@
 # You should have received a copy of the GNU General Public License
 # along with SickRage. If not, see <http://www.gnu.org/licenses/>.
 
-from sickbeard import logger
-from sickbeard import tvcache
+from sickbeard import logger, tvcache
+
 from sickrage.providers.nzb.NZBProvider import NZBProvider
 
 
 class WombleProvider(NZBProvider):
+
     def __init__(self):
+
         NZBProvider.__init__(self, "Womble's Index")
+
         self.public = True
         self.cache = WombleCache(self, min_time=15)  # only poll Womble's Index every 15 minutes max
         self.urls = {'base_url': 'http://newshost.co.za/'}

--- a/sickbeard/providers/womble.py
+++ b/sickbeard/providers/womble.py
@@ -26,18 +26,13 @@ class WombleProvider(NZBProvider):
     def __init__(self):
         NZBProvider.__init__(self, "Womble's Index")
         self.public = True
-        self.cache = WombleCache(self)
+        self.cache = WombleCache(self, min_time=15)  # only poll Womble's Index every 15 minutes max
         self.urls = {'base_url': 'http://newshost.co.za/'}
         self.url = self.urls['base_url']
         self.supports_backlog = False
 
 
 class WombleCache(tvcache.TVCache):
-    def __init__(self, provider_obj):
-        tvcache.TVCache.__init__(self, provider_obj)
-        # only poll Womble's Index every 15 minutes max
-        self.minTime = 15
-
     def updateCache(self):
         # check if we should update
         if not self.shouldUpdate():

--- a/sickbeard/providers/xthor.py
+++ b/sickbeard/providers/xthor.py
@@ -1,4 +1,4 @@
-# -*- coding: latin-1 -*-
+# coding=utf-8
 # Author: adaur <adaur.underground@gmail.com>
 # Rewrite: Dustyn Gibson (miigotu) <miigotu@gmail.com>
 # URL: https://sickrage.github.io
@@ -19,16 +19,15 @@
 # along with SickRage. If not, see <http://www.gnu.org/licenses/>.
 
 import re
-import requests
 import cookielib
+from requests.utils import dict_from_cookiejar
 from urllib import urlencode
 
-from sickbeard import logger
-from sickbeard import tvcache
+from sickbeard import logger, tvcache
 from sickbeard.bs4_parser import BS4Parser
-from sickrage.providers.torrent.TorrentProvider import TorrentProvider
 
-from sickrage.helper.common import try_int, convert_size
+from sickrage.helper.common import convert_size, try_int
+from sickrage.providers.torrent.TorrentProvider import TorrentProvider
 
 
 class XthorProvider(TorrentProvider):  # pylint: disable=too-many-instance-attributes
@@ -56,7 +55,7 @@ class XthorProvider(TorrentProvider):  # pylint: disable=too-many-instance-attri
 
     def login(self):
 
-        if any(requests.utils.dict_from_cookiejar(self.session.cookies).values()):
+        if any(dict_from_cookiejar(self.session.cookies).values()):
             return True
 
         login_params = {'username': self.username,
@@ -80,11 +79,11 @@ class XthorProvider(TorrentProvider):  # pylint: disable=too-many-instance-attri
             return results
 
         """
-            Séries / Pack TV 13
-            Séries / TV FR 14
-            Séries / HD FR 15
-            Séries / TV VOSTFR 16
-            Séries / HD VOSTFR 17
+            SÃ©ries / Pack TV 13
+            SÃ©ries / TV FR 14
+            SÃ©ries / HD FR 15
+            SÃ©ries / TV VOSTFR 16
+            SÃ©ries / HD VOSTFR 17
             Mangas (Anime) 32
             Sport 34
         """
@@ -125,7 +124,7 @@ class XthorProvider(TorrentProvider):  # pylint: disable=too-many-instance-attri
                         logger.log(u"Data returned from provider does not contain any torrents", logger.DEBUG)
                         continue
 
-                    # Catégorie, Nom du Torrent, (Download), (Bookmark), Com., Taille, Complété, Seeders, Leechers
+                    # CatÃ©gorie, Nom du Torrent, (Download), (Bookmark), Com., Taille, ComplÃ©tÃ©, Seeders, Leechers
                     labels = [label.get_text(strip=True) for label in torrent_rows[0].find_all('td')]
 
                     for row in torrent_rows[1:]:
@@ -169,6 +168,5 @@ class XthorCache(tvcache.TVCache):
     def _getRSSData(self):
         search_strings = {'RSS': ['']}
         return {'entries': self.provider.search(search_strings)}
-
 
 provider = XthorProvider()

--- a/sickbeard/providers/xthor.py
+++ b/sickbeard/providers/xthor.py
@@ -51,7 +51,7 @@ class XthorProvider(TorrentProvider):  # pylint: disable=too-many-instance-attri
         self.password = None
         self.freeleech = None
         self.proper_strings = ['PROPER']
-        self.cache = XthorCache(self, min_time=30)
+        self.cache = tvcache.TVCache(self, min_time=30)
 
     def login(self):
 
@@ -162,11 +162,5 @@ class XthorProvider(TorrentProvider):  # pylint: disable=too-many-instance-attri
 
     def seed_ratio(self):
         return self.ratio
-
-
-class XthorCache(tvcache.TVCache):
-    def _getRSSData(self):
-        search_strings = {'RSS': ['']}
-        return {'entries': self.provider.search(search_strings)}
 
 provider = XthorProvider()

--- a/sickbeard/providers/xthor.py
+++ b/sickbeard/providers/xthor.py
@@ -52,7 +52,7 @@ class XthorProvider(TorrentProvider):  # pylint: disable=too-many-instance-attri
         self.password = None
         self.freeleech = None
         self.proper_strings = ['PROPER']
-        self.cache = XthorCache(self)
+        self.cache = XthorCache(self, min_time=30)
 
     def login(self):
 
@@ -80,11 +80,11 @@ class XthorProvider(TorrentProvider):  # pylint: disable=too-many-instance-attri
             return results
 
         """
-            SÃ©ries / Pack TV 13
-            SÃ©ries / TV FR 14
-            SÃ©ries / HD FR 15
-            SÃ©ries / TV VOSTFR 16
-            SÃ©ries / HD VOSTFR 17
+            Séries / Pack TV 13
+            Séries / TV FR 14
+            Séries / HD FR 15
+            Séries / TV VOSTFR 16
+            Séries / HD VOSTFR 17
             Mangas (Anime) 32
             Sport 34
         """
@@ -125,7 +125,7 @@ class XthorProvider(TorrentProvider):  # pylint: disable=too-many-instance-attri
                         logger.log(u"Data returned from provider does not contain any torrents", logger.DEBUG)
                         continue
 
-                    # CatÃ©gorie, Nom du Torrent, (Download), (Bookmark), Com., Taille, ComplÃ©tÃ©, Seeders, Leechers
+                    # Catégorie, Nom du Torrent, (Download), (Bookmark), Com., Taille, Complété, Seeders, Leechers
                     labels = [label.get_text(strip=True) for label in torrent_rows[0].find_all('td')]
 
                     for row in torrent_rows[1:]:
@@ -166,12 +166,6 @@ class XthorProvider(TorrentProvider):  # pylint: disable=too-many-instance-attri
 
 
 class XthorCache(tvcache.TVCache):
-    def __init__(self, provider_obj):
-
-        tvcache.TVCache.__init__(self, provider_obj)
-
-        self.minTime = 30
-
     def _getRSSData(self):
         search_strings = {'RSS': ['']}
         return {'entries': self.provider.search(search_strings)}

--- a/sickbeard/tvcache.py
+++ b/sickbeard/tvcache.py
@@ -74,11 +74,11 @@ class CacheDBConnection(db.DBConnection):
 
 
 class TVCache(object):
-    def __init__(self, provider):
+    def __init__(self, provider, **kwargs):
         self.provider = provider
         self.providerID = self.provider.get_id()
         self.providerDB = None
-        self.minTime = 10
+        self.minTime = kwargs.pop(u'min_time', 10)
 
     def _getDB(self):
         # init provider database if not done already

--- a/sickbeard/tvcache.py
+++ b/sickbeard/tvcache.py
@@ -79,6 +79,7 @@ class TVCache(object):
         self.providerID = self.provider.get_id()
         self.providerDB = None
         self.minTime = kwargs.pop(u'min_time', 10)
+        self.search_params = kwargs.pop(u'search_params', dict(RSS=['']))
 
     def _getDB(self):
         # init provider database if not done already
@@ -96,7 +97,7 @@ class TVCache(object):
         return self.provider._get_title_and_url(item)
 
     def _getRSSData(self):
-        return None
+        return {u'entries': self.provider.search(self.search_params)} if self.search_params else None
 
     def _checkAuth(self, data):
         return True


### PR DESCRIPTION
- Add kwarg for `min_time` and remove unnecessary `__init__`'s from providers
- Optimize imports and continue provider standardization 
- Replace custom provider cache with kwarg'd `TVCache` for standardization  
