### PR TITLE
Disable auto pp when postpone if no subs

### DIFF
--- a/gui/slick/views/config_postProcessing.mako
+++ b/gui/slick/views/config_postProcessing.mako
@@ -112,6 +112,8 @@
                                 <span class="component-title">Postpone if no subtitle</span>
                                 <span class="component-desc">Wait to process a file until subtitles are present</span>
                                 <span class="component-desc">Language names are allowed in subtitle filename (en.srt, pt-br.srt, ita.srt, etc.)</span>
+                                <span class="component-desc">&nbsp;</span>
+                                <span class="component-desc"><b>NOTE:</b> Automatic post processor must be disabled</span>
                             </label>
                         </div>
                         <div class="field-pair">

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -4205,6 +4205,8 @@ class ConfigPostProcessing(Config):
         # If 'postpone if no subs' is enabled, we must have SRT in allowed extensions list
         if sickbeard.POSTPONE_IF_NO_SUBS:
             allowed_extensions += ',srt'
+            # Auto PP must be disabled because FINDSUBTITLE thread that calls manual PP (like nzbtomedia)
+            sickbeard.PROCESS_AUTOMATICALLY = 0
         sickbeard.ALLOWED_EXTENSIONS = ','.join({x.strip() for x in allowed_extensions.split(',') if x.strip()})
         sickbeard.NAMING_CUSTOM_ABD = config.checkbox_to_value(naming_custom_abd)
         sickbeard.NAMING_CUSTOM_SPORTS = config.checkbox_to_value(naming_custom_sports)


### PR DESCRIPTION
It works like nzbtomedia
When subtitles are found, postprocessor is called to PP files
