### PR TITLE
Quick'n'dirty, return true rather than false when PP finds `exists sa…

### DIFF
--- a/sickbeard/postProcessor.py
+++ b/sickbeard/postProcessor.py
@@ -516,7 +516,7 @@ class PostProcessor(object):
             to_return = (show, season, [], quality, version)
 
             qual_str = common.Quality.qualityStrings[quality] if quality is not None else quality
-            self._log("Found result in history for %s - Season: %s - Quality: %s - Version: %s" 
+            self._log("Found result in history for %s - Season: %s - Quality: %s - Version: %s"
                 % (show.name if show else "UNDEFINED", season, qual_str, version), logger.DEBUG)
 
             return to_return
@@ -683,7 +683,7 @@ class PostProcessor(object):
                     u"Looks like this is an air-by-date or sports show, attempting to convert the date to season/episode",
                     logger.DEBUG)
 
-                try:   
+                try:
                     airdate = episodes[0].toordinal()
                 except AttributeError:
                     self._log(u"Could not convert to a valid airdate: %s" % episodes[0], logger.DEBUG)
@@ -971,8 +971,8 @@ class PostProcessor(object):
 
         if not priority_download:
             if existing_file_status == PostProcessor.EXISTS_SAME:
-                self._log(u"File exists and new file is same size, marking it unsafe to replace")
-                return False
+                self._log(u"File exists and new file is same size, pretending we did something")
+                return True
 
             if new_ep_quality <= old_ep_quality != common.Quality.UNKNOWN and existing_file_status != PostProcessor.DOESNT_EXIST:
                 if self.is_proper and new_ep_quality == old_ep_quality:


### PR DESCRIPTION
…me size` so it is added to the DB as processed.

Fixes https://github.com/SickRage/sickrage-issues/issues/483
