### PR TITLE
Optional webbrowser

### DIFF
--- a/sickbeard/__init__.py
+++ b/sickbeard/__init__.py
@@ -18,7 +18,6 @@
 # along with SickRage. If not, see <http://www.gnu.org/licenses/>.
 # pylint: disable=too-many-lines
 
-import webbrowser
 import datetime
 import socket
 import os
@@ -2165,6 +2164,13 @@ def save_config():  # pylint: disable=too-many-statements, too-many-branches
 
 
 def launchBrowser(protocol='http', startPort=None, web_root='/'):
+
+    try:
+        import webbrowser
+    except ImportError:
+        logger.log(u"Unable to load the webbrowser module, cannot launch the browser.", logger.WARNING)
+        return
+
     if not startPort:
         startPort = WEB_PORT
 


### PR DESCRIPTION
Proposed changes in this pull request:
Makes the 'webbrowser' dependency only required when actually launching the browser, eg when the sickbeard.LAUNCH_BROWSER option is enabled. By doing so, the webbrowser module is loaded only when the user has checked that setting, and systems where a web browser cannot be found (eg, a NAS) will now compile (and will only log an exception at runtime).
