### PR TITLE
Catch TooManyRedirects error instead of throwing tracback

### DIFF
--- a/sickbeard/helpers.py
+++ b/sickbeard/helpers.py
@@ -1449,7 +1449,7 @@ def getURL(url, post_data=None, params=None, headers=None, timeout=30, session=N
     except (SocketTimeout, TypeError) as e:
         logger.log(u"Connection timed out (sockets) accessing getURL %s Error: %r" % (url, ex(e)), logger.WARNING)
         return None
-    except requests.exceptions.HTTPError as e:
+    except (requests.exceptions.HTTPError, requests.exceptions.TooManyRedirects) as e:
         logger.log(u"HTTP error in getURL %s Error: %r" % (url, ex(e)), logger.WARNING)
         return None
     except requests.exceptions.ConnectionError as e:
@@ -1506,7 +1506,7 @@ def download_file(url, filename, session=None, headers=None):
         remove_file_failed(filename)
         logger.log(u"Connection timed out (sockets) while loading download URL %s Error: %r" % (url, ex(e)), logger.WARNING)
         return None
-    except requests.exceptions.HTTPError as e:
+    except (requests.exceptions.HTTPError, requests.exceptions.TooManyRedirects) as e:
         remove_file_failed(filename)
         logger.log(u"HTTP error %r while loading download URL %s " % (ex(e), url), logger.WARNING)
         return False


### PR DESCRIPTION
```
2016-01-20 17:20:07 SEARCHQUEUE-DAILY-SEARCH :: [****] :: Traceback (most recent call last):
  File "/SickRage/sickbeard/helpers.py", line 1442, in getURL
    resp = session.get(url, timeout=timeout, allow_redirects=True, verify=session.verify)
  File "/SickRage/lib/requests/sessions.py", line 480, in get
    return self.request('GET', url, **kwargs)
  File "/SickRage/lib/requests/sessions.py", line 468, in request
    resp = self.send(prep, **send_kwargs)
  File "/SickRage/lib/requests/sessions.py", line 597, in send
    history = [resp for resp in gen] if allow_redirects else []
  File "/SickRage/lib/requests/sessions.py", line 113, in resolve_redirects
    raise TooManyRedirects('Exceeded %s redirects.' % self.max_redirects)
TooManyRedirects: Exceeded 30 redirects.
```
