### PR TITLE
Build in some additional checks for when an anidb aid can't be mapped to a tvdb …

### DIFF
--- a/lib/adba/aniDBfileInfo.py
+++ b/lib/adba/aniDBfileInfo.py
@@ -71,21 +71,17 @@ def _remove_file_failed(file):
 def download_file(url, filename):
     try:
         r = requests.get(url, stream=True, verify=False)
+        r.raise_for_status()
         with open(filename, 'wb') as fp:
             for chunk in r.iter_content(chunk_size=1024):
                 if chunk:
                     fp.write(chunk)
                     fp.flush()
 
-    except requests.HTTPError, e:
+    except (requests.HTTPError, requests.exceptions.RequestException):
         _remove_file_failed(filename)
         return False
-    except requests.ConnectionError, e:
-        return False
-    except requests.Timeout, e:
-        return False
-    except Exception:
-        _remove_file_failed(filename)
+    except (requests.ConnectionError, requests.Timeout):
         return False
 
     return True

--- a/lib/anidbhttp/model.py
+++ b/lib/anidbhttp/model.py
@@ -4,9 +4,11 @@ from sickrage.helper.encoding import ek
 import sickbeard
 from sickbeard import helpers
 import requests
+import logging
 
 __all__ = ["Anime", "Category", "Title", "Episode", "Tag"]
-
+log = logging.getLogger(__name__)
+log.addHandler(logging.NullHandler())
 
 class Entity(object):
     def __init__(self, id):
@@ -184,7 +186,11 @@ class Anime(Entity, Titled, Typed, Described):
         No params required.
         """
         from adba.aniDBtvDBmaper import TvDBMap
-        self._tvdbid = TvDBMap().get_tvdb_for_anidb(self.id) if self.id else None
+        try:
+            self._tvdbid = TvDBMap().get_tvdb_for_anidb(self.id) if self.id else None
+        except Exception:
+            self._tvdbid = None
+            log.debug("Couldn't map aid [{0}] to tvdbid ".format(self.id))
 
     def cache_image(self, image_url):
         """


### PR DESCRIPTION
…id. Possibly due to github giving an error page one anime-list.xml file download.
