### PR TITLE
Hot-fix help & info not displaying without git.

### DIFF
--- a/sickbeard/versionChecker.py
+++ b/sickbeard/versionChecker.py
@@ -374,7 +374,7 @@ class GitUpdateManager(UpdateManager):
         return self._newest_commit_hash
 
     def get_cur_version(self):
-        return self._run_git(self._git_path, "describe --abbrev=0 " + self._cur_commit_hash)[0]
+        return self._run_git(self._git_path, 'describe --abbrev=0 {}'.format(self._cur_commit_hash))[0]
 
     def get_newest_version(self):
         if self._newest_commit_hash:


### PR DESCRIPTION
If SickRage does not have a path to git (e.g. with a portable Git install), Help & Info page does not display and raises a traceback.
