### PR TITLE
Added new optional paramater root_dir to addShow.

### DIFF
--- a/sickbeard/show_queue.py
+++ b/sickbeard/show_queue.py
@@ -17,7 +17,7 @@
 # You should have received a copy of the GNU General Public License
 # along with SickRage. If not, see <http://www.gnu.org/licenses/>.
 
-
+import os
 import traceback
 
 import sickbeard
@@ -34,8 +34,11 @@ from sickbeard.blackandwhitelist import BlackAndWhiteList
 from sickrage.helper.exceptions import CantRefreshShowException, CantRemoveShowException, CantUpdateShowException
 from sickrage.helper.exceptions import EpisodeDeletedException, ex, MultipleShowObjectsException
 from sickrage.helper.exceptions import ShowDirectoryNotFoundException
+from sickbeard.helpers import get_show_name_from_indexer
 from libtrakt import TraktAPI
-
+from sickrage.helper.encoding import ek
+from sickbeard.helpers import makeDir, chmodAsParent
+from sickrage.helper.common import sanitize_filename
 
 class ShowQueue(generic_queue.GenericQueue):
     def __init__(self):
@@ -142,13 +145,14 @@ class ShowQueue(generic_queue.GenericQueue):
         return queueItemObj
 
     def addShow(self, indexer, indexer_id, showDir, default_status=None, quality=None, flatten_folders=None,
-                lang=None, subtitles=None, anime=None, scene=None, paused=None, blacklist=None, whitelist=None, default_status_after=None):
+                lang=None, subtitles=None, anime=None, scene=None, paused=None, blacklist=None, whitelist=None, 
+                default_status_after=None, root_dir=None):
 
         if lang is None:
             lang = sickbeard.INDEXER_DEFAULT_LANGUAGE
 
         queueItemObj = QueueItemAdd(indexer, indexer_id, showDir, default_status, quality, flatten_folders, lang,
-                                    subtitles, anime, scene, paused, blacklist, whitelist, default_status_after)
+                                    subtitles, anime, scene, paused, blacklist, whitelist, default_status_after, root_dir)
 
         self.add_item(queueItemObj)
 
@@ -232,7 +236,7 @@ class ShowQueueItem(generic_queue.QueueItem):
 
 class QueueItemAdd(ShowQueueItem):
     def __init__(self, indexer, indexer_id, showDir, default_status, quality, flatten_folders, lang, subtitles, anime,
-                 scene, paused, blacklist, whitelist, default_status_after):
+                 scene, paused, blacklist, whitelist, default_status_after, root_dir):
 
         self.indexer = indexer
         self.indexer_id = indexer_id
@@ -248,6 +252,7 @@ class QueueItemAdd(ShowQueueItem):
         self.blacklist = blacklist
         self.whitelist = whitelist
         self.default_status_after = default_status_after
+        self.root_dir = root_dir
 
         self.show = None
 
@@ -283,7 +288,7 @@ class QueueItemAdd(ShowQueueItem):
 
         ShowQueueItem.run(self)
 
-        logger.log(u"Starting to add show " + self.showDir)
+        logger.log(u"Starting to add show {0}".format("by ShowDir: {0}".format(self.showDir) if self.showDir else "by Indexer Id: {0}".format(self.indexer_id)))
         # make sure the Indexer IDs are valid
         try:
 
@@ -295,7 +300,23 @@ class QueueItemAdd(ShowQueueItem):
 
             t = sickbeard.indexerApi(self.indexer).indexer(**lINDEXER_API_PARMS)
             s = t[self.indexer_id]
-
+            
+            ## Let's try to create the show Dir if it's not provided. This way we force the show dir to build build using the
+            # Indexers provided series name
+            if not self.showDir and self.root_dir:
+                show_name = get_show_name_from_indexer(self.indexer, self.indexer_id, self.lang)
+                if show_name:
+                    self.showDir = ek(os.path.join, self.root_dir, sanitize_filename(show_name))
+                    dir_exists = makeDir(self.showDir)
+                    if not dir_exists:
+                        logger.log(u"Unable to create the folder {0}, can't add the show".format(self.showDir))
+                        return
+                
+                    chmodAsParent(self.showDir)
+                else:
+                    logger.log(u"Unable to get a show {0}, can't add the show".format(self.showDir))
+                    return
+                
             # this usually only happens if they have an NFO in their show dir which gave us a Indexer ID that has no proper english version of the show
             if getattr(s, 'seriesname', None) is None:
                 logger.log(u"Show in " + self.showDir + " has no name on " + str(

--- a/sickbeard/show_queue.py
+++ b/sickbeard/show_queue.py
@@ -34,7 +34,7 @@ from sickbeard.blackandwhitelist import BlackAndWhiteList
 from sickrage.helper.exceptions import CantRefreshShowException, CantRemoveShowException, CantUpdateShowException
 from sickrage.helper.exceptions import EpisodeDeletedException, ex, MultipleShowObjectsException
 from sickrage.helper.exceptions import ShowDirectoryNotFoundException
-from sickbeard.helpers import get_show_name_from_indexer
+from sickbeard.helpers import get_showname_from_indexer
 from libtrakt import TraktAPI
 from sickrage.helper.encoding import ek
 from sickbeard.helpers import makeDir, chmodAsParent
@@ -304,7 +304,7 @@ class QueueItemAdd(ShowQueueItem):
             ## Let's try to create the show Dir if it's not provided. This way we force the show dir to build build using the
             # Indexers provided series name
             if not self.showDir and self.root_dir:
-                show_name = get_show_name_from_indexer(self.indexer, self.indexer_id, self.lang)
+                show_name = get_showname_from_indexer(self.indexer, self.indexer_id, self.lang)
                 if show_name:
                     self.showDir = ek(os.path.join, self.root_dir, sanitize_filename(show_name))
                     dir_exists = makeDir(self.showDir)


### PR DESCRIPTION
Added logic to create the showpath using the root_dir and the showname provided by the indexer.

This will be required to create proper show directory names when shows are added from lists like trakt, imdb, anidb, etc..
