### PR TITLE
!!!Show Dir is now build after indexing!!!

### DIFF
--- a/sickbeard/helpers.py
+++ b/sickbeard/helpers.py
@@ -1776,3 +1776,18 @@ def is_ip_private(ip):
     priv_20 = re.compile(r"^192\.168\.\d{1,3}.\d{1,3}$")
     priv_16 = re.compile(r"^172.(1[6-9]|2[0-9]|3[0-1]).[0-9]{1,3}.[0-9]{1,3}$")
     return priv_lo.match(ip) or priv_24.match(ip) or priv_20.match(ip) or priv_16.match(ip)
+
+def getShowNameFromIndexer(indexer, indexer_id, lang='en'):
+    lINDEXER_API_PARMS = sickbeard.indexerApi(indexer).api_params.copy()
+    if lang:
+        lINDEXER_API_PARMS['language'] = lang
+
+    logger.log(u"" + str(sickbeard.indexerApi(indexer).name) + ": " + repr(lINDEXER_API_PARMS))
+
+    t = sickbeard.indexerApi(indexer).indexer(**lINDEXER_API_PARMS)
+    s = t[int(indexer_id)]
+    
+    if hasattr(s,'data'):
+        return s.data.get('seriesname')
+    
+    return None

--- a/sickbeard/show_queue.py
+++ b/sickbeard/show_queue.py
@@ -17,7 +17,7 @@
 # You should have received a copy of the GNU General Public License
 # along with SickRage. If not, see <http://www.gnu.org/licenses/>.
 
-
+import os
 import traceback
 
 import sickbeard
@@ -34,8 +34,11 @@ from sickbeard.blackandwhitelist import BlackAndWhiteList
 from sickrage.helper.exceptions import CantRefreshShowException, CantRemoveShowException, CantUpdateShowException
 from sickrage.helper.exceptions import EpisodeDeletedException, ex, MultipleShowObjectsException
 from sickrage.helper.exceptions import ShowDirectoryNotFoundException
+from sickbeard.helpers import getShowNameFromIndexer
 from libtrakt import TraktAPI
-
+from sickrage.helper.encoding import ek
+from sickbeard.helpers import makeDir, chmodAsParent
+from sickrage.helper.common import sanitize_filename
 
 class ShowQueue(generic_queue.GenericQueue):
     def __init__(self):
@@ -142,13 +145,14 @@ class ShowQueue(generic_queue.GenericQueue):
         return queueItemObj
 
     def addShow(self, indexer, indexer_id, showDir, default_status=None, quality=None, flatten_folders=None,
-                lang=None, subtitles=None, anime=None, scene=None, paused=None, blacklist=None, whitelist=None, default_status_after=None):
+                lang=None, subtitles=None, anime=None, scene=None, paused=None, blacklist=None, whitelist=None, 
+                default_status_after=None, root_dir=None):
 
         if lang is None:
             lang = sickbeard.INDEXER_DEFAULT_LANGUAGE
 
         queueItemObj = QueueItemAdd(indexer, indexer_id, showDir, default_status, quality, flatten_folders, lang,
-                                    subtitles, anime, scene, paused, blacklist, whitelist, default_status_after)
+                                    subtitles, anime, scene, paused, blacklist, whitelist, default_status_after, root_dir)
 
         self.add_item(queueItemObj)
 
@@ -226,7 +230,7 @@ class ShowQueueItem(generic_queue.QueueItem):
 
 class QueueItemAdd(ShowQueueItem):
     def __init__(self, indexer, indexer_id, showDir, default_status, quality, flatten_folders, lang, subtitles, anime,
-                 scene, paused, blacklist, whitelist, default_status_after):
+                 scene, paused, blacklist, whitelist, default_status_after, root_dir):
 
         self.indexer = indexer
         self.indexer_id = indexer_id
@@ -242,6 +246,7 @@ class QueueItemAdd(ShowQueueItem):
         self.blacklist = blacklist
         self.whitelist = whitelist
         self.default_status_after = default_status_after
+        self.root_dir = root_dir
 
         self.show = None
 
@@ -277,7 +282,7 @@ class QueueItemAdd(ShowQueueItem):
 
         ShowQueueItem.run(self)
 
-        logger.log(u"Starting to add show " + self.showDir)
+        logger.log(u"Starting to add show {0}".format("by ShowDir: {0}".format(self.showDir) if self.showDir else "by Indexer Id: {0}".format(self.indexer_id)))
         # make sure the Indexer IDs are valid
         try:
 
@@ -289,7 +294,23 @@ class QueueItemAdd(ShowQueueItem):
 
             t = sickbeard.indexerApi(self.indexer).indexer(**lINDEXER_API_PARMS)
             s = t[self.indexer_id]
-
+            
+            ## Let's try to create the show Dir if it's not provided. This way we force the show dir to build build using the
+            # Indexers provided series name
+            if not self.showDir and self.root_dir:
+                show_name = getShowNameFromIndexer(self.indexer, self.indexer_id, self.lang)
+                if show_name:
+                    self.showDir = ek(os.path.join, self.root_dir, sanitize_filename(show_name))
+                    dir_exists = makeDir(self.showDir)
+                    if not dir_exists:
+                        logger.log(u"Unable to create the folder {0}, can't add the show".format(self.showDir))
+                        return
+                
+                    chmodAsParent(self.showDir)
+                else:
+                    logger.log(u"Unable to get a show {0}, can't add the show".format(self.showDir))
+                    return
+                
             # this usually only happens if they have an NFO in their show dir which gave us a Indexer ID that has no proper english version of the show
             if getattr(s, 'seriesname', None) is None:
                 logger.log(u"Show in " + self.showDir + " has no name on " + str(

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -37,6 +37,7 @@ from sickbeard import search_queue
 from sickbeard import naming
 from sickbeard import subtitles
 from sickbeard import network_timezones
+from sickbeard.helpers import getShowNameFromIndexer
 from sickbeard.providers import newznab, rsstorrent
 from sickbeard.common import Quality, Overview, statusStrings, cpu_presets
 from sickbeard.common import SNATCHED, UNAIRED, IGNORED, WANTED, FAILED, SKIPPED
@@ -2735,20 +2736,15 @@ class HomeAddShows(Home):
             logger.log(u"There was an error creating the show, no root directory setting found")
             return "No root directories setup, please go back and add one."
 
-        show_dir = ek(os.path.join, location, sanitize_filename(showName))
-        dir_exists = helpers.makeDir(show_dir)
-        if not dir_exists:
-            logger.log(u"Unable to create the folder " + show_dir + ", can't add the show")
-            return
-
-        helpers.chmodAsParent(show_dir)
+        show_name = getShowNameFromIndexer(1, indexerId)
+        show_dir = None
         
         # add the show
-        sickbeard.showQueueScheduler.action.addShow(1, int(indexerId), show_dir, int(defaultStatus), quality,
-                                                    flatten_folders, indexerLang, subtitles, anime,
-                                                    scene, None, blacklist, whitelist, int(defaultStatusAfter))
+        sickbeard.showQueueScheduler.action.addShow(1, int(indexerId), show_dir, int(defaultStatus), quality,flatten_folders, 
+                                                    indexerLang, subtitles, anime, scene, None, blacklist, whitelist, 
+                                                    int(defaultStatusAfter), root_dir=location)
         
-        ui.notifications.message('Show added', 'Adding the specified show into ' + show_dir)
+        ui.notifications.message('Show added', 'Adding the specified show {0}'.format(show_name))
 
         # done adding show
         return self.redirect('/home/')


### PR DESCRIPTION
I needed to do this because anidb is giving back different show names then tvdb. As we're using tvdb as indexer, i thought it was better to use that.

but!!! For this i've made some changes to show_queue.py. When no ShowDir is provided but there is a Root_dir (forex: d:\series\anime). Then the showname is used provided by the indexer.

For this I also added a helper function that gets showname by id from indexer. As we have one indexer now, impact is limited.

But, It is possible i've overseen something. So please test this very well!.

When i'm going to refactor the other lists, i'll also implement this for imdb lists and trakt lists.
