### PR TITLE
Fix download link on transmithenet

### DIFF
--- a/sickbeard/providers/transmitthenet.py
+++ b/sickbeard/providers/transmitthenet.py
@@ -134,8 +134,17 @@ class TransmitTheNetProvider(TorrentProvider):  # pylint: disable=too-many-insta
                             if self.freeleech and not freeleech:
                                 continue
 
+                            #Normal Download Link
                             download_item = torrent_row.find('a', {'title': 'Download Torrent'})
+                            
                             if not download_item:
+                                #If the user has downloaded it
+                                download_item = torrent_row.find('a', {'title': 'Previously Grabbed Torrent File'})
+                            if not download_item:
+                                #If the user is seeding
+                                download_item = torrent_row.find('a', {'title': 'Currently Seeding Torrent'})
+                            if not download_item:
+                                #If there are none
                                 continue
 
                             download_url = urljoin(self.url, download_item['href'])


### PR DESCRIPTION
Since the site supports autodl now it,it causes users to not get any results if autodl had downloaded it them.
## Proposed changes in this pull request:
## 
## 
- [ ] PR is based on the DEVELOP branch
- [ ] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [ ] Read [contribution guide](https://github.com/SickRage/SickRage/blob/master/.github/CONTRIBUTING.md)
