### PR TITLE
Prevent return Null as season number.

### DIFF
--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -1231,7 +1231,7 @@ class Home(WebRoot):
 
         main_db_con = db.DBConnection()
         seasonResults = main_db_con.select(
-            "SELECT DISTINCT season FROM tv_episodes WHERE showid = ? ORDER BY season DESC",
+            "SELECT DISTINCT season FROM tv_episodes WHERE showid = ? and season is not Null ORDER BY season DESC",
             [showObj.indexerid]
         )
 


### PR DESCRIPTION
If in the season column ep tv_episodes there are null values, displayShow.mako can crash.

Need to investigate how these rows with season is null got in my db.
