### PR TITLE
Avoid `None` as a redundant second argument to `dict.get()`

### DIFF
--- a/sickbeard/providers/rarbg.py
+++ b/sickbeard/providers/rarbg.py
@@ -69,7 +69,7 @@ class RarbgProvider(TorrentProvider):  # pylint: disable=too-many-instance-attri
             logger.log("Unable to connect to provider", logger.WARNING)
             return False
 
-        self.token = response.get("token", None)
+        self.token = response.get("token")
         self.token_expires = datetime.datetime.now() + datetime.timedelta(minutes=14) if self.token else None
         return self.token is not None
 

--- a/sickbeard/providers/torrentday.py
+++ b/sickbeard/providers/torrentday.py
@@ -47,7 +47,7 @@ class TorrentDayProvider(TorrentProvider):  # pylint: disable=too-many-instance-
         # URLs
         self.url = 'https://classic.torrentday.com'
         self.urls = {
-            'login': urljoin(self.url, '/torrents/'),
+            'login': urljoin(self.url, '/t'),
             'search': urljoin(self.url, '/V3/API/API.php'),
             'download': urljoin(self.url, '/download.php/')
         }

--- a/sickbeard/traktChecker.py
+++ b/sickbeard/traktChecker.py
@@ -527,10 +527,10 @@ class TraktChecker(object):
                 tvdb = False
                 tvrage = False
 
-                if not watchlist_el['show']['ids']["tvdb"] is None:
+                if watchlist_el['show']['ids']["tvdb"] is not None:
                     tvdb = True
 
-                if not watchlist_el['show']['ids']["tvrage"] is None:
+                if watchlist_el['show']['ids']["tvrage"] is not None:
                     tvrage = True
 
                 title = watchlist_el['show']['title']
@@ -562,10 +562,10 @@ class TraktChecker(object):
                 tvdb = False
                 tvrage = False
 
-                if not watchlist_el['show']['ids']["tvdb"] is None:
+                if watchlist_el['show']['ids']["tvdb"] is not None:
                     tvdb = True
 
-                if not watchlist_el['show']['ids']["tvrage"] is None:
+                if watchlist_el['show']['ids']["tvrage"] is not None:
                     tvrage = True
 
                 title = watchlist_el['show']['title']
@@ -616,10 +616,10 @@ class TraktChecker(object):
                 tvdb = False
                 tvrage = False
 
-                if not watchlist_el['show']['ids']["tvdb"] is None:
+                if watchlist_el['show']['ids']["tvdb"] is not None:
                     tvdb = True
 
-                if not watchlist_el['show']['ids']["tvrage"] is None:
+                if watchlist_el['show']['ids']["tvrage"] is not None:
                     tvrage = True
 
                 title = watchlist_el['show']['title']

--- a/sickrage/helper/common.py
+++ b/sickrage/helper/common.py
@@ -118,7 +118,7 @@ def http_code_description(http_code):
     :return: The description of the provided ``http_code``
     """
 
-    description = http_status_code.get(try_int(http_code), None)
+    description = http_status_code.get(try_int(http_code))
 
     if isinstance(description, list):
         return '({0!s})'.format(', '.join(description))


### PR DESCRIPTION
- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read [contribution guide](https://github.com/SickRage/SickRage/blob/master/.github/CONTRIBUTING.md)
