### PR TITLE
Fix commit hash update notifications when using source install.

### DIFF
--- a/sickbeard/versionChecker.py
+++ b/sickbeard/versionChecker.py
@@ -641,7 +641,7 @@ class GitUpdateManager(UpdateManager):
                 # Notify update successful
                 if sickbeard.NOTIFY_ON_UPDATE:
                     try:
-                        notifiers.notify_git_update(sickbeard.CUR_COMMIT_HASH if sickbeard.CUR_COMMIT_HASH else "")
+                        notifiers.notify_git_update(sickbeard.CUR_COMMIT_HASH or "")
                     except Exception:
                         logger.log(u"Unable to send update notification. Continuing the update process", logger.DEBUG)
                 return True
@@ -892,7 +892,7 @@ class SourceUpdateManager(UpdateManager):
 
         # Notify update successful
         try:
-            notifiers.notify_git_update(sickbeard.NEWEST_VERSION_STRING)
+            notifiers.notify_git_update(sickbeard.CUR_COMMIT_HASH or "")
         except Exception:
             logger.log(u"Unable to send update notification. Continuing the update process", logger.DEBUG)
         return True


### PR DESCRIPTION
- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read [contribution guide](https://github.com/SickRage/SickRage/blob/master/.github/CONTRIBUTING.md)

Fixes https://github.com/SickRage/sickrage-issues/issues/1118

Add diff url in pushbullet update notification in the documented way.
