### PR TITLE
Updated "Sync File Extension" list for qBittorrent

### DIFF
--- a/sickbeard/__init__.py
+++ b/sickbeard/__init__.py
@@ -559,7 +559,7 @@ TRACKERS_LIST += "udp://9.rarbg.to:2710/announce"
 
 REQUIRE_WORDS = ""
 IGNORED_SUBS_LIST = "dk,fin,heb,kor,nor,nordic,pl,swe"
-SYNC_FILES = "!sync,lftp-pget-status,part,bts,!qb"
+SYNC_FILES = "!sync,lftp-pget-status,part,bts,!qb,!qB"
 
 CALENDAR_UNPROTECTED = False
 CALENDAR_ICONS = False


### PR DESCRIPTION
**Fixes**:  "_Sync File Extensions_" missing value for qBitTorrent 3.3.x

**Proposed changes in this pull request**:
- added extension "!qB" to the pre-filled field "Sync File Extensions" under Post-Processing tab.

Newer versions of qBittorrent use “!qB” as temporary file extension for incomplete files but the field comes precompiled with the previous “!qb” extension: the new extension has been added to help users of qbittorrent 3.x.x.

(old extension "!qb" has not been removed to assure backwards compatibility)
