### PR TITLE
Avoid connection issue reports

### DIFF
--- a/sickbeard/helpers.py
+++ b/sickbeard/helpers.py
@@ -1450,16 +1450,16 @@ def getURL(url, post_data=None, params=None, headers=None, timeout=30, session=N
             return None
 
     except (SocketTimeout, TypeError) as e:
-        logger.log(u"Connection timed out (sockets) accessing getURL %s Error: %r" % (url, ex(e)), logger.WARNING)
+        logger.log(u"Connection timed out (sockets) accessing getURL %s Error: %r" % (url, ex(e)), logger.DEBUG)
         return None
     except (requests.exceptions.HTTPError, requests.exceptions.TooManyRedirects) as e:
-        logger.log(u"HTTP error in getURL %s Error: %r" % (url, ex(e)), logger.WARNING)
+        logger.log(u"HTTP error in getURL %s Error: %r" % (url, ex(e)), logger.DEBUG)
         return None
     except requests.exceptions.ConnectionError as e:
-        logger.log(u"Connection error to getURL %s Error: %r" % (url, ex(e)), logger.WARNING)
+        logger.log(u"Connection error to getURL %s Error: %r" % (url, ex(e)), logger.DEBUG)
         return None
     except requests.exceptions.Timeout as e:
-        logger.log(u"Connection timed out accessing getURL %s Error: %r" % (url, ex(e)), logger.WARNING)
+        logger.log(u"Connection timed out accessing getURL %s Error: %r" % (url, ex(e)), logger.DEBUG)
         return None
     except requests.exceptions.ContentDecodingError:
         logger.log(u"Content-Encoding was gzip, but content was not compressed. getURL: %s" % url, logger.DEBUG)

--- a/sickbeard/helpers.py
+++ b/sickbeard/helpers.py
@@ -1466,8 +1466,8 @@ def getURL(url, post_data=None, params=None, headers=None, timeout=30, session=N
         logger.log(traceback.format_exc(), logger.DEBUG)
         return None
     except Exception as e:
-        logger.log(u"Unknown exception in getURL %s Error: %r" % (url, ex(e)), logger.WARNING)
-        logger.log(traceback.format_exc(), logger.WARNING)
+        logger.log(u"Unknown exception in getURL %s Error: %r" % (url, ex(e)), logger.ERROR)
+        logger.log(traceback.format_exc(), logger.DEBUG)
         return None
 
     return (resp.text, resp.content)[need_bytes] if not json else resp.json()
@@ -1527,7 +1527,8 @@ def download_file(url, filename, session=None, headers=None):
         return False
     except Exception:
         remove_file_failed(filename)
-        logger.log(u"Unknown exception while loading download URL %s : %r" % (url, traceback.format_exc()), logger.WARNING)
+        logger.log(u"Unknown exception while loading download URL %s : %r" % (url, traceback.format_exc()), logger.ERROR)
+        logger.log(traceback.format_exc(), logger.DEBUG)
         return False
 
     return True

--- a/sickbeard/properFinder.py
+++ b/sickbeard/properFinder.py
@@ -91,8 +91,23 @@ class ProperFinder(object):
             except AuthException as e:
                 logger.log(u"Authentication error: " + ex(e), logger.DEBUG)
                 continue
+            except (SocketTimeout, TypeError) as e:
+                logger.log(u"Connection timed out (sockets) while searching " + curProvider.name + ", skipping: " + ex(e), logger.DEBUG)
+                continue
+            except (requests.exceptions.HTTPError, requests.exceptions.TooManyRedirects) as e:
+                logger.log(u"HTTP error while searching propers in " + curProvider.name + ", skipping: " + ex(e), logger.DEBUG)
+                continue
+            except requests.exceptions.ConnectionError as e:
+                logger.log(u"Connection error while searching propers in " + curProvider.name + ", skipping: " + ex(e), logger.DEBUG)
+                continue
+            except requests.exceptions.Timeout as e:
+                logger.log(u"Connection timed out while searching propers in " + curProvider.name + ", skipping: " + ex(e), logger.DEBUG)
+                continue
+            except requests.exceptions.ContentDecodingError:
+                logger.log(u"Content-Encoding was gzip, but content was not compressed while searching propers in " + curProvider.name + ", skipping: " + ex(e), logger.DEBUG)
+                continue
             except Exception as e:
-                logger.log(u"Error while searching " + curProvider.name + ", skipping: " + ex(e), logger.DEBUG)
+                logger.log(u"Unknown exception while searching propers in " + curProvider.name + ", skipping: " + ex(e), logger.ERROR)
                 logger.log(traceback.format_exc(), logger.DEBUG)
                 continue
 

--- a/sickbeard/search.py
+++ b/sickbeard/search.py
@@ -497,8 +497,23 @@ def searchProviders(show, episodes, manualSearch=False, downCurQuality=False):
             except AuthException as e:
                 logger.log(u"Authentication error: " + ex(e), logger.ERROR)
                 break
+            except (SocketTimeout, TypeError) as e:
+                logger.log(u"Connection timed out (sockets) while searching " + curProvider.name + ", skipping: " + ex(e), logger.DEBUG)
+                break
+            except (requests.exceptions.HTTPError, requests.exceptions.TooManyRedirects) as e:
+                logger.log(u"HTTP error while searching " + curProvider.name + ", skipping: " + ex(e), logger.DEBUG)
+                break
+            except requests.exceptions.ConnectionError as e:
+                logger.log(u"Connection error while searching " + curProvider.name + ", skipping: " + ex(e), logger.DEBUG)
+                break
+            except requests.exceptions.Timeout as e:
+                logger.log(u"Connection timed out while searching " + curProvider.name + ", skipping: " + ex(e), logger.DEBUG)
+                break
+            except requests.exceptions.ContentDecodingError:
+                logger.log(u"Content-Encoding was gzip, but content was not compressed while searching " + curProvider.name + ", skipping: " + ex(e), logger.DEBUG)
+                break
             except Exception as e:
-                logger.log(u"Error while searching " + curProvider.name + ", skipping: " + ex(e), logger.ERROR)
+                logger.log(u"Unknown exception while searching " + curProvider.name + ", skipping: " + ex(e), logger.ERROR)
                 logger.log(traceback.format_exc(), logger.DEBUG)
                 break
 


### PR DESCRIPTION
Avoid issues like this:

HTTPSConnectionPool(host='*', port=443): Read timed out
https://github.com/SickRage/sickrage-issues/issues/583
https://github.com/SickRage/sickrage-issues/issues/467

and others
