### PR TITLE
`Help & Info` page improvements

### DIFF
--- a/SickBeard.py
+++ b/SickBeard.py
@@ -18,9 +18,6 @@
 # You should have received a copy of the GNU General Public License
 # along with SickRage. If not, see <http://www.gnu.org/licenses/>.
 
-# Check needed software dependencies to nudge users to fix their setup
-
-# pylint: disable=line-too-long
 
 """
 Usage: SickBeard.py [OPTION]...

--- a/gui/slick/views/config.mako
+++ b/gui/slick/views/config.mako
@@ -3,9 +3,9 @@
     import sickbeard
     from sickbeard import db
     from sickbeard.helpers import anon_url
-    from sickbeard.versionChecker import CheckVersion
     import sys
 %>
+
 <%block name="content">
 % if not header is UNDEFINED:
     <h1 class="header">${header}</h1>
@@ -13,77 +13,40 @@
     <h1 class="title">${title}</h1>
 % endif
 
-##cpu_usage = ${psutil.cpu_percent()}
-##ram = ${psutil.phymem_usage()}
-##ram_total = ${ram.total / 2**20}
-##ram_used = ${ram.used / 2**20}
-##ram_free = ${ram.free / 2**20}
-##ram_percent_used = ${ram.percent}
-##disk = ${psutil.disk_usage('/')}
-##disk_total = ${disk.total / 2**30}
-##disk_used = ${disk.used / 2**30}
-##disk_free = ${disk.free / 2**30}
-##disk_percent_used = ${disk.percent}
 <div id="config-content">
 <table class="infoTable" cellspacing="1" border="0" cellpadding="0" width="100%">
-    <tr><td class="infoTableHeader" style="vertical-align: top;">Version:</td><td class="infoTableCell">
-% if sickbeard.VERSION_NOTIFY:
+    % if sr_version:
+    <tr><td class="infoTableHeader" style="vertical-align: top;">SickRage Version:</td>
+        <td class="infoTableCell">
         Branch: <a href="${anon_url('https://github.com/SickRage/SickRage/tree/%s' % sickbeard.BRANCH)}">${sickbeard.BRANCH}</a><br>
         Commit: <a href="${anon_url('https://github.com/SickRage/SickRage/commit/%s' % sickbeard.CUR_COMMIT_HASH)}">${sickbeard.CUR_COMMIT_HASH}</a><br>
-        <%
-        updater = CheckVersion().updater
-        %>
-
-        % if updater is not None:
-            <%
-            updater.need_update()
-            %>
-
-            Version: <a href="${anon_url('https://github.com/SickRage/SickRage/releases/tag/%s' % updater.get_cur_version())}">${updater.get_cur_version()}</a>
-        % endif
-        <!-- &ndash; build.date //-->
-% else:
-        You don't have version checking turned on. Please turn on "Check for Update" in Config > General.<br>
-% endif
-    </td></tr>
-
-<%
-    sr_user = None
-    try:
-        import os, pwd
-        sr_user = pwd.getpwuid(os.getuid()).pw_name
-    except ImportError:
-        import getpass
-        sr_user = getpass.getuser()
-%>
-% if sr_user:
+        Version: <a href="${anon_url('https://github.com/SickRage/SickRage/releases/tag/%s' % sr_version)}">${sr_version}</a>
+        </td>
+    </tr>
+    % endif
+    <tr><td class="infoTableHeader">Python Version:</td><td class="infoTableCell">${sys.version[:120]}</td></tr>
+    <tr><td class="infoTableHeader">SSL Version:</td><td class="infoTableCell">${ssl_version}</td></tr>
+    <tr><td class="infoTableHeader" style="vertical-align: top;">Locale:</td><td class="infoTableCell">${'.'.join(sr_locale)}</td></tr>
+    <tr><td>&nbsp;</td><td>&nbsp;</td></tr>
+    <tr class="infoTableSeperator"><td>&nbsp;</td><td>&nbsp;</td></tr>
     <tr><td class="infoTableHeader">User:</td><td class="infoTableCell">${sr_user}</td></tr>
-% endif
-
-% try:
-    <% import locale %>
-    <% sr_locale = locale.getdefaultlocale() %>
-    <tr><td class="infoTableHeader" style="vertical-align: top;">Locale:</td><td class="infoTableCell">
-        Language: ${sr_locale[0]}<br>
-        Encoding: ${sr_locale[1]}
-    </td></tr>
-% except:
-    ""
-% endtry
-
+    <tr><td class="infoTableHeader">Program Directory:</td><td class="infoTableCell">${sickbeard.PROG_DIR}</td></tr>
     <tr><td class="infoTableHeader">Configuration File:</td><td class="infoTableCell">${sickbeard.CONFIG_FILE}</td></tr>
     <tr><td class="infoTableHeader">Database:</td><td class="infoTableCell">${db.dbFilename()}</td></tr>
     <tr><td class="infoTableHeader">Cache Directory:</td><td class="infoTableCell">${sickbeard.CACHE_DIR}</td></tr>
     <tr><td class="infoTableHeader">Log Directory:</td><td class="infoTableCell">${sickbeard.LOG_DIR}</td></tr>
+    % if sickbeard.MY_ARGS:
     <tr><td class="infoTableHeader">Arguments:</td><td class="infoTableCell">${sickbeard.MY_ARGS}</td></tr>
-% if sickbeard.WEB_ROOT:
+    % endif
+    % if sickbeard.WEB_ROOT:
     <tr><td class="infoTableHeader">Web Root:</td><td class="infoTableCell">${sickbeard.WEB_ROOT}</td></tr>
-% endif
-    <tr><td class="infoTableHeader">Python Version:</td><td class="infoTableCell">${sys.version[:120]}</td></tr>
-    <tr class="infoTableSeperator"><td class="infoTableHeader"><i class="icon16-sb"></i> Website:</td><td class="infoTableCell"><a href="${anon_url('http://sickrage.github.io/')}" rel="noreferrer" onclick="window.open(this.href, '_blank'); return false;">http://sickrage.github.io/</a></td></tr>
+    % endif
+    <tr><td>&nbsp;</td><td>&nbsp;</td></tr>
+    <tr class="infoTableSeperator"><td>&nbsp;</td><td>&nbsp;</td></tr>
+    <tr><td class="infoTableHeader"><i class="icon16-sb"></i> Website:</td><td class="infoTableCell"><a href="${anon_url('http://sickrage.github.io/')}" rel="noreferrer" onclick="window.open(this.href, '_blank'); return false;">http://sickrage.github.io/</a></td></tr>
     <tr><td class="infoTableHeader"><i class="icon16-WiKi"></i> Wiki:</td><td class="infoTableCell"><a href="${anon_url('https://github.com/SickRage/sickrage-issues/wiki')}" rel="noreferrer" onclick="window.open(this.href, '_blank'); return false;">https://github.com/SickRage/sickrage-issues/wiki</a></td></tr>
     <tr><td class="infoTableHeader"><i class="icon16-github"></i> Source:</td><td class="infoTableCell"><a href="${anon_url('https://github.com/SickRage/SickRage/')}" rel="noreferrer" onclick="window.open(this.href, '_blank'); return false;">https://github.com/SickRage/SickRage/</a></td></tr>
-    <tr><td class="infoTableHeader"><i class="icon16-mirc"></i> IRChat:</td><td class="infoTableCell"><a href="irc://irc.freenode.net/#sickrage-issues" rel="noreferrer"><i>#sickrage-issues</i> on <i>irc.freenode.net</i></a></td></tr>
+    <tr><td class="infoTableHeader"><i class="icon16-mirc"></i> IRC Chat:</td><td class="infoTableCell"><a href="irc://irc.freenode.net/#sickrage-issues" rel="noreferrer"><i>#sickrage-issues</i> on <i>irc.freenode.net</i></a></td></tr>
 </table>
 </div>
 </%block>

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -3757,7 +3757,41 @@ class Config(WebRoot):
     def index(self):
         t = PageTemplate(rh=self, filename="config.mako")
 
-        return t.render(submenu=self.ConfigMenu(), title='SickRage Configuration', header='SickRage Configuration', topmenu="config")
+        try:
+            import pwd
+            sr_user = pwd.getpwuid(os.getuid()).pw_name
+        except ImportError:
+            try:
+                import getpass
+                sr_user = getpass.getuser()
+            except StandardError:
+                sr_user = 'Unknown'
+
+        try:
+            import locale
+            sr_locale = locale.getdefaultlocale()
+        except StandardError:
+            sr_locale = 'Unknown', 'Unknown'
+
+        try:
+            import ssl
+            ssl_version = ssl.OPENSSL_VERSION
+        except StandardError:
+            ssl_version = 'Unknown'
+
+        sr_version = ''
+        if sickbeard.VERSION_NOTIFY:
+            updater = CheckVersion().updater
+            if updater:
+                updater.need_update()
+                sr_version = updater.get_cur_version()
+
+        return t.render(
+            submenu=self.ConfigMenu(), title='SickRage Configuration',
+            header='SickRage Configuration', topmenu="config",
+            sr_user=sr_user, sr_locale=sr_locale, ssl_version=ssl_version,
+            sr_version=sr_version
+        )
 
 
 @route('/config/general(/?.*)')


### PR DESCRIPTION
Add openssl version on `Help & Info` page
Add SickRage program directory to `Help & Info` page
Move most python out of `Help & Info` page into webserve
Organize and make `Help & Info` page easier on the eyes

Partially implements the ssl version for:
https://github.com/SickRage/sickrage-issues/issues/595
