### PR TITLE
Allow file globs in list of "Sync File Extensions" in postprocessing

### DIFF
--- a/gui/slick/views/config_postProcessing.mako
+++ b/gui/slick/views/config_postProcessing.mako
@@ -103,7 +103,7 @@
                             </label>
                             <label class="nocheck">
                                 <span class="component-title">&nbsp;</span>
-                                <span class="component-desc">comma seperated list of extensions SickRage ignores when Post Processing</span>
+                                <span class="component-desc">comma seperated list of extensions or filename globs SickRage ignores when Post Processing</span>
                             </label>
                         </div>
                         <div class="field-pair">

--- a/sickrage/helper/common.py
+++ b/sickrage/helper/common.py
@@ -21,6 +21,7 @@ from __future__ import unicode_literals
 
 import re
 import sickbeard
+from fnmatch import fnmatch
 
 dateFormat = '%Y-%m-%d'
 dateTimeFormat = '%Y-%m-%d %H:%M:%S'
@@ -135,7 +136,9 @@ def is_sync_file(filename):
     if isinstance(filename, (str, unicode)):
         extension = filename.rpartition('.')[2].lower()
 
-        return extension in sickbeard.SYNC_FILES.split(',') or filename.startswith('.syncthing')
+        return extension in sickbeard.SYNC_FILES.split(',') or \
+            filename.startswith('.syncthing') or \
+            any(fnmatch(filename, match) for match in sickbeard.SYNC_FILES.split(','))
 
     return False
 


### PR DESCRIPTION
I use owncloud to sync files into my SickRage postprocessing watch folder, during transfer the temporary files are named something like:

> foo.mp4.~6c3d207e

or 

> bar.avi.~4fdfdf96 

The common denominator being "_.~_"
As such allowing a file match like above in the setting for postponing processing while sync files are present is needed for my setup.
Hopefully this pull request wouldn't likely cause issues for anyone else?
