### PR TITLE
Fix "'NoneType' object has no attribute 'indexerid'" when deleting a show

### DIFF
--- a/sickbeard/show_queue.py
+++ b/sickbeard/show_queue.py
@@ -171,7 +171,7 @@ class ShowQueue(generic_queue.GenericQueue):
 
         # remove other queued actions for this show.
         for item in self.queue:
-            if all([item, item.show, item != self.currentItem, show.indexerid == item.show.indexerid]):
+            if item and item.show and item != self.currentItem and show.indexerid == item.show.indexerid:
                 self.queue.remove(item)
 
         queue_item_obj = QueueItemRemove(show=show, full=full)


### PR DESCRIPTION
When deleting a show while new shows are being added I ran into the following error.

```
2016-02-29 00:14:44 Thread-16 :: Failed doing webui callback: Traceback (most recent call last):
  File "/srv/sickrage/SickRage/sickbeard/webserve.py", line 287, in async_call
    result = function(**kwargs)
  File "/srv/sickrage/SickRage/sickbeard/webserve.py", line 1606, in deleteShow
    error, show = Show.delete(show, full)
  File "/srv/sickrage/SickRage/sickrage/show/Show.py", line 51, in delete
    sickbeard.showQueueScheduler.action.removeShow(show, bool(remove_files))
  File "/srv/sickrage/SickRage/sickbeard/show_queue.py", line 174, in removeShow
    if all([item, item.show, item != self.currentItem, show.indexerid == item.show.indexerid]):
AttributeError: 'NoneType' object has no attribute 'indexerid'
 [4ff8246]
2016-02-29 00:14:22 Thread-15 :: Failed doing webui callback: Traceback (most recent call last):
  File "/srv/sickrage/SickRage/sickbeard/webserve.py", line 287, in async_call
    result = function(**kwargs)
  File "/srv/sickrage/SickRage/sickbeard/webserve.py", line 1606, in deleteShow
    error, show = Show.delete(show, full)
  File "/srv/sickrage/SickRage/sickrage/show/Show.py", line 51, in delete
    sickbeard.showQueueScheduler.action.removeShow(show, bool(remove_files))
  File "/srv/sickrage/SickRage/sickbeard/show_queue.py", line 174, in removeShow
    if all([item, item.show, item != self.currentItem, show.indexerid == item.show.indexerid]):
AttributeError: 'NoneType' object has no attribute 'indexerid'
 [4ff8246]
```

The reason is that the any([...]) check that was being used evaluates all items of the list so that checking `item.show` doesn't do anything to guard against it being None later in the list (when `item.show.indexerid` is used).
