### PR TITLE
Rework how session and request parameters are handled

### DIFF
--- a/sickbeard/helpers.py
+++ b/sickbeard/helpers.py
@@ -1377,80 +1377,58 @@ def _getTempDir():
 
 def make_session():
     session = requests.Session()
-    # session.mount('http://', CachingHTTPAdapter())
-    # session.mount('http://', CachingHTTPAdapter())
-    session = CacheControl(sess=session, cache_etags=True)
-    return session
 
-
-def _setUpSession(session, headers):
-    """
-    Returns a session initialized with default cache and parameter settings
-
-    :param session: session object to (re)use
-    :param headers: Headers to pass to session
-    :return: session object
-    """
-
-    # request session clear residual referer
-    # pylint: disable=superfluous-parens
-    # These extra parens are necessary!
-    if 'Referer' in session.headers and 'Referer' not in (headers or {}):
-        session.headers.pop('Referer')
-
-    # request session headers
     session.headers.update({'User-Agent': USER_AGENT, 'Accept-Encoding': 'gzip,deflate'})
-    if headers:
-        session.headers.update(headers)
 
-    # request session ssl verify
-    session.verify = certifi.old_where() if sickbeard.SSL_VERIFY else False
+    return CacheControl(sess=session, cache_etags=True)
+
+
+def request_defaults(kwargs):
+    hooks = kwargs.pop(u'hooks', None)
+    cookies = kwargs.pop(u'cookies', None)
+    verify = certifi.old_where() if all([sickbeard.SSL_VERIFY, kwargs.pop(u'verify', True)]) else False
 
     # request session proxies
-    if 'Referer' not in session.headers and sickbeard.PROXY_SETTING:
+    if sickbeard.PROXY_SETTING:
         logger.log(u"Using global proxy: " + sickbeard.PROXY_SETTING, logger.DEBUG)
         scheme, address = urllib2.splittype(sickbeard.PROXY_SETTING)
         address = sickbeard.PROXY_SETTING if scheme else 'http://' + sickbeard.PROXY_SETTING
-        session.proxies = {
+        proxies = {
             "http": address,
             "https": address,
         }
-        session.headers.update({'Referer': address})
+    else:
+        proxies = None
 
-    if 'Content-Type' in session.headers:
-        session.headers.pop('Content-Type')
-
-    return session
+    return hooks, cookies, verify, proxies
 
 
-def getURL(url, post_data=None, params=None, headers=None,  # pylint:disable=too-many-arguments, too-many-return-statements, too-many-branches
+def getURL(url, post_data=None, params=None, headers=None,  # pylint:disable=too-many-arguments, too-many-return-statements, too-many-branches, too-many-locals
            timeout=30, session=None, **kwargs):
     """
-    Returns a byte-string retrieved from the url provider.
+    Returns data retrieved from the url provider.
     """
-    response_type = kwargs.pop(u'returns', 'text')
-    hooks = kwargs.pop(u'hooks', None)
-    session = _setUpSession(session, headers)
-
-    if params and isinstance(params, (list, dict)):
-        for param in params:
-            if isinstance(params[param], unicode):
-                params[param] = params[param].encode('utf-8')
-
-    session.params = params
-
     try:
-        # decide if we get or post data to server
-        if post_data:
-            if isinstance(post_data, (list, dict)):
-                for param in post_data:
-                    if isinstance(post_data[param], unicode):
-                        post_data[param] = post_data[param].encode('utf-8')
+        response_type = kwargs.pop(u'returns', 'text')
+        stream = kwargs.pop(u'stream', False)
 
-            session.headers.update({'Content-Type': 'application/x-www-form-urlencoded'})
-            resp = session.post(url, data=post_data, timeout=timeout, allow_redirects=True, verify=session.verify, hooks=hooks)
-        else:
-            resp = session.get(url, timeout=timeout, allow_redirects=True, verify=session.verify, hooks=hooks)
+        hooks, cookies, verify, proxies = request_defaults(kwargs)
+
+        if params and isinstance(params, (list, dict)):
+            for param in params:
+                if isinstance(params[param], unicode):
+                    params[param] = params[param].encode('utf-8')
+
+        if post_data and isinstance(post_data, (list, dict)):
+            for param in post_data:
+                if isinstance(post_data[param], unicode):
+                    post_data[param] = post_data[param].encode('utf-8')
+
+        resp = session.request(
+            'POST' if post_data else 'GET', url, data=post_data, params=params,
+            timeout=timeout, allow_redirects=True, hooks=hooks, stream=stream,
+            headers=headers, cookies=cookies, proxies=proxies, verify=verify
+        )
 
         if not resp.ok:
             logger.log(u"Requested getURL %s returned status code is %s: %s"
@@ -1484,7 +1462,7 @@ def getURL(url, post_data=None, params=None, headers=None,  # pylint:disable=too
     return resp if response_type == u'response' or response_type is None else resp.json() if response_type == u'json' else getattr(resp, response_type, resp)
 
 
-def download_file(url, filename, session=None, headers=None):  # pylint:disable=too-many-return-statements
+def download_file(url, filename, session=None, headers=None, **kwargs):  # pylint:disable=too-many-return-statements
     """
     Downloads a file specified
 
@@ -1495,11 +1473,13 @@ def download_file(url, filename, session=None, headers=None):  # pylint:disable=
     :return: True on success, False on failure
     """
 
-    session = _setUpSession(session, headers)
-    session.stream = True
-
     try:
-        with closing(session.get(url, allow_redirects=True, verify=session.verify)) as resp:
+        hooks, cookies, verify, proxies = request_defaults(kwargs)
+
+        with closing(session.get(url, allow_redirects=True, stream=True,
+                                 verify=verify, headers=headers, cookies=cookies,
+                                 hooks=hooks, proxies=proxies)) as resp:
+
             if not resp.ok:
                 logger.log(u"Requested download url %s returned status code is %s: %s"
                            % (url, resp.status_code, http_code_description(resp.status_code)), logger.DEBUG)
@@ -1519,7 +1499,7 @@ def download_file(url, filename, session=None, headers=None):  # pylint:disable=
     except (SocketTimeout, TypeError) as e:
         remove_file_failed(filename)
         logger.log(u"Connection timed out (sockets) while loading download URL %s Error: %r" % (url, ex(e)), logger.WARNING)
-        return None
+        return False
     except (requests.exceptions.HTTPError, requests.exceptions.TooManyRedirects) as e:
         remove_file_failed(filename)
         logger.log(u"HTTP error %r while loading download URL %s " % (ex(e), url), logger.WARNING)

--- a/sickbeard/providers/bitcannon.py
+++ b/sickbeard/providers/bitcannon.py
@@ -47,7 +47,7 @@ class BitCannonProvider(TorrentProvider):
 
         url = "http://localhost:3000/"
         if self.custom_url:
-            if not validators.url(self.custom_url):
+            if not validators.url(self.custom_url, require_tld=False):
                 logger.log("Invalid custom url set, please check your settings", logger.WARNING)
                 return results
             url = self.custom_url

--- a/sickbeard/providers/newznab.py
+++ b/sickbeard/providers/newznab.py
@@ -333,13 +333,13 @@ class NewznabProvider(NZBProvider):  # pylint: disable=too-many-instance-attribu
                             title = item.title.get_text(strip=True)
                             download_url = None
                             if item.link:
-                                if validators.url(item.link.get_text(strip=True)):
+                                if validators.url(item.link.get_text(strip=True), require_tld=False):
                                     download_url = item.link.get_text(strip=True)
-                                elif validators.url(item.link.next.strip()):
+                                elif validators.url(item.link.next.strip(), require_tld=False):
                                     download_url = item.link.next.strip()
 
                             if not download_url and item.enclosure:
-                                if validators.url(item.enclosure.get('url', '').strip()):
+                                if validators.url(item.enclosure.get('url', '').strip(), require_tld=False):
                                     download_url = item.enclosure.get('url', '').strip()
 
                             if not (title and download_url):

--- a/sickbeard/providers/transmitthenet.py
+++ b/sickbeard/providers/transmitthenet.py
@@ -138,7 +138,7 @@ class TransmitTheNetProvider(TorrentProvider):  # pylint: disable=too-many-insta
                             if not download_item:
                                 continue
 
-                            download_url = urljoin(self.urls, download_item['href'])
+                            download_url = urljoin(self.url, download_item['href'])
 
                             temp_anchor = torrent_row.find('a', {"data-src": True})
                             title = temp_anchor['data-src'].rsplit('.', 1)[0]

--- a/sickrage/providers/GenericProvider.py
+++ b/sickrage/providers/GenericProvider.py
@@ -93,7 +93,7 @@ class GenericProvider(object):  # pylint: disable=too-many-instance-attributes
             if url.endswith(GenericProvider.TORRENT) and filename.endswith(GenericProvider.NZB):
                 filename = replace_extension(filename, GenericProvider.TORRENT)
 
-            if download_file(url, filename, session=self.session, headers=self.headers):
+            if download_file(url, filename, session=self.session, headers=self.headers, hooks={'response': self.get_url_hook}):
                 if self._verify_download(filename):
                     logger.log(u'Saved result to %s' % filename, logger.INFO)
                     return True


### PR DESCRIPTION
- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read [contribution guide](https://github.com/SickRage/SickRage/blob/master/.github/CONTRIBUTING.md)

Prevents residual params in the session
Prevents session getting stuck in stream mode
Allows ssl_verify to be disabled without a restart
Allows passing verify as a kwarg to disable it on a per request basis
Allows passing headers without contaminating the session
Removes old code from glype that was poisoning the session/headers/proxies
