### PR TITLE
Add trackers to KAT magnets to avoid dead magnets like publicbt

### DIFF
--- a/sickbeard/providers/kat.py
+++ b/sickbeard/providers/kat.py
@@ -110,7 +110,7 @@ class KatProvider(TorrentProvider):  # pylint: disable=too-many-instance-attribu
                             # so that proxies work.
                             download_url = item.enclosure['url']
                             if sickbeard.TORRENT_METHOD != "blackhole" or 'torcache' not in download_url:
-                                download_url = item.find('torrent:magneturi').next.replace('CDATA', '').strip('[]')
+                                download_url = item.find('torrent:magneturi').next.replace('CDATA', '').strip('[]') + self._custom_trackers
 
                             if not (title and download_url):
                                 continue


### PR DESCRIPTION
https://www.reddit.com/r/sickrage/comments/42wop2/not_fetching_all_trackers_only_fetching_dead_ones/
