### PR TITLE
Use provider's get_url for getting rss feeds instead of urllib/httplib2

### DIFF
--- a/sickbeard/providers/rsstorrent.py
+++ b/sickbeard/providers/rsstorrent.py
@@ -41,8 +41,8 @@ class TorrentRssProvider(TorrentProvider):  # pylint: disable=too-many-instance-
         TorrentProvider.__init__(self, name)
 
         self.cache = TorrentRssCache(self, min_time=15)
-        self.urls = {'base_url': re.sub(r'/$', '', url)}
-        self.url = self.urls['base_url']
+        self.url = url.rstrip('/')
+
         self.ratio = None
         self.supports_backlog = False
 
@@ -206,6 +206,6 @@ class TorrentRssCache(tvcache.TVCache):
         logger.log(u"Cache update URL: %s" % self.provider.url, logger.DEBUG)
 
         if self.provider.cookies:
-            self.provider.headers.update({'Cookie': self.provider.cookies})
+            add_dict_to_cookiejar(self.provider.session.cookies, dict(x.rsplit('=', 1) for x in self.provider.cookies.split(';')))
 
         return self.getRSSFeed(self.provider.url)

--- a/sickbeard/rssfeeds.py
+++ b/sickbeard/rssfeeds.py
@@ -1,18 +1,18 @@
 # coding=utf-8
-import re
-import urlparse
 from feedparser.api import parse
+
 from sickbeard import logger
+
 from sickrage.helper.exceptions import ex
 
 
-def getFeed(url, request_headers=None, handlers=None):
-    parsed = list(urlparse.urlparse(url))
-    parsed[2] = re.sub("/{2,}", "/", parsed[2])  # replace two or more / with one
-
+def getFeed(url, request_hook=None):
     try:
-        feed = parse(url, False, False, request_headers, handlers=handlers)
+        data = request_hook(url, returns='text', timeout=30)
+        if not data:
+            raise
 
+        feed = parse(data, response_headers={'content-type': 'application/xml'})
         if feed:
             if 'entries' in feed:
                 return feed
@@ -21,7 +21,7 @@ def getFeed(url, request_headers=None, handlers=None):
                 err_desc = feed.feed['error']['description']
                 logger.log(u'RSS ERROR:[%s] CODE:[%s]' % (err_desc, err_code), logger.DEBUG)
         else:
-            logger.log(u'RSS error loading url: ' + url, logger.DEBUG)
+            logger.log(u'RSS error loading data: ' + url, logger.DEBUG)
 
     except Exception as e:
         logger.log(u'RSS error: ' + ex(e), logger.DEBUG)

--- a/sickbeard/tvcache.py
+++ b/sickbeard/tvcache.py
@@ -20,14 +20,12 @@
 import time
 import datetime
 import itertools
-import urllib2
 
 import sickbeard
 from sickbeard import db
 from sickbeard import logger
 from sickbeard.rssfeeds import getFeed
 from sickbeard import show_name_helpers
-from sickrage.helper.encoding import ss
 from sickrage.helper.exceptions import AuthException, ex
 from sickrage.show.Show import Show
 from sickbeard.name_parser.parser import NameParser, InvalidNameException, InvalidShowException
@@ -134,21 +132,7 @@ class TVCache(object):
             logger.log(u"Error while searching " + self.provider.name + ", skipping: " + repr(e), logger.DEBUG)
 
     def getRSSFeed(self, url):
-        handlers = []
-
-        if sickbeard.PROXY_SETTING:
-            logger.log(u"Using global proxy for url: " + url, logger.DEBUG)
-            scheme, address = urllib2.splittype(sickbeard.PROXY_SETTING)
-            address = sickbeard.PROXY_SETTING if scheme else 'http://' + sickbeard.PROXY_SETTING
-            handlers = [urllib2.ProxyHandler({'http': address, 'https': address})]
-            self.provider.headers.update({'Referer': address})
-        elif 'Referer' in self.provider.headers:
-            self.provider.headers.pop('Referer')
-
-        return getFeed(
-            url,
-            request_headers=self.provider.headers,
-            handlers=handlers)
+        return getFeed(url, request_hook=self.provider.get_url)
 
     @staticmethod
     def _translateTitle(title):
@@ -276,7 +260,7 @@ class TVCache(object):
             # get quality of release
             quality = parse_result.quality
 
-            name = ss(name)
+            assert isinstance(name, unicode)
 
             # get release group
             release_group = parse_result.release_group


### PR DESCRIPTION
Fixes bozo, and removes old code
Normalizes logging
Ensures proper decoding of feed and returning unicode

@labrys 
