### PR TITLE
Changed the color of the root folder(s)

### DIFF
--- a/gui/slick/css/style.css
+++ b/gui/slick/css/style.css
@@ -817,6 +817,7 @@ ul#rootDirStaticList li {
     margin: 2px;
     list-style: none outside none;
     cursor: pointer;
+    color: green;
     background: url('../css/lib/images/ui-bg_highlight-soft_75_efefef_1x100.png') repeat-x scroll 50% 50% #EFEFEF;
 }
 


### PR DESCRIPTION
On the dark theme the text was black on a black background. So hard to read.
This changes the text on both to green, that's easier on the eye.

![1](https://cloud.githubusercontent.com/assets/7928052/12822212/3d536914-cb67-11e5-8d60-bff05cd07a4c.png)
![2](https://cloud.githubusercontent.com/assets/7928052/12822213/3d733816-cb67-11e5-8477-a89c8391142f.png)

![naamloos](https://cloud.githubusercontent.com/assets/7928052/12823800/53d11414-cb6e-11e5-9271-80fff291a779.png)
