### PR TITLE
 Add custom notification email subject for more privacy

### DIFF
--- a/gui/slick/views/config_notifications.mako
+++ b/gui/slick/views/config_notifications.mako
@@ -1843,6 +1843,17 @@
                                 </label>
                             </div>
                             <div class="field-pair">
+                                <label for="email_subject">
+                                    <span class="component-title">Email Subject</span>
+                                    <input type="text" name="email_subject" id="email_subject" value="${sickbeard.EMAIL_SUBJECT}" class="form-control input-sm input350" autocapitalize="off" />
+                                </label>
+                                <label>
+                                    <span class="component-title">&nbsp;</span>
+                                    <span class="component-desc">Use a custom subject for some privacy protection?<br>
+                                                                 (Leave blank for the default SickRage subject)</span>
+                                </label>
+                            </div>
+                            <div class="field-pair">
                                 <label for="email_show">
                                     <span class="component-title">Show notification list</span>
                                     <select name="email_show" id="email_show" class="form-control input-sm">

--- a/sickbeard/__init__.py
+++ b/sickbeard/__init__.py
@@ -503,6 +503,7 @@ EMAIL_USER = None
 EMAIL_PASSWORD = None
 EMAIL_FROM = None
 EMAIL_LIST = None
+EMAIL_SUBJECT = None
 
 GUI_NAME = None
 HOME_LAYOUT = None
@@ -625,7 +626,7 @@ def initialize(consoleLogging=True):  # pylint: disable=too-many-locals, too-man
             USE_PUSHOVER, PUSHOVER_USERKEY, PUSHOVER_APIKEY, PUSHOVER_DEVICE, PUSHOVER_NOTIFY_ONDOWNLOAD, PUSHOVER_NOTIFY_ONSUBTITLEDOWNLOAD, PUSHOVER_NOTIFY_ONSNATCH, PUSHOVER_SOUND, \
             USE_LIBNOTIFY, LIBNOTIFY_NOTIFY_ONSNATCH, LIBNOTIFY_NOTIFY_ONDOWNLOAD, LIBNOTIFY_NOTIFY_ONSUBTITLEDOWNLOAD, USE_NMJ, NMJ_HOST, NMJ_DATABASE, NMJ_MOUNT, USE_NMJv2, NMJv2_HOST, NMJv2_DATABASE, NMJv2_DBLOC, USE_SYNOINDEX, \
             USE_SYNOLOGYNOTIFIER, SYNOLOGYNOTIFIER_NOTIFY_ONSNATCH, SYNOLOGYNOTIFIER_NOTIFY_ONDOWNLOAD, SYNOLOGYNOTIFIER_NOTIFY_ONSUBTITLEDOWNLOAD, \
-            USE_EMAIL, EMAIL_HOST, EMAIL_PORT, EMAIL_TLS, EMAIL_USER, EMAIL_PASSWORD, EMAIL_FROM, EMAIL_NOTIFY_ONSNATCH, EMAIL_NOTIFY_ONDOWNLOAD, EMAIL_NOTIFY_ONSUBTITLEDOWNLOAD, EMAIL_LIST, \
+            USE_EMAIL, EMAIL_HOST, EMAIL_PORT, EMAIL_TLS, EMAIL_USER, EMAIL_PASSWORD, EMAIL_FROM, EMAIL_NOTIFY_ONSNATCH, EMAIL_NOTIFY_ONDOWNLOAD, EMAIL_NOTIFY_ONSUBTITLEDOWNLOAD, EMAIL_LIST, EMAIL_SUBJECT, \
             USE_LISTVIEW, METADATA_KODI, METADATA_KODI_12PLUS, METADATA_MEDIABROWSER, METADATA_PS3, metadata_provider_dict, \
             NEWZBIN, NEWZBIN_USERNAME, NEWZBIN_PASSWORD, GIT_PATH, MOVE_ASSOCIATED_FILES, SYNC_FILES, POSTPONE_IF_SYNC_FILES, POSTPONE_IF_NO_SUBS, dailySearchScheduler, NFO_RENAME, \
             GUI_NAME, HOME_LAYOUT, HISTORY_LAYOUT, DISPLAY_SHOW_SPECIALS, COMING_EPS_LAYOUT, COMING_EPS_SORT, COMING_EPS_DISPLAY_PAUSED, COMING_EPS_MISSED_RANGE, FUZZY_DATING, TRIM_ZERO, DATE_PRESET, TIME_PRESET, TIME_PRESET_W_SECONDS, THEME_NAME, \
@@ -1168,6 +1169,7 @@ def initialize(consoleLogging=True):  # pylint: disable=too-many-locals, too-man
         EMAIL_PASSWORD = check_setting_str(CFG, 'Email', 'email_password', '', censor_log=True)
         EMAIL_FROM = check_setting_str(CFG, 'Email', 'email_from', '')
         EMAIL_LIST = check_setting_str(CFG, 'Email', 'email_list', '')
+        EMAIL_SUBJECT = check_setting_str(CFG, 'Email', 'email_subject', '')
 
         USE_SUBTITLES = bool(check_setting_int(CFG, 'Subtitles', 'use_subtitles', 0))
         SUBTITLES_LANGUAGES = check_setting_str(CFG, 'Subtitles', 'subtitles_languages', '').split(',')
@@ -2116,6 +2118,7 @@ def save_config():  # pylint: disable=too-many-statements, too-many-branches
     new_config['Email']['email_password'] = helpers.encrypt(EMAIL_PASSWORD, ENCRYPTION_VERSION)
     new_config['Email']['email_from'] = EMAIL_FROM
     new_config['Email']['email_list'] = EMAIL_LIST
+    new_config['Email']['email_subject'] = EMAIL_SUBJECT
 
     new_config['Newznab'] = {}
     new_config['Newznab']['newznab_data'] = NEWZNAB_DATA

--- a/sickbeard/notifiers/emailnotify.py
+++ b/sickbeard/notifiers/emailnotify.py
@@ -46,7 +46,11 @@ class Notifier(object):
 
     def test_notify(self, host, port, smtp_from, use_tls, user, pwd, to):  # pylint: disable=too-many-arguments
         msg = MIMEText('This is a test message from SickRage.  If you\'re reading this, the test succeeded.')
-        msg[b'Subject'] = 'SickRage: Test Message'
+        if sickbeard.EMAIL_SUBJECT:
+            msg[b'Subject'] = '[TEST] ' + sickbeard.EMAIL_SUBJECT
+        else:
+            msg[b'Subject'] = 'SickRage: Test Message'
+
         msg[b'From'] = smtp_from
         msg[b'To'] = to
         msg[b'Date'] = formatdate(localtime=True)
@@ -85,7 +89,10 @@ class Notifier(object):
                     except Exception:
                         msg = MIMEText('Episode Snatched')
 
-                msg[b'Subject'] = 'Snatched: ' + ep_name
+                if sickbeard.EMAIL_SUBJECT:
+                    msg[b'Subject'] = '[SN] ' + sickbeard.EMAIL_SUBJECT
+                else:
+                    msg[b'Subject'] = 'Snatched: ' + ep_name
                 msg[b'From'] = sickbeard.EMAIL_FROM
                 msg[b'To'] = ','.join(to)
                 msg[b'Date'] = formatdate(localtime=True)
@@ -128,7 +135,10 @@ class Notifier(object):
                     except Exception:
                         msg = MIMEText('Episode Downloaded')
 
-                msg[b'Subject'] = 'Downloaded: ' + ep_name
+                if sickbeard.EMAIL_SUBJECT:
+                    msg[b'Subject'] = '[DL] ' + sickbeard.EMAIL_SUBJECT
+                else:
+                    msg[b'Subject'] = 'Downloaded: ' + ep_name
                 msg[b'From'] = sickbeard.EMAIL_FROM
                 msg[b'To'] = ','.join(to)
                 msg[b'Date'] = formatdate(localtime=True)
@@ -171,7 +181,10 @@ class Notifier(object):
                     except Exception:
                         msg = MIMEText('Episode Subtitle Downloaded')
 
-                msg[b'Subject'] = lang + ' Subtitle Downloaded: ' + ep_name
+                if sickbeard.EMAIL_SUBJECT:
+                    msg[b'Subject'] = '[ST] ' + sickbeard.EMAIL_SUBJECT
+                else:
+                    msg[b'Subject'] = lang + ' Subtitle Downloaded: ' + ep_name
                 msg[b'From'] = sickbeard.EMAIL_FROM
                 msg[b'To'] = ','.join(to)
                 if self._sendmail(sickbeard.EMAIL_HOST, sickbeard.EMAIL_PORT, sickbeard.EMAIL_FROM, sickbeard.EMAIL_TLS,

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -4902,7 +4902,7 @@ class ConfigNotifications(Config):
                           pushbullet_device_list=None,
                           use_email=None, email_notify_onsnatch=None, email_notify_ondownload=None,
                           email_notify_onsubtitledownload=None, email_host=None, email_port=25, email_from=None,
-                          email_tls=None, email_user=None, email_password=None, email_list=None, email_show_list=None,
+                          email_tls=None, email_user=None, email_password=None, email_list=None, email_subject=None, email_show_list=None,
                           email_show=None):
 
         results = []
@@ -5041,6 +5041,7 @@ class ConfigNotifications(Config):
         sickbeard.EMAIL_USER = email_user
         sickbeard.EMAIL_PASSWORD = email_password
         sickbeard.EMAIL_LIST = email_list
+        sickbeard.EMAIL_SUBJECT = email_subject
 
         sickbeard.USE_PYTIVO = config.checkbox_to_value(use_pytivo)
         sickbeard.PYTIVO_NOTIFY_ONSNATCH = config.checkbox_to_value(pytivo_notify_onsnatch)


### PR DESCRIPTION
Proposed changes in this pull request:
- add an input-field for a custom email notification text in email notification settings for more privacy
- default behaviour with blank custom subject
- prefixes for custom subject: 
  - [SN] for snatched
  - [DL] for downloaded
  - [ST] for subtitle downloaded

rework of master PR: 
closes #1114
