### PR TITLE
prefer tlsv1

### DIFF
--- a/SickBeard.py
+++ b/SickBeard.py
@@ -71,7 +71,7 @@ if sys.version_info < (2, 7):
 # https://mail.python.org/pipermail/python-dev/2014-September/136300.html
 if sys.version_info >= (2, 7, 9):
     import ssl
-    ssl._create_default_https_context = ssl._create_unverified_context  # pylint: disable=protected-access
+    ssl._create_default_https_context = lambda: ssl._create_unverified_context(ssl.PROTOCOL_TLSv1)  # pylint: disable=protected-access
 
 import shutil_custom  # pylint: disable=import-error
 shutil.copyfile = shutil_custom.copyfile_custom


### PR DESCRIPTION
Fixes get requests failing due failed SSL handshake
manifests in sickrage log as 

```
2016-02-27 09:28:10 WARNING  Thread-37 :: Error getting xml for [https://api.example.com/api?apikey=**********&t=caps]
```

debugging in python

before

```
magneto:~# python
Python 2.7.10 (default, Aug 17 2015, 22:55:51)
[GCC 4.3.2] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import urllib2; urllib2.urlopen("https://api.example.com/api?...").read()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  ... snip ...
urllib2.URLError: <urlopen error [SSL: TLSV1_UNRECOGNIZED_NAME] unknown error (_ssl.c:590)>
```

after

```
>>> import ssl; ssl._create_default_https_context = lambda: ssl._create_unverified_context(ssl.PROTOCOL_TLSv1)
>>> import urllib2; urllib2.urlopen("https://api.example.com/api?...").read()
<caps><server appversion="1.0.0" version="0.1" ... snip ...
```
