### PR TITLE
Improve log messages in PP

### DIFF
--- a/sickbeard/processTV.py
+++ b/sickbeard/processTV.py
@@ -378,14 +378,24 @@ def validateDir(path, dirName, nzbNameOriginal, failed, result):  # pylint: disa
         try:
             NameParser().parse(video, cache_result=False)
             return True
-        except (InvalidNameException, InvalidShowException):
+        except InvalidNameException:
+            result.output += logHelper(u"{} : Invalid name exception".format(video), logger.DEBUG)
+            result.output += logHelper(u"Trying to parse folder name as fallback", logger.DEBUG)
+            pass
+        except InvalidShowException as e:
+            result.output += logHelper(u"Invalid show exception. Error: {}".format(e), logger.DEBUG)
+            result.output += logHelper(u"Trying to parse folder name as fallback", logger.DEBUG)
             pass
 
     for proc_dir in allDirs:
         try:
             NameParser().parse(proc_dir, cache_result=False)
             return True
-        except (InvalidNameException, InvalidShowException):
+        except InvalidNameException:
+            result.output += logHelper(u"{} : Invalid name exception (folder)".format(dirName), logger.DEBUG)
+            pass
+        except InvalidShowException as e:
+            result.output += logHelper(u"Invalid show exception (folder). Error: {}".format(e), logger.DEBUG)
             pass
 
     if sickbeard.UNPACK:
@@ -396,7 +406,11 @@ def validateDir(path, dirName, nzbNameOriginal, failed, result):  # pylint: disa
             try:
                 NameParser().parse(packed, cache_result=False)
                 return True
-            except (InvalidNameException, InvalidShowException):
+            except InvalidNameException:
+                result.output += logHelper(u"{} : Invalid name exception".format(packed), logger.DEBUG)
+                pass
+            except InvalidShowException as e:
+                result.output += logHelper(u"{} : Invalid show exception. Error: {}".format(packed, e), logger.DEBUG)
                 pass
 
     result.output += logHelper(u"%s : No processable items found in folder" % dirName, logger.DEBUG)

--- a/sickbeard/processTV.py
+++ b/sickbeard/processTV.py
@@ -383,7 +383,7 @@ def validateDir(path, dirName, nzbNameOriginal, failed, result):  # pylint: disa
             result.output += logHelper(u"Trying to parse folder name as fallback", logger.DEBUG)
             pass
         except InvalidShowException as e:
-            result.output += logHelper(u"Invalid show exception. Error: {}".format(e), logger.DEBUG)
+            result.output += logHelper(u"Invalid show exception. Error: {}".format(e), logger.WARNING)
             result.output += logHelper(u"Trying to parse folder name as fallback", logger.DEBUG)
             pass
 
@@ -395,7 +395,7 @@ def validateDir(path, dirName, nzbNameOriginal, failed, result):  # pylint: disa
             result.output += logHelper(u"{} : Invalid name exception (folder)".format(dirName), logger.DEBUG)
             pass
         except InvalidShowException as e:
-            result.output += logHelper(u"Invalid show exception (folder). Error: {}".format(e), logger.DEBUG)
+            result.output += logHelper(u"Invalid show exception (folder). Error: {}".format(e), logger.WARNING)
             pass
 
     if sickbeard.UNPACK:


### PR DESCRIPTION
@labrys 

as we talked in IRC: there is something wrong going on:
moving the file outiside the folder (to PP root) and erasing the folder it works!

```
Processing folder The.100.S03E03.1080p.HDTV.x264-BRISK[rarbg]
Invalid show exception. Error: Unable to parse The.100.S03E03.1080p.HDTV.x264-BRISK.mkv
Trying to parse folder name as fallback
Invalid show exception (folder). Error: Unable to parse The.100.S03E03.1080p.HDTV.x264-BRISK[rarbg]
The.100.S03E03.1080p.HDTV.x264-BRISK[rarbg] : No processable items found in folder
```
