### PR TITLE
Fix 'Error while searching ****, skipping: entries'

### DIFF
--- a/sickbeard/rssfeeds.py
+++ b/sickbeard/rssfeeds.py
@@ -2,8 +2,6 @@
 import re
 import urlparse
 from feedparser.api import parse
-from feedparser.util import FeedParserDict
-
 from sickbeard import logger
 from sickrage.helper.exceptions import ex
 
@@ -28,4 +26,4 @@ def getFeed(url, request_headers=None, handlers=None):
     except Exception as e:
         logger.log(u'RSS error: ' + ex(e), logger.DEBUG)
 
-    return FeedParserDict()
+    return {'entries': []}


### PR DESCRIPTION
Providers/ expect: self.cache.getRSSFeed(urll)['entries']

https://github.com/SickRage/SickRage/search?utf8=%E2%9C%93&q=%22getRSSFeed%22&type=Code

Instead of change all providers and/or other files, just return a dict with no entries instead of just {}

Fixes https://github.com/SickRage/sickrage-issues/issues/660
