### PR TITLE
Create gists as secret instead of public

### DIFF
--- a/sickbeard/logger.py
+++ b/sickbeard/logger.py
@@ -290,7 +290,7 @@ class Logger(object):  # pylint: disable=too-many-instance-attributes
                         if LOGGING_LEVELS[level] == ERROR:
                             paste_data = ''.join(log_data[i:i + 50])
                             if paste_data:
-                                gist = git.get_user().create_gist(True, {'sickrage.log': InputFileContent(paste_data)})
+                                gist = git.get_user().create_gist(False, {'sickrage.log': InputFileContent(paste_data)})
                             break
                     else:
                         gist = 'No ERROR found'


### PR DESCRIPTION
``` python
    def create_gist(self, public, files, description=github.GithubObject.NotSet):
        """
        :calls: `POST /gists <http://developer.github.com/v3/gists>`_
        :param public: bool
        :param files: dict of string to :class:`github.InputFileContent.InputFileContent`
        :param description: string
        :rtype: :class:`github.Gist.Gist`
        """
```

https://github.com/SickRage/SickRage/blob/develop/lib/github/AuthenticatedUser.py#L453
