### PR TITLE
Fetch only current branch. Not all branches

### DIFF
--- a/sickbeard/versionChecker.py
+++ b/sickbeard/versionChecker.py
@@ -529,7 +529,7 @@ class GitUpdateManager(UpdateManager):
         self.update_remote_origin()
 
         # get all new info from github
-        output, _, exit_status = self._run_git(self._git_path, 'fetch %s' % sickbeard.GIT_REMOTE)
+        output, _, exit_status = self._run_git(self._git_path, 'fetch %s %s' % (sickbeard.GIT_REMOTE, self.branch))
         if not exit_status == 0:
             logger.log(u"Unable to contact github, can't check for update", logger.WARNING)
             return


### PR DESCRIPTION
Fixes SickRage/sickrage-issues/issues/496

User's don't need to fetch all branches
Devs can checkout feature branches using cmd line
