### PR TITLE
Why would we need to offset datetime.datetime.now() to the current tz…

### DIFF
--- a/sickbeard/dailysearcher.py
+++ b/sickbeard/dailysearcher.py
@@ -56,7 +56,7 @@ class DailySearcher(object):  # pylint:disable=too-few-public-methods
         else:
             curDate = (datetime.date.today() + datetime.timedelta(days=2)).toordinal()
 
-        curTime = datetime.datetime.now(network_timezones.sb_timezone)
+        curTime = datetime.datetime.now()
 
         main_db_con = db.DBConnection()
         sql_results = main_db_con.select("SELECT showid, airdate, season, episode FROM tv_episodes WHERE status = ? AND (airdate <= ? and airdate > 1)",


### PR DESCRIPTION
- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read [contribution guide](https://github.com/SickRage/SickRage/blob/master/.github/CONTRIBUTING.md)

…, when now() is already the current tz? ofc 0 == 1440 == 24 hours...

Fixes https://github.com/SickRage/sickrage-issues/issues/1208
