### PR TITLE
Fix cachecontrol

### DIFF
--- a/sickbeard/clients/generic.py
+++ b/sickbeard/clients/generic.py
@@ -6,7 +6,7 @@ from hashlib import sha1
 from base64 import b16encode, b32decode
 
 import sickbeard
-from sickbeard import logger
+from sickbeard import logger, helpers
 from bencode import bencode, bdecode
 import requests
 import cookielib
@@ -27,7 +27,7 @@ class GenericClient(object):
         self.response = None
         self.auth = None
         self.last_time = time.time()
-        self.session = requests.Session()
+        self.session = helpers.make_session()
         self.session.auth = (self.username, self.password)
         self.session.cookies = cookielib.CookieJar()
 

--- a/sickbeard/helpers.py
+++ b/sickbeard/helpers.py
@@ -58,6 +58,8 @@ from sickrage.helper.encoding import ek
 from sickrage.helper.exceptions import ex
 from sickrage.show.Show import Show
 from cachecontrol import CacheControl
+# from httpcache import CachingHTTPAdapter
+
 from itertools import izip, cycle
 
 import shutil
@@ -1374,6 +1376,14 @@ def _getTempDir():
     return ek(os.path.join, tempfile.gettempdir(), "sickrage-%s" % uid)
 
 
+def make_session():
+    session = requests.Session()
+    # session.mount('http://', CachingHTTPAdapter())
+    # session.mount('http://', CachingHTTPAdapter())
+    session = CacheControl(sess=session, cache_etags=True)
+    return session
+
+
 def _setUpSession(session, headers):
     """
     Returns a session initialized with default cache and parameter settings
@@ -1382,9 +1392,6 @@ def _setUpSession(session, headers):
     :param headers: Headers to pass to session
     :return: session object
     """
-
-    # request session
-    session = CacheControl(sess=session, cache_etags=True)
 
     # request session clear residual referer
     # pylint: disable=superfluous-parens
@@ -1753,7 +1760,7 @@ def getDiskSpaceUsage(diskPath=None):
 
 def getTVDBFromID(indexer_id, indexer):  # pylint:disable=too-many-return-statements
 
-    session = requests.Session()
+    session = make_session()
     tvdb_id = ''
     if indexer == 'IMDB':
         url = "http://www.thetvdb.com/api/GetSeriesByRemoteID.php?imdbid=%s" % indexer_id

--- a/sickbeard/imdbPopular.py
+++ b/sickbeard/imdbPopular.py
@@ -2,7 +2,6 @@
 import re
 import os
 import posixpath
-import requests
 from bs4 import BeautifulSoup
 from datetime import date
 
@@ -25,7 +24,7 @@ class imdbPopular(object):
             'year': '%s,%s' % (date.today().year - 1, date.today().year + 1)
         }
 
-        self.session = requests.Session()
+        self.session = helpers.make_session()
 
     def fetch_popular_shows(self):
         """Get popular show information from IMDB"""

--- a/sickbeard/indexers/indexer_config.py
+++ b/sickbeard/indexers/indexer_config.py
@@ -1,17 +1,19 @@
 # coding=utf-8
 
 from tvdb_api.tvdb_api import Tvdb
-import requests
+from sickbeard import helpers
 
 initConfig = {
-    'valid_languages': ["da", "fi", "nl", "de", "it", "es", "fr", "pl", "hu", "el", "tr",
-                        "ru", "he", "ja", "pt", "zh", "cs", "sl", "hr", "ko", "en", "sv", "no"
-                        ],
-    'langabbv_to_id': {'el': 20, 'en': 7, 'zh': 27,
-                       'it': 15, 'cs': 28, 'es': 16, 'ru': 22, 'nl': 13, 'pt': 26, 'no': 9,
-                       'tr': 21, 'pl': 18, 'fr': 17, 'hr': 31, 'de': 14, 'da': 10, 'fi': 11,
-                       'hu': 19, 'ja': 25, 'he': 24, 'ko': 32, 'sv': 8, 'sl': 30
-                       }
+    'valid_languages': [
+        "da", "fi", "nl", "de", "it", "es", "fr", "pl", "hu", "el", "tr",
+        "ru", "he", "ja", "pt", "zh", "cs", "sl", "hr", "ko", "en", "sv", "no"
+    ],
+    'langabbv_to_id': {
+        'el': 20, 'en': 7, 'zh': 27,
+        'it': 15, 'cs': 28, 'es': 16, 'ru': 22, 'nl': 13, 'pt': 26, 'no': 9,
+        'tr': 21, 'pl': 18, 'fr': 17, 'hr': 31, 'de': 14, 'da': 10, 'fi': 11,
+        'hu': 19, 'ja': 25, 'he': 24, 'ko': 32, 'sv': 8, 'sl': 30
+    }
 }
 
 INDEXER_TVDB = 1
@@ -22,11 +24,12 @@ indexerConfig = {
         'id': INDEXER_TVDB,
         'name': 'theTVDB',
         'module': Tvdb,
-        'api_params': {'apikey': 'F9C450E78D99172E',
-                       'language': 'en',
-                       'useZip': True,
-                       },
-        'session': requests.Session(),
+        'api_params': {
+            'apikey': 'F9C450E78D99172E',
+            'language': 'en',
+            'useZip': True,
+        },
+        'session': helpers.make_session(),
         'trakt_id': 'tvdb_id',
         'xem_origin': 'tvdb',
         'icon': 'thetvdb16.png',

--- a/sickbeard/metadata/helpers.py
+++ b/sickbeard/metadata/helpers.py
@@ -20,9 +20,8 @@
 
 from sickbeard import helpers
 from sickbeard import logger
-import requests
 
-meta_session = requests.Session()
+meta_session = helpers.make_session()
 
 
 def getShowImage(url, imgNum=None):

--- a/sickbeard/network_timezones.py
+++ b/sickbeard/network_timezones.py
@@ -20,7 +20,6 @@
 
 import re
 import datetime
-import requests
 from dateutil import tz
 
 from sickbeard import db
@@ -40,7 +39,7 @@ def update_network_dict():
     """Update timezone information from SR repositories"""
 
     url = 'http://sickrage.github.io/sb_network_timezones/network_timezones.txt'
-    url_data = helpers.getURL(url, session=requests.Session(), returns='text')
+    url_data = helpers.getURL(url, session=helpers.make_session(), returns='text')
     if not url_data:
         logger.log(u'Updating network timezones failed, this can happen from time to time. URL: %s' % url, logger.WARNING)
         load_network_dict()

--- a/sickbeard/notifiers/plex.py
+++ b/sickbeard/notifiers/plex.py
@@ -19,7 +19,6 @@
 # along with SickRage. If not, see <http://www.gnu.org/licenses/>.
 
 import re
-import requests
 try:
     import xml.etree.cElementTree as etree
 except ImportError:
@@ -27,7 +26,7 @@ except ImportError:
 
 import sickbeard
 from sickbeard import logger, common
-from sickbeard.helpers import getURL
+from sickbeard.helpers import getURL, make_session
 
 from sickrage.helper.exceptions import ex
 
@@ -40,7 +39,7 @@ class Notifier(object):
             'X-Plex-Client-Identifier': sickbeard.common.USER_AGENT,
             'X-Plex-Version': '2016.02.10'
         }
-        self.session = requests.Session()
+        self.session = make_session()
 
     @staticmethod
     def _notify_pht(message, title='SickRage', host=None, username=None, password=None, force=False):  # pylint: disable=too-many-arguments

--- a/sickbeard/notifiers/pushbullet.py
+++ b/sickbeard/notifiers/pushbullet.py
@@ -19,11 +19,10 @@
 # along with SickRage. If not, see <http://www.gnu.org/licenses/>.
 
 import json
-import requests
 import traceback
 
 import sickbeard
-from sickbeard import logger
+from sickbeard import logger, helpers
 from sickbeard.common import notifyStrings
 from sickbeard.common import NOTIFY_SNATCH
 from sickbeard.common import NOTIFY_DOWNLOAD
@@ -35,7 +34,7 @@ from sickbeard.common import NOTIFY_SUBTITLE_DOWNLOAD
 
 
 class Notifier(object):
-    session = requests.Session()
+    session = helpers.make_session()
     TEST_EVENT = 'Test'
 
     def __init__(self):

--- a/sickbeard/nzbSplitter.py
+++ b/sickbeard/nzbSplitter.py
@@ -20,7 +20,6 @@
 
 # pylint: disable=line-too-long
 
-import requests  # pylint: disable=import-error
 import re
 
 try:
@@ -150,7 +149,7 @@ def split_result(obj):
     :param obj: to search for results
     :return: a list of episode objects or an empty list
     """
-    url_data = helpers.getURL(obj.url, session=requests.Session(), returns='content')
+    url_data = helpers.getURL(obj.url, session=helpers.make_session(), returns='content')
     if url_data is None:
         logger.log(u"Unable to load url " + obj.url + ", can't download season NZB", logger.ERROR)
         return []

--- a/sickbeard/postProcessor.py
+++ b/sickbeard/postProcessor.py
@@ -421,7 +421,7 @@ class PostProcessor(object):  # pylint: disable=too-many-instance-attributes
                 helpers.copyFile(cur_file_path, new_file_path)
                 helpers.chmodAsParent(new_file_path)
             except (IOError, OSError) as e:
-                logger.log(u"Unable to copy file " + cur_file_path + " to " + new_file_path + ": " + ex(e), logger.ERROR)
+                self._log(u"Unable to copy file " + cur_file_path + " to " + new_file_path + ": " + ex(e), logger.ERROR)
                 raise
 
         self._combined_file_operation(file_path, new_path, new_base_name, associated_files, action=_int_copy,

--- a/sickbeard/scene_exceptions.py
+++ b/sickbeard/scene_exceptions.py
@@ -295,9 +295,7 @@ def _anidb_exceptions_fetcher():
         setLastRefresh('anidb')
     return anidb_exception_dict
 
-
-xem_session = requests.Session()
-
+xem_session = helpers.make_session()
 
 def _xem_exceptions_fetcher():
     if shouldRefresh('xem'):

--- a/sickbeard/showUpdater.py
+++ b/sickbeard/showUpdater.py
@@ -26,7 +26,6 @@ except ImportError:
 
 import time
 import datetime
-import requests
 import threading
 
 import sickbeard
@@ -40,7 +39,7 @@ class ShowUpdater(object):  # pylint: disable=too-few-public-methods
         self.lock = threading.Lock()
         self.amActive = False
 
-        self.session = requests.Session()
+        self.session = helpers.make_session()
 
     def run(self, force=False):  # pylint: disable=unused-argument, too-many-locals, too-many-branches, too-many-statements
 

--- a/sickbeard/versionChecker.py
+++ b/sickbeard/versionChecker.py
@@ -27,7 +27,6 @@ import stat
 import traceback
 import time
 import datetime
-import requests
 import shutil
 import shutil_custom
 
@@ -58,7 +57,7 @@ class CheckVersion(object):
             elif self.install_type == 'source':
                 self.updater = SourceUpdateManager()
 
-        self.session = requests.Session()
+        self.session = helpers.make_session()
 
     def run(self, force=False):
 
@@ -701,7 +700,7 @@ class SourceUpdateManager(UpdateManager):
         self._newest_commit_hash = None
         self._num_commits_behind = 0
 
-        self.session = requests.Session()
+        self.session = helpers.make_session()
 
     @staticmethod
     def _find_installed_branch():

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -2238,7 +2238,7 @@ class HomeChangeLog(Home):
 
     def index(self):
         try:
-            changes = helpers.getURL('http://sickrage.github.io/sickrage-news/CHANGES.md', session=requests.Session(), returns='text')
+            changes = helpers.getURL('http://sickrage.github.io/sickrage-news/CHANGES.md', session=helpers.make_session(), returns='text')
         except Exception:
             logger.log(u'Could not load changes from repo, giving a link!', logger.DEBUG)
             changes = 'Could not load changes from the repo. [Click here for CHANGES.md](http://sickrage.github.io/sickrage-news/CHANGES.md)'

--- a/sickrage/show/recommendations/anidb.py
+++ b/sickrage/show/recommendations/anidb.py
@@ -1,15 +1,16 @@
 # coding=utf-8
-import requests
 from anidbhttp import anidbquery
 from anidbhttp.query import QUERY_HOT
+from sickbeard import helpers
 from sickrage.helper.common import try_int
 
 from recommended import RecommendedShow
 
+
 class AnidbPopular(object):
     def __init__(self):
         self.cache_subfolder = __name__.split('.')[-1] if '.' in __name__ else __name__
-        self.session = requests.Session()
+        self.session = helpers.make_session()
 
     def fetch_latest_hot_shows(self):
         """Get popular show information from IMDB"""
@@ -21,7 +22,7 @@ class AnidbPopular(object):
         for show in shows:
             try:
                 recommended_show = RecommendedShow(show.id, show.titles['x-jat'][0], 1, show.tvdbid, cache_subfolder=self.cache_subfolder,
-                     rating=str(show.ratings['temporary']['rating']), votes=str(try_int(show.ratings['temporary']['count'],0)), image_href=show.url)
+                     rating=str(show.ratings['temporary']['rating']), votes=str(try_int(show.ratings['temporary']['count'], 0)), image_href=show.url)
 
                 # Check cache or get and save image
                 recommended_show.cache_image("http://img7.anidb.net/pics/anime/{0}".format(show.image_path))

--- a/sickrage/show/recommendations/imdb.py
+++ b/sickrage/show/recommendations/imdb.py
@@ -2,7 +2,6 @@
 import re
 import os
 import posixpath
-import requests
 from bs4 import BeautifulSoup
 from datetime import date
 
@@ -25,7 +24,7 @@ class imdbPopular(object):
             'year': '%s,%s' % (date.today().year - 1, date.today().year + 1)
         }
 
-        self.session = requests.Session()
+        self.session = helpers.make_session()
 
     def fetch_popular_shows(self):
         """Get popular show information from IMDB"""

--- a/sickrage/show/recommendations/recommended.py
+++ b/sickrage/show/recommendations/recommended.py
@@ -23,7 +23,6 @@ Recommend shows based on lists from indexers
 
 import os
 import posixpath
-import requests
 
 import sickbeard
 from sickbeard import helpers
@@ -62,7 +61,7 @@ class RecommendedShow(object):
 
         # Check if the show is currently already in the db
         self.show_in_list = self.indexer_id in {show.indexerid for show in sickbeard.showList if show.indexerid}
-        self.session = requests.Session()
+        self.session = helpers.make_session()
 
     def cache_image(self, image_url):
         """
@@ -72,9 +71,9 @@ class RecommendedShow(object):
         """
         if not self.cache_subfolder:
             return
-        
+
         self.image_src = ek(posixpath.join, u'images', self.cache_subfolder, ek(os.path.basename, image_url))
-        
+
         path = ek(os.path.abspath, ek(os.path.join, sickbeard.CACHE_DIR, u'images', self.cache_subfolder))
 
         if not ek(os.path.exists, path):

--- a/tests/torrent_tests.py
+++ b/tests/torrent_tests.py
@@ -31,10 +31,9 @@ sys.path.insert(1, os.path.abspath(os.path.join(os.path.dirname(__file__), '../l
 sys.path.insert(1, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
 from bs4 import BeautifulSoup
-from sickbeard.helpers import getURL
+from sickbeard.helpers import getURL, make_session
 from sickbeard.providers.bitcannon import BitCannonProvider
 from sickbeard.tv import TVEpisode, TVShow
-import requests  # pylint: disable=import-error
 import tests.test_lib as test
 import urlparse
 
@@ -81,7 +80,7 @@ class TorrentBasicTests(test.SickbeardTestDBCase):
         url = 'http://kickass.to/'
         search_url = 'http://kickass.to/usearch/American%20Dad%21%20S08%20-S08E%20category%3Atv/?field=seeders&sorder=desc'
 
-        html = getURL(search_url, session=requests.Session(), returns='text')
+        html = getURL(search_url, session=make_session(), returns='text')
         if not html:
             return
 


### PR DESCRIPTION
Every request in SR was re-initializing the cache, so no request was honoring cachecontrol (like, never has)

This is probably why caching to disk was causing breakage, and also why we are spamming xem.

@thezoggy

Verified the problem with wireshark, verified the fix the same way.
