### PR TITLE
Bitcannon isn't public

### DIFF
--- a/sickbeard/providers/bitcannon.py
+++ b/sickbeard/providers/bitcannon.py
@@ -33,8 +33,6 @@ class BitCannonProvider(TorrentProvider):  # pylint: disable=too-many-instance-a
 
         TorrentProvider.__init__(self, "BitCannon")
 
-        self.public = True
-
         self.minseed = None
         self.minleech = None
         self.ratio = 0


### PR DESCRIPTION
Its a privatly run torrent indexer
SickRage/sickrage-issues#763
