### PR TITLE
BTDigg, RARBG, change response= to returns=

### DIFF
--- a/gui/slick/views/config_providers.mako
+++ b/gui/slick/views/config_providers.mako
@@ -60,8 +60,8 @@ $('#config-components').tabs();
                         % endif
 
                         <div>
-                            <p class="note">* Provider does not support backlog searches at this time.</p>
-                            <p class="note">! Provider is <b>NOT WORKING</b>.</p>
+                            <p class="note"><span class="red-text">*</span> Provider does not support backlog searches at this time.</p>
+                            <p class="note"><span class="red-text">!</span> Provider is <b>NOT WORKING</b>.</p>
                         </div>
                     </div>
 
@@ -69,6 +69,8 @@ $('#config-components').tabs();
                         <ul id="provider_order_list">
                         % for curProvider in sickbeard.providers.sortedProviderList():
                             <%
+                                ## These will show the '!' not saying they are broken
+                                broken_providers = {'btdigg'}
                                 if curProvider.provider_type == GenericProvider.NZB and not sickbeard.USE_NZBS:
                                     continue
                                 elif curProvider.provider_type == GenericProvider.TORRENT and not sickbeard.USE_TORRENTS:
@@ -84,7 +86,8 @@ $('#config-components').tabs();
                                 <input type="checkbox" id="enable_${curName}" class="provider_enabler" ${('', 'checked="checked"')[curProvider.is_enabled() is True]}/>
                                 <a href="${anon_url(curURL)}" class="imgLink" rel="noreferrer" onclick="window.open(this.href, '_blank'); return false;"><img src="${srRoot}/images/providers/${curProvider.image_name()}" alt="${curProvider.name}" title="${curProvider.name}" width="16" height="16" style="vertical-align:middle;"/></a>
                                 <span style="vertical-align:middle;">${curProvider.name}</span>
-                                ${('*', '')[bool(curProvider.supports_backlog)]}
+                                ${('<span class="red-text">*</span>', '')[bool(curProvider.supports_backlog)]}
+                                ${('<span class="red-text">!</span>', '')[bool(curProvider.get_id() not in broken_providers)]}
                                 <span class="ui-icon ui-icon-arrowthick-2-n-s pull-right" style="vertical-align:middle;"></span>
                                 <span class="ui-icon ${('ui-icon-locked','ui-icon-unlocked')[bool(curProvider.public)]} pull-right" style="vertical-align:middle;"></span>
                             </li>

--- a/sickbeard/providers/abnormal.py
+++ b/sickbeard/providers/abnormal.py
@@ -69,7 +69,7 @@ class ABNormalProvider(TorrentProvider):  # pylint: disable=too-many-instance-at
             "password": self.password,
         }
 
-        response = self.get_url(self.urls["login"], post_data=login_params, timeout=30, response="text")
+        response = self.get_url(self.urls["login"], post_data=login_params, timeout=30, returns="text")
         if not response:
             logger.log("Unable to connect to provider", logger.WARNING)
             return False
@@ -108,7 +108,7 @@ class ABNormalProvider(TorrentProvider):  # pylint: disable=too-many-instance-at
                                logger.DEBUG)
 
                 search_params["search"] = search_string
-                data = self.get_url(self.urls["search"], params=search_params, response="text")
+                data = self.get_url(self.urls["search"], params=search_params, returns="text")
                 if not data:
                     continue
 

--- a/sickbeard/providers/alpharatio.py
+++ b/sickbeard/providers/alpharatio.py
@@ -71,7 +71,7 @@ class AlphaRatioProvider(TorrentProvider):  # pylint: disable=too-many-instance-
             "remember_me": "on",
         }
 
-        response = self.get_url(self.urls["login"], post_data=login_params, timeout=30, response="text")
+        response = self.get_url(self.urls["login"], post_data=login_params, timeout=30, returns="text")
         if not response:
             logger.log("Unable to connect to provider", logger.WARNING)
             return False
@@ -120,7 +120,7 @@ class AlphaRatioProvider(TorrentProvider):  # pylint: disable=too-many-instance-
 
                 search_params["searchstr"] = search_string
                 search_url = self.urls["search"]
-                data = self.get_url(search_url, params=search_params, response="text")
+                data = self.get_url(search_url, params=search_params, returns="text")
                 if not data:
                     logger.log("No data returned from provider", logger.DEBUG)
                     continue

--- a/sickbeard/providers/bitcannon.py
+++ b/sickbeard/providers/bitcannon.py
@@ -70,7 +70,7 @@ class BitCannonProvider(TorrentProvider):
                     logger.log("Search string: {}".format(search_string), logger.DEBUG)
 
                 search_url = urljoin(url, "api/search")
-                parsed_json = self.get_url(search_url, params=search_params, json=True, response="text")
+                parsed_json = self.get_url(search_url, params=search_params, json=True, returns="text")
                 if not parsed_json:
                     logger.log("No data returned from provider", logger.DEBUG)
                     continue

--- a/sickbeard/providers/btdigg.py
+++ b/sickbeard/providers/btdigg.py
@@ -18,8 +18,9 @@
 # You should have received a copy of the GNU General Public License
 # along with SickRage. If not, see <http://www.gnu.org/licenses/>.
 
-import traceback
-from requests.compat import urlencode
+from __future__ import unicode_literals
+
+from requests.compat import urljoin
 
 from sickbeard import logger, tvcache
 
@@ -35,92 +36,69 @@ class BTDiggProvider(TorrentProvider):
 
         self.public = True
         self.ratio = 0
-        self.urls = {'url': u'https://btdigg.org/',
-                     'api': u'https://api.btdigg.org/api/private-341ada3245790954/s02'}
+        self.url = "https://btdigg.org"
+        self.urls = {"api": urljoin(self.url, "api/private-341ada3245790954/s02")}
 
-        self.proper_strings = ['PROPER', 'REPACK']
-
-        self.url = self.urls['url']
-
-        # # Unsupported
-        # self.minseed = 1
-        # self.minleech = 0
+        self.proper_strings = ["PROPER", "REPACK"]
 
         # Use this hacky way for RSS search since most results will use this codecs
-        params = {'RSS': ['x264', 'x264.HDTV', '720.HDTV.x264']}
+        cache_params = {"RSS": ["x264", "x264.HDTV", "720.HDTV.x264"]}
+
         # Only poll BTDigg every 30 minutes max, since BTDigg takes some time to crawl
-        self.cache = tvcache.TVCache(self, min_time=30, search_params=params)
+        self.cache = tvcache.TVCache(self, min_time=30, search_params=cache_params)
 
     def search(self, search_strings, age=0, ep_obj=None):  # pylint: disable=too-many-locals
         results = []
-        search_params = {'p': 0}
-
+        search_params = {"p": 0}
         for mode in search_strings:
             items = []
-            logger.log(u"Search Mode: {}".format(mode), logger.DEBUG)
+            logger.log("Search Mode: {}".format(mode), logger.DEBUG)
             for search_string in search_strings[mode]:
-                search_params['q'] = search_string
-
-                if mode != 'RSS':
-                    logger.log(u"Search string: {}".format(search_string.decode("utf-8")),
+                search_params["q"] = search_string
+                if mode != "RSS":
+                    search_params["order"] = 0
+                    logger.log("Search string: {}".format(search_string.decode("utf-8")),
                                logger.DEBUG)
-                    search_params['order'] = '0'
                 else:
-                    search_params['order'] = '2'
+                    search_params["order"] = 2
 
-                search_url = self.urls['api'] + '?' + urlencode(search_params)
-                logger.log(u"Search URL: %s" % search_url, logger.DEBUG)
-
-                jdata = self.get_url(search_url, json=True)
+                jdata = self.get_url(self.urls["api"], params=search_params, response="json")
                 if not jdata:
-                    logger.log(u"No data returned to be parsed!!!", logger.DEBUG)
+                    logger.log("Provider did not return data", logger.DEBUG)
                     continue
 
-                try:
-
-                    for torrent in jdata:
-                        if not torrent['name']:
-                            logger.log(u"Ignoring result since it has no name", logger.DEBUG)
+                for torrent in jdata:
+                    try:
+                        title = torrent.pop("name", "")
+                        download_url = torrent.pop("magnet") + self._custom_trackers if torrent["magnet"] else None
+                        if not all([title, download_url]):
                             continue
 
-                        if torrent['ff']:
-                            logger.log(u"Ignoring result for %s since it's a fake (level = %s)" % (torrent['name'], torrent['ff']), logger.DEBUG)
+                        if float(torrent.pop("ff")):
+                            logger.log("Ignoring result for {} since it's been reported as fake (level = {})".format
+                                       (title, torrent["ff"]), logger.DEBUG)
                             continue
 
-                        if not torrent['files']:
-                            logger.log(u"Ignoring result for %s without files" % torrent['name'], logger.DEBUG)
+                        if not int(torrent.pop("files")):
+                            logger.log("Ignoring result for {} because it has no files".format
+                                       (title), logger.DEBUG)
                             continue
-
-                        download_url = torrent['magnet'] + self._custom_trackers if torrent['magnet'] else None
 
                         # Provider doesn't provide seeders/leechers
                         seeders = 1
                         leechers = 0
-                        title = torrent['name']
-                        torrent_size = torrent['size']
+
+                        torrent_size = torrent.pop("size")
                         size = convert_size(torrent_size) or -1
 
-                        if not all([title, download_url]):
-                            continue
-
-                        # Filter unseeded torrent (Unsupported)
-                        # if seeders < self.minseed or leechers < self.minleech:
-                        #     if mode != 'RSS':
-                        #         logger.log(u"Discarding torrent because it doesn't meet the minimum seeders or leechers: {} (S:{} L:{})".format
-                        #                    (title, seeders, leechers), logger.DEBUG)
-                        #     continue
-
                         item = title, download_url, size, seeders, leechers
-                        if mode != 'RSS':
-                            logger.log(u"Found result: %s " % title, logger.DEBUG)
+                        if mode != "RSS":
+                            logger.log("Found result: %s " % title, logger.DEBUG)
 
                         items.append(item)
 
-                except Exception:
-                    logger.log(u"Failed parsing provider. Traceback: %s" % traceback.format_exc(), logger.WARNING)
-
-            # For each search mode sort all the items by seeders if available
-            # items.sort(key=lambda tup: tup[3], reverse=True)
+                    except StandardError:
+                        continue
 
             results += items
 

--- a/sickbeard/providers/btdigg.py
+++ b/sickbeard/providers/btdigg.py
@@ -62,7 +62,7 @@ class BTDiggProvider(TorrentProvider):
                 else:
                     search_params["order"] = 2
 
-                jdata = self.get_url(self.urls["api"], params=search_params, response="json")
+                jdata = self.get_url(self.urls["api"], params=search_params, returns="json")
                 if not jdata:
                     logger.log("Provider did not return data", logger.DEBUG)
                     continue

--- a/sickbeard/providers/kat.py
+++ b/sickbeard/providers/kat.py
@@ -81,7 +81,7 @@ class KatProvider(TorrentProvider):  # pylint: disable=too-many-instance-attribu
                         return results
                     search_url = urljoin(self.custom_url, search_url.split(self.url)[1])
 
-                data = self.get_url(search_url, params=search_params, response="text")
+                data = self.get_url(search_url, params=search_params, returns="text")
                 if not data:
                     logger.log("URL did not return data, maybe try a custom url, or a different one", logger.DEBUG)
                     continue

--- a/sickbeard/providers/thepiratebay.py
+++ b/sickbeard/providers/thepiratebay.py
@@ -102,9 +102,9 @@ class ThePirateBayProvider(TorrentProvider):  # pylint: disable=too-many-instanc
                     logger.log("Search string: {search}".format
                                (search=search_string.decode("utf-8")), logger.DEBUG)
 
-                    data = self.get_url(search_url, params=search_params, response="text")
+                    data = self.get_url(search_url, params=search_params, returns="text")
                 else:
-                    data = self.get_url(search_url, response="text")
+                    data = self.get_url(search_url, returns="text")
 
                 if not data:
                     logger.log("URL did not return data, maybe try a custom url, or a different one", logger.DEBUG)

--- a/sickbeard/providers/torrentbytes.py
+++ b/sickbeard/providers/torrentbytes.py
@@ -69,7 +69,7 @@ class TorrentBytesProvider(TorrentProvider):  # pylint: disable=too-many-instanc
                         "password": self.password,
                         "login": "Log in!"}
 
-        response = self.get_url(self.urls["login"], post_data=login_params, timeout=30, response="text")
+        response = self.get_url(self.urls["login"], post_data=login_params, timeout=30, returns="text")
         if not response:
             logger.log("Unable to connect to provider", logger.WARNING)
             return False
@@ -99,7 +99,7 @@ class TorrentBytesProvider(TorrentProvider):  # pylint: disable=too-many-instanc
                                logger.DEBUG)
 
                 search_params["search"] = search_string
-                data = self.get_url(self.urls["search"], params=search_params, response="text")
+                data = self.get_url(self.urls["search"], params=search_params, returns="text")
                 if not data:
                     logger.log("No data returned from provider", logger.DEBUG)
                     continue

--- a/sickbeard/providers/torrentleech.py
+++ b/sickbeard/providers/torrentleech.py
@@ -71,7 +71,7 @@ class TorrentLeechProvider(TorrentProvider):  # pylint: disable=too-many-instanc
             "remember_me": "on",
         }
 
-        response = self.get_url(self.urls["login"], post_data=login_params, timeout=30, response='text')
+        response = self.get_url(self.urls["login"], post_data=login_params, timeout=30, returns="text")
         if not response:
             logger.log("Unable to connect to provider", logger.WARNING)
             return False
@@ -123,7 +123,7 @@ class TorrentLeechProvider(TorrentProvider):  # pylint: disable=too-many-instanc
                     "query": search_string
                 }
 
-                data = self.get_url(self.urls["search"], params=search_params, response='text')
+                data = self.get_url(self.urls["search"], params=search_params, returns="text")
                 if not data:
                     logger.log("No data returned from provider", logger.DEBUG)
                     continue


### PR DESCRIPTION
- Use unicode_literals, remove u prefixes, use " instead of ' for strings
- Use .format instead of token string formatting throughout
- Pass params to get_url, and specify json response type
- Remove duplicitous logging
- General BTDigg cleanup
- Add ! to config_providers since btdigg api is currently not working.
