### PR TITLE
Remove branch name from title

### DIFF
--- a/gui/slick/views/layouts/main.mako
+++ b/gui/slick/views/layouts/main.mako
@@ -32,7 +32,7 @@
         <meta name="theme-color" content="#333333">
         % endif
 
-        <title>SickRage - BRANCH:[${sickbeard.BRANCH}] - ${title}</title>
+        <title>SickRage - ${title}</title>
 
         <!--[if lt IE 9]>
             <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>


### PR DESCRIPTION
With it the full title isnt shown , and most people dont care having it there , since it will be always master that is shown.
Or would an option to hide it be better?
To me without it there it looks way cleaner , and the branch name can be seen on the help and info page
