### PR TITLE
Change width of infoTable to 100% in config.mako

### DIFF
--- a/gui/slick/views/config.mako
+++ b/gui/slick/views/config.mako
@@ -15,7 +15,7 @@
 % endif
 
 <div id="config-content">
-<table class="infoTable" cellspacing="1" border="0" cellpadding="0" width="145%">
+<table class="infoTable" cellspacing="1" border="0" cellpadding="0" width="100%">
     % if sr_version:
     <tr><td class="infoTableHeader" style="vertical-align: top;"><i class="icon16-config-sickrage"></i> SickRage Info:</td>
         <td class="infoTableCell">


### PR DESCRIPTION
Avoids the page being too wide.

@neoatomic
Hope this is okay?
