### PR TITLE
Fixes too many threads and VIRT memory

### DIFF
--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -88,8 +88,12 @@ from tornado.routes import route
 from tornado.web import RequestHandler, HTTPError, authenticated
 from tornado.gen import coroutine
 from tornado.ioloop import IOLoop
-from tornado.concurrent import run_on_executor
+
 from concurrent.futures import ThreadPoolExecutor
+from tornado.process import cpu_count
+
+from tornado.concurrent import run_on_executor
+
 from mako.runtime import UNDEFINED
 
 mako_lookup = None
@@ -255,7 +259,7 @@ class WebHandler(BaseHandler):
         super(WebHandler, self).__init__(*args, **kwargs)
         self.io_loop = IOLoop.current()
 
-    executor = ThreadPoolExecutor(50)
+    executor = ThreadPoolExecutor(cpu_count())
 
     @authenticated
     @coroutine


### PR DESCRIPTION
Proposed changes in this pull request:
This fix halves VIRT alloc, to halve it again add:
`export MALLOC_ARENA_MAX=2` (or 1) to your runscript on linux)
- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read [contribution guide](https://github.com/SickRage/SickRage/blob/master/.github/CONTRIBUTING.md)

… export MALLOC_ARENA_MAX=2 (or 1) to your runscript on linux)
