### PR TITLE
Add support for pre-executed scripts in subtitles

### DIFF
--- a/gui/slick/views/config_subtitles.mako
+++ b/gui/slick/views/config_subtitles.mako
@@ -147,6 +147,17 @@ $('#subtitles_dir').fileBrowser({ title: 'Select Subtitles Download Directory' }
                                 </div>
                                 <div class="field-pair">
                                         <label>
+                                        <span class="component-title">Pre Scripts</span>
+                                           <input type="text" name="subtitles_pre_scripts" value="${'|'.join(sickbeard.SUBTITLES_PRE_SCRIPTS)}" class="form-control input-sm input350" autocapitalize="off" />
+                                        </label>
+                                        <label>
+                                        <span class="component-desc">
+                                            <p>Show's media filename is passed as argument for the pre scripts. Pre-scripts are executed before trying to find subtitles from usual sources.</p>
+                                        </span>
+                                        </label>
+                                </div>
+                                <div class="field-pair">
+                                        <label>
                                         <span class="component-title">Extra Scripts</span>
                                            <input type="text" name="subtitles_extra_scripts" value="${'|'.join(sickbeard.SUBTITLES_EXTRA_SCRIPTS)}" class="form-control input-sm input350" autocapitalize="off" />
                                         </label>

--- a/sickbeard/__init__.py
+++ b/sickbeard/__init__.py
@@ -534,6 +534,7 @@ EMBEDDED_SUBTITLES_ALL = False
 SUBTITLES_HEARING_IMPAIRED = False
 SUBTITLES_FINDER_FREQUENCY = 1
 SUBTITLES_MULTI = False
+SUBTITLES_PRE_SCRIPTS = []
 SUBTITLES_EXTRA_SCRIPTS = []
 SUBTITLES_DOWNLOAD_IN_PP = False
 
@@ -630,7 +631,7 @@ def initialize(consoleLogging=True):  # pylint: disable=too-many-locals, too-man
             GUI_NAME, HOME_LAYOUT, HISTORY_LAYOUT, DISPLAY_SHOW_SPECIALS, COMING_EPS_LAYOUT, COMING_EPS_SORT, COMING_EPS_DISPLAY_PAUSED, COMING_EPS_MISSED_RANGE, FUZZY_DATING, TRIM_ZERO, DATE_PRESET, TIME_PRESET, TIME_PRESET_W_SECONDS, THEME_NAME, \
             POSTER_SORTBY, POSTER_SORTDIR, HISTORY_LIMIT, CREATE_MISSING_SHOW_DIRS, ADD_SHOWS_WO_DIR, \
             METADATA_WDTV, METADATA_TIVO, METADATA_MEDE8ER, IGNORE_WORDS, TRACKERS_LIST, IGNORED_SUBS_LIST, REQUIRE_WORDS, CALENDAR_UNPROTECTED, CALENDAR_ICONS, NO_RESTART, \
-            USE_SUBTITLES, SUBTITLES_LANGUAGES, SUBTITLES_DIR, SUBTITLES_SERVICES_LIST, SUBTITLES_SERVICES_ENABLED, SUBTITLES_HISTORY, SUBTITLES_FINDER_FREQUENCY, SUBTITLES_MULTI, SUBTITLES_DOWNLOAD_IN_PP, EMBEDDED_SUBTITLES_ALL, SUBTITLES_EXTRA_SCRIPTS, SUBTITLES_PERFECT_MATCH, subtitlesFinderScheduler, \
+            USE_SUBTITLES, SUBTITLES_LANGUAGES, SUBTITLES_DIR, SUBTITLES_SERVICES_LIST, SUBTITLES_SERVICES_ENABLED, SUBTITLES_HISTORY, SUBTITLES_FINDER_FREQUENCY, SUBTITLES_MULTI, SUBTITLES_DOWNLOAD_IN_PP, EMBEDDED_SUBTITLES_ALL, SUBTITLES_PRE_SCRIPTS, SUBTITLES_EXTRA_SCRIPTS, SUBTITLES_PERFECT_MATCH, subtitlesFinderScheduler, \
             SUBTITLES_HEARING_IMPAIRED, ADDIC7ED_USER, ADDIC7ED_PASS, LEGENDASTV_USER, LEGENDASTV_PASS, OPENSUBTITLES_USER, OPENSUBTITLES_PASS, \
             USE_FAILED_DOWNLOADS, DELETE_FAILED, ANON_REDIRECT, LOCALHOST_IP, DEBUG, DBDEBUG, DEFAULT_PAGE, PROXY_SETTING, PROXY_INDEXERS, \
             AUTOPOSTPROCESSER_FREQUENCY, SHOWUPDATE_HOUR, \
@@ -1186,6 +1187,7 @@ def initialize(consoleLogging=True):  # pylint: disable=too-many-locals, too-man
         SUBTITLES_FINDER_FREQUENCY = check_setting_int(CFG, 'Subtitles', 'subtitles_finder_frequency', 1)
         SUBTITLES_MULTI = bool(check_setting_int(CFG, 'Subtitles', 'subtitles_multi', 1))
         SUBTITLES_DOWNLOAD_IN_PP = bool(check_setting_int(CFG, 'Subtitles', 'subtitles_download_in_pp', 0))
+        SUBTITLES_PRE_SCRIPTS = [x.strip() for x in check_setting_str(CFG, 'Subtitles', 'subtitles_pre_scripts', '').split('|') if x.strip()]
         SUBTITLES_EXTRA_SCRIPTS = [x.strip() for x in check_setting_str(CFG, 'Subtitles', 'subtitles_extra_scripts', '').split('|') if x.strip()]
 
         ADDIC7ED_USER = check_setting_str(CFG, 'Subtitles', 'addic7ed_username', '', censor_log=True)
@@ -2137,6 +2139,7 @@ def save_config():  # pylint: disable=too-many-statements, too-many-branches
     new_config['Subtitles']['subtitles_hearing_impaired'] = int(SUBTITLES_HEARING_IMPAIRED)
     new_config['Subtitles']['subtitles_finder_frequency'] = int(SUBTITLES_FINDER_FREQUENCY)
     new_config['Subtitles']['subtitles_multi'] = int(SUBTITLES_MULTI)
+    new_config['Subtitles']['subtitles_pre_scripts'] = '|'.join(SUBTITLES_PRE_SCRIPTS)
     new_config['Subtitles']['subtitles_extra_scripts'] = '|'.join(SUBTITLES_EXTRA_SCRIPTS)
     new_config['Subtitles']['subtitles_download_in_pp'] = int(SUBTITLES_DOWNLOAD_IN_PP)
     new_config['Subtitles']['addic7ed_username'] = ADDIC7ED_USER

--- a/sickbeard/providers/binsearch.py
+++ b/sickbeard/providers/binsearch.py
@@ -21,7 +21,7 @@
 from __future__ import unicode_literals
 
 import re
-from requests.compat import urlencode, urljoin
+from requests.compat import urljoin
 
 from sickbeard import logger, tvcache
 
@@ -32,10 +32,10 @@ class BinSearchProvider(NZBProvider):
 
     def __init__(self):
 
-        NZBProvider.__init__(self, "BinSearch")
+        NZBProvider.__init__(self, 'BinSearch')
 
-        self.url = "https://www.binsearch.info"
-        self.urls = {"rss": urljoin(self.url, "rss.php")}
+        self.url = 'https://www.binsearch.info'
+        self.urls = {'rss': urljoin(self.url, 'rss.php')}
 
         self.public = True
         self.supports_backlog = False
@@ -45,20 +45,20 @@ class BinSearchProvider(NZBProvider):
 
 class BinSearchCache(tvcache.TVCache):
     def __init__(self, provider_obj, **kwargs):
-        kwargs.pop("search_params", None)  # does not use _getRSSData so strip param from kwargs...
+        kwargs.pop('search_params', None)  # does not use _getRSSData so strip param from kwargs...
         search_params = None  # ...and pass None instead
         tvcache.TVCache.__init__(self, provider_obj, search_params=search_params, **kwargs)
 
         # compile and save our regular expressions
 
         # this pulls the title from the URL in the description
-        self.descTitleStart = re.compile(r"^.*https?://www\.binsearch\.info/.b=")
-        self.descTitleEnd = re.compile("&amp;.*$")
+        self.descTitleStart = re.compile(r'^.*https?://www\.binsearch\.info/.b=')
+        self.descTitleEnd = re.compile('&amp;.*$')
 
         # these clean up the horrible mess of a title if the above fail
         self.titleCleaners = [
-            re.compile(r".?yEnc.?\(\d+/\d+\)$"),
-            re.compile(r" \[\d+/\d+\] "),
+            re.compile(r'.?yEnc.?\(\d+/\d+\)$'),
+            re.compile(r' \[\d+/\d+\] '),
         ]
 
     def _get_title_and_url(self, item):
@@ -70,22 +70,22 @@ class BinSearchCache(tvcache.TVCache):
         Returns: A tuple containing two strings representing title and URL respectively
         """
 
-        title = item.get("description")
+        title = item.get('description')
         if title:
             if self.descTitleStart.match(title):
-                title = self.descTitleStart.sub("", title)
-                title = self.descTitleEnd.sub("", title)
-                title = title.replace("+", ".")
+                title = self.descTitleStart.sub('', title)
+                title = self.descTitleEnd.sub('', title)
+                title = title.replace('+', '.')
             else:
                 # just use the entire title, looks hard/impossible to parse
-                title = item.get("title")
+                title = item.get('title')
                 if title:
                     for titleCleaner in self.titleCleaners:
-                        title = titleCleaner.sub("", title)
+                        title = titleCleaner.sub('', title)
 
-        url = item.get("link")
+        url = item.get('link')
         if url:
-            url = url.replace("&amp;", "&")
+            url = url.replace('&amp;', '&')
 
         return title, url
 
@@ -101,12 +101,14 @@ class BinSearchCache(tvcache.TVCache):
         self.setLastUpdate()
 
         cl = []
-        for group in ["alt.binaries.hdtv", "alt.binaries.hdtv.x264", "alt.binaries.tv", "alt.binaries.tvseries", "alt.binaries.teevee"]:
-            urlArgs = {"max": 50, "g": group}
-            url = self.provider.urls['rss'] + "?" + urlencode(urlArgs)
-            logger.log("Cache update URL: {}".format(url), logger.DEBUG)
+        for group in ['alt.binaries.hdtv', 'alt.binaries.hdtv.x264', 'alt.binaries.tv', 'alt.binaries.tvseries', 'alt.binaries.teevee']:
+            search_params = {'max': 50, 'g': group}
+            data = self.getRSSFeed(self.provider.urls['rss'], search_params)['entries']
+            if not data:
+                logger.log('No data returned from provider', logger.DEBUG)
+                continue
 
-            for item in self.getRSSFeed(url)["entries"] or []:
+            for item in data:
                 ci = self._parseItem(item)
                 if ci:
                     cl.append(ci)
@@ -116,6 +118,6 @@ class BinSearchCache(tvcache.TVCache):
             cache_db_con.mass_action(cl)
 
     def _checkAuth(self, data):
-        return data if data["feed"] and data["feed"]["title"] != "Invalid Link" else None
+        return data if data['feed'] and data['feed']['title'] != 'Invalid Link' else None
 
 provider = BinSearchProvider()

--- a/sickbeard/providers/womble.py
+++ b/sickbeard/providers/womble.py
@@ -18,6 +18,10 @@
 # You should have received a copy of the GNU General Public License
 # along with SickRage. If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import unicode_literals
+
+from requests.compat import urljoin
+
 from sickbeard import logger, tvcache
 
 from sickrage.providers.nzb.NZBProvider import NZBProvider
@@ -27,37 +31,38 @@ class WombleProvider(NZBProvider):
 
     def __init__(self):
 
-        NZBProvider.__init__(self, "Womble's Index")
+        NZBProvider.__init__(self, 'Womble\'s Index')
 
         self.public = True
-        self.cache = WombleCache(self, min_time=15)  # only poll Womble's Index every 15 minutes max
-        self.urls = {'base_url': 'http://newshost.co.za/'}
-        self.url = self.urls['base_url']
+
+        self.url = 'http://newshost.co.za'
+        self.urls = {'rss': urljoin(self.url, 'rss')}
         self.supports_backlog = False
+
+        self.cache = WombleCache(self, min_time=20)
 
 
 class WombleCache(tvcache.TVCache):
     def updateCache(self):
-        # check if we should update
+
         if not self.shouldUpdate():
             return
 
-        # clear cache
         self._clearCache()
-
-        # set updated
         self.setLastUpdate()
 
         cl = []
-        for url in [self.provider.url + 'rss/?sec=tv-x264&fr=false',
-                    self.provider.url + 'rss/?sec=tv-sd&fr=false',
-                    self.provider.url + 'rss/?sec=tv-dvd&fr=false',
-                    self.provider.url + 'rss/?sec=tv-hd&fr=false']:
-            logger.log(u"Cache update URL: %s" % url, logger.DEBUG)
+        search_params_list = [{'sec': 'tv-x264'}, {'sec': 'tv-hd'}, {'sec': 'tv-sd'}, {'sec': 'tv-dvd'}]
+        for search_params in search_params_list:
+            search_params.update({'fr': 'false'})
+            data = self.getRSSFeed(self.provider.urls['rss'], params=search_params)['entries']
+            if not data:
+                logger.log('No data returned from provider', logger.DEBUG)
+                continue
 
-            for item in self.getRSSFeed(url)['entries'] or []:
+            for item in data:
                 ci = self._parseItem(item)
-                if ci is not None:
+                if ci:
                     cl.append(ci)
 
         if len(cl) > 0:

--- a/sickbeard/rssfeeds.py
+++ b/sickbeard/rssfeeds.py
@@ -6,9 +6,9 @@ from sickbeard import logger
 from sickrage.helper.exceptions import ex
 
 
-def getFeed(url, request_hook=None):
+def getFeed(url, params=None, request_hook=None):
     try:
-        data = request_hook(url, returns='text', timeout=30)
+        data = request_hook(url, params=params, returns='text', timeout=30)
         if not data:
             raise
 

--- a/sickbeard/tvcache.py
+++ b/sickbeard/tvcache.py
@@ -131,8 +131,8 @@ class TVCache(object):
         except Exception as e:
             logger.log(u"Error while searching " + self.provider.name + ", skipping: " + repr(e), logger.DEBUG)
 
-    def getRSSFeed(self, url):
-        return getFeed(url, request_hook=self.provider.get_url)
+    def getRSSFeed(self, url, params=None):
+        return getFeed(url, params=params, request_hook=self.provider.get_url)
 
     @staticmethod
     def _translateTitle(title):

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -5091,7 +5091,7 @@ class ConfigSubtitles(Config):
 
     def saveSubtitles(self, use_subtitles=None, subtitles_plugins=None, subtitles_languages=None, subtitles_dir=None, subtitles_perfect_match=None,
                       service_order=None, subtitles_history=None, subtitles_finder_frequency=None, subtitles_download_in_pp=None,
-                      subtitles_multi=None, embedded_subtitles_all=None, subtitles_extra_scripts=None, subtitles_hearing_impaired=None,
+                      subtitles_multi=None, embedded_subtitles_all=None, subtitles_pre_scripts=None, subtitles_extra_scripts=None, subtitles_hearing_impaired=None,
                       addic7ed_user=None, addic7ed_pass=None, legendastv_user=None, legendastv_pass=None, opensubtitles_user=None, opensubtitles_pass=None):
 
         results = []
@@ -5107,6 +5107,7 @@ class ConfigSubtitles(Config):
         sickbeard.SUBTITLES_HEARING_IMPAIRED = config.checkbox_to_value(subtitles_hearing_impaired)
         sickbeard.SUBTITLES_MULTI = config.checkbox_to_value(subtitles_multi)
         sickbeard.SUBTITLES_DOWNLOAD_IN_PP = config.checkbox_to_value(subtitles_download_in_pp)
+        sickbeard.SUBTITLES_PRE_SCRIPTS = [x.strip() for x in subtitles_pre_scripts.split('|') if x.strip()]
         sickbeard.SUBTITLES_EXTRA_SCRIPTS = [x.strip() for x in subtitles_extra_scripts.split('|') if x.strip()]
 
         # Subtitles services

--- a/tests/feedparser_tests.py
+++ b/tests/feedparser_tests.py
@@ -22,7 +22,7 @@ class FeedParserTests(unittest.TestCase):
         """
         Test womble
         """
-        result = womble.cache.getRSSFeed('http://newshost.co.za/rss/?sec=tv-sd&fr=false')
+        result = womble.cache.getRSSFeed(womble.urls['rss'], params={'sec': 'tv-sd', 'fr': 'false'})
         self.assertTrue('entries' in result)
         self.assertTrue('feed' in result)
         for item in result['entries'] or []:


### PR DESCRIPTION
This patch adds new option for pre-executing scripts when searching
subtitles. Filename of media is sent as an argument for the script.

This allows one to use 3rd party utilities to enable even more sources
for subtitles. Or if for some case, one needs to do some pre-processing
before fetching/searching for subtitles.

---

I previously made a feature request for this, but then I decided to share the work by doing it by-myself.

Simple patch adding one more feature that won't hurt and gives users some more possibilities. It's just my opinion, but I was pretty sure that this feature should had existed already a long time ago since I used a lot of time searching for this feature and didn't believe it wasn't already implemented..

It could be made better. It could provide better list of arguments, but at the moment, it already provides enough to allow user to use 3rd party utilities and to know which media file they are about to process.
