### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/lib/MultipartPostHandler.py
+++ b/lib/MultipartPostHandler.py
@@ -46,10 +46,10 @@ class MultipartPostHandler(urllib2.BaseHandler):
                 data = urllib.urlencode(v_vars, doseq)
             else:
                 boundary, data = MultipartPostHandler.multipart_encode(v_vars, v_files)
-                contenttype = 'multipart/form-data; boundary=%s' % boundary
+                contenttype = 'multipart/form-data; boundary={0!s}'.format(boundary)
                 if(request.has_header('Content-Type')
                    and request.get_header('Content-Type').find('multipart/form-data') != 0):
-                    print "Replacing %s with %s" % (request.get_header('content-type'), 'multipart/form-data')
+                    print "Replacing {0!s} with {1!s}".format(request.get_header('content-type'), 'multipart/form-data')
                 request.add_unredirected_header('Content-Type', contenttype)
 
             request.add_data(data)
@@ -62,8 +62,8 @@ class MultipartPostHandler(urllib2.BaseHandler):
         if buffer is None:
             buffer = ''
         for(key, value) in vars:
-            buffer += '--%s\r\n' % boundary
-            buffer += 'Content-Disposition: form-data; name="%s"' % key
+            buffer += '--{0!s}\r\n'.format(boundary)
+            buffer += 'Content-Disposition: form-data; name="{0!s}"'.format(key)
             buffer += '\r\n\r\n' + value + '\r\n'
         for(key, fd) in files:
             
@@ -77,12 +77,12 @@ class MultipartPostHandler(urllib2.BaseHandler):
                 
             filename = os.path.basename(name_in)
             contenttype = mimetypes.guess_type(filename)[0] or 'application/octet-stream'
-            buffer += '--%s\r\n' % boundary
-            buffer += 'Content-Disposition: form-data; name="%s"; filename="%s"\r\n' % (key, filename)
-            buffer += 'Content-Type: %s\r\n' % contenttype
+            buffer += '--{0!s}\r\n'.format(boundary)
+            buffer += 'Content-Disposition: form-data; name="{0!s}"; filename="{1!s}"\r\n'.format(key, filename)
+            buffer += 'Content-Type: {0!s}\r\n'.format(contenttype)
             # buffer += 'Content-Length: %s\r\n' % file_size
             buffer += '\r\n' + data_in + '\r\n'
-        buffer += '--%s--\r\n\r\n' % boundary
+        buffer += '--{0!s}--\r\n\r\n'.format(boundary)
         return boundary, buffer
 
     https_request = http_request

--- a/lib/adba/aniDBAbstracter.py
+++ b/lib/adba/aniDBAbstracter.py
@@ -183,7 +183,7 @@ class Anime(aniDBabstractObject):
             self.allAnimeXML = read_anidb_xml()
 
         regex = re.compile(
-            '( \(\d{4}\))|[%s]' % re.escape(string.punctuation))  # remove any punctuation and e.g. ' (2011)'
+            '( \(\d{{4}}\))|[{0!s}]'.format(re.escape(string.punctuation)))  # remove any punctuation and e.g. ' (2011)'
         #regex = re.compile('[%s]'  % re.escape(string.punctuation)) # remove any punctuation and e.g. ' (2011)'
         name = regex.sub('', name.lower())
         lastAid = 0

--- a/lib/adba/aniDBcommands.py
+++ b/lib/adba/aniDBcommands.py
@@ -34,7 +34,7 @@ class Command:
         self.waiter.acquire()
 
     def __repr__(self):
-        return "Command(%s,%s) %s\n%s\n" % (repr(self.tag), repr(self.command), repr(self.parameters), self.raw_data())
+        return "Command({0!s},{1!s}) {2!s}\n{3!s}\n".format(repr(self.tag), repr(self.command), repr(self.parameters), self.raw_data())
 
     def authorize(self, mode, tag, session, callback):
         self.mode = mode
@@ -60,7 +60,7 @@ class Command:
         for key, value in parameters.iteritems():
             if value == None:
                 continue
-            tmp.append("%s=%s" % (self.escape(key), self.escape(value)))
+            tmp.append("{0!s}={1!s}".format(self.escape(key), self.escape(value)))
         return ' '.join([command, '&'.join(tmp)])
 
     def escape(self, data):

--- a/lib/adba/aniDBlink.py
+++ b/lib/adba/aniDBlink.py
@@ -92,7 +92,7 @@ class AniDBLink(threading.Thread):
                 self._handle_timeouts()
 
                 continue
-            self.log("NetIO < %s" % repr(data))
+            self.log("NetIO < {0!s}".format(repr(data)))
             try:
                 for i in range(2):
                     try:
@@ -100,7 +100,7 @@ class AniDBLink(threading.Thread):
                         resp = None
                         if tmp[:2] == '\x00\x00':
                             tmp = zlib.decompressobj().decompress(tmp[2:])
-                            self.log("UnZip | %s" % repr(tmp))
+                            self.log("UnZip | {0!s}".format(repr(tmp)))
                         resp = ResponseResolver(tmp)
                     except:
                         sys.excepthook(*sys.exc_info())
@@ -200,14 +200,14 @@ class AniDBLink(threading.Thread):
         if command.command == 'AUTH' and self.logPrivate:
             self.log("NetIO > sensitive data is not logged!")
         else:
-            self.log("NetIO > %s" % repr(data))
+            self.log("NetIO > {0!s}".format(repr(data)))
 
     def new_tag(self):
         if not len(self.tags):
             maxtag = "T000"
         else:
             maxtag = max(self.tags)
-        newtag = "T%03d" % (int(maxtag[1:]) + 1)
+        newtag = "T{0:03d}".format((int(maxtag[1:]) + 1))
         return newtag
 
     def request(self, command):

--- a/lib/adba/aniDBresponses.py
+++ b/lib/adba/aniDBresponses.py
@@ -59,7 +59,7 @@ class Response:
         self.maper = AniDBMaper()
 
     def __repr__(self):
-        tmp = "%s(%s,%s,%s) %s\n" % (
+        tmp = "{0!s}({1!s},{2!s},{3!s}) {4!s}\n".format(
         self.__class__.__name__, repr(self.restag), repr(self.rescode), repr(self.resstr), repr(self.attrs))
 
         m = 0
@@ -71,7 +71,7 @@ class Response:
         for line in self.datalines:
             tmp += "  Line:\n"
             for k, v in line.iteritems():
-                tmp += "    %s:%s %s\n" % (k, (m - len(k)) * ' ', v)
+                tmp += "    {0!s}:{1!s} {2!s}\n".format(k, (m - len(k)) * ' ', v)
         return tmp
 
     def parse(self):

--- a/lib/babelfish/converters/__init__.py
+++ b/lib/babelfish/converters/__init__.py
@@ -75,7 +75,7 @@ class CaseInsensitiveDict(collections.MutableMapping):
         return CaseInsensitiveDict(self._store.values())
 
     def __repr__(self):
-        return '%s(%r)' % (self.__class__.__name__, dict(self.items()))
+        return '{0!s}({1!r})'.format(self.__class__.__name__, dict(self.items()))
 
 
 class LanguageConverter(object):

--- a/lib/babelfish/country.py
+++ b/lib/babelfish/country.py
@@ -57,7 +57,7 @@ class Country(CountryMeta(str('CountryBase'), (object,), {})):
     """
     def __init__(self, country):
         if country not in COUNTRIES:
-            raise ValueError('%r is not a valid country' % country)
+            raise ValueError('{0!r} is not a valid country'.format(country))
 
         #: ISO-3166 2-letter country code
         self.alpha2 = country
@@ -101,7 +101,7 @@ class Country(CountryMeta(str('CountryBase'), (object,), {})):
         return not self == other
 
     def __repr__(self):
-        return '<Country [%s]>' % self
+        return '<Country [{0!s}]>'.format(self)
 
     def __str__(self):
         return self.alpha2

--- a/lib/babelfish/language.py
+++ b/lib/babelfish/language.py
@@ -79,7 +79,7 @@ class Language(LanguageMeta(str('LanguageBase'), (object,), {})):
         if unknown is not None and language not in LANGUAGES:
             language = unknown
         if language not in LANGUAGES:
-            raise ValueError('%r is not a valid language' % language)
+            raise ValueError('{0!r} is not a valid language'.format(language))
         self.alpha3 = language
         self.country = None
         if isinstance(country, Country):
@@ -132,7 +132,7 @@ class Language(LanguageMeta(str('LanguageBase'), (object,), {})):
                 language.script = Script(subtag.capitalize())
             if language.script is not None:
                 if subtags:
-                    raise ValueError('Wrong IETF format. Unmatched subtags: %r' % subtags)
+                    raise ValueError('Wrong IETF format. Unmatched subtags: {0!r}'.format(subtags))
                 break
         return language
 
@@ -171,7 +171,7 @@ class Language(LanguageMeta(str('LanguageBase'), (object,), {})):
     __nonzero__ = __bool__
 
     def __repr__(self):
-        return '<Language [%s]>' % self
+        return '<Language [{0!s}]>'.format(self)
 
     def __str__(self):
         try:

--- a/lib/babelfish/script.py
+++ b/lib/babelfish/script.py
@@ -40,7 +40,7 @@ class Script(object):
     """
     def __init__(self, script):
         if script not in SCRIPTS:
-            raise ValueError('%r is not a valid script' % script)
+            raise ValueError('{0!r} is not a valid script'.format(script))
 
         #: ISO-15924 4-letter script code
         self.code = script
@@ -70,7 +70,7 @@ class Script(object):
         return not self == other
 
     def __repr__(self):
-        return '<Script [%s]>' % self
+        return '<Script [{0!s}]>'.format(self)
 
     def __str__(self):
         return self.code

--- a/lib/babelfish/tests.py
+++ b/lib/babelfish/tests.py
@@ -57,15 +57,14 @@ if sys.version_info[:2] <= (2, 6):
             if isinstance(expected_regexp, basestring):
                 expected_regexp = re.compile(expected_regexp)
             if not expected_regexp.search(str(exc_value)):
-                raise self.failureException('"%s" does not match "%s"' %
-                         (expected_regexp.pattern, str(exc_value)))
+                raise self.failureException('"{0!s}" does not match "{1!s}"'.format(expected_regexp.pattern, str(exc_value)))
             return True
 
     class _Py26FixTestCase(object):
         def assertIsNone(self, obj, msg=None):
             """Same as self.assertTrue(obj is None), with a nicer default message."""
             if obj is not None:
-                standardMsg = '%s is not None' % (safe_repr(obj),)
+                standardMsg = '{0!s} is not None'.format(safe_repr(obj))
                 self.fail(self._formatMessage(msg, standardMsg))
 
         def assertIsNotNone(self, obj, msg=None):
@@ -77,28 +76,28 @@ if sys.version_info[:2] <= (2, 6):
         def assertIn(self, member, container, msg=None):
             """Just like self.assertTrue(a in b), but with a nicer default message."""
             if member not in container:
-                standardMsg = '%s not found in %s' % (safe_repr(member),
+                standardMsg = '{0!s} not found in {1!s}'.format(safe_repr(member),
                                                       safe_repr(container))
                 self.fail(self._formatMessage(msg, standardMsg))
 
         def assertNotIn(self, member, container, msg=None):
             """Just like self.assertTrue(a not in b), but with a nicer default message."""
             if member in container:
-                standardMsg = '%s unexpectedly found in %s' % (safe_repr(member),
+                standardMsg = '{0!s} unexpectedly found in {1!s}'.format(safe_repr(member),
                                                             safe_repr(container))
                 self.fail(self._formatMessage(msg, standardMsg))
 
         def assertIs(self, expr1, expr2, msg=None):
             """Just like self.assertTrue(a is b), but with a nicer default message."""
             if expr1 is not expr2:
-                standardMsg = '%s is not %s' % (safe_repr(expr1),
+                standardMsg = '{0!s} is not {1!s}'.format(safe_repr(expr1),
                                                  safe_repr(expr2))
                 self.fail(self._formatMessage(msg, standardMsg))
 
         def assertIsNot(self, expr1, expr2, msg=None):
             """Just like self.assertTrue(a is not b), but with a nicer default message."""
             if expr1 is expr2:
-                standardMsg = 'unexpectedly identical: %s' % (safe_repr(expr1),)
+                standardMsg = 'unexpectedly identical: {0!s}'.format(safe_repr(expr1))
                 self.fail(self._formatMessage(msg, standardMsg))
 
 else:

--- a/lib/bencode/__init__.py
+++ b/lib/bencode/__init__.py
@@ -23,7 +23,7 @@ class BencodeException(Exception):
         self.data = data
 
     def __repr__(self):
-        return "<BencodeException mode = %s>[%s]=>[%s]" % (self.mode, self.message, self.data)
+        return "<BencodeException mode = {0!s}>[{1!s}]=>[{2!s}]".format(self.mode, self.message, self.data)
 
 
 class BencodeEncodeError(BencodeException):
@@ -50,7 +50,7 @@ def _encode_int(data):
     :return String: becoded string
     """
     if isinstance(data, (int, long)):
-        return "%s%s%s" % ("i", str(data), "e")
+        return "{0!s}{1!s}{2!s}".format("i", str(data), "e")
     else:
         raise BencodeEncodeError("Invalid Integer", data)
 
@@ -62,7 +62,7 @@ def _encode_string(data):
     :return: String: bencoded Strings
     """
     if isinstance(data, (str, basestring, unicode,)):
-        return "%s:%s" % (str(len(data)), data)
+        return "{0!s}:{1!s}".format(str(len(data)), data)
     else:
         raise BencodeEncodeError("Invalid String", data)
 
@@ -94,7 +94,7 @@ def _encode_list(lst):
     """
     if isinstance(lst, (list, set, tuple,)):
         lst = list(lst)
-        return "%s%s%s" % ("l", _recursive_baselist_encode(lst), "e")
+        return "{0!s}{1!s}{2!s}".format("l", _recursive_baselist_encode(lst), "e")
     else:
         raise BencodeEncodeError("Invalid Collection ", lst)
 
@@ -118,8 +118,8 @@ def _encode_dict(dct):
             elif isinstance(value, dict):
                 value = _encode_dict(value)
             key = _encode_string(key)
-            valrs += "%s%s" % (key, value)
-        strs = "%s%s%s" % ("d", valrs, "e")
+            valrs += "{0!s}{1!s}".format(key, value)
+        strs = "{0!s}{1!s}{2!s}".format("d", valrs, "e")
     else:
         raise BencodeEncodeError("Invalid Dictionary", dct)
     return strs

--- a/lib/bs4/__init__.py
+++ b/lib/bs4/__init__.py
@@ -140,7 +140,7 @@ class BeautifulSoup(Tag):
         if len(kwargs) > 0:
             arg = kwargs.keys().pop()
             raise TypeError(
-                "__init__() got an unexpected keyword argument '%s'" % arg)
+                "__init__() got an unexpected keyword argument '{0!s}'".format(arg))
 
         if builder is None:
             original_features = features
@@ -195,7 +195,7 @@ class BeautifulSoup(Tag):
                 if isinstance(markup, unicode):
                     markup = markup.encode("utf8")
                 warnings.warn(
-                    '"%s" looks like a filename, not markup. You should probably open this file and pass the filehandle into Beautiful Soup.' % markup)
+                    '"{0!s}" looks like a filename, not markup. You should probably open this file and pass the filehandle into Beautiful Soup.'.format(markup))
             if markup[:5] == "http:" or markup[:6] == "https:":
                 # TODO: This is ugly but I couldn't get it to work in
                 # Python 3 otherwise.
@@ -204,7 +204,7 @@ class BeautifulSoup(Tag):
                     if isinstance(markup, unicode):
                         markup = markup.encode("utf8")
                     warnings.warn(
-                        '"%s" looks like a URL. Beautiful Soup is not an HTTP client. You should probably use an HTTP client to get the document behind the URL, and feed that document to Beautiful Soup.' % markup)
+                        '"{0!s}" looks like a URL. Beautiful Soup is not an HTTP client. You should probably use an HTTP client to get the document behind the URL, and feed that document to Beautiful Soup.'.format(markup))
 
         for (self.markup, self.original_encoding, self.declared_html_encoding,
          self.contains_replacement_characters) in (
@@ -428,8 +428,8 @@ class BeautifulSoup(Tag):
             # Print the XML declaration
             encoding_part = ''
             if eventual_encoding != None:
-                encoding_part = ' encoding="%s"' % eventual_encoding
-            prefix = u'<?xml version="1.0"%s?>\n' % encoding_part
+                encoding_part = ' encoding="{0!s}"'.format(eventual_encoding)
+            prefix = u'<?xml version="1.0"{0!s}?>\n'.format(encoding_part)
         else:
             prefix = u''
         if not pretty_print:

--- a/lib/bs4/builder/_html5lib.py
+++ b/lib/bs4/builder/_html5lib.py
@@ -64,7 +64,7 @@ class HTML5TreeBuilder(HTMLTreeBuilder):
 
     def test_fragment_to_document(self, fragment):
         """See `TreeBuilder`."""
-        return u'<html><head></head><body>%s</body></html>' % fragment
+        return u'<html><head></head><body>{0!s}</body></html>'.format(fragment)
 
 
 class TreeBuilderForHtml5lib(html5lib.treebuilders._base.TreeBuilder):

--- a/lib/bs4/builder/_htmlparser.py
+++ b/lib/bs4/builder/_htmlparser.py
@@ -90,7 +90,7 @@ class BeautifulSoupHTMLParser(HTMLParser):
         if character is not None:
             data = character
         else:
-            data = "&%s;" % name
+            data = "&{0!s};".format(name)
         self.handle_data(data)
 
     def handle_comment(self, data):
@@ -239,8 +239,7 @@ if major == 3 and minor == 2 and not CONSTRUCTOR_TAKES_STRICT:
             else:
                 offset = offset + len(self.__starttag_text)
             if self.strict:
-                self.error("junk characters in start tag: %r"
-                           % (rawdata[k:endpos][:20],))
+                self.error("junk characters in start tag: {0!r}".format(rawdata[k:endpos][:20]))
             self.handle_data(rawdata[i:endpos])
             return endpos
         if end.endswith('/>'):
@@ -254,7 +253,7 @@ if major == 3 and minor == 2 and not CONSTRUCTOR_TAKES_STRICT:
 
     def set_cdata_mode(self, elem):
         self.cdata_elem = elem.lower()
-        self.interesting = re.compile(r'</\s*%s\s*>' % self.cdata_elem, re.I)
+        self.interesting = re.compile(r'</\s*{0!s}\s*>'.format(self.cdata_elem), re.I)
 
     BeautifulSoupHTMLParser.parse_starttag = parse_starttag
     BeautifulSoupHTMLParser.set_cdata_mode = set_cdata_mode

--- a/lib/bs4/builder/_lxml.py
+++ b/lib/bs4/builder/_lxml.py
@@ -219,7 +219,7 @@ class LXMLTreeBuilderForXML(TreeBuilder):
 
     def test_fragment_to_document(self, fragment):
         """See `TreeBuilder`."""
-        return u'<?xml version="1.0" encoding="utf-8"?>\n%s' % fragment
+        return u'<?xml version="1.0" encoding="utf-8"?>\n{0!s}'.format(fragment)
 
 
 class LXMLTreeBuilder(HTMLTreeBuilder, LXMLTreeBuilderForXML):
@@ -245,4 +245,4 @@ class LXMLTreeBuilder(HTMLTreeBuilder, LXMLTreeBuilderForXML):
 
     def test_fragment_to_document(self, fragment):
         """See `TreeBuilder`."""
-        return u'<html><body>%s</body></html>' % fragment
+        return u'<html><body>{0!s}</body></html>'.format(fragment)

--- a/lib/bs4/dammit.py
+++ b/lib/bs4/dammit.py
@@ -67,7 +67,7 @@ class EntitySubstitution(object):
                 lookup[character] = name
             # But we do want to turn &quot; into the quotation mark.
             reverse_lookup[name] = character
-        re_definition = "[%s]" % "".join(characters_for_re)
+        re_definition = "[{0!s}]".format("".join(characters_for_re))
         return lookup, reverse_lookup, re.compile(re_definition)
     (CHARACTER_TO_HTML_ENTITY, HTML_ENTITY_TO_CHARACTER,
      CHARACTER_TO_HTML_ENTITY_RE) = _populate_class_variables()
@@ -89,14 +89,14 @@ class EntitySubstitution(object):
     @classmethod
     def _substitute_html_entity(cls, matchobj):
         entity = cls.CHARACTER_TO_HTML_ENTITY.get(matchobj.group(0))
-        return "&%s;" % entity
+        return "&{0!s};".format(entity)
 
     @classmethod
     def _substitute_xml_entity(cls, matchobj):
         """Used with a regular expression to substitute the
         appropriate XML entity for an XML special character."""
         entity = cls.CHARACTER_TO_XML_ENTITY[matchobj.group(0)]
-        return "&%s;" % entity
+        return "&{0!s};".format(entity)
 
     @classmethod
     def quoted_attribute_value(self, value):

--- a/lib/bs4/diagnose.py
+++ b/lib/bs4/diagnose.py
@@ -20,8 +20,8 @@ import cProfile
 
 def diagnose(data):
     """Diagnostic suite for isolating common problems."""
-    print "Diagnostic running on Beautiful Soup %s" % __version__
-    print "Python version %s" % sys.version
+    print "Diagnostic running on Beautiful Soup {0!s}".format(__version__)
+    print "Python version {0!s}".format(sys.version)
 
     basic_parsers = ["html.parser", "html5lib", "lxml"]
     for name in basic_parsers:
@@ -31,14 +31,14 @@ def diagnose(data):
         else:
             basic_parsers.remove(name)
             print (
-                "I noticed that %s is not installed. Installing it may help." %
-                name)
+                "I noticed that {0!s} is not installed. Installing it may help.".format(
+                name))
 
     if 'lxml' in basic_parsers:
         basic_parsers.append(["lxml", "xml"])
         try:
             from lxml import etree
-            print "Found lxml version %s" % ".".join(map(str,etree.LXML_VERSION))
+            print "Found lxml version {0!s}".format(".".join(map(str,etree.LXML_VERSION)))
         except ImportError, e:
             print (
                 "lxml is not installed or couldn't be imported.")
@@ -47,7 +47,7 @@ def diagnose(data):
     if 'html5lib' in basic_parsers:
         try:
             import html5lib
-            print "Found html5lib version %s" % html5lib.__version__
+            print "Found html5lib version {0!s}".format(html5lib.__version__)
         except ImportError, e:
             print (
                 "html5lib is not installed or couldn't be imported.")
@@ -55,25 +55,25 @@ def diagnose(data):
     if hasattr(data, 'read'):
         data = data.read()
     elif os.path.exists(data):
-        print '"%s" looks like a filename. Reading data from the file.' % data
+        print '"{0!s}" looks like a filename. Reading data from the file.'.format(data)
         data = open(data).read()
     elif data.startswith("http:") or data.startswith("https:"):
-        print '"%s" looks like a URL. Beautiful Soup is not an HTTP client.' % data
+        print '"{0!s}" looks like a URL. Beautiful Soup is not an HTTP client.'.format(data)
         print "You need to use some other library to get the document behind the URL, and feed that document to Beautiful Soup."
         return
     print
 
     for parser in basic_parsers:
-        print "Trying to parse your markup with %s" % parser
+        print "Trying to parse your markup with {0!s}".format(parser)
         success = False
         try:
             soup = BeautifulSoup(data, parser)
             success = True
         except Exception, e:
-            print "%s could not parse the markup." % parser
+            print "{0!s} could not parse the markup.".format(parser)
             traceback.print_exc()
         if success:
-            print "Here's what %s did with the markup:" % parser
+            print "Here's what {0!s} did with the markup:".format(parser)
             print soup.prettify()
 
         print "-" * 80
@@ -86,7 +86,7 @@ def lxml_trace(data, html=True, **kwargs):
     """
     from lxml import etree
     for event, element in etree.iterparse(StringIO(data), html=html, **kwargs):
-        print("%s, %4s, %s" % (event, element.tag, element.text))
+        print("{0!s}, {1:4!s}, {2!s}".format(event, element.tag, element.text))
 
 class AnnouncingParser(HTMLParser):
     """Announces HTMLParser parse events, without doing anything else."""
@@ -95,31 +95,31 @@ class AnnouncingParser(HTMLParser):
         print(s)
 
     def handle_starttag(self, name, attrs):
-        self._p("%s START" % name)
+        self._p("{0!s} START".format(name))
 
     def handle_endtag(self, name):
-        self._p("%s END" % name)
+        self._p("{0!s} END".format(name))
 
     def handle_data(self, data):
-        self._p("%s DATA" % data)
+        self._p("{0!s} DATA".format(data))
 
     def handle_charref(self, name):
-        self._p("%s CHARREF" % name)
+        self._p("{0!s} CHARREF".format(name))
 
     def handle_entityref(self, name):
-        self._p("%s ENTITYREF" % name)
+        self._p("{0!s} ENTITYREF".format(name))
 
     def handle_comment(self, data):
-        self._p("%s COMMENT" % data)
+        self._p("{0!s} COMMENT".format(data))
 
     def handle_decl(self, data):
-        self._p("%s DECL" % data)
+        self._p("{0!s} DECL".format(data))
 
     def unknown_decl(self, data):
-        self._p("%s UNKNOWN-DECL" % data)
+        self._p("{0!s} UNKNOWN-DECL".format(data))
 
     def handle_pi(self, data):
-        self._p("%s PI" % data)
+        self._p("{0!s} PI".format(data))
 
 def htmlparser_trace(data):
     """Print out the HTMLParser events that occur during parsing.
@@ -157,20 +157,20 @@ def rdoc(num_elements=1000):
         if choice == 0:
             # New tag.
             tag_name = random.choice(tag_names)
-            elements.append("<%s>" % tag_name)
+            elements.append("<{0!s}>".format(tag_name))
         elif choice == 1:
             elements.append(rsentence(random.randint(1,4)))
         elif choice == 2:
             # Close a tag.
             tag_name = random.choice(tag_names)
-            elements.append("</%s>" % tag_name)
+            elements.append("</{0!s}>".format(tag_name))
     return "<html>" + "\n".join(elements) + "</html>"
 
 def benchmark_parsers(num_elements=100000):
     """Very basic head-to-head performance benchmark."""
-    print "Comparative parser benchmark on Beautiful Soup %s" % __version__
+    print "Comparative parser benchmark on Beautiful Soup {0!s}".format(__version__)
     data = rdoc(num_elements)
-    print "Generated a large invalid HTML document (%d bytes)." % len(data)
+    print "Generated a large invalid HTML document ({0:d} bytes).".format(len(data))
     
     for parser in ["lxml", ["lxml", "html"], "html5lib", "html.parser"]:
         success = False
@@ -180,23 +180,23 @@ def benchmark_parsers(num_elements=100000):
             b = time.time()
             success = True
         except Exception, e:
-            print "%s could not parse the markup." % parser
+            print "{0!s} could not parse the markup.".format(parser)
             traceback.print_exc()
         if success:
-            print "BS4+%s parsed the markup in %.2fs." % (parser, b-a)
+            print "BS4+{0!s} parsed the markup in {1:.2f}s.".format(parser, b-a)
 
     from lxml import etree
     a = time.time()
     etree.HTML(data)
     b = time.time()
-    print "Raw lxml parsed the markup in %.2fs." % (b-a)
+    print "Raw lxml parsed the markup in {0:.2f}s.".format((b-a))
 
     import html5lib
     parser = html5lib.HTMLParser()
     a = time.time()
     parser.parse(data)
     b = time.time()
-    print "Raw html5lib parsed the markup in %.2fs." % (b-a)
+    print "Raw html5lib parsed the markup in {0:.2f}s.".format((b-a))
 
 def profile(num_elements=100000, parser="lxml"):
 

--- a/lib/bs4/element.py
+++ b/lib/bs4/element.py
@@ -709,7 +709,7 @@ class NavigableString(unicode, PageElement):
             return self
         else:
             raise AttributeError(
-                "'%s' object has no attribute '%s'" % (
+                "'{0!s}' object has no attribute '{1!s}'".format(
                     self.__class__.__name__, attr))
 
     def output_ready(self, formatter="minimal"):
@@ -764,11 +764,11 @@ class Doctype(PreformattedString):
     def for_name_and_ids(cls, name, pub_id, system_id):
         value = name or ''
         if pub_id is not None:
-            value += ' PUBLIC "%s"' % pub_id
+            value += ' PUBLIC "{0!s}"'.format(pub_id)
             if system_id is not None:
-                value += ' "%s"' % system_id
+                value += ' "{0!s}"'.format(system_id)
         elif system_id is not None:
-            value += ' SYSTEM "%s"' % system_id
+            value += ' SYSTEM "{0!s}"'.format(system_id)
 
         return Doctype(value)
 
@@ -993,14 +993,14 @@ class Tag(PageElement):
             # BS3: soup.aTag -> "soup.find("a")
             tag_name = tag[:-3]
             warnings.warn(
-                '.%sTag is deprecated, use .find("%s") instead.' % (
+                '.{0!s}Tag is deprecated, use .find("{1!s}") instead.'.format(
                     tag_name, tag_name))
             return self.find(tag_name)
         # We special case contents to avoid recursion.
         elif not tag.startswith("__") and not tag=="contents":
             return self.find(tag)
         raise AttributeError(
-            "'%s' object has no attribute '%s'" % (self.__class__, tag))
+            "'{0!s}' object has no attribute '{1!s}'".format(self.__class__, tag))
 
     def __eq__(self, other):
         """Returns true iff this tag has the same name, the same attributes,
@@ -1110,7 +1110,7 @@ class Tag(PageElement):
         if self.is_empty_element:
             close = '/'
         else:
-            closeTag = '</%s%s>' % (prefix, self.name)
+            closeTag = '</{0!s}{1!s}>'.format(prefix, self.name)
 
         pretty_print = self._should_pretty_print(indent_level)
         space = ''
@@ -1137,7 +1137,7 @@ class Tag(PageElement):
                 # Even if this particular tag is not pretty-printed,
                 # we should indent up to the start of the tag.
                 s.append(indent_space)
-            s.append('<%s%s%s%s>' % (
+            s.append('<{0!s}{1!s}{2!s}{3!s}>'.format(
                     prefix, self.name, attribute_string, close))
             if pretty_print:
                 s.append("\n")
@@ -1296,7 +1296,7 @@ class Tag(PageElement):
             for partial_selector in selector.split(','):
                 partial_selector = partial_selector.strip()
                 if partial_selector == '':
-                    raise ValueError('Invalid group selection syntax: %s' % selector)
+                    raise ValueError('Invalid group selection syntax: {0!s}'.format(selector))
                 candidates = self.select(partial_selector, limit=limit)
                 for candidate in candidates:
                     if candidate not in context:
@@ -1311,10 +1311,10 @@ class Tag(PageElement):
 
         if tokens[-1] in self._selector_combinators:
             raise ValueError(
-                'Final combinator "%s" is missing an argument.' % tokens[-1])
+                'Final combinator "{0!s}" is missing an argument.'.format(tokens[-1]))
 
         if self._select_debug:
-            print 'Running CSS selector "%s"' % selector
+            print 'Running CSS selector "{0!s}"'.format(selector)
 
         for index, token in enumerate(tokens):
             new_context = []
@@ -1327,7 +1327,7 @@ class Tag(PageElement):
                 continue
 
             if self._select_debug:
-                print ' Considering token "%s"' % token
+                print ' Considering token "{0!s}"'.format(token)
             recursive_candidate_generator = None
             tag_name = None
 
@@ -1423,7 +1423,7 @@ class Tag(PageElement):
                 tag_name = token
             else:
                 raise ValueError(
-                    'Unsupported or invalid CSS selector: "%s"' % token)
+                    'Unsupported or invalid CSS selector: "{0!s}"'.format(token))
             if recursive_candidate_generator:
                 # This happens when the selector looks like  "> foo".
                 #
@@ -1437,11 +1437,11 @@ class Tag(PageElement):
                 next_token = tokens[index+1]
                 def recursive_select(tag):
                     if self._select_debug:
-                        print '    Calling select("%s") recursively on %s %s' % (next_token, tag.name, tag.attrs)
+                        print '    Calling select("{0!s}") recursively on {1!s} {2!s}'.format(next_token, tag.name, tag.attrs)
                         print '-' * 40
                     for i in tag.select(next_token, recursive_candidate_generator):
                         if self._select_debug:
-                            print '(Recursive select picked up candidate %s %s)' % (i.name, i.attrs)
+                            print '(Recursive select picked up candidate {0!s} {1!s})'.format(i.name, i.attrs)
                         yield i
                     if self._select_debug:
                         print '-' * 40
@@ -1455,7 +1455,7 @@ class Tag(PageElement):
                         check = "[any]"
                     else:
                         check = tag_name
-                    print '   Default candidate generator, tag name="%s"' % check
+                    print '   Default candidate generator, tag name="{0!s}"'.format(check)
                 if self._select_debug:
                     # This is redundant with later code, but it stops
                     # a bunch of bogus tags from cluttering up the
@@ -1476,7 +1476,7 @@ class Tag(PageElement):
             count = 0
             for tag in current_context:
                 if self._select_debug:
-                    print "    Running candidate generator on %s %s" % (
+                    print "    Running candidate generator on {0!s} {1!s}".format(
                         tag.name, repr(tag.attrs))
                 for candidate in _use_candidate_generator(tag):
                     if not isinstance(candidate, Tag):
@@ -1492,7 +1492,7 @@ class Tag(PageElement):
                             break
                     if checker is None or result:
                         if self._select_debug:
-                            print "     SUCCESS %s %s" % (candidate.name, repr(candidate.attrs))
+                            print "     SUCCESS {0!s} {1!s}".format(candidate.name, repr(candidate.attrs))
                         if id(candidate) not in new_context_ids:
                             # If a tag matches a selector more than once,
                             # don't include it in the context more than once.
@@ -1501,7 +1501,7 @@ class Tag(PageElement):
                             if limit and len(new_context) >= limit:
                                 break
                     elif self._select_debug:
-                        print "     FAILURE %s %s" % (candidate.name, repr(candidate.attrs))
+                        print "     FAILURE {0!s} {1!s}".format(candidate.name, repr(candidate.attrs))
 
 
             current_context = new_context
@@ -1509,7 +1509,7 @@ class Tag(PageElement):
         if self._select_debug:
             print "Final verdict:"
             for i in current_context:
-                print " %s %s" % (i.name, i.attrs)
+                print " {0!s} {1!s}".format(i.name, i.attrs)
         return current_context
 
     # Old names for backwards compatibility
@@ -1523,8 +1523,8 @@ class Tag(PageElement):
         """This was kind of misleading because has_key() (attributes)
         was different from __in__ (contents). has_key() is gone in
         Python 3, anyway."""
-        warnings.warn('has_key is deprecated. Use has_attr("%s") instead.' % (
-                key))
+        warnings.warn('has_key is deprecated. Use has_attr("{0!s}") instead.'.format((
+                key)))
         return self.has_attr(key)
 
 # Next, a couple classes to represent queries and their results.
@@ -1593,7 +1593,7 @@ class SoupStrainer(object):
         if self.text:
             return self.text
         else:
-            return "%s|%s" % (self.name, self.attrs)
+            return "{0!s}|{1!s}".format(self.name, self.attrs)
 
     def search_tag(self, markup_name=None, markup_attrs={}):
         found = None
@@ -1659,7 +1659,7 @@ class SoupStrainer(object):
                 found = markup
         else:
             raise Exception(
-                "I don't know how to match against a %s" % markup.__class__)
+                "I don't know how to match against a {0!s}".format(markup.__class__))
         return found
 
     def _matches(self, markup, match_against):

--- a/lib/bs4/testing.py
+++ b/lib/bs4/testing.py
@@ -92,7 +92,7 @@ class HTMLTreeBuilderSmokeTest(object):
 
     def _document_with_doctype(self, doctype_fragment):
         """Generate and parse a document with the given doctype."""
-        doctype = '<!DOCTYPE %s>' % doctype_fragment
+        doctype = '<!DOCTYPE {0!s}>'.format(doctype_fragment)
         markup = doctype + '\n<p>foo</p>'
         soup = self.soup(markup)
         return doctype, soup

--- a/lib/bs4/tests/test_tree.py
+++ b/lib/bs4/tests/test_tree.py
@@ -1681,7 +1681,7 @@ class TestSoupSelector(TreeTest):
         el_ids.sort()
         expected_ids.sort()
         self.assertEqual(expected_ids, el_ids,
-            "Selector %s, expected [%s], got [%s]" % (
+            "Selector {0!s}, expected [{1!s}], got [{2!s}]".format(
                 selector, ', '.join(expected_ids), ', '.join(el_ids)
             )
         )

--- a/lib/cachecontrol/controller.py
+++ b/lib/cachecontrol/controller.py
@@ -37,7 +37,7 @@ class CacheController(object):
         """Normalize the URL to create a safe key for the cache"""
         (scheme, authority, path, query, fragment) = parse_uri(uri)
         if not scheme or not authority:
-            raise Exception("Only absolute URIs are allowed. uri = %s" % uri)
+            raise Exception("Only absolute URIs are allowed. uri = {0!s}".format(uri))
 
         scheme = scheme.lower()
         authority = authority.lower()

--- a/lib/concurrent/futures/_base.py
+++ b/lib/concurrent/futures/_base.py
@@ -170,7 +170,7 @@ def _create_and_install_waiters(fs, return_when):
         elif return_when == ALL_COMPLETED:
             waiter = _AllCompletedWaiter(pending_count, stop_on_exception=False)
         else:
-            raise ValueError("Invalid return condition: %r" % return_when)
+            raise ValueError("Invalid return condition: {0!r}".format(return_when))
 
     for f in fs:
         f._waiters.append(waiter)
@@ -215,7 +215,7 @@ def as_completed(fs, timeout=None):
                 wait_timeout = end_time - time.time()
                 if wait_timeout < 0:
                     raise TimeoutError(
-                            '%d (of %d) futures unfinished' % (
+                            '{0:d} (of {1:d}) futures unfinished'.format(
                             len(pending), len(fs)))
 
             waiter.event.wait(wait_timeout)
@@ -307,16 +307,16 @@ class Future(object):
         with self._condition:
             if self._state == FINISHED:
                 if self._exception:
-                    return '<Future at %s state=%s raised %s>' % (
+                    return '<Future at {0!s} state={1!s} raised {2!s}>'.format(
                         hex(id(self)),
                         _STATE_TO_DESCRIPTION_MAP[self._state],
                         self._exception.__class__.__name__)
                 else:
-                    return '<Future at %s state=%s returned %s>' % (
+                    return '<Future at {0!s} state={1!s} returned {2!s}>'.format(
                         hex(id(self)),
                         _STATE_TO_DESCRIPTION_MAP[self._state],
                         self._result.__class__.__name__)
-            return '<Future at %s state=%s>' % (
+            return '<Future at {0!s} state={1!s}>'.format(
                     hex(id(self)),
                    _STATE_TO_DESCRIPTION_MAP[self._state])
 

--- a/lib/concurrent/futures/process.py
+++ b/lib/concurrent/futures/process.py
@@ -263,7 +263,7 @@ def _check_system_limits():
         # minimum number of semaphores available
         # according to POSIX
         return
-    _system_limited = "system provides too few semaphores (%d available, 256 necessary)" % nsems_max
+    _system_limited = "system provides too few semaphores ({0:d} available, 256 necessary)".format(nsems_max)
     raise NotImplementedError(_system_limited)
 
 class ProcessPoolExecutor(_base.Executor):

--- a/lib/configobj.py
+++ b/lib/configobj.py
@@ -297,7 +297,7 @@ class InterpolationLoopError(InterpolationError):
     def __init__(self, option):
         InterpolationError.__init__(
             self,
-            'interpolation loop detected in value "%s".' % option)
+            'interpolation loop detected in value "{0!s}".'.format(option))
 
 
 class RepeatSectionError(ConfigObjError):
@@ -313,7 +313,7 @@ class MissingInterpolationOption(InterpolationError):
     def __init__(self, option):
         InterpolationError.__init__(
             self,
-            'missing option "%s" in interpolation.' % option)
+            'missing option "{0!s}" in interpolation.'.format(option))
 
 
 class UnreprError(ConfigObjError):
@@ -601,7 +601,7 @@ class Section(dict):
         creating a new sub-section.
         """
         if not isinstance(key, basestring):
-            raise ValueError('The key "%s" is not a string.' % key)
+            raise ValueError('The key "{0!s}" is not a string.'.format(key))
         
         # add the comment
         if not self.comments.has_key(key):
@@ -639,9 +639,9 @@ class Section(dict):
                 elif isinstance(value, (list, tuple)):
                     for entry in value:
                         if not isinstance(entry, basestring):
-                            raise TypeError('Value is not a string "%s".' % entry)
+                            raise TypeError('Value is not a string "{0!s}".'.format(entry))
                 else:
-                    raise TypeError('Value is not a string "%s".' % value)
+                    raise TypeError('Value is not a string "{0!s}".'.format(value))
             dict.__setitem__(self, key, value)
 
 
@@ -761,8 +761,8 @@ class Section(dict):
 
     def __repr__(self):
         """x.__repr__() <==> repr(x)"""
-        return '{%s}' % ', '.join([('%s: %s' % (repr(key), repr(self[key])))
-            for key in (self.scalars + self.sections)])
+        return '{{{0!s}}}'.format(', '.join([('{0!s}: {1!s}'.format(repr(key), repr(self[key])))
+            for key in (self.scalars + self.sections)]))
 
     __str__ = __repr__
     __str__.__doc__ = "x.__str__() <==> str(x)"
@@ -839,7 +839,7 @@ class Section(dict):
         elif oldkey in self.sections:
             the_list = self.sections
         else:
-            raise KeyError('Key "%s" not found.' % oldkey)
+            raise KeyError('Key "{0!s}" not found.'.format(oldkey))
         pos = the_list.index(oldkey)
         #
         val = self[oldkey]
@@ -981,7 +981,7 @@ class Section(dict):
                 else:
                     return self.main._bools[val.lower()]
             except KeyError:
-                raise ValueError('Value "%s" is neither True nor False' % val)
+                raise ValueError('Value "{0!s}" is neither True nor False'.format(val))
 
 
     def as_int(self, key):
@@ -1209,7 +1209,7 @@ class ConfigObj(Section):
         # TODO: check the values too.
         for entry in options:
             if entry not in defaults:
-                raise TypeError('Unrecognised option "%s".' % entry)
+                raise TypeError('Unrecognised option "{0!s}".'.format(entry))
         
         # Add any explicit options to the defaults
         defaults.update(options)
@@ -1228,7 +1228,7 @@ class ConfigObj(Section):
                 h.close()
             elif self.file_error:
                 # raise an error if the file doesn't exist
-                raise IOError('Config file not found: "%s".' % self.filename)
+                raise IOError('Config file not found: "{0!s}".'.format(self.filename))
             else:
                 # file doesn't already exist
                 if self.create_empty:
@@ -1288,9 +1288,9 @@ class ConfigObj(Section):
         self._parse(infile)
         # if we had any errors, now is the time to raise them
         if self._errors:
-            info = "at line %s." % self._errors[0].line_number
+            info = "at line {0!s}.".format(self._errors[0].line_number)
             if len(self._errors) > 1:
-                msg = "Parsing failed with several errors.\nFirst error %s" % info
+                msg = "Parsing failed with several errors.\nFirst error {0!s}".format(info)
                 error = ConfigObjError(msg)
             else:
                 error = self._errors[0]
@@ -1342,9 +1342,9 @@ class ConfigObj(Section):
         
         
     def __repr__(self):
-        return ('ConfigObj({%s})' % 
-                ', '.join([('%s: %s' % (repr(key), repr(self[key]))) 
-                for key in (self.scalars + self.sections)]))
+        return ('ConfigObj({{{0!s}}})'.format( 
+                ', '.join([('{0!s}: {1!s}'.format(repr(key), repr(self[key]))) 
+                for key in (self.scalars + self.sections)])))
     
     
     def _handle_bom(self, infile):
@@ -1743,7 +1743,7 @@ class ConfigObj(Section):
             if self.stringify:
                 value = str(value)
             else:
-                raise TypeError('Value "%s" is not a string.' % value)
+                raise TypeError('Value "{0!s}" is not a string.'.format(value))
 
         if not value:
             return '""'
@@ -1760,7 +1760,7 @@ class ConfigObj(Section):
             # for normal values either single or double quotes will do
             elif '\n' in value:
                 # will only happen if multiline is off - e.g. '\n' in key
-                raise ConfigObjError('Value "%s" cannot be safely quoted.' % value)
+                raise ConfigObjError('Value "{0!s}" cannot be safely quoted.'.format(value))
             elif ((value[0] not in wspace_plus) and
                     (value[-1] not in wspace_plus) and
                     (',' not in value)):
@@ -1779,7 +1779,7 @@ class ConfigObj(Section):
     
     def _get_single_quote(self, value):
         if ("'" in value) and ('"' in value):
-            raise ConfigObjError('Value "%s" cannot be safely quoted.' % value)
+            raise ConfigObjError('Value "{0!s}" cannot be safely quoted.'.format(value))
         elif '"' in value:
             quot = squot
         else:
@@ -1789,7 +1789,7 @@ class ConfigObj(Section):
     
     def _get_triple_quote(self, value):
         if (value.find('"""') != -1) and (value.find("'''") != -1):
-            raise ConfigObjError('Value "%s" cannot be safely quoted.' % value)
+            raise ConfigObjError('Value "{0!s}" cannot be safely quoted.'.format(value))
         if value.find('"""') == -1:
             quot = tdquot
         else:
@@ -1894,9 +1894,9 @@ class ConfigObj(Section):
             except ConfigObjError, e:
                 # FIXME: Should these errors have a reference
                 #        to the already parsed ConfigObj ?
-                raise ConfigspecError('Parsing configspec failed: %s' % e)
+                raise ConfigspecError('Parsing configspec failed: {0!s}'.format(e))
             except IOError, e:
-                raise IOError('Reading configspec failed: %s' % e)
+                raise IOError('Reading configspec failed: {0!s}'.format(e))
         
         self.configspec = configspec
             
@@ -1936,7 +1936,7 @@ class ConfigObj(Section):
             val = self._decode_element(self._quote(this_entry))
         else:
             val = repr(this_entry)
-        return '%s%s%s%s%s' % (indent_string,
+        return '{0!s}{1!s}{2!s}{3!s}{4!s}'.format(indent_string,
                                self._decode_element(self._quote(entry, multiline=False)),
                                self._a_to_u(' = '),
                                val,
@@ -1945,7 +1945,7 @@ class ConfigObj(Section):
 
     def _write_marker(self, indent_string, depth, entry, comment):
         """Write a section marker line"""
-        return '%s%s%s%s%s' % (indent_string,
+        return '{0!s}{1!s}{2!s}{3!s}{4!s}'.format(indent_string,
                                self._a_to_u('[' * depth),
                                self._quote(self._decode_element(entry), multiline=False),
                                self._a_to_u(']' * depth),
@@ -2228,7 +2228,7 @@ class ConfigObj(Section):
                 out[entry] = False
             else:
                 ret_false = False
-                msg = 'Value %r was provided as a section' % entry
+                msg = 'Value {0!r} was provided as a section'.format(entry)
                 out[entry] = validator.baseErrorClass(msg)
         for entry in incorrect_sections:
             ret_true = False
@@ -2236,7 +2236,7 @@ class ConfigObj(Section):
                 out[entry] = False
             else:
                 ret_false = False
-                msg = 'Section %r was provided as a single value' % entry
+                msg = 'Section {0!r} was provided as a single value'.format(entry)
                 out[entry] = validator.baseErrorClass(msg)
                 
         # Missing sections will have been created as empty ones when the

--- a/lib/dateutil/parser.py
+++ b/lib/dateutil/parser.py
@@ -214,8 +214,8 @@ class _resultbase(object):
         for attr in self.__slots__:
             value = getattr(self, attr)
             if value is not None:
-                l.append("%s=%s" % (attr, repr(value)))
-        return "%s(%s)" % (classname, ", ".join(l))
+                l.append("{0!s}={1!s}".format(attr, repr(value)))
+        return "{0!s}({1!s})".format(classname, ", ".join(l))
 
     def __len__(self):
         return (sum(getattr(self, attr) is not None

--- a/lib/dateutil/relativedelta.py
+++ b/lib/dateutil/relativedelta.py
@@ -37,7 +37,7 @@ class weekday(object):
         if not self.n:
             return s
         else:
-            return "%s(%+d)" % (s, self.n)
+            return "{0!s}({1:+d})".format(s, self.n)
 
 MO, TU, WE, TH, FR, SA, SU = weekdays = tuple([weekday(x) for x in range(7)])
 
@@ -238,7 +238,7 @@ class relativedelta(object):
                             self.day = yday-ydayidx[idx-1]
                         break
                 else:
-                    raise ValueError("invalid year day (%d)" % yday)
+                    raise ValueError("invalid year day ({0:d})".format(yday))
 
         self._fix()
 

--- a/lib/dateutil/rrule.py
+++ b/lib/dateutil/rrule.py
@@ -88,7 +88,7 @@ class weekday(object):
         if not self.n:
             return s
         else:
-            return "%s(%+d)" % (s, self.n)
+            return "{0!s}({1:+d})".format(s, self.n)
 
 MO, TU, WE, TH, FR, SA, SU = weekdays = tuple([weekday(x) for x in range(7)])
 
@@ -1487,9 +1487,9 @@ class _rrulestr(object):
                                                ignoretz=ignoretz,
                                                tzinfos=tzinfos)
             except AttributeError:
-                raise ValueError("unknown parameter '%s'" % name)
+                raise ValueError("unknown parameter '{0!s}'".format(name))
             except (KeyError, ValueError):
-                raise ValueError("invalid '%s': %s" % (name, value))
+                raise ValueError("invalid '{0!s}': {1!s}".format(name, value))
         return rrule(dtstart=dtstart, cache=cache, **rrkwargs)
 
     def _parse_rfc(self, s,

--- a/lib/dateutil/tz/tz.py
+++ b/lib/dateutil/tz/tz.py
@@ -48,7 +48,7 @@ class tzutc(datetime.tzinfo):
         return not self.__eq__(other)
 
     def __repr__(self):
-        return "%s()" % self.__class__.__name__
+        return "{0!s}()".format(self.__class__.__name__)
 
     __reduce__ = object.__reduce__
 
@@ -77,7 +77,7 @@ class tzoffset(datetime.tzinfo):
         return not self.__eq__(other)
 
     def __repr__(self):
-        return "%s(%s, %s)" % (self.__class__.__name__,
+        return "{0!s}({1!s}, {2!s})".format(self.__class__.__name__,
                                repr(self._name),
                                self._offset.days*86400+self._offset.seconds)
 
@@ -151,7 +151,7 @@ class tzlocal(datetime.tzinfo):
         return not self.__eq__(other)
 
     def __repr__(self):
-        return "%s()" % self.__class__.__name__
+        return "{0!s}()".format(self.__class__.__name__)
 
     __reduce__ = object.__reduce__
 
@@ -168,8 +168,8 @@ class _ttinfo(object):
         for attr in self.__slots__:
             value = getattr(self, attr)
             if value is not None:
-                l.append("%s=%s" % (attr, repr(value)))
-        return "%s(%s)" % (self.__class__.__name__, ", ".join(l))
+                l.append("{0!s}={1!s}".format(attr, repr(value)))
+        return "{0!s}({1!s})".format(self.__class__.__name__, ", ".join(l))
 
     def __eq__(self, other):
         if not isinstance(other, _ttinfo):
@@ -262,7 +262,7 @@ class tzfile(datetime.tzinfo):
             # change.
 
             if timecnt:
-                self._trans_list = struct.unpack(">%dl" % timecnt,
+                self._trans_list = struct.unpack(">{0:d}l".format(timecnt),
                                                  fileobj.read(timecnt*4))
             else:
                 self._trans_list = []
@@ -275,7 +275,7 @@ class tzfile(datetime.tzinfo):
             # appears next in the file.
 
             if timecnt:
-                self._trans_idx = struct.unpack(">%dB" % timecnt,
+                self._trans_idx = struct.unpack(">{0:d}B".format(timecnt),
                                                 fileobj.read(timecnt))
             else:
                 self._trans_idx = []
@@ -321,7 +321,7 @@ class tzfile(datetime.tzinfo):
             # time zone environment variables.
 
             if ttisstdcnt:
-                isstd = struct.unpack(">%db" % ttisstdcnt,
+                isstd = struct.unpack(">{0:d}b".format(ttisstdcnt),
                                       fileobj.read(ttisstdcnt))
 
             # Finally, there are tzh_ttisgmtcnt UTC/local
@@ -333,7 +333,7 @@ class tzfile(datetime.tzinfo):
             # ronment variables.
 
             if ttisgmtcnt:
-                isgmt = struct.unpack(">%db" % ttisgmtcnt,
+                isgmt = struct.unpack(">{0:d}b".format(ttisgmtcnt),
                                       fileobj.read(ttisgmtcnt))
 
             # ** Everything has been read **
@@ -483,11 +483,11 @@ class tzfile(datetime.tzinfo):
         return not self.__eq__(other)
 
     def __repr__(self):
-        return "%s(%s)" % (self.__class__.__name__, repr(self._filename))
+        return "{0!s}({1!s})".format(self.__class__.__name__, repr(self._filename))
 
     def __reduce__(self):
         if not os.path.isfile(self._filename):
-            raise ValueError("Unpickable %s class" % self.__class__.__name__)
+            raise ValueError("Unpickable {0!s} class".format(self.__class__.__name__))
         return (self.__class__, (self._filename,))
 
 
@@ -569,7 +569,7 @@ class tzrange(datetime.tzinfo):
         return not self.__eq__(other)
 
     def __repr__(self):
-        return "%s(...)" % self.__class__.__name__
+        return "{0!s}(...)".format(self.__class__.__name__)
 
     __reduce__ = object.__reduce__
 
@@ -647,7 +647,7 @@ class tzstr(tzrange):
         return relativedelta.relativedelta(**kwargs)
 
     def __repr__(self):
-        return "%s(%s)" % (self.__class__.__name__, repr(self._s))
+        return "{0!s}({1!s})".format(self.__class__.__name__, repr(self._s))
 
 
 class _tzicalvtzcomp(object):
@@ -723,7 +723,7 @@ class _tzicalvtz(datetime.tzinfo):
         return self._find_comp(dt).tzname
 
     def __repr__(self):
-        return "<tzicalvtz %s>" % repr(self._tzid)
+        return "<tzicalvtz {0!s}>".format(repr(self._tzid))
 
     __reduce__ = object.__reduce__
 
@@ -863,7 +863,7 @@ class tzical(object):
                     elif name == "TZOFFSETFROM":
                         if parms:
                             raise ValueError(
-                                "unsupported %s parm: %s " % (name, parms[0]))
+                                "unsupported {0!s} parm: {1!s} ".format(name, parms[0]))
                         tzoffsetfrom = self._parse_offset(value)
                     elif name == "TZOFFSETTO":
                         if parms:
@@ -895,7 +895,7 @@ class tzical(object):
                 invtz = True
 
     def __repr__(self):
-        return "%s(%s)" % (self.__class__.__name__, repr(self._s))
+        return "{0!s}({1!s})".format(self.__class__.__name__, repr(self._s))
 
 if sys.platform != "win32":
     TZFILES = ["/etc/localtime", "localtime"]

--- a/lib/dateutil/tz/win.py
+++ b/lib/dateutil/tz/win.py
@@ -219,7 +219,7 @@ class tzwin(tzwinbase):
          self._dstminute) = tup[12:17]
 
     def __repr__(self):
-        return "tzwin(%s)" % repr(self._name)
+        return "tzwin({0!s})".format(repr(self._name))
 
     def __reduce__(self):
         return (self.__class__, (self._name,))
@@ -273,7 +273,7 @@ class tzwinlocal(tzwinbase):
 
     def __str__(self):
         # str will return the standard name, not the daylight name.
-        return "tzwinlocal(%s)" % repr(self._stdname)
+        return "tzwinlocal({0!s})".format(repr(self._stdname))
 
     def __reduce__(self):
         return (self.__class__, ())

--- a/lib/dateutil/zoneinfo/rebuild.py
+++ b/lib/dateutil/zoneinfo/rebuild.py
@@ -31,7 +31,7 @@ def rebuild(filename, tag=None, format="gz", zonegroups=[], metadata=None):
         with open(os.path.join(zonedir, METADATA_FN), 'w') as f:
             json.dump(metadata, f, indent=4, sort_keys=True)
         target = os.path.join(moduledir, ZONEFILENAME)
-        with tar_open(target, "w:%s" % format) as tf:
+        with tar_open(target, "w:{0!s}".format(format)) as tf:
             for entry in os.listdir(zonedir):
                 entrypath = os.path.join(zonedir, entry)
                 tf.add(entrypath, entry)

--- a/lib/decorator.py
+++ b/lib/decorator.py
@@ -108,7 +108,7 @@ class FunctionMaker(object):
                           'kwonlydefaults'):
                     setattr(self, a, getattr(argspec, a))
                 for i, arg in enumerate(self.args):
-                    setattr(self, 'arg%d' % i, arg)
+                    setattr(self, 'arg{0:d}'.format(i), arg)
                 if sys.version < '3':  # easy way
                     self.shortsignature = self.signature = (
                         inspect.formatargspec(
@@ -122,8 +122,8 @@ class FunctionMaker(object):
                     elif self.kwonlyargs:
                         allargs.append('*')  # single star syntax
                     for a in self.kwonlyargs:
-                        allargs.append('%s=None' % a)
-                        allshortargs.append('%s=%s' % (a, a))
+                        allargs.append('{0!s}=None'.format(a))
+                        allshortargs.append('{0!s}={1!s}'.format(a, a))
                     if self.varkw:
                         allargs.append('**' + self.varkw)
                         allshortargs.append('**' + self.varkw)
@@ -146,7 +146,7 @@ class FunctionMaker(object):
         # check existence required attributes
         assert hasattr(self, 'name')
         if not hasattr(self, 'signature'):
-            raise TypeError('You are decorating a non function: %s' % func)
+            raise TypeError('You are decorating a non function: {0!s}'.format(func))
 
     def update(self, func, **kw):
         "Update the signature of func with the data in self"
@@ -171,13 +171,13 @@ class FunctionMaker(object):
         evaldict = evaldict or {}
         mo = DEF.match(src)
         if mo is None:
-            raise SyntaxError('not a valid function template\n%s' % src)
+            raise SyntaxError('not a valid function template\n{0!s}'.format(src))
         name = mo.group(1)  # extract the function name
         names = set([name] + [arg.strip(' *') for arg in
                               self.shortsignature.split(',')])
         for n in names:
             if n in ('_func_', '_call_'):
-                raise NameError('%s is overridden in\n%s' % (n, src))
+                raise NameError('{0!s} is overridden in\n{1!s}'.format(n, src))
 
         if not src.endswith('\n'):  # add a newline for old Pythons
             src += '\n'
@@ -185,7 +185,7 @@ class FunctionMaker(object):
         # Ensure each generated function has a unique filename for profilers
         # (such as cProfile) that depend on the tuple of (<filename>,
         # <definition line>, <function name>) being unique.
-        filename = '<decorator-gen-%d>' % (next(self._compile_count),)
+        filename = '<decorator-gen-{0:d}>'.format(next(self._compile_count))
         try:
             code = compile(src, filename, 'single')
             exec(code, evaldict)
@@ -256,7 +256,7 @@ def decorator(caller, _func=None):
         doc = caller.__call__.__doc__
     evaldict = dict(_call_=caller, _decorate_=decorate)
     return FunctionMaker.create(
-        '%s(func)' % name, 'return _decorate_(func, _call_)',
+        '{0!s}(func)'.format(name), 'return _decorate_(func, _call_)',
         evaldict, doc=doc, module=caller.__module__,
         __wrapped__=caller)
 
@@ -318,13 +318,12 @@ def dispatch_on(*dispatch_args):
     dispatching on the given arguments.
     """
     assert dispatch_args, 'No dispatch args passed'
-    dispatch_str = '(%s,)' % ', '.join(dispatch_args)
+    dispatch_str = '({0!s},)'.format(', '.join(dispatch_args))
 
     def check(arguments, wrong=operator.ne, msg=''):
         """Make sure one passes the expected number of arguments"""
         if wrong(len(arguments), len(dispatch_args)):
-            raise TypeError('Expected %d arguments, got %d%s' %
-                            (len(dispatch_args), len(arguments), msg))
+            raise TypeError('Expected {0:d} arguments, got {1:d}{2!s}'.format(len(dispatch_args), len(arguments), msg))
 
     def gen_func_dec(func):
         """Decorator turning a function into a generic function"""
@@ -332,7 +331,7 @@ def dispatch_on(*dispatch_args):
         # first check the dispatch arguments
         argset = set(getfullargspec(func).args)
         if not set(dispatch_args) <= argset:
-            raise NameError('Unknown dispatch arguments %s' % dispatch_str)
+            raise NameError('Unknown dispatch arguments {0!s}'.format(dispatch_str))
 
         typemap = {}
 
@@ -358,7 +357,7 @@ def dispatch_on(*dispatch_args):
                 n_vas = len(vas)
                 if n_vas > 1:
                     raise RuntimeError(
-                        'Ambiguous dispatch for %s: %s' % (t, vas))
+                        'Ambiguous dispatch for {0!s}: {1!s}'.format(t, vas))
                 elif n_vas == 1:
                     va, = vas
                     mro = type('t', (t, va), {}).__mro__[1:]
@@ -407,7 +406,7 @@ def dispatch_on(*dispatch_args):
             return func(*args, **kw)
 
         return FunctionMaker.create(
-            func, 'return _f_(%s, %%(shortsignature)s)' % dispatch_str,
+            func, 'return _f_({0!s}, %(shortsignature)s)'.format(dispatch_str),
             dict(_f_=_dispatch), register=register, default=func,
             typemap=typemap, vancestors=vancestors, ancestors=ancestors,
             dispatch_info=dispatch_info, __wrapped__=func)

--- a/lib/dogpile/cache/plugins/mako_cache.py
+++ b/lib/dogpile/cache/plugins/mako_cache.py
@@ -68,7 +68,7 @@ class MakoPlugin(CacheImpl):
         try:
             return self.regions[region]
         except KeyError:
-            raise KeyError("No such region '%s'" % region)
+            raise KeyError("No such region '{0!s}'".format(region))
 
     def get_and_replace(self, key, creation_function, **kw):
         expiration_time = kw.pop("timeout", None)

--- a/lib/dogpile/cache/region.py
+++ b/lib/dogpile/cache/region.py
@@ -269,8 +269,7 @@ class CacheRegion(object):
             proxy = proxy()
 
         if not issubclass(type(proxy), ProxyBackend):
-            raise TypeError("Type %s is not a valid ProxyBackend"
-                            % type(proxy))
+            raise TypeError("Type {0!s} is not a valid ProxyBackend".format(type(proxy)))
 
         self.backend = proxy.wrap(self.backend)
 
@@ -365,13 +364,13 @@ class CacheRegion(object):
         """
         config_dict = coerce_string_conf(config_dict)
         return self.configure(
-            config_dict["%sbackend" % prefix],
+            config_dict["{0!s}backend".format(prefix)],
             expiration_time=config_dict.get(
-                "%sexpiration_time" % prefix, None),
+                "{0!s}expiration_time".format(prefix), None),
             _config_argument_dict=config_dict,
-            _config_prefix="%sarguments." % prefix,
+            _config_prefix="{0!s}arguments.".format(prefix),
             wrap=config_dict.get(
-                "%swrap" % prefix, None),
+                "{0!s}wrap".format(prefix), None),
         )
 
     @memoized_property

--- a/lib/dogpile/cache/util.py
+++ b/lib/dogpile/cache/util.py
@@ -42,8 +42,7 @@ class PluginLoader(object):
                 return impl.load()
             else:
                 raise Exception(
-                    "Can't load plugin %s %s" %
-                    (self.group, name))
+                    "Can't load plugin {0!s} {1!s}".format(self.group, name))
 
     def register(self, name, modulepath, objname):
         def load():
@@ -66,9 +65,9 @@ def function_key_generator(namespace, fn, to_str=compat.string_type):
     """
 
     if namespace is None:
-        namespace = '%s:%s' % (fn.__module__, fn.__name__)
+        namespace = '{0!s}:{1!s}'.format(fn.__module__, fn.__name__)
     else:
-        namespace = '%s:%s|%s' % (fn.__module__, fn.__name__, namespace)
+        namespace = '{0!s}:{1!s}|{2!s}'.format(fn.__module__, fn.__name__, namespace)
 
     args = inspect.getargspec(fn)
     has_self = args[0] and args[0][0] in ('self', 'cls')
@@ -88,9 +87,9 @@ def function_key_generator(namespace, fn, to_str=compat.string_type):
 def function_multi_key_generator(namespace, fn, to_str=compat.string_type):
 
     if namespace is None:
-        namespace = '%s:%s' % (fn.__module__, fn.__name__)
+        namespace = '{0!s}:{1!s}'.format(fn.__module__, fn.__name__)
     else:
-        namespace = '%s:%s|%s' % (fn.__module__, fn.__name__, namespace)
+        namespace = '{0!s}:{1!s}|{2!s}'.format(fn.__module__, fn.__name__, namespace)
 
     args = inspect.getargspec(fn)
     has_self = args[0] and args[0][0] in ('self', 'cls')
@@ -186,7 +185,7 @@ class KeyReentrantMutex(object):
         current_thread = compat.threading.current_thread().ident
         keys = self.keys.get(current_thread)
         assert keys is not None, "this thread didn't do the acquire"
-        assert self.key in keys, "No acquire held for key '%s'" % self.key
+        assert self.key in keys, "No acquire held for key '{0!s}'".format(self.key)
         keys.remove(self.key)
         if not keys:
             # when list of keys empty, remove

--- a/lib/dogpile/core/dogpile.py
+++ b/lib/dogpile/core/dogpile.py
@@ -128,7 +128,7 @@ class Lock(object):
             self.mutex.acquire()
 
         try:
-            log.debug("value creation lock %r acquired" % self.mutex)
+            log.debug("value creation lock {0!r} acquired".format(self.mutex))
 
             # see if someone created the value already
             try:

--- a/lib/enum34/__init__.py
+++ b/lib/enum34/__init__.py
@@ -6,7 +6,7 @@ __all__ = ['Enum', 'IntEnum', 'unique']
 
 version = 1, 0, 4
 
-pyver = float('%s.%s' % _sys.version_info[:2])
+pyver = float('{0!s}.{1!s}'.format(*_sys.version_info[:2]))
 
 try:
     any
@@ -86,7 +86,7 @@ def _is_sunder(name):
 def _make_class_unpicklable(cls):
     """Make the given class un-picklable."""
     def _break_on_call_reduce(self, protocol=None):
-        raise TypeError('%r cannot be pickled' % self)
+        raise TypeError('{0!r} cannot be pickled'.format(self))
     cls.__reduce_ex__ = _break_on_call_reduce
     cls.__module__ = '<unknown>'
 
@@ -126,11 +126,11 @@ class _EnumDict(dict):
             pass
         elif key in self._member_names:
             # descriptor overwriting an enum?
-            raise TypeError('Attempted to reuse key: %r' % key)
+            raise TypeError('Attempted to reuse key: {0!r}'.format(key))
         elif not _is_descriptor(value):
             if key in self:
                 # enum overwriting a descriptor?
-                raise TypeError('Key already defined as: %r' % self[key])
+                raise TypeError('Key already defined as: {0!r}'.format(self[key]))
             self._member_names.append(key)
         super(_EnumDict, self).__setitem__(key, value)
 
@@ -187,8 +187,8 @@ class EnumMeta(type):
         # check for illegal enum names (any others?)
         invalid_names = set(members) & set(['mro'])
         if invalid_names:
-            raise ValueError('Invalid enum member name(s): %s' % (
-                ', '.join(invalid_names), ))
+            raise ValueError('Invalid enum member name(s): {0!s}'.format(
+                ', '.join(invalid_names) ))
 
         # create our new Enum type
         enum_class = super(EnumMeta, metacls).__new__(metacls, cls, bases, classdict)
@@ -339,7 +339,7 @@ class EnumMeta(type):
         # (see issue19025).
         if attr in cls._member_map_:
             raise AttributeError(
-                    "%s: cannot delete Enum member." % cls.__name__)
+                    "{0!s}: cannot delete Enum member.".format(cls.__name__))
         super(EnumMeta, cls).__delattr__(attr)
 
     def __dir__(self):
@@ -385,7 +385,7 @@ class EnumMeta(type):
         return len(cls._member_names_)
 
     def __repr__(cls):
-        return "<enum %r>" % cls.__name__
+        return "<enum {0!r}>".format(cls.__name__)
 
     def __setattr__(cls, name, value):
         """Block attempts to reassign Enum members.
@@ -418,7 +418,7 @@ class EnumMeta(type):
                 try:
                     class_name = class_name.encode('ascii')
                 except UnicodeEncodeError:
-                    raise TypeError('%r is not representable in ASCII' % class_name)
+                    raise TypeError('{0!r} is not representable in ASCII'.format(class_name))
         metacls = cls.__class__
         if type is None:
             bases = (cls, )
@@ -639,18 +639,18 @@ def __new__(cls, value):
         for member in cls._member_map_.values():
             if member.value == value:
                 return member
-    raise ValueError("%s is not a valid %s" % (value, cls.__name__))
+    raise ValueError("{0!s} is not a valid {1!s}".format(value, cls.__name__))
 temp_enum_dict['__new__'] = __new__
 del __new__
 
 def __repr__(self):
-    return "<%s.%s: %r>" % (
+    return "<{0!s}.{1!s}: {2!r}>".format(
             self.__class__.__name__, self._name_, self._value_)
 temp_enum_dict['__repr__'] = __repr__
 del __repr__
 
 def __str__(self):
-    return "%s.%s" % (self.__class__.__name__, self._name_)
+    return "{0!s}.{1!s}".format(self.__class__.__name__, self._name_)
 temp_enum_dict['__str__'] = __str__
 del __str__
 
@@ -694,29 +694,29 @@ if pyver < 2.6:
                 return 0
             return -1
         return NotImplemented
-        raise TypeError("unorderable types: %s() and %s()" % (self.__class__.__name__, other.__class__.__name__))
+        raise TypeError("unorderable types: {0!s}() and {1!s}()".format(self.__class__.__name__, other.__class__.__name__))
     temp_enum_dict['__cmp__'] = __cmp__
     del __cmp__
 
 else:
 
     def __le__(self, other):
-        raise TypeError("unorderable types: %s() <= %s()" % (self.__class__.__name__, other.__class__.__name__))
+        raise TypeError("unorderable types: {0!s}() <= {1!s}()".format(self.__class__.__name__, other.__class__.__name__))
     temp_enum_dict['__le__'] = __le__
     del __le__
 
     def __lt__(self, other):
-        raise TypeError("unorderable types: %s() < %s()" % (self.__class__.__name__, other.__class__.__name__))
+        raise TypeError("unorderable types: {0!s}() < {1!s}()".format(self.__class__.__name__, other.__class__.__name__))
     temp_enum_dict['__lt__'] = __lt__
     del __lt__
 
     def __ge__(self, other):
-        raise TypeError("unorderable types: %s() >= %s()" % (self.__class__.__name__, other.__class__.__name__))
+        raise TypeError("unorderable types: {0!s}() >= {1!s}()".format(self.__class__.__name__, other.__class__.__name__))
     temp_enum_dict['__ge__'] = __ge__
     del __ge__
 
     def __gt__(self, other):
-        raise TypeError("unorderable types: %s() > %s()" % (self.__class__.__name__, other.__class__.__name__))
+        raise TypeError("unorderable types: {0!s}() > {1!s}()".format(self.__class__.__name__, other.__class__.__name__))
     temp_enum_dict['__gt__'] = __gt__
     del __gt__
     
@@ -782,9 +782,8 @@ def unique(enumeration):
             duplicates.append((name, member.name))
     if duplicates:
         duplicate_names = ', '.join(
-                ["%s -> %s" % (alias, name) for (alias, name) in duplicates]
+                ["{0!s} -> {1!s}".format(alias, name) for (alias, name) in duplicates]
                 )
-        raise ValueError('duplicate names found in %r: %s' %
-                (enumeration, duplicate_names)
+        raise ValueError('duplicate names found in {0!r}: {1!s}'.format(enumeration, duplicate_names)
                 )
     return enumeration

--- a/lib/enum34/enum.py
+++ b/lib/enum34/enum.py
@@ -6,7 +6,7 @@ __all__ = ['Enum', 'IntEnum', 'unique']
 
 version = 1, 0, 4
 
-pyver = float('%s.%s' % _sys.version_info[:2])
+pyver = float('{0!s}.{1!s}'.format(*_sys.version_info[:2]))
 
 try:
     any
@@ -86,7 +86,7 @@ def _is_sunder(name):
 def _make_class_unpicklable(cls):
     """Make the given class un-picklable."""
     def _break_on_call_reduce(self, protocol=None):
-        raise TypeError('%r cannot be pickled' % self)
+        raise TypeError('{0!r} cannot be pickled'.format(self))
     cls.__reduce_ex__ = _break_on_call_reduce
     cls.__module__ = '<unknown>'
 
@@ -126,11 +126,11 @@ class _EnumDict(dict):
             pass
         elif key in self._member_names:
             # descriptor overwriting an enum?
-            raise TypeError('Attempted to reuse key: %r' % key)
+            raise TypeError('Attempted to reuse key: {0!r}'.format(key))
         elif not _is_descriptor(value):
             if key in self:
                 # enum overwriting a descriptor?
-                raise TypeError('Key already defined as: %r' % self[key])
+                raise TypeError('Key already defined as: {0!r}'.format(self[key]))
             self._member_names.append(key)
         super(_EnumDict, self).__setitem__(key, value)
 
@@ -187,8 +187,8 @@ class EnumMeta(type):
         # check for illegal enum names (any others?)
         invalid_names = set(members) & set(['mro'])
         if invalid_names:
-            raise ValueError('Invalid enum member name(s): %s' % (
-                ', '.join(invalid_names), ))
+            raise ValueError('Invalid enum member name(s): {0!s}'.format(
+                ', '.join(invalid_names) ))
 
         # create our new Enum type
         enum_class = super(EnumMeta, metacls).__new__(metacls, cls, bases, classdict)
@@ -339,7 +339,7 @@ class EnumMeta(type):
         # (see issue19025).
         if attr in cls._member_map_:
             raise AttributeError(
-                    "%s: cannot delete Enum member." % cls.__name__)
+                    "{0!s}: cannot delete Enum member.".format(cls.__name__))
         super(EnumMeta, cls).__delattr__(attr)
 
     def __dir__(self):
@@ -385,7 +385,7 @@ class EnumMeta(type):
         return len(cls._member_names_)
 
     def __repr__(cls):
-        return "<enum %r>" % cls.__name__
+        return "<enum {0!r}>".format(cls.__name__)
 
     def __setattr__(cls, name, value):
         """Block attempts to reassign Enum members.
@@ -418,7 +418,7 @@ class EnumMeta(type):
                 try:
                     class_name = class_name.encode('ascii')
                 except UnicodeEncodeError:
-                    raise TypeError('%r is not representable in ASCII' % class_name)
+                    raise TypeError('{0!r} is not representable in ASCII'.format(class_name))
         metacls = cls.__class__
         if type is None:
             bases = (cls, )
@@ -639,18 +639,18 @@ def __new__(cls, value):
         for member in cls._member_map_.values():
             if member.value == value:
                 return member
-    raise ValueError("%s is not a valid %s" % (value, cls.__name__))
+    raise ValueError("{0!s} is not a valid {1!s}".format(value, cls.__name__))
 temp_enum_dict['__new__'] = __new__
 del __new__
 
 def __repr__(self):
-    return "<%s.%s: %r>" % (
+    return "<{0!s}.{1!s}: {2!r}>".format(
             self.__class__.__name__, self._name_, self._value_)
 temp_enum_dict['__repr__'] = __repr__
 del __repr__
 
 def __str__(self):
-    return "%s.%s" % (self.__class__.__name__, self._name_)
+    return "{0!s}.{1!s}".format(self.__class__.__name__, self._name_)
 temp_enum_dict['__str__'] = __str__
 del __str__
 
@@ -694,29 +694,29 @@ if pyver < 2.6:
                 return 0
             return -1
         return NotImplemented
-        raise TypeError("unorderable types: %s() and %s()" % (self.__class__.__name__, other.__class__.__name__))
+        raise TypeError("unorderable types: {0!s}() and {1!s}()".format(self.__class__.__name__, other.__class__.__name__))
     temp_enum_dict['__cmp__'] = __cmp__
     del __cmp__
 
 else:
 
     def __le__(self, other):
-        raise TypeError("unorderable types: %s() <= %s()" % (self.__class__.__name__, other.__class__.__name__))
+        raise TypeError("unorderable types: {0!s}() <= {1!s}()".format(self.__class__.__name__, other.__class__.__name__))
     temp_enum_dict['__le__'] = __le__
     del __le__
 
     def __lt__(self, other):
-        raise TypeError("unorderable types: %s() < %s()" % (self.__class__.__name__, other.__class__.__name__))
+        raise TypeError("unorderable types: {0!s}() < {1!s}()".format(self.__class__.__name__, other.__class__.__name__))
     temp_enum_dict['__lt__'] = __lt__
     del __lt__
 
     def __ge__(self, other):
-        raise TypeError("unorderable types: %s() >= %s()" % (self.__class__.__name__, other.__class__.__name__))
+        raise TypeError("unorderable types: {0!s}() >= {1!s}()".format(self.__class__.__name__, other.__class__.__name__))
     temp_enum_dict['__ge__'] = __ge__
     del __ge__
 
     def __gt__(self, other):
-        raise TypeError("unorderable types: %s() > %s()" % (self.__class__.__name__, other.__class__.__name__))
+        raise TypeError("unorderable types: {0!s}() > {1!s}()".format(self.__class__.__name__, other.__class__.__name__))
     temp_enum_dict['__gt__'] = __gt__
     del __gt__
     
@@ -782,9 +782,8 @@ def unique(enumeration):
             duplicates.append((name, member.name))
     if duplicates:
         duplicate_names = ', '.join(
-                ["%s -> %s" % (alias, name) for (alias, name) in duplicates]
+                ["{0!s} -> {1!s}".format(alias, name) for (alias, name) in duplicates]
                 )
-        raise ValueError('duplicate names found in %r: %s' %
-                (enumeration, duplicate_names)
+        raise ValueError('duplicate names found in {0!r}: {1!s}'.format(enumeration, duplicate_names)
                 )
     return enumeration

--- a/lib/enum34/test_enum.py
+++ b/lib/enum34/test_enum.py
@@ -4,7 +4,7 @@ import unittest
 from enum import Enum, IntEnum, unique, EnumMeta
 from pickle import dumps, loads, PicklingError, HIGHEST_PROTOCOL
 
-pyver = float('%s.%s' % sys.version_info[:2])
+pyver = float('{0!s}.{1!s}'.format(*sys.version_info[:2]))
 
 try:
     any
@@ -96,9 +96,9 @@ def test_pickle_dump_load(assertion, source, target=None,
                 assertion(loads(dumps(source, protocol=protocol)), target)
         except Exception:
             exc, tb = sys.exc_info()[1:]
-            failures.append('%2d: %s' %(protocol, exc))
+            failures.append('{0:2d}: {1!s}'.format(protocol, exc))
     if failures:
-        raise ValueError('Failed with protocols: %s' % ', '.join(failures))
+        raise ValueError('Failed with protocols: {0!s}'.format(', '.join(failures)))
 
 def test_pickle_exception(assertion, exception, obj,
         protocol=(0, HIGHEST_PROTOCOL)):
@@ -109,9 +109,9 @@ def test_pickle_exception(assertion, exception, obj,
             assertion(exception, dumps, obj, protocol=protocol)
         except Exception:
             exc = sys.exc_info()[1]
-            failures.append('%d: %s %s' % (protocol, exc.__class__.__name__, exc))
+            failures.append('{0:d}: {1!s} {2!s}'.format(protocol, exc.__class__.__name__, exc))
     if failures:
-        raise ValueError('Failed with protocols: %s' % ', '.join(failures))
+        raise ValueError('Failed with protocols: {0!s}'.format(', '.join(failures)))
 
 
 class TestHelpers(unittest.TestCase):
@@ -278,7 +278,7 @@ class TestEnum(unittest.TestCase):
             self.assertEqual(str(e), 'Season.' + season)
             self.assertEqual(
                     repr(e),
-                    '<Season.%s: %s>' % (season, i),
+                    '<Season.{0!s}: {1!s}>'.format(season, i),
                     )
 
     def test_value_name(self):
@@ -607,7 +607,7 @@ class TestEnum(unittest.TestCase):
                 shiny = 'rare'
 
             self.__class__.NestedEnum = NestedEnum
-            self.NestedEnum.__qualname__ = '%s.NestedEnum' % self.__class__.__name__
+            self.NestedEnum.__qualname__ = '{0!s}.NestedEnum'.format(self.__class__.__name__)
             test_pickle_exception(
                     self.assertRaises, PicklingError, self.NestedEnum.twigs,
                     protocol=(0, 3))
@@ -941,7 +941,7 @@ class TestEnum(unittest.TestCase):
             this = 'that'
             these = 'those'
             def really(self):
-                return 'no, not %s' % self.value
+                return 'no, not {0!s}'.format(self.value)
         self.assertFalse(type(whatever.really) is whatever)
         self.assertEqual(whatever.this.really(), 'no, not that')
 
@@ -1042,7 +1042,7 @@ class TestEnum(unittest.TestCase):
             green = 2
             blue = 3
             def __repr__(self):
-                return "don't you just love shades of %s?" % self.name
+                return "don't you just love shades of {0!s}?".format(self.name)
         self.assertEqual(
                 repr(Color.blue),
                 "don't you just love shades of blue?",
@@ -1051,7 +1051,7 @@ class TestEnum(unittest.TestCase):
     def test_inherited_repr(self):
         class MyEnum(Enum):
             def __repr__(self):
-                return "My name is %s." % self.name
+                return "My name is {0!s}.".format(self.name)
         class MyIntEnum(int, MyEnum):
             this = 1
             that = 2
@@ -1115,7 +1115,7 @@ class TestEnum(unittest.TestCase):
                 return self._intname
             def __repr__(self):
                 # repr() is updated to include the name and type info
-                return "%s(%r, %s)" % (type(self).__name__,
+                return "{0!s}({1!r}, {2!s})".format(type(self).__name__,
                                              self.__name__,
                                              int.__repr__(self))
             def __str__(self):
@@ -1131,7 +1131,7 @@ class TestEnum(unittest.TestCase):
                 temp = int(self) + int( other)
                 if isinstance(self, NamedInt) and isinstance(other, NamedInt):
                     return NamedInt(
-                        '(%s + %s)' % (self.__name__, other.__name__),
+                        '({0!s} + {1!s})'.format(self.__name__, other.__name__),
                         temp )
                 else:
                     return temp
@@ -1227,7 +1227,7 @@ class TestEnum(unittest.TestCase):
                 return self._intname
             def __repr__(self):
                 # repr() is updated to include the name and type info
-                return "%s(%r, %s)" % (type(self).__name__,
+                return "{0!s}({1!r}, {2!s})".format(type(self).__name__,
                                              self.__name__,
                                              int.__repr__(self))
             def __str__(self):
@@ -1243,7 +1243,7 @@ class TestEnum(unittest.TestCase):
                 temp = int(self) + int( other)
                 if isinstance(self, NamedInt) and isinstance(other, NamedInt):
                     return NamedInt(
-                        '(%s + %s)' % (self.__name__, other.__name__),
+                        '({0!s} + {1!s})'.format(self.__name__, other.__name__),
                         temp )
                 else:
                     return temp
@@ -1283,7 +1283,7 @@ class TestEnum(unittest.TestCase):
                 return self._intname
             def __repr__(self):
                 # repr() is updated to include the name and type info
-                return "%s(%r, %s)" % (type(self).__name__,
+                return "{0!s}({1!r}, {2!s})".format(type(self).__name__,
                                              self.__name__,
                                              int.__repr__(self))
             def __str__(self):
@@ -1299,7 +1299,7 @@ class TestEnum(unittest.TestCase):
                 temp = int(self) + int( other)
                 if isinstance(self, NamedInt) and isinstance(other, NamedInt):
                     return NamedInt(
-                        '(%s + %s)' % (self.__name__, other.__name__),
+                        '({0!s} + {1!s})'.format(self.__name__, other.__name__),
                         temp )
                 else:
                     return temp
@@ -1337,7 +1337,7 @@ class TestEnum(unittest.TestCase):
                 return self._intname
             def __repr__(self):
                 # repr() is updated to include the name and type info
-                return "%s(%r, %s)" % (type(self).__name__,
+                return "{0!s}({1!r}, {2!s})".format(type(self).__name__,
                                              self.__name__,
                                              int.__repr__(self))
             def __str__(self):
@@ -1353,7 +1353,7 @@ class TestEnum(unittest.TestCase):
                 temp = int(self) + int( other)
                 if isinstance(self, NamedInt) and isinstance(other, NamedInt):
                     return NamedInt(
-                        '(%s + %s)' % (self.__name__, other.__name__),
+                        '({0!s} + {1!s})'.format(self.__name__, other.__name__),
                         temp )
                 else:
                     return temp
@@ -1390,7 +1390,7 @@ class TestEnum(unittest.TestCase):
                 return self._intname
             def __repr__(self):
                 # repr() is updated to include the name and type info
-                return "%s(%r, %s)" % (type(self).__name__,
+                return "{0!s}({1!r}, {2!s})".format(type(self).__name__,
                                              self.__name__,
                                              int.__repr__(self))
             def __str__(self):
@@ -1406,7 +1406,7 @@ class TestEnum(unittest.TestCase):
                 temp = int(self) + int( other)
                 if isinstance(self, NamedInt) and isinstance(other, NamedInt):
                     return NamedInt(
-                        '(%s + %s)' % (self.__name__, other.__name__),
+                        '({0!s} + {1!s})'.format(self.__name__, other.__name__),
                         temp )
                 else:
                     return temp
@@ -1475,7 +1475,7 @@ class TestEnum(unittest.TestCase):
             red = ()
             green = ()
             blue = ()
-        self.assertEqual(len(Color), 3, "wrong number of elements: %d (should be %d)" % (len(Color), 3))
+        self.assertEqual(len(Color), 3, "wrong number of elements: {0:d} (should be {1:d})".format(len(Color), 3))
         self.assertEqual(list(Color), [Color.red, Color.green, Color.blue])
         if pyver >= 3.0:
             self.assertEqual(list(map(int, Color)), [1, 2, 3])
@@ -1491,7 +1491,7 @@ class TestEnum(unittest.TestCase):
             red = ()
             green = ()
             blue = ()
-        self.assertEqual(len(Color), 3, "wrong number of elements: %d (should be %d)" % (len(Color), 3))
+        self.assertEqual(len(Color), 3, "wrong number of elements: {0:d} (should be {1:d})".format(len(Color), 3))
         Color.red
         Color.green
         Color.blue
@@ -1548,7 +1548,7 @@ class TestEnum(unittest.TestCase):
                 return self.name
         class Color(Shade):
             def hex(self):
-                return '%s hexlified!' % self.value
+                return '{0!s} hexlified!'.format(self.value)
         class MoreColor(Color):
             cyan = 4
             magenta = 5
@@ -1564,8 +1564,7 @@ class TestEnum(unittest.TestCase):
                         a = self.name
                         e = cls(self.value).name
                         raise ValueError(
-                                "aliases not allowed in UniqueEnum:  %r --> %r"
-                                % (a, e)
+                                "aliases not allowed in UniqueEnum:  {0!r} --> {1!r}".format(a, e)
                                 )
             class Color(UniqueEnum):
                 red = 1

--- a/lib/enzyme/mkv.py
+++ b/lib/enzyme/mkv.py
@@ -53,7 +53,7 @@ class MKV(object):
             seek_head.load(stream, specs, ignore_element_names=['Void', 'CRC-32'])
             self._parse_seekhead(seek_head, segment, stream, specs)
         except ParserError as e:
-            raise MalformedMKVError('Parsing error: %s' % e)
+            raise MalformedMKVError('Parsing error: {0!s}'.format(e))
 
     def _parse_seekhead(self, seek_head, segment, stream, specs):
         for seek in seek_head:
@@ -96,7 +96,7 @@ class MKV(object):
                 'chapters': [c.__dict__ for c in self.chapters], 'tags': [t.__dict__ for t in self.tags]}
 
     def __repr__(self):
-        return '<%s [%r, %r, %r, %r]>' % (self.__class__.__name__, self.info, self.video_tracks, self.audio_tracks, self.subtitle_tracks)
+        return '<{0!s} [{1!r}, {2!r}, {3!r}, {4!r}]>'.format(self.__class__.__name__, self.info, self.video_tracks, self.audio_tracks, self.subtitle_tracks)
 
 
 class Info(object):
@@ -125,7 +125,7 @@ class Info(object):
         return cls(title, duration, date_utc, timecode_scale, muxing_app, writing_app)
 
     def __repr__(self):
-        return '<%s [title=%r, duration=%s, date=%s]>' % (self.__class__.__name__, self.title, self.duration, self.date_utc)
+        return '<{0!s} [title={1!r}, duration={2!s}, date={3!s}]>'.format(self.__class__.__name__, self.title, self.duration, self.date_utc)
 
     def __str__(self):
         return repr(self.__dict__)
@@ -168,7 +168,7 @@ class Track(object):
                    forced=forced, lacing=lacing, codec_id=codec_id, codec_name=codec_name)
 
     def __repr__(self):
-        return '<%s [%d, name=%r, language=%s]>' % (self.__class__.__name__, self.number, self.name, self.language)
+        return '<{0!s} [{1:d}, name={2!r}, language={3!s}]>'.format(self.__class__.__name__, self.number, self.name, self.language)
 
     def __str__(self):
         return str(self.__dict__)
@@ -218,7 +218,7 @@ class VideoTrack(Track):
         return videotrack
 
     def __repr__(self):
-        return '<%s [%d, %dx%d, %s, name=%r, language=%s]>' % (self.__class__.__name__, self.number, self.width, self.height,
+        return '<{0!s} [{1:d}, {2:d}x{3:d}, {4!s}, name={5!r}, language={6!s}]>'.format(self.__class__.__name__, self.number, self.width, self.height,
                                                             self.codec_id, self.name, self.language)
 
     def __str__(self):
@@ -250,7 +250,7 @@ class AudioTrack(Track):
         return audiotrack
 
     def __repr__(self):
-        return '<%s [%d, %d channel(s), %.0fHz, %s, name=%r, language=%s]>' % (self.__class__.__name__, self.number, self.channels,
+        return '<{0!s} [{1:d}, {2:d} channel(s), {3:.0f}Hz, {4!s}, name={5!r}, language={6!s}]>'.format(self.__class__.__name__, self.number, self.channels,
                                                                             self.sampling_frequency, self.codec_id, self.name, self.language)
 
 
@@ -278,7 +278,7 @@ class Tag(object):
         return cls(targets, simpletags)
 
     def __repr__(self):
-        return '<%s [targets=%r, simpletags=%r]>' % (self.__class__.__name__, self.targets, self.simpletags)
+        return '<{0!s} [targets={1!r}, simpletags={2!r}]>'.format(self.__class__.__name__, self.targets, self.simpletags)
 
 
 class SimpleTag(object):
@@ -306,7 +306,7 @@ class SimpleTag(object):
         return cls(name, language, default, string, binary)
 
     def __repr__(self):
-        return '<%s [%s, language=%s, default=%s, string=%s]>' % (self.__class__.__name__, self.name, self.language, self.default, self.string)
+        return '<{0!s} [{1!s}, language={2!s}, default={3!s}, string={4!s}]>'.format(self.__class__.__name__, self.name, self.language, self.default, self.string)
 
 
 class Chapter(object):
@@ -348,4 +348,4 @@ class Chapter(object):
         return cls(start, hidden, enabled, end)
 
     def __repr__(self):
-        return '<%s [%s, enabled=%s]>' % (self.__class__.__name__, self.start, self.enabled)
+        return '<{0!s} [{1!s}, enabled={2!s}]>'.format(self.__class__.__name__, self.start, self.enabled)

--- a/lib/enzyme/parsers/ebml/core.py
+++ b/lib/enzyme/parsers/ebml/core.py
@@ -62,7 +62,7 @@ class Element(object):
         self.data = data
 
     def __repr__(self):
-        return '<%s [%s, %r]>' % (self.__class__.__name__, self.name, self.data)
+        return '<{0!s} [{1!s}, {2!r}]>'.format(self.__class__.__name__, self.name, self.data)
 
 
 class MasterElement(Element):
@@ -118,7 +118,7 @@ class MasterElement(Element):
             return default
         element = self[name]
         if element.type == MASTER:
-            raise ValueError('%s is a MasterElement' % name)
+            raise ValueError('{0!s} is a MasterElement'.format(name))
         return element.data
 
     def __getitem__(self, key):
@@ -128,7 +128,7 @@ class MasterElement(Element):
         if not children:
             raise KeyError(key)
         if len(children) > 1:
-            raise KeyError('More than 1 child with key %s (%d)' % (key, len(children)))
+            raise KeyError('More than 1 child with key {0!s} ({1:d})'.format(key, len(children)))
         return children[0]
 
     def __contains__(self, item):
@@ -208,7 +208,7 @@ def parse_element(stream, specs, load_children=False, ignore_element_types=None,
     if element_size is None:
         raise ReadError('Cannot read element size')
     if element_id not in specs:
-        logger.error('Element with id 0x%x is not in the specs' % element_id)
+        logger.error('Element with id 0x{0:x} is not in the specs'.format(element_id))
         stream.seek(element_size, 1)
         return None
     element_type, element_name, element_level = specs[element_id]

--- a/lib/enzyme/parsers/ebml/readers.py
+++ b/lib/enzyme/parsers/ebml/readers.py
@@ -24,7 +24,7 @@ def _read(stream, size):
     """
     data = stream.read(size)
     if len(data) < size:
-        raise ReadError('Less than %d bytes read (%d)' % (size, len(data)))
+        raise ReadError('Less than {0:d} bytes read ({1:d})'.format(size, len(data)))
     return data
 
 

--- a/lib/fanart/__init__.py
+++ b/lib/fanart/__init__.py
@@ -9,9 +9,9 @@ __classifiers__ = [
     'Topic :: Internet :: WWW/HTTP',
     'Topic :: Software Development :: Libraries',
 ]
-__copyright__ = "2012, %s " % __author__
+__copyright__ = "2012, {0!s} ".format(__author__)
 __license__ = """
-   Copyright %s.
+   Copyright {0!s}.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -24,18 +24,18 @@ __license__ = """
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either expressed or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-""" % __copyright__
+""".format(__copyright__)
 
 __docformat__ = 'restructuredtext en'
 
 __doc__ = """
 :abstract: Python interface to fanart.tv API
-:version: %s
-:author: %s
+:version: {0!s}
+:author: {1!s}
 :contact: http://z4r.github.com/
 :date: 2012-04-04
-:copyright: %s
-""" % (__version__, __author__, __license__)
+:copyright: {2!s}
+""".format(__version__, __author__, __license__)
 
 
 def values(obj):

--- a/lib/fanart/errors.py
+++ b/lib/fanart/errors.py
@@ -4,7 +4,7 @@ class FanartError(Exception):
 
     def __repr__(self):
         name = self.__class__.__name__
-        return '%s%r' % (name, self.args)
+        return '{0!s}{1!r}'.format(name, self.args)
 
 
 class ResponseFanartError(FanartError):

--- a/lib/fanart/immutable.py
+++ b/lib/fanart/immutable.py
@@ -20,7 +20,7 @@ class Immutable(object):
         return hash(repr(self))
 
     def __repr__(self):
-        return '%s(%s)' % (
+        return '{0!s}({1!s})'.format(
             self.__class__.__name__,
             ', '.join(['{0}={1}'.format(k, repr(v)) for k, v in self])
         )

--- a/lib/feedparser/__init__.py
+++ b/lib/feedparser/__init__.py
@@ -34,7 +34,7 @@ __version__ = '5.2.1'
 # HTTP "User-Agent" header to send to servers when downloading feeds.
 # If you are embedding feedparser in a larger application, you should
 # change this to your application name and URL.
-USER_AGENT = "feedparser/%s +https://github.com/kurtmckee/feedparser/" % __version__
+USER_AGENT = "feedparser/{0!s} +https://github.com/kurtmckee/feedparser/".format(__version__)
 
 from . import api
 from .api import parse

--- a/lib/feedparser/datetimes/greek.py
+++ b/lib/feedparser/datetimes/greek.py
@@ -49,8 +49,8 @@ def _parse_date_greek(dateString):
         return
     wday = _greek_wdays[m.group(1)]
     month = _greek_months[m.group(3)]
-    rfc822date = '%(wday)s, %(day)s %(month)s %(year)s %(hour)s:%(minute)s:%(second)s %(zonediff)s' % \
+    rfc822date = '{wday!s}, {day!s} {month!s} {year!s} {hour!s}:{minute!s}:{second!s} {zonediff!s}'.format(** \
                  {'wday': wday, 'day': m.group(2), 'month': month, 'year': m.group(4),\
                   'hour': m.group(5), 'minute': m.group(6), 'second': m.group(7),\
-                  'zonediff': m.group(8)}
+                  'zonediff': m.group(8)})
     return _parse_date_rfc822(rfc822date)

--- a/lib/feedparser/datetimes/hungarian.py
+++ b/lib/feedparser/datetimes/hungarian.py
@@ -36,8 +36,8 @@ def _parse_date_hungarian(dateString):
     hour = m.group(4)
     if len(hour) == 1:
         hour = '0' + hour
-    w3dtfdate = '%(year)s-%(month)s-%(day)sT%(hour)s:%(minute)s%(zonediff)s' % \
+    w3dtfdate = '{year!s}-{month!s}-{day!s}T{hour!s}:{minute!s}{zonediff!s}'.format(** \
                 {'year': m.group(1), 'month': month, 'day': day,\
                  'hour': hour, 'minute': m.group(5),\
-                 'zonediff': m.group(6)}
+                 'zonediff': m.group(6)})
     return _parse_date_w3dtf(w3dtfdate)

--- a/lib/feedparser/datetimes/korean.py
+++ b/lib/feedparser/datetimes/korean.py
@@ -12,20 +12,18 @@ _korean_am    = '\uc624\uc804' # bfc0 c0fc in euc-kr
 _korean_pm    = '\uc624\ud6c4' # bfc0 c8c4 in euc-kr
 
 _korean_onblog_date_re = \
-    re.compile('(\d{4})%s\s+(\d{2})%s\s+(\d{2})%s\s+(\d{2}):(\d{2}):(\d{2})' % \
-               (_korean_year, _korean_month, _korean_day))
+    re.compile('(\d{{4}}){0!s}\s+(\d{{2}}){1!s}\s+(\d{{2}}){2!s}\s+(\d{{2}}):(\d{{2}}):(\d{{2}})'.format(_korean_year, _korean_month, _korean_day))
 _korean_nate_date_re = \
-    re.compile('(\d{4})-(\d{2})-(\d{2})\s+(%s|%s)\s+(\d{,2}):(\d{,2}):(\d{,2})' % \
-               (_korean_am, _korean_pm))
+    re.compile('(\d{{4}})-(\d{{2}})-(\d{{2}})\s+({0!s}|{1!s})\s+(\d{{,2}}):(\d{{,2}}):(\d{{,2}})'.format(_korean_am, _korean_pm))
 def _parse_date_onblog(dateString):
     '''Parse a string according to the OnBlog 8-bit date format'''
     m = _korean_onblog_date_re.match(dateString)
     if not m:
         return
-    w3dtfdate = '%(year)s-%(month)s-%(day)sT%(hour)s:%(minute)s:%(second)s%(zonediff)s' % \
+    w3dtfdate = '{year!s}-{month!s}-{day!s}T{hour!s}:{minute!s}:{second!s}{zonediff!s}'.format(** \
                 {'year': m.group(1), 'month': m.group(2), 'day': m.group(3),\
                  'hour': m.group(4), 'minute': m.group(5), 'second': m.group(6),\
-                 'zonediff': '+09:00'}
+                 'zonediff': '+09:00'})
     return _parse_date_w3dtf(w3dtfdate)
 
 def _parse_date_nate(dateString):
@@ -40,8 +38,8 @@ def _parse_date_nate(dateString):
     hour = str(hour)
     if len(hour) == 1:
         hour = '0' + hour
-    w3dtfdate = '%(year)s-%(month)s-%(day)sT%(hour)s:%(minute)s:%(second)s%(zonediff)s' % \
+    w3dtfdate = '{year!s}-{month!s}-{day!s}T{hour!s}:{minute!s}:{second!s}{zonediff!s}'.format(** \
                 {'year': m.group(1), 'month': m.group(2), 'day': m.group(3),\
                  'hour': hour, 'minute': m.group(6), 'second': m.group(7),\
-                 'zonediff': '+09:00'}
+                 'zonediff': '+09:00'})
     return _parse_date_w3dtf(w3dtfdate)

--- a/lib/feedparser/datetimes/perforce.py
+++ b/lib/feedparser/datetimes/perforce.py
@@ -19,7 +19,7 @@ def _parse_date_perforce(aDateString):
         return None
     dow, year, month, day, hour, minute, second, tz = m.groups()
     months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
-    dateString = "%s, %s %s %s %s:%s:%s %s" % (dow, day, months[int(month) - 1], year, hour, minute, second, tz)
+    dateString = "{0!s}, {1!s} {2!s} {3!s} {4!s}:{5!s}:{6!s} {7!s}".format(dow, day, months[int(month) - 1], year, hour, minute, second, tz)
     tm = rfc822.parsedate_tz(dateString)
     if tm:
         return time.gmtime(rfc822.mktime_tz(tm))

--- a/lib/feedparser/encodings.py
+++ b/lib/feedparser/encodings.py
@@ -227,7 +227,7 @@ def convert_to_utf8(http_headers, data, result):
 
     if http_headers and (not acceptable_content_type):
         if 'content-type' in http_headers:
-            msg = '%s is not an XML media type' % http_headers['content-type']
+            msg = '{0!s} is not an XML media type'.format(http_headers['content-type'])
         else:
             msg = 'no Content-type specified'
         error = NonXMLContentType(msg)
@@ -263,13 +263,11 @@ def convert_to_utf8(http_headers, data, result):
     if not known_encoding:
         error = CharacterEncodingUnknown(
             'document encoding unknown, I tried ' +
-            '%s, %s, utf-8, windows-1252, and iso-8859-2 but nothing worked' %
-            (rfc3023_encoding, xml_encoding))
+            '{0!s}, {1!s}, utf-8, windows-1252, and iso-8859-2 but nothing worked'.format(rfc3023_encoding, xml_encoding))
         rfc3023_encoding = ''
     elif proposed_encoding != rfc3023_encoding:
         error = CharacterEncodingOverride(
-            'document declared as %s, but parsed as %s' %
-            (rfc3023_encoding, proposed_encoding))
+            'document declared as {0!s}, but parsed as {1!s}'.format(rfc3023_encoding, proposed_encoding))
         rfc3023_encoding = proposed_encoding
 
     result['encoding'] = rfc3023_encoding

--- a/lib/feedparser/html.py
+++ b/lib/feedparser/html.py
@@ -119,17 +119,17 @@ class _BaseHTMLProcessor(sgmllib.SGMLParser, object):
                 value=value.replace('>','&gt;').replace('<','&lt;').replace('"','&quot;')
                 value = self.bare_ampersand.sub("&amp;", value)
                 uattrs.append((key, value))
-            strattrs = ''.join([' %s="%s"' % (key, value) for key, value in uattrs])
+            strattrs = ''.join([' {0!s}="{1!s}"'.format(key, value) for key, value in uattrs])
         if tag in self.elements_no_end_tag:
-            self.pieces.append('<%s%s />' % (tag, strattrs))
+            self.pieces.append('<{0!s}{1!s} />'.format(tag, strattrs))
         else:
-            self.pieces.append('<%s%s>' % (tag, strattrs))
+            self.pieces.append('<{0!s}{1!s}>'.format(tag, strattrs))
 
     def unknown_endtag(self, tag):
         # called for each end tag, e.g. for </pre>, tag will be 'pre'
         # Reconstruct the original end tag.
         if tag not in self.elements_no_end_tag:
-            self.pieces.append("</%s>" % tag)
+            self.pieces.append("</{0!s}>".format(tag))
 
     def handle_charref(self, ref):
         # called for each character reference, e.g. for '&#160;', ref will be '160'
@@ -141,17 +141,17 @@ class _BaseHTMLProcessor(sgmllib.SGMLParser, object):
             value = int(ref)
 
         if value in _cp1252:
-            self.pieces.append('&#%s;' % hex(ord(_cp1252[value]))[1:])
+            self.pieces.append('&#{0!s};'.format(hex(ord(_cp1252[value]))[1:]))
         else:
-            self.pieces.append('&#%s;' % ref)
+            self.pieces.append('&#{0!s};'.format(ref))
 
     def handle_entityref(self, ref):
         # called for each entity reference, e.g. for '&copy;', ref will be 'copy'
         # Reconstruct the original entity reference.
         if ref in name2codepoint or ref == 'apos':
-            self.pieces.append('&%s;' % ref)
+            self.pieces.append('&{0!s};'.format(ref))
         else:
-            self.pieces.append('&amp;%s' % ref)
+            self.pieces.append('&amp;{0!s}'.format(ref))
 
     def handle_data(self, text):
         # called for each block of plain text, i.e. outside of any tag and
@@ -162,19 +162,19 @@ class _BaseHTMLProcessor(sgmllib.SGMLParser, object):
     def handle_comment(self, text):
         # called for each HTML comment, e.g. <!-- insert Javascript code here -->
         # Reconstruct the original comment.
-        self.pieces.append('<!--%s-->' % text)
+        self.pieces.append('<!--{0!s}-->'.format(text))
 
     def handle_pi(self, text):
         # called for each processing instruction, e.g. <?instruction>
         # Reconstruct original processing instruction.
-        self.pieces.append('<?%s>' % text)
+        self.pieces.append('<?{0!s}>'.format(text))
 
     def handle_decl(self, text):
         # called for the DOCTYPE, if present, e.g.
         # <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
         #     "http://www.w3.org/TR/html4/loose.dtd">
         # Reconstruct original DOCTYPE
-        self.pieces.append('<!%s>' % text)
+        self.pieces.append('<!{0!s}>'.format(text))
 
     _new_declname_match = re.compile(r'[a-zA-Z][-_.a-zA-Z0-9:]*\s*').match
     def _scan_name(self, i, declstartpos):
@@ -195,10 +195,10 @@ class _BaseHTMLProcessor(sgmllib.SGMLParser, object):
             return None, -1
 
     def convert_charref(self, name):
-        return '&#%s;' % name
+        return '&#{0!s};'.format(name)
 
     def convert_entityref(self, name):
-        return '&%s;' % name
+        return '&{0!s};'.format(name)
 
     def output(self):
         '''Return processed HTML as a single string'''

--- a/lib/feedparser/http.py
+++ b/lib/feedparser/http.py
@@ -116,7 +116,7 @@ def _build_urllib2_request(url, agent, accept_header, etag, modified, referrer, 
         # in English.
         short_weekdays = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']
         months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
-        request.add_header('If-Modified-Since', '%s, %02d %s %04d %02d:%02d:%02d GMT' % (short_weekdays[modified[6]], modified[2], months[modified[1] - 1], modified[0], modified[3], modified[4], modified[5]))
+        request.add_header('If-Modified-Since', '{0!s}, {1:02d} {2!s} {3:04d} {4:02d}:{5:02d}:{6:02d} GMT'.format(short_weekdays[modified[6]], modified[2], months[modified[1] - 1], modified[0], modified[3], modified[4], modified[5]))
     if referrer:
         request.add_header('Referer', referrer)
     if gzip and zlib:
@@ -128,7 +128,7 @@ def _build_urllib2_request(url, agent, accept_header, etag, modified, referrer, 
     else:
         request.add_header('Accept-encoding', '')
     if auth:
-        request.add_header('Authorization', 'Basic %s' % auth)
+        request.add_header('Authorization', 'Basic {0!s}'.format(auth))
     if accept_header:
         request.add_header('Accept', accept_header)
     # use this for whatever -- cookies, special headers, etc
@@ -161,7 +161,7 @@ def get(url, etag=None, modified=None, agent=None, referrer=None, handlers=None,
         if realhost:
             user_passwd, realhost = urllib.parse.splituser(realhost)
             if user_passwd:
-                url = '%s://%s%s' % (urltype, realhost, rest)
+                url = '{0!s}://{1!s}{2!s}'.format(urltype, realhost, rest)
                 auth = base64.standard_b64encode(user_passwd).strip()
 
     # iri support

--- a/lib/feedparser/mixin.py
+++ b/lib/feedparser/mixin.py
@@ -244,7 +244,7 @@ class _FeedParserMixin(
                     attrs.append(('xmlns',namespace))
             if tag == 'svg':
                 self.svgOK += 1
-            return self.handle_data('<%s%s>' % (tag, self.strattrs(attrs)), escape=0)
+            return self.handle_data('<{0!s}{1!s}>'.format(tag, self.strattrs(attrs)), escape=0)
 
         # match namespaces
         if tag.find(':') != -1:
@@ -307,7 +307,7 @@ class _FeedParserMixin(
             self.contentparams['type'] = 'application/xhtml+xml'
         if self.incontent and self.contentparams.get('type') == 'application/xhtml+xml':
             tag = tag.split(':')[-1]
-            self.handle_data('</%s>' % tag, escape=0)
+            self.handle_data('</{0!s}>'.format(tag), escape=0)
 
         # track xml:base and xml:lang going out of scope
         if self.basestack:
@@ -327,7 +327,7 @@ class _FeedParserMixin(
             return
         ref = ref.lower()
         if ref in ('34', '38', '39', '60', '62', 'x22', 'x26', 'x27', 'x3c', 'x3e'):
-            text = '&#%s;' % ref
+            text = '&#{0!s};'.format(ref)
         else:
             if ref[0] == 'x':
                 c = int(ref[1:], 16)
@@ -341,7 +341,7 @@ class _FeedParserMixin(
         if not self.elementstack:
             return
         if ref in ('lt', 'gt', 'quot', 'amp', 'apos'):
-            text = '&%s;' % ref
+            text = '&{0!s};'.format(ref)
         elif ref in self.entities:
             text = self.entities[ref]
             if text.startswith('&#') and text.endswith(';'):
@@ -350,7 +350,7 @@ class _FeedParserMixin(
             try:
                 name2codepoint[ref]
             except KeyError:
-                text = '&%s;' % ref
+                text = '&{0!s};'.format(ref)
             else:
                 text = chr(name2codepoint[ref]).encode('utf-8')
         self.elementstack[-1][2].append(text)
@@ -429,7 +429,7 @@ class _FeedParserMixin(
         return data
 
     def strattrs(self, attrs):
-        return ''.join([' %s="%s"' % (t[0],_xmlescape(t[1],{'"':'&quot;'})) for t in attrs])
+        return ''.join([' {0!s}="{1!s}"'.format(t[0], _xmlescape(t[1],{'"':'&quot;'})) for t in attrs])
 
     def push(self, element, expectingText):
         self.elementstack.append([element, expectingText, []])
@@ -699,12 +699,12 @@ class _FeedParserMixin(
 
     def _sync_author_detail(self, key='author'):
         context = self._getContext()
-        detail = context.get('%ss' % key, [FeedParserDict()])[-1]
+        detail = context.get('{0!s}s'.format(key), [FeedParserDict()])[-1]
         if detail:
             name = detail.get('name')
             email = detail.get('email')
             if name and email:
-                context[key] = '%s (%s)' % (name, email)
+                context[key] = '{0!s} ({1!s})'.format(name, email)
             elif name:
                 context[key] = name
             elif email:
@@ -728,7 +728,7 @@ class _FeedParserMixin(
                     author = author[:-1]
                 author = author.strip()
             if author or email:
-                context.setdefault('%s_detail' % key, detail)
+                context.setdefault('{0!s}_detail'.format(key), detail)
             if author:
                 detail['name'] = author
             if email:

--- a/lib/feedparser/parsers/loose.py
+++ b/lib/feedparser/parsers/loose.py
@@ -69,4 +69,4 @@ class _LooseFeedParser(object):
         return data
 
     def strattrs(self, attrs):
-        return ''.join([' %s="%s"' % (n,v.replace('"','&quot;')) for n,v in attrs])
+        return ''.join([' {0!s}="{1!s}"'.format(n, v.replace('"','&quot;')) for n,v in attrs])

--- a/lib/feedparser/parsers/strict.py
+++ b/lib/feedparser/parsers/strict.py
@@ -67,7 +67,7 @@ class _StrictFeedParser(object):
             givenprefix = None
         prefix = self._matchnamespaces.get(lowernamespace, givenprefix)
         if givenprefix and (prefix == None or (prefix == '' and lowernamespace == '')) and givenprefix not in self.namespacesInUse:
-            raise UndeclaredNamespace("'%s' is not associated with a namespace" % givenprefix)
+            raise UndeclaredNamespace("'{0!s}' is not associated with a namespace".format(givenprefix))
         localname = str(localname).lower()
 
         # qname implementation is horribly broken in Python 2.1 (it

--- a/lib/feedparser/util.py
+++ b/lib/feedparser/util.py
@@ -138,7 +138,7 @@ class FeedParserDict(dict):
         try:
             return self.__getitem__(key)
         except KeyError:
-            raise AttributeError("object has no attribute '%s'" % key)
+            raise AttributeError("object has no attribute '{0!s}'".format(key))
 
     def __hash__(self):
         return id(self)

--- a/lib/github/ContentFile.py
+++ b/lib/github/ContentFile.py
@@ -49,7 +49,7 @@ class ContentFile(github.GithubObject.CompletableGithubObject):
 
     @property
     def decoded_content(self):
-        assert self.encoding == "base64", "unsupported encoding: %s" % self.encoding
+        assert self.encoding == "base64", "unsupported encoding: {0!s}".format(self.encoding)
         if atLeastPython3:
             content = bytearray(self.content, "utf-8")  # pragma no cover (covered by tests with Python 3.2)
         else:

--- a/lib/github/MainClass.py
+++ b/lib/github/MainClass.py
@@ -196,12 +196,12 @@ class Github(object):
         """
         assert isinstance(full_name_or_id, (str, unicode, int, long)), full_name_or_id
         url_base = "/repositories/" if isinstance(full_name_or_id, int) or isinstance(full_name_or_id, long) else "/repos/"
-        url = "%s%s" % (url_base, full_name_or_id)
+        url = "{0!s}{1!s}".format(url_base, full_name_or_id)
         if lazy:
             return Repository.Repository(self.__requester, {}, {"url": url}, completed=False)
         headers, data = self.__requester.requestJsonAndCheck(
             "GET",
-            "%s%s" % (url_base, full_name_or_id)
+            "{0!s}{1!s}".format(url_base, full_name_or_id)
         )
         return Repository.Repository(self.__requester, headers, data, completed=True)
 
@@ -318,7 +318,7 @@ class Github(object):
             query_chunks.append(query)
 
         for qualifier, value in qualifiers.items():
-            query_chunks.append("%s:%s" % (qualifier, value))
+            query_chunks.append("{0!s}:{1!s}".format(qualifier, value))
 
         url_parameters["q"] = ' '.join(query_chunks)
         assert url_parameters["q"], "need at least one qualifier"
@@ -353,7 +353,7 @@ class Github(object):
             query_chunks.append(query)
 
         for qualifier, value in qualifiers.items():
-            query_chunks.append("%s:%s" % (qualifier, value))
+            query_chunks.append("{0!s}:{1!s}".format(qualifier, value))
 
         url_parameters["q"] = ' '.join(query_chunks)
         assert url_parameters["q"], "need at least one qualifier"
@@ -388,7 +388,7 @@ class Github(object):
             query_chunks.append(query)
 
         for qualifier, value in qualifiers.items():
-            query_chunks.append("%s:%s" % (qualifier, value))
+            query_chunks.append("{0!s}:{1!s}".format(qualifier, value))
 
         url_parameters["q"] = ' '.join(query_chunks)
         assert url_parameters["q"], "need at least one qualifier"
@@ -423,7 +423,7 @@ class Github(object):
             query_chunks.append(query)
 
         for qualifier, value in qualifiers.items():
-            query_chunks.append("%s:%s" % (qualifier, value))
+            query_chunks.append("{0!s}:{1!s}".format(qualifier, value))
 
         url_parameters["q"] = ' '.join(query_chunks)
         assert url_parameters["q"], "need at least one qualifier"

--- a/lib/github/Requester.py
+++ b/lib/github/Requester.py
@@ -332,7 +332,7 @@ class Requester:
             conn = self.__connectionClass(url.hostname, url.port, **kwds)
             headers = {}
             if url.username and url.password:
-                auth = '%s:%s' % (url.username, url.password)
+                auth = '{0!s}:{1!s}'.format(url.username, url.password)
                 headers['Proxy-Authorization'] = 'Basic ' + base64.b64encode(auth)
             conn.set_tunnel(self.__hostname, self.__port, headers)
         else:

--- a/lib/guessit/__main__.py
+++ b/lib/guessit/__main__.py
@@ -81,10 +81,10 @@ def display_properties(options):
         properties_list = list(sorted(properties.keys()))
         for property_name in properties_list:
             property_values = properties.get(property_name)
-            print(2 * ' ' + '[+] %s' % (property_name,))
+            print(2 * ' ' + '[+] {0!s}'.format(property_name))
             if property_values and options.values:
                 for property_value in property_values:
-                    print(4 * ' ' + '[!] %s' % (property_value,))
+                    print(4 * ' ' + '[!] {0!s}'.format(property_value))
 
 
 def main(args=None):  # pylint:disable=too-many-branches

--- a/lib/guessit/reutils.py
+++ b/lib/guessit/reutils.py
@@ -16,6 +16,6 @@ def build_or_pattern(patterns, escape=False):
             or_pattern.append('(?:')
         else:
             or_pattern.append('|')
-        or_pattern.append('(?:%s)' % re.escape(pattern) if escape else pattern)
+        or_pattern.append('(?:{0!s})'.format(re.escape(pattern)) if escape else pattern)
     or_pattern.append(')')
     return ''.join(or_pattern)

--- a/lib/guessit/rules/common/date.py
+++ b/lib/guessit/rules/common/date.py
@@ -11,13 +11,13 @@ _dsep = r'[-/ \.]'
 _dsep_bis = r'[-/ \.x]'
 
 date_regexps = [
-    re.compile(r'%s((\d{8}))%s' % (_dsep, _dsep), re.IGNORECASE),
-    re.compile(r'%s((\d{6}))%s' % (_dsep, _dsep), re.IGNORECASE),
-    re.compile(r'(?:^|[^\d])((\d{2})%s(\d{1,2})%s(\d{1,2}))(?:$|[^\d])' % (_dsep, _dsep), re.IGNORECASE),
-    re.compile(r'(?:^|[^\d])((\d{1,2})%s(\d{1,2})%s(\d{2}))(?:$|[^\d])' % (_dsep, _dsep), re.IGNORECASE),
-    re.compile(r'(?:^|[^\d])((\d{4})%s(\d{1,2})%s(\d{1,2}))(?:$|[^\d])' % (_dsep_bis, _dsep), re.IGNORECASE),
-    re.compile(r'(?:^|[^\d])((\d{1,2})%s(\d{1,2})%s(\d{4}))(?:$|[^\d])' % (_dsep, _dsep_bis), re.IGNORECASE),
-    re.compile(r'(?:^|[^\d])((\d{1,2}(?:st|nd|rd|th)?%s(?:[a-z]{3,10})%s\d{4}))(?:$|[^\d])' % (_dsep, _dsep),
+    re.compile(r'{0!s}((\d{{8}})){1!s}'.format(_dsep, _dsep), re.IGNORECASE),
+    re.compile(r'{0!s}((\d{{6}})){1!s}'.format(_dsep, _dsep), re.IGNORECASE),
+    re.compile(r'(?:^|[^\d])((\d{{2}}){0!s}(\d{{1,2}}){1!s}(\d{{1,2}}))(?:$|[^\d])'.format(_dsep, _dsep), re.IGNORECASE),
+    re.compile(r'(?:^|[^\d])((\d{{1,2}}){0!s}(\d{{1,2}}){1!s}(\d{{2}}))(?:$|[^\d])'.format(_dsep, _dsep), re.IGNORECASE),
+    re.compile(r'(?:^|[^\d])((\d{{4}}){0!s}(\d{{1,2}}){1!s}(\d{{1,2}}))(?:$|[^\d])'.format(_dsep_bis, _dsep), re.IGNORECASE),
+    re.compile(r'(?:^|[^\d])((\d{{1,2}}){0!s}(\d{{1,2}}){1!s}(\d{{4}}))(?:$|[^\d])'.format(_dsep, _dsep_bis), re.IGNORECASE),
+    re.compile(r'(?:^|[^\d])((\d{{1,2}}(?:st|nd|rd|th)?{0!s}(?:[a-z]{{3,10}}){1!s}\d{{4}}))(?:$|[^\d])'.format(_dsep, _dsep),
                re.IGNORECASE)]
 
 

--- a/lib/guessit/rules/common/numeral.py
+++ b/lib/guessit/rules/common/numeral.py
@@ -81,7 +81,7 @@ def __parse_roman(value):
     :rtype:
     """
     if not __romanNumeralPattern.search(value):
-        raise ValueError('Invalid Roman numeral: %s' % value)
+        raise ValueError('Invalid Roman numeral: {0!s}'.format(value))
 
     result = 0
     index = 0

--- a/lib/guessit/test/test_yml.py
+++ b/lib/guessit/test/test_yml.py
@@ -66,15 +66,13 @@ class EntryResult(object):
         if self.ok:
             return self.string + ': OK!'
         elif self.warning:
-            return '%s%s: WARNING! (valid=%i, extra=%i)' % ('-' if self.negates else '', self.string, len(self.valid),
+            return '{0!s}{1!s}: WARNING! (valid={2:d}, extra={3:d})'.format('-' if self.negates else '', self.string, len(self.valid),
                                                             len(self.extra))
         elif self.error:
-            return '%s%s: ERROR! (valid=%i, missing=%i, different=%i, extra=%i, others=%i)' % \
-                   ('-' if self.negates else '', self.string, len(self.valid), len(self.missing), len(self.different),
+            return '{0!s}{1!s}: ERROR! (valid={2:d}, missing={3:d}, different={4:d}, extra={5:d}, others={6:d})'.format('-' if self.negates else '', self.string, len(self.valid), len(self.missing), len(self.different),
                     len(self.extra), len(self.others))
         else:
-            return '%s%s: UNKOWN! (valid=%i, missing=%i, different=%i, extra=%i, others=%i)' % \
-                   ('-' if self.negates else '', self.string, len(self.valid), len(self.missing), len(self.different),
+            return '{0!s}{1!s}: UNKOWN! (valid={2:d}, missing={3:d}, different={4:d}, extra={5:d}, others={6:d})'.format('-' if self.negates else '', self.string, len(self.valid), len(self.missing), len(self.different),
                     len(self.extra), len(self.others))
 
     @property

--- a/lib/guessit/yamlutils.py
+++ b/lib/guessit/yamlutils.py
@@ -35,7 +35,7 @@ class OrderedDictYAMLLoader(yaml.Loader):
             self.flatten_mapping(node)
         else:  # pragma: no cover
             raise yaml.constructor.ConstructorError(None, None,
-                                                    'expected a mapping node, but found %s' % node.id, node.start_mark)
+                                                    'expected a mapping node, but found {0!s}'.format(node.id), node.start_mark)
 
         mapping = OrderedDict()
         for key_node, value_node in node.value:
@@ -44,8 +44,7 @@ class OrderedDictYAMLLoader(yaml.Loader):
                 hash(key)
             except TypeError as exc:  # pragma: no cover
                 raise yaml.constructor.ConstructorError('while constructing a mapping',
-                                                        node.start_mark, 'found unacceptable key (%s)'
-                                                        % exc, key_node.start_mark)
+                                                        node.start_mark, 'found unacceptable key ({0!s})'.format(exc), key_node.start_mark)
             value = self.construct_object(value_node, deep=deep)
             mapping[key] = value
         return mapping

--- a/lib/hachoir_core/benchmark.py
+++ b/lib/hachoir_core/benchmark.py
@@ -9,7 +9,7 @@ class BenchmarkError(Exception):
     """
     def __init__(self, message):
         Exception.__init__(self,
-            "Benchmark internal error: %s" % message)
+            "Benchmark internal error: {0!s}".format(message))
 
 class BenchmarkStat:
     """

--- a/lib/hachoir_core/bits.py
+++ b/lib/hachoir_core/bits.py
@@ -257,8 +257,8 @@ def _createStructFormat():
     for struct_format in "BHILQ":
         try:
             size = calcsize(struct_format)
-            format[BIG_ENDIAN][size] = '>%s' % struct_format
-            format[LITTLE_ENDIAN][size] = '<%s' % struct_format
+            format[BIG_ENDIAN][size] = '>{0!s}'.format(struct_format)
+            format[LITTLE_ENDIAN][size] = '<{0!s}'.format(struct_format)
         except struct_error:
             pass
     return format

--- a/lib/hachoir_core/dict.py
+++ b/lib/hachoir_core/dict.py
@@ -178,6 +178,6 @@ class Dict(object):
         self._value_list.insert(index, value)
 
     def __repr__(self):
-        items = ( "%r: %r" % (key, value) for key, value in self.iteritems() )
-        return "{%s}" % ", ".join(items)
+        items = ( "{0!r}: {1!r}".format(key, value) for key, value in self.iteritems() )
+        return "{{{0!s}}}".format(", ".join(items))
 

--- a/lib/hachoir_core/field/basic_field_set.py
+++ b/lib/hachoir_core/field/basic_field_set.py
@@ -62,7 +62,7 @@ class BasicFieldSet(Field):
         # Sanity checks (post-conditions)
         assert self.endian in (BIG_ENDIAN, LITTLE_ENDIAN, MIDDLE_ENDIAN)
         if (self._size is not None) and (self._size <= 0):
-            raise ParserError("Invalid parser '%s' size: %s" % (self.path, self._size))
+            raise ParserError("Invalid parser '{0!s}' size: {1!s}".format(self.path, self._size))
 
     def reset(self):
         self._field_array_count = {}
@@ -91,7 +91,7 @@ class BasicFieldSet(Field):
             # Callback prototype: def f(field, new_value)
             # Called to ask to set new value
             "set-field-value"
-        ), "Event name %r is invalid" % event_name
+        ), "Event name {0!r} is invalid".format(event_name)
         if local:
             if self._event_handler is None:
                 self._event_handler = EventHandler()
@@ -116,7 +116,7 @@ class BasicFieldSet(Field):
             self._field_array_count[key] += 1
         except KeyError:
             self._field_array_count[key] = 0
-        field._name = key + "[%u]" % self._field_array_count[key]
+        field._name = key + "[{0:d}]".format(self._field_array_count[key])
 
     def readFirstFields(self, number):
         """

--- a/lib/hachoir_core/field/bit_field.py
+++ b/lib/hachoir_core/field/bit_field.py
@@ -32,8 +32,7 @@ class RawBits(Field):
         if self._size < config.max_bit_length:
             return unicode(self.value)
         else:
-            return _("<%s size=%u>" %
-                (self.__class__.__name__, self._size))
+            return _("<{0!s} size={1:d}>".format(self.__class__.__name__, self._size))
     createRawDisplay = createDisplay
 
 class Bits(RawBits):

--- a/lib/hachoir_core/field/byte_field.py
+++ b/lib/hachoir_core/field/byte_field.py
@@ -21,7 +21,7 @@ class RawBytes(Field):
     def __init__(self, parent, name, length, description="Raw data"):
         assert issubclass(parent.__class__, Field)
         if not(0 < length <= MAX_LENGTH):
-            raise FieldError("Invalid RawBytes length (%s)!" % length)
+            raise FieldError("Invalid RawBytes length ({0!s})!".format(length))
         Field.__init__(self, parent, name, length*8, description)
         self._display = None
 
@@ -43,9 +43,9 @@ class RawBytes(Field):
         else:
             display = str2hex(display, format=r"\x%02x")
             if truncated:
-                return '"%s(...)"' % display
+                return '"{0!s}(...)"'.format(display)
             else:
-                return '"%s"' % display
+                return '"{0!s}"'.format(display)
 
     def createDisplay(self):
         return self._createDisplay(True)

--- a/lib/hachoir_core/field/fake_array.py
+++ b/lib/hachoir_core/field/fake_array.py
@@ -21,7 +21,7 @@ class FakeArray:
         else:
             self.fieldset = fieldset
             self.name = name
-        self._format = "%s[%%u]" % self.name
+        self._format = "{0!s}[%u]".format(self.name)
         self._cache = {}
         self._known_size = False
         self._max_index = -1

--- a/lib/hachoir_core/field/field.py
+++ b/lib/hachoir_core/field/field.py
@@ -22,7 +22,7 @@ def joinPath(path, name):
     if path != "/":
         return "/".join((path, name))
     else:
-        return "/%s" % name
+        return "/{0!s}".format(name)
 
 class MissingField(KeyError, FieldError):
     def __init__(self, field, key):
@@ -31,10 +31,10 @@ class MissingField(KeyError, FieldError):
         self.key = key
 
     def __str__(self):
-        return 'Can\'t get field "%s" from %s' % (self.key, self.field.path)
+        return 'Can\'t get field "{0!s}" from {1!s}'.format(self.key, self.field.path)
 
     def __unicode__(self):
-        return u'Can\'t get field "%s" from %s' % (self.key, self.field.path)
+        return u'Can\'t get field "{0!s}" from {1!s}'.format(self.key, self.field.path)
 
 class Field(Logger):
     # static size can have two differents value: None (no static size), an
@@ -101,7 +101,7 @@ class Field(Logger):
     def __unicode__(self):
         return self.display
     def __repr__(self):
-        return "<%s path=%r, address=%s, size=%s>" % (
+        return "<{0!s} path={1!r}, address={2!s}, size={3!s}>".format(
             self.__class__.__name__, self.path, self._address, self._size)
 
     def hasValue(self):
@@ -129,7 +129,7 @@ class Field(Logger):
             try:
                 self.__display = self.createDisplay()
             except HACHOIR_ERRORS, err:
-                self.error("Unable to create display: %s" % err)
+                self.error("Unable to create display: {0!s}".format(err))
                 self.__display = u""
         return self.__display
     display = property(lambda self: self._getDisplay(),
@@ -146,7 +146,7 @@ class Field(Logger):
             try:
                 self.__raw_display = self.createRawDisplay()
             except HACHOIR_ERRORS, err:
-                self.error("Unable to create raw display: %s" % err)
+                self.error("Unable to create raw display: {0!s}".format(err))
                 self.__raw_display = u""
         return self.__raw_display
     raw_display = property(lambda self: self._getRawDisplay(),

--- a/lib/hachoir_core/field/float.py
+++ b/lib/hachoir_core/field/float.py
@@ -59,8 +59,7 @@ def floatFactory(name, format, mantissa_bits, exponent_bits, doc):
                 try:
                     return struct.unpack(self.struct_format, raw)[0]
                 except struct.error, err:
-                    raise ValueError("[%s] conversion error: %s" %
-                        (self.__class__.__name__, err))
+                    raise ValueError("[{0!s}] conversion error: {1!s}".format(self.__class__.__name__, err))
             else:
                 try:
                     value = self["mantissa"].value * (2.0 ** float(self["exponent"].value))
@@ -69,8 +68,8 @@ def floatFactory(name, format, mantissa_bits, exponent_bits, doc):
                     else:
                         return value
                 except OverflowError:
-                    raise ValueError("[%s] floating point overflow" %
-                        self.__class__.__name__)
+                    raise ValueError("[{0!s}] floating point overflow".format(
+                        self.__class__.__name__))
 
         def createFields(self):
             yield Bit(self, "negative")

--- a/lib/hachoir_core/field/generic_field_set.py
+++ b/lib/hachoir_core/field/generic_field_set.py
@@ -92,8 +92,7 @@ class GenericFieldSet(BasicFieldSet):
         self._array_cache = {}
 
     def __str__(self):
-        return '<%s path=%s, current_size=%s, current length=%s>' % \
-            (self.__class__.__name__, self.path, self._current_size, len(self._fields))
+        return '<{0!s} path={1!s}, current_size={2!s}, current length={3!s}>'.format(self.__class__.__name__, self.path, self._current_size, len(self._fields))
 
     def __len__(self):
         """
@@ -146,18 +145,16 @@ class GenericFieldSet(BasicFieldSet):
         May raise a StopIteration() on error
         """
         if not issubclass(field.__class__, Field):
-            raise ParserError("Field type (%s) is not a subclass of 'Field'!"
-                % field.__class__.__name__)
+            raise ParserError("Field type ({0!s}) is not a subclass of 'Field'!".format(field.__class__.__name__))
         assert isinstance(field._name, str)
         if field._name.endswith("[]"):
             self.setUniqueFieldName(field)
         if config.debug:
-            self.info("[+] DBG: _addField(%s)" % field.name)
+            self.info("[+] DBG: _addField({0!s})".format(field.name))
 
         # required for the msoffice parser
         if field._address != self._current_size:
-            self.warning("Fix address of %s to %s (was %s)" %
-                (field.path, self._current_size, field._address))
+            self.warning("Fix address of {0!s} to {1!s} (was {2!s})".format(field.path, self._current_size, field._address))
             field._address = self._current_size
 
         ask_stop = False
@@ -167,11 +164,11 @@ class GenericFieldSet(BasicFieldSet):
             field_size = field.size
         except HACHOIR_ERRORS, err:
             if field.is_field_set and field.current_length and field.eof:
-                self.warning("Error when getting size of '%s': %s" % (field.name, err))
+                self.warning("Error when getting size of '{0!s}': {1!s}".format(field.name, err))
                 field._stopFeeding()
                 ask_stop = True
             else:
-                self.warning("Error when getting size of '%s': delete it" % field.name)
+                self.warning("Error when getting size of '{0!s}': delete it".format(field.name))
                 self.__is_feeding = False
                 raise
         self.__is_feeding = False
@@ -182,7 +179,7 @@ class GenericFieldSet(BasicFieldSet):
             if self.autofix and self._current_size:
                 self._fixFieldSize(field, field.size + dsize)
             else:
-                raise ParserError("Field %s is too large!" % field.path)
+                raise ParserError("Field {0!s} is too large!".format(field.path))
 
         self._current_size += field.size
         try:
@@ -204,7 +201,7 @@ class GenericFieldSet(BasicFieldSet):
             # Don't add the field <=> delete item
             if self._size is None:
                 self._size = self._current_size + new_size
-        self.warning("[Autofix] Delete '%s' (too large)" % field.path)
+        self.warning("[Autofix] Delete '{0!s}' (too large)".format(field.path))
         raise StopIteration()
 
     def _getField(self, name, const):
@@ -273,7 +270,7 @@ class GenericFieldSet(BasicFieldSet):
         # If last field is too big, delete it
         while self._size < self._current_size:
             field = self._deleteField(len(self._fields)-1)
-            message.append("delete field %s" % field.path)
+            message.append("delete field {0!s}".format(field.path))
         assert self._current_size <= self._size
 
         # If field size current is smaller: add a raw field
@@ -299,7 +296,7 @@ class GenericFieldSet(BasicFieldSet):
             if self.autofix:
                 new_field = self._fixLastField()
             else:
-                raise ParserError("Invalid parser \"%s\" size!" % self.path)
+                raise ParserError("Invalid parser \"{0!s}\" size!".format(self.path))
         self._field_generator = None
         return new_field
 
@@ -319,8 +316,7 @@ class GenericFieldSet(BasicFieldSet):
         """
         if self.__is_feeding \
         or (self._field_generator and self._field_generator.gi_running):
-            self.warning("Unable to get %s (and generator is already running)"
-                % field_name)
+            self.warning("Unable to get {0!s} (and generator is already running)".format(field_name))
             return None
         try:
             while True:
@@ -441,7 +437,7 @@ class GenericFieldSet(BasicFieldSet):
         # TODO: Check in self and not self.field
         # Problem is that "generator is already executing"
         if name not in self._fields:
-            raise ParserError("Unable to replace %s: field doesn't exist!" % name)
+            raise ParserError("Unable to replace {0!s}: field doesn't exist!".format(name))
         assert 1 <= len(new_fields)
         old_field = self[name]
         total_size = sum( (field.size for field in new_fields) )
@@ -455,8 +451,7 @@ class GenericFieldSet(BasicFieldSet):
         field._address = old_field.address
         if field.name != name and field.name in self._fields:
             raise ParserError(
-                "Unable to replace %s: name \"%s\" is already used!"
-                % (name, field.name))
+                "Unable to replace {0!s}: name \"{1!s}\" is already used!".format(name, field.name))
         self._fields.replace(name, field.name, field)
         self.raiseEvent("field-replaced", old_field, field)
         if 1 < len(new_fields):
@@ -468,8 +463,7 @@ class GenericFieldSet(BasicFieldSet):
                 field._address = address
                 if field.name in self._fields:
                     raise ParserError(
-                        "Unable to replace %s: name \"%s\" is already used!"
-                        % (name, field.name))
+                        "Unable to replace {0!s}: name \"{1!s}\" is already used!".format(name, field.name))
                 self._fields.insert(index, field.name, field)
                 self.raiseEvent("field-inserted", index, field)
                 index += 1

--- a/lib/hachoir_core/field/helper.py
+++ b/lib/hachoir_core/field/helper.py
@@ -7,7 +7,7 @@ from hachoir_core.stream import FileOutputStream
 
 def createRawField(parent, size, name="raw[]", description=None):
     if size <= 0:
-        raise FieldError("Unable to create raw field of %s bits" % size)
+        raise FieldError("Unable to create raw field of {0!s} bits".format(size))
     if (size % 8) == 0:
         return RawBytes(parent, name, size/8, description)
     else:
@@ -15,7 +15,7 @@ def createRawField(parent, size, name="raw[]", description=None):
 
 def createPaddingField(parent, nbits, name="padding[]", description=None):
     if nbits <= 0:
-        raise FieldError("Unable to create padding of %s bits" % nbits)
+        raise FieldError("Unable to create padding of {0!s} bits".format(nbits))
     if (nbits % 8) == 0:
         return PaddingBytes(parent, name, nbits/8, description)
     else:
@@ -23,7 +23,7 @@ def createPaddingField(parent, nbits, name="padding[]", description=None):
 
 def createNullField(parent, nbits, name="padding[]", description=None):
     if nbits <= 0:
-        raise FieldError("Unable to create null padding of %s bits" % nbits)
+        raise FieldError("Unable to create null padding of {0!s} bits".format(nbits))
     if (nbits % 8) == 0:
         return NullBytes(parent, name, nbits/8, description)
     else:

--- a/lib/hachoir_core/field/integer.py
+++ b/lib/hachoir_core/field/integer.py
@@ -12,7 +12,7 @@ class GenericInteger(Bits):
     """
     def __init__(self, parent, name, signed, size, description=None):
         if not (8 <= size <= 16384):
-            raise FieldError("Invalid integer size (%s): have to be in 8..16384" % size)
+            raise FieldError("Invalid integer size ({0!s}): have to be in 8..16384".format(size))
         Bits.__init__(self, parent, name, size, description)
         self.signed = signed
 

--- a/lib/hachoir_core/field/link.py
+++ b/lib/hachoir_core/field/link.py
@@ -15,7 +15,7 @@ class Link(Field):
     def createDisplay(self):
         value = self.value
         if value is None:
-            return "<%s>" % MissingField.__name__
+            return "<{0!s}>".format(MissingField.__name__)
         return value.path
 
     def _getField(self, name, const):

--- a/lib/hachoir_core/field/new_seekable_field_set.py
+++ b/lib/hachoir_core/field/new_seekable_field_set.py
@@ -26,7 +26,7 @@ class NewRootSeekableFieldSet(GenericFieldSet):
         if not relative:
             address -= self.absolute_address
         if address < 0:
-            raise ParserError("Seek below field set start (%s.%s)" % divmod(address, 8))
+            raise ParserError("Seek below field set start ({0!s}.{1!s})".format(*divmod(address, 8)))
         self._current_size = address
         return None
 
@@ -47,7 +47,7 @@ class NewRootSeekableFieldSet(GenericFieldSet):
         # If last field is too big, delete it
         while self._size < self._current_size:
             field = self._deleteField(len(self._fields)-1)
-            message.append("delete field %s" % field.path)
+            message.append("delete field {0!s}".format(field.path))
         assert self._current_size <= self._size
 
         blocks = [(x.absolute_address, x.size) for x in self._fields]
@@ -58,7 +58,7 @@ class NewRootSeekableFieldSet(GenericFieldSet):
             self.setUniqueFieldName(field)
             self._fields.append(field.name, field)
             fields.append(field)
-            message.append("found unparsed segment: start %s, length %s" % (start, length))
+            message.append("found unparsed segment: start {0!s}, length {1!s}".format(start, length))
 
         self.seekBit(self._size, relative=False)
         message = ", ".join(message)

--- a/lib/hachoir_core/field/padding.py
+++ b/lib/hachoir_core/field/padding.py
@@ -36,12 +36,12 @@ class PaddingBits(Bits):
             self.warning("padding contents doesn't look normal (invalid pattern)")
             return False
         if self.MAX_SIZE < self._size:
-            self.info("only check first %u bits" % self.MAX_SIZE)
+            self.info("only check first {0:d} bits".format(self.MAX_SIZE))
         return True
 
     def createDisplay(self):
         if self._display_pattern:
-            return u"<padding pattern=%s>" % self.pattern
+            return u"<padding pattern={0!s}>".format(self.pattern)
         else:
             return Bits.createDisplay(self)
 
@@ -75,7 +75,7 @@ class PaddingBytes(Bytes):
             return False
 
         if self.MAX_SIZE < self._size/8:
-            self.info("only check first %s of padding" % humanFilesize(self.MAX_SIZE))
+            self.info("only check first {0!s} of padding".format(humanFilesize(self.MAX_SIZE)))
             content = self._parent.stream.readBytes(
                 self.absolute_address, self.MAX_SIZE)
         else:
@@ -94,7 +94,7 @@ class PaddingBytes(Bytes):
 
     def createDisplay(self):
         if self._display_pattern:
-            return u"<padding pattern=%s>" % makePrintable(self.pattern, "ASCII", quote="'")
+            return u"<padding pattern={0!s}>".format(makePrintable(self.pattern, "ASCII", quote="'"))
         else:
             return Bytes.createDisplay(self)
 

--- a/lib/hachoir_core/field/seekable_field_set.py
+++ b/lib/hachoir_core/field/seekable_field_set.py
@@ -26,7 +26,7 @@ class RootSeekableFieldSet(GenericFieldSet):
         if not relative:
             address -= self.absolute_address
         if address < 0:
-            raise ParserError("Seek below field set start (%s.%s)" % divmod(address, 8))
+            raise ParserError("Seek below field set start ({0!s}.{1!s})".format(*divmod(address, 8)))
         self._current_size = address
         return None
 
@@ -47,7 +47,7 @@ class RootSeekableFieldSet(GenericFieldSet):
         # If last field is too big, delete it
         while self._size < self._current_size:
             field = self._deleteField(len(self._fields)-1)
-            message.append("delete field %s" % field.path)
+            message.append("delete field {0!s}".format(field.path))
         assert self._current_size <= self._size
 
         blocks = [(x.absolute_address, x.size) for x in self._fields]
@@ -59,7 +59,7 @@ class RootSeekableFieldSet(GenericFieldSet):
             self.setUniqueFieldName(field)
             self._fields.append(field.name, field)
             fields.append(field)
-            message.append("found unparsed segment: start %s, length %s" % (start, length))
+            message.append("found unparsed segment: start {0!s}, length {1!s}".format(start, length))
         self.seekBit(self._size + self.absolute_address, relative=False)
         message = ", ".join(message)
         if fields:

--- a/lib/hachoir_core/field/static_field_set.py
+++ b/lib/hachoir_core/field/static_field_set.py
@@ -26,8 +26,7 @@ class StaticFieldSet(FieldSet):
     def _computeItemSize(item):
         item_class = item[0]
         if item_class.static_size is None:
-            raise ParserError("Unable to get static size of field type: %s"
-                % item_class.__name__)
+            raise ParserError("Unable to get static size of field type: {0!s}".format(item_class.__name__))
         if callable(item_class.static_size):
             if isinstance(item[-1], dict):
                 return item_class.static_size(*item[1:-1], **item[-1])

--- a/lib/hachoir_core/field/string_field.py
+++ b/lib/hachoir_core/field/string_field.py
@@ -130,8 +130,7 @@ class GenericString(Bytes):
         elif charset in self.UTF_CHARSET:
             self._character_size = None
         else:
-            raise FieldError("Invalid charset for %s: \"%s\"" %
-                (self.path, charset))
+            raise FieldError("Invalid charset for {0!s}: \"{1!s}\"".format(self.path, charset))
         self._charset = charset
 
         # It is a fixed string?
@@ -139,8 +138,7 @@ class GenericString(Bytes):
             assert self._format == "fixed"
             # Arbitrary limits, just to catch some bugs...
             if not (1 <= nbytes <= 0xffff):
-                raise FieldError("Invalid string size for %s: %s" %
-                    (self.path, nbytes))
+                raise FieldError("Invalid string size for {0!s}: {1!s}".format(self.path, nbytes))
             self._content_size = nbytes   # content length in bytes
             self._size = nbytes * 8
             self._content_offset = 0
@@ -156,8 +154,7 @@ class GenericString(Bytes):
                 length = self._parent.stream.searchBytesLength(
                     suffix, False, self.absolute_address)
                 if length is None:
-                    raise FieldError("Unable to find end of string %s (format %s)!"
-                        % (self.path, self._format))
+                    raise FieldError("Unable to find end of string {0!s} (format {1!s})!".format(self.path, self._format))
                 if 1 < len(suffix):
                     # Fix length for little endian bug with UTF-xx charset:
                     #   u"abc" -> "a\0b\0c\0\0\0" (UTF-16-LE)
@@ -194,8 +191,7 @@ class GenericString(Bytes):
                 # Choose right charset using the BOM
                 bom_endian = self.UTF_BOM[bomsize]
                 if bom not in bom_endian:
-                    raise FieldError("String %s has invalid BOM (%s)!"
-                        % (self.path, repr(bom)))
+                    raise FieldError("String {0!s} has invalid BOM ({1!s})!".format(self.path, repr(bom)))
                 self._charset = bom_endian[bom]
                 self._content_size -= nbytes
                 self._content_offset += nbytes
@@ -243,13 +239,13 @@ class GenericString(Bytes):
         and self._charset == "UTF-16-LE":
             try:
                 text = unicode(text+"\0", self._charset, "strict")
-                self.warning("Fix truncated %s string: add missing nul byte" % self._charset)
+                self.warning("Fix truncated {0!s} string: add missing nul byte".format(self._charset))
                 return text
             except UnicodeDecodeError, err:
                 pass
 
         # On error, use FALLBACK_CHARSET
-        self.warning(u"Unable to convert string to Unicode: %s" % err)
+        self.warning(u"Unable to convert string to Unicode: {0!s}".format(err))
         return unicode(text, FALLBACK_CHARSET, "strict")
 
     def _guessCharset(self):
@@ -305,12 +301,12 @@ class GenericString(Bytes):
             value = self.value
         if config.max_string_length < len(value):
             # Truncate string if needed
-            value = "%s(...)" % value[:config.max_string_length]
+            value = "{0!s}(...)".format(value[:config.max_string_length])
         if not self._charset or not human:
             return makePrintable(value, "ASCII", quote='"', to_unicode=True)
         else:
             if value:
-                return '"%s"' % value.replace('"', '\\"')
+                return '"{0!s}"'.format(value.replace('"', '\\"'))
             else:
                 return _("(empty)")
 
@@ -345,10 +341,10 @@ class GenericString(Bytes):
         info = self.charset
         if self._strip:
             if isinstance(self._strip, (str, unicode)):
-                info += ",strip=%s" % makePrintable(self._strip, "ASCII", quote="'")
+                info += ",strip={0!s}".format(makePrintable(self._strip, "ASCII", quote="'"))
             else:
                 info += ",strip=True"
-        return "%s<%s>" % (Bytes.getFieldType(self), info)
+        return "{0!s}<{1!s}>".format(Bytes.getFieldType(self), info)
 
 def stringFactory(name, format, doc):
     class NewString(GenericString):

--- a/lib/hachoir_core/field/sub_file.py
+++ b/lib/hachoir_core/field/sub_file.py
@@ -12,7 +12,7 @@ class SubFile(Bytes):
             if not isinstance(filename, unicode):
                 filename = makePrintable(filename, "ISO-8859-1")
             if not description:
-                description = 'File "%s" (%s)' % (filename, humanFilesize(length))
+                description = 'File "{0!s}" ({1!s})'.format(filename, humanFilesize(length))
         Bytes.__init__(self, parent, name, length, description)
         def createInputStream(cis, **args):
             tags = args.setdefault("tags",[])
@@ -66,7 +66,7 @@ def CompressedField(field, decompressor):
             stream = field.stream
         input = CompressedStream(stream, decompressor)
         if source is None:
-            source = "Compressed source: '%s' (offset=%s)" % (stream.source, field.absolute_address)
+            source = "Compressed source: '{0!s}' (offset={1!s})".format(stream.source, field.absolute_address)
         return InputIOStream(input, source=source, **args)
     field.setSubIStream(createInputStream)
     return field

--- a/lib/hachoir_core/field/vector.py
+++ b/lib/hachoir_core/field/vector.py
@@ -6,8 +6,7 @@ class GenericVector(FieldSet):
         assert issubclass(item_class, Field)
         assert isinstance(item_class.static_size, (int, long))
         if not(0 < nb_items):
-            raise ParserError('Unable to create empty vector "%s" in %s' \
-                % (name, parent.path))
+            raise ParserError('Unable to create empty vector "{0!s}" in {1!s}'.format(name, parent.path))
         size = nb_items * item_class.static_size
         self.__nb_items = nb_items
         self._item_class = item_class

--- a/lib/hachoir_core/language.py
+++ b/lib/hachoir_core/language.py
@@ -4,7 +4,7 @@ class Language:
     def __init__(self, code):
         code = str(code)
         if code not in ISO639_2:
-            raise ValueError("Invalid language code: %r" % code)
+            raise ValueError("Invalid language code: {0!r}".format(code))
         self.code = code
 
     def __cmp__(self, other):
@@ -19,5 +19,5 @@ class Language:
        return self.__unicode__()
 
     def __repr__(self):
-        return "<Language '%s', code=%r>" % (unicode(self), self.code)
+        return "<Language '{0!s}', code={1!r}>".format(unicode(self), self.code)
 

--- a/lib/hachoir_core/log.py
+++ b/lib/hachoir_core/log.py
@@ -55,7 +55,7 @@ class Log:
 
     def _writeIntoFile(self, message):
         timestamp = time.strftime("%Y-%m-%d %H:%M:%S")
-        self.__file.write(u"%s - %s\n" % (timestamp, message))
+        self.__file.write(u"{0!s} - {1!s}\n".format(timestamp, message))
         self.__file.flush()
 
     def newMessage(self, level, text, ctxt=None):
@@ -84,7 +84,7 @@ class Log:
         if hasattr(ctxt, "_logger"):
             _ctxt = ctxt._logger()
             if _ctxt is not None:
-                text = "[%s] %s" % (_ctxt, text)
+                text = "[{0!s}] {1!s}".format(_ctxt, text)
 
         # Add message to log buffer
         if self.use_buffer:
@@ -99,12 +99,12 @@ class Log:
         # Display on stdout (if used)
         if self.use_print:
             sys.stdout.flush()
-            sys.stderr.write("%s %s\n" % (prefix, text))
+            sys.stderr.write("{0!s} {1!s}\n".format(prefix, text))
             sys.stderr.flush()
 
         # Write into outfile (if used)
         if self.__file:
-            self._writeIntoFile("%s %s" % (prefix, text))
+            self._writeIntoFile("{0!s} {1!s}".format(prefix, text))
 
         # Use callback (if used)
         if self.on_new_message:
@@ -135,7 +135,7 @@ log = Log()
 
 class Logger(object):
     def _logger(self):
-        return "<%s>" % self.__class__.__name__
+        return "<{0!s}>".format(self.__class__.__name__)
     def info(self, text):
         log.newMessage(Log.LOG_INFO, text, self)
     def warning(self, text):

--- a/lib/hachoir_core/stream/input.py
+++ b/lib/hachoir_core/stream/input.py
@@ -336,7 +336,7 @@ class InputPipe(object):
             buf = self.buffers[self.first]
             if buf[2] != self.last:
                 break
-            info("Discarding buffer %u." % self.first)
+            info("Discarding buffer {0:d}.".format(self.first))
             self.buffers[self.last][1] = buf[1]
             self.buffers[buf[1]][2] = self.last
             self.buffers[self.first] = None
@@ -383,7 +383,7 @@ class InputIOStream(InputStream):
                 else:
                     charset = getTerminalCharset()
                     errmsg = unicode(str(err), charset)
-                    source = args.get("source", "<inputio:%r>" % input)
+                    source = args.get("source", "<inputio:{0!r}>".format(input))
                     raise InputStreamError(_("Unable to get size of %s: %s") % (source, errmsg))
         self._input = input
         InputStream.__init__(self, size=size, **args)
@@ -446,7 +446,7 @@ class InputSubStream(InputStream):
         self.stream = stream
         self._offset = offset
         if source is None:
-            source = "<substream input=%s offset=%s size=%s>" % (stream.source, offset, size)
+            source = "<substream input={0!s} offset={1!s} size={2!s}>".format(stream.source, offset, size)
         InputStream.__init__(self, source=source, size=size, **args)
         self.stream.askSize(self)
 
@@ -470,7 +470,7 @@ class FragmentedStream(InputStream):
         data = field.getData()
         self.fragments = [ (0, data.absolute_address, data.size) ]
         self.next = field.next
-        args.setdefault("source", "%s%s" % (self.stream.source, field.path))
+        args.setdefault("source", "{0!s}{1!s}".format(self.stream.source, field.path))
         InputStream.__init__(self, **args)
         if not self.next:
             self._current_size = data.size

--- a/lib/hachoir_core/text_handler.py
+++ b/lib/hachoir_core/text_handler.py
@@ -55,6 +55,6 @@ def hexadecimal(field):
     assert hasattr(field, "value") and hasattr(field, "size")
     size = field.size
     padding = alignValue(size, 4) // 4
-    pattern = u"0x%%0%ux" % padding
+    pattern = u"0x%0{0:d}x".format(padding)
     return pattern % field.value
 

--- a/lib/hachoir_core/tools.py
+++ b/lib/hachoir_core/tools.py
@@ -28,7 +28,7 @@ def deprecated(comment=None):
     """
     def _deprecated(func):
         def newFunc(*args, **kwargs):
-            message = "Call to deprecated function %s" % func.__name__
+            message = "Call to deprecated function {0!s}".format(func.__name__)
             if comment:
                 message += ": " + comment
             warn(message, category=DeprecationWarning, stacklevel=2)
@@ -100,17 +100,17 @@ def humanDurationNanosec(nsec):
 
     # Nano second
     if nsec < 1000:
-        return u"%u nsec" % nsec
+        return u"{0:d} nsec".format(nsec)
 
     # Micro seconds
     usec, nsec = divmod(nsec, 1000)
     if usec < 1000:
-        return u"%.2f usec" % (usec+float(nsec)/1000)
+        return u"{0:.2f} usec".format((usec+float(nsec)/1000))
 
     # Milli seconds
     msec, usec = divmod(usec, 1000)
     if msec < 1000:
-        return u"%.2f ms" % (msec + float(usec)/1000)
+        return u"{0:.2f} ms".format((msec + float(usec)/1000))
     return humanDuration(msec)
 
 def humanDuration(delta):
@@ -133,15 +133,15 @@ def humanDuration(delta):
     # Milliseconds
     text = []
     if 1000 <= delta.microseconds:
-        text.append(u"%u ms" % (delta.microseconds//1000))
+        text.append(u"{0:d} ms".format((delta.microseconds//1000)))
 
     # Seconds
     minutes, seconds = divmod(delta.seconds, 60)
     hours, minutes = divmod(minutes, 60)
     if seconds:
-        text.append(u"%u sec" % seconds)
+        text.append(u"{0:d} sec".format(seconds))
     if minutes:
-        text.append(u"%u min" % minutes)
+        text.append(u"{0:d} min".format(minutes))
     if hours:
         text.append(ngettext("%u hour", "%u hours", hours) % hours)
 
@@ -178,8 +178,8 @@ def humanFilesize(size):
     for unit in units:
         size = size / divisor
         if size < divisor:
-            return "%.1f %s" % (size, unit)
-    return "%u %s" % (size, unit)
+            return "{0:.1f} {1!s}".format(size, unit)
+    return "{0:d} {1!s}".format(size, unit)
 
 def humanBitSize(size):
     """
@@ -202,8 +202,8 @@ def humanBitSize(size):
     for unit in units:
         size = size / divisor
         if size < divisor:
-            return "%.1f %s" % (size, unit)
-    return u"%u %s" % (size, unit)
+            return "{0:.1f} {1!s}".format(size, unit)
+    return u"{0:d} {1!s}".format(size, unit)
 
 def humanBitRate(size):
     """
@@ -230,14 +230,14 @@ def humanFrequency(hertz):
     """
     divisor = 1000
     if hertz < divisor:
-        return u"%u Hz" % hertz
+        return u"{0:d} Hz".format(hertz)
     units = [u"kHz", u"MHz", u"GHz", u"THz"]
     hertz = float(hertz)
     for unit in units:
         hertz = hertz / divisor
         if hertz < divisor:
-            return u"%.1f %s" % (hertz, unit)
-    return u"%s %s" % (hertz, unit)
+            return u"{0:.1f} {1!s}".format(hertz, unit)
+    return u"{0!s} {1!s}".format(hertz, unit)
 
 regex_control_code = re.compile(r"([\x00-\x1f\x7f])")
 controlchars = tuple({
@@ -248,7 +248,7 @@ controlchars = tuple({
         ord("\t"): r"\t",
         ord("\a"): r"\a",
         ord("\b"): r"\b",
-    }.get(code, '\\x%02x' % code)
+    }.get(code, '\\x{0:02x}'.format(code))
     for code in xrange(128)
 )
 
@@ -433,7 +433,7 @@ def humanUnixAttributes(mode):
             chars[9] = 'T'
         else:
             chars[9] = 't'
-    return u"%s (%o)" % (''.join(chars), mode)
+    return u"{0!s} ({1:o})".format(''.join(chars), mode)
 
 def createDict(data, index):
     """

--- a/lib/hachoir_metadata/archive.py
+++ b/lib/hachoir_metadata/archive.py
@@ -54,7 +54,7 @@ class ZipMetadata(MultipleMetadata):
         max_nb = maxNbFile(self)
         for index, field in enumerate(zip.array("file")):
             if max_nb is not None and max_nb <= index:
-                self.warning("ZIP archive contains many files, but only first %s files are processed" % max_nb)
+                self.warning("ZIP archive contains many files, but only first {0!s} files are processed".format(max_nb))
                 break
             self.processFile(field)
 
@@ -73,14 +73,14 @@ class ZipMetadata(MultipleMetadata):
             if field["compressed_size"].value:
                 meta.compr_size = field["compressed_size"].value
         computeCompressionRate(meta)
-        self.addGroup(field.name, meta, "File \"%s\"" % meta.get('filename'))
+        self.addGroup(field.name, meta, "File \"{0!s}\"".format(meta.get('filename')))
 
 class TarMetadata(MultipleMetadata):
     def extract(self, tar):
         max_nb = maxNbFile(self)
         for index, field in enumerate(tar.array("file")):
             if max_nb is not None and max_nb <= index:
-                self.warning("TAR archive contains many files, but only first %s files are processed" % max_nb)
+                self.warning("TAR archive contains many files, but only first {0!s} files are processed".format(max_nb))
                 break
             meta = Metadata(self)
             self.extractFile(field, meta)
@@ -101,8 +101,7 @@ class TarMetadata(MultipleMetadata):
         except ValueError:
             pass
         meta.file_type = field["type"].display
-        meta.author = "%s (uid=%s), group %s (gid=%s)" %\
-            (field["uname"].value, field.getOctal("uid"),
+        meta.author = "{0!s} (uid={1!s}), group {2!s} (gid={3!s})".format(field["uname"].value, field.getOctal("uid"),
              field["gname"].value, field.getOctal("gid"))
 
 
@@ -110,13 +109,13 @@ class CabMetadata(MultipleMetadata):
     def extract(self, cab):
         if "folder[0]" in cab:
             self.useFolder(cab["folder[0]"])
-        self.format_version = "Microsoft Cabinet version %s.%s" % (cab["major_version"].display, cab["minor_version"].display)
-        self.comment = "%s folders, %s files" % (
+        self.format_version = "Microsoft Cabinet version {0!s}.{1!s}".format(cab["major_version"].display, cab["minor_version"].display)
+        self.comment = "{0!s} folders, {1!s} files".format(
             cab["nb_folder"].value, cab["nb_files"].value)
         max_nb = maxNbFile(self)
         for index, field in enumerate(cab.array("file")):
             if max_nb is not None and max_nb <= index:
-                self.warning("CAB archive contains many files, but only first %s files are processed" % max_nb)
+                self.warning("CAB archive contains many files, but only first {0!s} files are processed".format(max_nb))
                 break
             self.useFile(field)
 
@@ -124,7 +123,7 @@ class CabMetadata(MultipleMetadata):
     def useFolder(self, folder):
         compr = folder["compr_method"].display
         if folder["compr_method"].value != 0:
-            compr += " (level %u)" % folder["compr_level"].value
+            compr += " (level {0:d})".format(folder["compr_level"].value)
         self.compression = compr
 
     @fault_tolerant
@@ -144,18 +143,18 @@ class CabMetadata(MultipleMetadata):
 
 class MarMetadata(MultipleMetadata):
     def extract(self, mar):
-        self.comment = "Contains %s files" % mar["nb_file"].value
-        self.format_version = "Microsoft Archive version %s" % mar["version"].value
+        self.comment = "Contains {0!s} files".format(mar["nb_file"].value)
+        self.format_version = "Microsoft Archive version {0!s}".format(mar["version"].value)
         max_nb = maxNbFile(self)
         for index, field in enumerate(mar.array("file")):
             if max_nb is not None and max_nb <= index:
-                self.warning("MAR archive contains many files, but only first %s files are processed" % max_nb)
+                self.warning("MAR archive contains many files, but only first {0!s} files are processed".format(max_nb))
                 break
             meta = Metadata(self)
             meta.filename = field["filename"].value
             meta.compression = "None"
             meta.file_size = field["filesize"].value
-            self.addGroup(field.name, meta, "File \"%s\"" % meta.getText('filename'))
+            self.addGroup(field.name, meta, "File \"{0!s}\"".format(meta.getText('filename')))
 
 registerExtractor(CabFile, CabMetadata)
 registerExtractor(GzipParser, GzipMetadata)

--- a/lib/hachoir_metadata/audio.py
+++ b/lib/hachoir_metadata/audio.py
@@ -56,7 +56,7 @@ def readVorbisComment(metadata, comment):
                 key = VORBIS_KEY_TO_ATTR[key]
                 setattr(metadata, key, value)
             elif value:
-                metadata.warning("Skip Vorbis comment %s: %s" % (key, value))
+                metadata.warning("Skip Vorbis comment {0!s}: {1!s}".format(key, value))
 
 class OggMetadata(MultipleMetadata):
     def extract(self, ogg):
@@ -106,7 +106,7 @@ class OggMetadata(MultipleMetadata):
 
     def theoraHeader(self, header, meta):
         meta.compression = "Theora"
-        meta.format_version = "Theora version %u.%u (revision %u)" % (\
+        meta.format_version = "Theora version {0:d}.{1:d} (revision {2:d})".format(\
             header["version_major"].value,
             header["version_minor"].value,
             header["version_revision"].value)
@@ -117,13 +117,13 @@ class OggMetadata(MultipleMetadata):
         if header["aspect_ratio_den"].value:
             meta.aspect_ratio = float(header["aspect_ratio_num"].value) / header["aspect_ratio_den"].value
         meta.pixel_format = header["pixel_format"].display
-        meta.comment = "Quality: %s" % header["quality"].value
+        meta.comment = "Quality: {0!s}".format(header["quality"].value)
 
     def vorbisHeader(self, header, meta):
         meta.compression = u"Vorbis"
         meta.sample_rate = header["audio_sample_rate"].value
         meta.nb_channel = header["audio_channels"].value
-        meta.format_version = u"Vorbis version %s" % header["vorbis_version"].value
+        meta.format_version = u"Vorbis version {0!s}".format(header["vorbis_version"].value)
         meta.bit_rate = header["bitrate_nominal"].value
 
 class AuMetadata(RootMetadata):
@@ -152,7 +152,7 @@ class RealAudioMetadata(RootMetadata):
         if "metadata" in real:
             self.useMetadata(real["metadata"])
         self.useRoot(real)
-        self.format_version = "Real audio version %s" % version
+        self.format_version = "Real audio version {0!s}".format(version)
         if version == 3:
             size = getValue(real, "data_size")
         elif "filesize" in real and "headersize" in real:
@@ -213,7 +213,7 @@ class RealMediaMetadata(MultipleMetadata):
         if key in self.KEY_TO_ATTR:
             setattr(self, self.KEY_TO_ATTR[key], value)
         elif value:
-            self.warning("Skip %s: %s" % (prop["name"].value, value))
+            self.warning("Skip {0!s}: {1!s}".format(prop["name"].value, value))
 
     @fault_tolerant
     def useFileProp(self, prop):
@@ -230,7 +230,7 @@ class RealMediaMetadata(MultipleMetadata):
     @fault_tolerant
     def useStreamProp(self, stream, index):
         meta = Metadata(self)
-        meta.comment = "Start: %s" % stream["stream_start"].value
+        meta.comment = "Start: {0!s}".format(stream["stream_start"].value)
         if getValue(stream, "mime_type") == "logical-fileinfo":
             for prop in stream.array("file_info/prop"):
                 self.useFileInfoProp(prop)
@@ -239,7 +239,7 @@ class RealMediaMetadata(MultipleMetadata):
             meta.duration = timedelta(milliseconds=stream["duration"].value)
             meta.mime_type = getValue(stream, "mime_type")
         meta.title = getValue(stream, "desc")
-        self.addGroup("stream[%u]" % index, meta, "Stream #%u" % (1+index))
+        self.addGroup("stream[{0:d}]".format(index), meta, "Stream #{0:d}".format((1+index)))
 
 class MpegAudioMetadata(RootMetadata):
     TAG_TO_KEY = {
@@ -279,7 +279,7 @@ class MpegAudioMetadata(RootMetadata):
         if "text" not in content:
             return
         if "title" in content and content["title"].value:
-            value = "%s: %s" % (content["title"].value, content["text"].value)
+            value = "{0!s}: {1!s}".format(content["title"].value, content["text"].value)
         else:
             value = content["text"].value
 
@@ -289,7 +289,7 @@ class MpegAudioMetadata(RootMetadata):
             if tag:
                 if isinstance(tag, str):
                     tag = makePrintable(tag, "ISO-8859-1", to_unicode=True)
-                self.warning("Skip ID3v2 tag %s: %s" % (tag, value))
+                self.warning("Skip ID3v2 tag {0!s}: {1!s}".format(tag, value))
             return
         key = self.TAG_TO_KEY[tag]
         setattr(self, key, value)
@@ -303,8 +303,7 @@ class MpegAudioMetadata(RootMetadata):
         if "/frames/frame[0]" in mp3:
             frame = mp3["/frames/frame[0]"]
             self.nb_channel = (frame.getNbChannel(), frame["channel_mode"].display)
-            self.format_version = u"MPEG version %s layer %s" % \
-                (frame["version"].display, frame["layer"].display)
+            self.format_version = u"MPEG version {0!s} layer {1!s}".format(frame["version"].display, frame["layer"].display)
             self.sample_rate = frame.getSampleRate()
             self.bits_per_sample = 16
             if mp3["frames"].looksConstantBitRate():

--- a/lib/hachoir_metadata/formatter.py
+++ b/lib/hachoir_metadata/formatter.py
@@ -12,7 +12,7 @@ def humanFrameRate(value):
         return value
 
 def humanComprRate(rate):
-    return u"%.1fx" % rate
+    return u"{0:.1f}x".format(rate)
 
 def humanAltitude(value):
     return ngettext("%.1f meter", "%.1f meters", value) % value
@@ -21,5 +21,5 @@ def humanPixelSize(value):
     return ngettext("%s pixel", "%s pixels", value) % value
 
 def humanDPI(value):
-    return u"%s DPI" % value
+    return u"{0!s} DPI".format(value)
 

--- a/lib/hachoir_metadata/image.py
+++ b/lib/hachoir_metadata/image.py
@@ -38,7 +38,7 @@ class BmpMetadata(RootMetadata):
                 self.nb_colors = hdr["used_colors"].value
             self.bits_per_pixel = bpp
         self.compression = hdr["compression"].display
-        self.format_version = u"Microsoft Bitmap version %s" % hdr.getFormatVersion()
+        self.format_version = u"Microsoft Bitmap version {0!s}".format(hdr.getFormatVersion())
 
         self.width_dpi = hdr["horizontal_dpi"].value
         self.height_dpi = hdr["vertical_dpi"].value
@@ -98,15 +98,15 @@ class IcoMetadata(MultipleMetadata):
                 % (1+index, image.get("width", "?"), image.get("height", "?")))
 
             # Read compression from data (if available)
-            key = "icon_data[%u]/header/codec" % index
+            key = "icon_data[{0:d}]/header/codec".format(index)
             if key in icon:
                 image.compression = icon[key].display
-            key = "icon_data[%u]/pixels" % index
+            key = "icon_data[{0:d}]/pixels".format(index)
             if key in icon:
                 computeComprRate(image, icon[key].size)
 
             # Store new image
-            self.addGroup("image[%u]" % index, image)
+            self.addGroup("image[{0:d}]".format(index), image)
 
 class PcxMetadata(RootMetadata):
     @fault_tolerant
@@ -119,7 +119,7 @@ class PcxMetadata(RootMetadata):
         if 1 <= pcx["bpp"].value <= 8:
             self.nb_colors = 2 ** pcx["bpp"].value
         self.compression = _("Run-length encoding (RLE)")
-        self.format_version = "PCX: %s" % pcx["version"].display
+        self.format_version = "PCX: {0!s}".format(pcx["version"].display)
         if "image_data" in pcx:
             computeComprRate(self, pcx["image_data"].size)
 
@@ -178,7 +178,7 @@ class PngMetadata(RootMetadata):
                 setattr(self, key, text)
             except KeyError:
                 if keyword.lower() != "comment":
-                    self.comment = "%s=%s" % (keyword, text)
+                    self.comment = "{0!s}={1!s}".format(keyword, text)
                 else:
                     self.comment = text
         compr_size = sum( data.size for data in png.array("data") )
@@ -227,7 +227,7 @@ class GifMetadata(RootMetadata):
         if self.has("bits_per_pixel"):
             self.nb_colors = (1 << self.get('bits_per_pixel'))
         self.compression = _("LZW")
-        self.format_version =  "GIF version %s" % gif["version"].value
+        self.format_version =  "GIF version {0!s}".format(gif["version"].value)
         for comments in gif.array("comments"):
             for comment in gif.array(comments.name + "/comment"):
                 self.comment = comment.value

--- a/lib/hachoir_metadata/jpeg.py
+++ b/lib/hachoir_metadata/jpeg.py
@@ -89,7 +89,7 @@ class JpegMetadata(RootMetadata):
     def startOfFrame(self, sof):
         # Set compression method
         key = sof["../type"].value
-        self.compression = "JPEG (%s)" % JpegChunk.START_OF_FRAME[key]
+        self.compression = "JPEG ({0!s})".format(JpegChunk.START_OF_FRAME[key])
 
         # Read image size and bits/pixel
         self.width = sof["width"].value
@@ -140,16 +140,15 @@ class JpegMetadata(RootMetadata):
         # Find the JPEG quality
         for index in xrange(100):
             if (hashval >= hashtable[index]) or (sumcoeff >= sumtable[index]):
-                quality = "%s%%" % (index + 1)
+                quality = "{0!s}%".format((index + 1))
                 if (hashval > hashtable[index]) or (sumcoeff > sumtable[index]):
                     quality += " " + _("(approximate)")
-                self.comment = "JPEG quality: %s" % quality
+                self.comment = "JPEG quality: {0!s}".format(quality)
                 return
 
     @fault_tolerant
     def extractAPP0(self, app0):
-        self.format_version = u"JFIF %u.%02u" \
-            % (app0["ver_maj"].value, app0["ver_min"].value)
+        self.format_version = u"JFIF {0:d}.{1:02d}".format(app0["ver_maj"].value, app0["ver_min"].value)
         if "y_density" in app0:
             self.width_dpi = app0["x_density"].value
             self.height_dpi = app0["y_density"].value
@@ -176,9 +175,9 @@ class JpegMetadata(RootMetadata):
             if not value:
                 return
             if isinstance(value, float):
-                value = (value, u"1/%g" % (1/value))
+                value = (value, u"1/{0:g}".format((1/value)))
         elif entry["type"].value in (BasicIFDEntry.TYPE_RATIONAL, BasicIFDEntry.TYPE_SIGNED_RATIONAL):
-            value = (value, u"%.3g" % value)
+            value = (value, u"{0:.3g}".format(value))
 
         # Store information
         setattr(self, key, value)
@@ -265,7 +264,7 @@ class JpegMetadata(RootMetadata):
                 continue
             if tag not in self.IPTC_KEY:
                 if tag != 0:
-                    self.warning("Skip IPTC key %s: %s" % (
+                    self.warning("Skip IPTC key {0!s}: {1!s}".format(
                         field["tag"].display, makeUnicode(value)))
                 continue
             setattr(self, self.IPTC_KEY[tag], value)

--- a/lib/hachoir_metadata/metadata.py
+++ b/lib/hachoir_metadata/metadata.py
@@ -53,7 +53,7 @@ class Metadata(Logger):
         try:
             return self.__data[key]
         except LookupError:
-            raise ValueError("Metadata has no value '%s'" % key)
+            raise ValueError("Metadata has no value '{0!s}'".format(key))
 
     def getItem(self, key, index):
         try:
@@ -79,7 +79,7 @@ class Metadata(Logger):
         item = self.getItem(key, index)
         if item is None:
             if default is None:
-                raise ValueError("Metadata has no value '%s' (index %s)" % (key, index))
+                raise ValueError("Metadata has no value '{0!s}' (index {1!s})".format(key, index))
             else:
                 return default
         return item.value
@@ -88,7 +88,7 @@ class Metadata(Logger):
         try:
             data = self.__data[key]
         except LookupError:
-            raise ValueError("Metadata has no value '%s'" % key)
+            raise ValueError("Metadata has no value '{0!s}'".format(key))
         return [ item.value for item in data ]
 
     def getText(self, key, default=None, index=0):
@@ -176,7 +176,7 @@ class Metadata(Logger):
             priority = MAX_PRIORITY
         if not title:
             title = self.header
-        text = ["%s:" % title]
+        text = ["{0!s}:".format(title)]
         for data in sorted(self):
             if priority < data.priority:
                 break
@@ -191,7 +191,7 @@ class Metadata(Logger):
                     value = item.text
                 else:
                     value = makeUnicode(item.value)
-                text.append("%s%s: %s" % (line_prefix, title, value))
+                text.append("{0!s}{1!s}: {2!s}".format(line_prefix, title, value))
         if 1 < len(text):
             return text
         else:
@@ -232,7 +232,7 @@ class MultipleMetadata(RootMetadata):
         Returns False if the group is skipped, True if it has been added.
         """
         if not metadata:
-            self.warning("Skip empty group %s" % key)
+            self.warning("Skip empty group {0!s}".format(key))
             return False
         if key.endswith("[]"):
             key = key[:-2]
@@ -240,7 +240,7 @@ class MultipleMetadata(RootMetadata):
                 self.__key_counter[key] += 1
             else:
                 self.__key_counter[key] = 1
-            key += "[%u]" % self.__key_counter[key]
+            key += "[{0:d}]".format(self.__key_counter[key])
         if header:
             metadata.setHeader(header)
         self.__groups.append(key, metadata)
@@ -283,10 +283,10 @@ def extractMetadata(parser, quality=QUALITY_NORMAL):
     try:
         metadata.extract(parser)
     except HACHOIR_ERRORS, err:
-        error("Error during metadata extraction: %s" % unicode(err))
+        error("Error during metadata extraction: {0!s}".format(unicode(err)))
         return None
     except Exception, err:
-        error("Error during metadata extraction: %s" % unicode(err))
+        error("Error during metadata extraction: {0!s}".format(unicode(err)))
         return None
     if metadata:
         metadata.mime_type = parser.mime_type

--- a/lib/hachoir_metadata/metadata_item.py
+++ b/lib/hachoir_metadata/metadata_item.py
@@ -71,12 +71,12 @@ class Data:
             try:
                 new_value = self.conversion(self.metadata, self.key, value)
             except HACHOIR_ERRORS, err:
-                self.metadata.warning("Error during conversion of %r value: %s" % (
+                self.metadata.warning("Error during conversion of {0!r} value: {1!s}".format(
                     self.key, err))
                 return
             if new_value is None:
                 dest_types = " or ".join(str(item.__name__) for item in self.type)
-                self.metadata.warning("Unable to convert %s=%r (%s) to %s" % (
+                self.metadata.warning("Unable to convert {0!s}={1!r} ({2!s}) to {3!s}".format(
                     self.key, value, type(value).__name__, dest_types))
                 return
             if isinstance(new_value, tuple):
@@ -91,7 +91,7 @@ class Data:
 
         if self.type and not isinstance(value, self.type):
             dest_types = " or ".join(str(item.__name__) for item in self.type)
-            self.metadata.warning("Key %r: value %r type (%s) is not %s" % (
+            self.metadata.warning("Key {0!r}: value {1!r} type ({2!s}) is not {3!s}".format(
                 self.key, value, type(value).__name__, dest_types))
             return
 
@@ -108,7 +108,7 @@ class Data:
 
         # Use filter
         if self.filter and not self.filter(value):
-            self.metadata.warning("Skip value %s=%r (filter)" % (self.key, value))
+            self.metadata.warning("Skip value {0!s}={1!r} (filter)".format(self.key, value))
             return
 
         # For string, if you have "verlongtext" and "verylo",

--- a/lib/hachoir_metadata/misc.py
+++ b/lib/hachoir_metadata/misc.py
@@ -39,7 +39,7 @@ class TorrentMetadata(RootMetadata):
             value = field.value
             setattr(self, key, value)
         elif field.name == "piece_length":
-            self.comment = "Piece length: %s" % field.display
+            self.comment = "Piece length: {0!s}".format(field.display)
 
 class TTF_Metadata(RootMetadata):
     NAMEID_TO_ATTR = {
@@ -61,8 +61,8 @@ class TTF_Metadata(RootMetadata):
     def extractHeader(self, header):
         self.creation_date = header["created"].value
         self.last_modification = header["modified"].value
-        self.comment = u"Smallest readable size in pixels: %s pixels" % header["lowest"].value
-        self.comment = u"Font direction: %s" % header["font_dir"].display
+        self.comment = u"Smallest readable size in pixels: {0!s} pixels".format(header["lowest"].value)
+        self.comment = u"Font direction: {0!s}".format(header["font_dir"].display)
 
     @fault_tolerant
     def extractNames(self, names):
@@ -158,7 +158,7 @@ class OLE2_Metadata(RootMetadata):
 
     @fault_tolerant
     def useWordDocument(self, doc):
-        self.comment = "Encrypted: %s" % doc["FIB/fEncrypted"].value
+        self.comment = "Encrypted: {0!s}".format(doc["FIB/fEncrypted"].value)
 
     @fault_tolerant
     def useProperty(self, summary, property, is_doc_summary):
@@ -201,7 +201,7 @@ class OLE2_Metadata(RootMetadata):
             and (not field):
                 # Ignore null time delta
                 return
-            value = "%s: %s" % (prefix, value)
+            value = "{0!s}: {1!s}".format(prefix, value)
         else:
             if (key == "last_modification") and (not field):
                 # Ignore null timestamp
@@ -238,7 +238,7 @@ class PcfMetadata(RootMetadata):
                 continue
             name = name.value
             if name not in self.PROP_TO_KEY:
-                warning("Skip %s=%r" % (name, value))
+                warning("Skip {0!s}={1!r}".format(name, value))
                 continue
             key = self.PROP_TO_KEY[name]
             setattr(self, key, value)
@@ -247,9 +247,9 @@ class SwfMetadata(RootMetadata):
     def extract(self, swf):
         self.height = swf["rect/ymax"].value # twips
         self.width = swf["rect/xmax"].value # twips
-        self.format_version = "flash version %s" % swf["version"].value
+        self.format_version = "flash version {0!s}".format(swf["version"].value)
         self.frame_rate = swf["frame_rate"].value
-        self.comment = "Frame count: %s" % swf["frame_count"].value
+        self.comment = "Frame count: {0!s}".format(swf["frame_count"].value)
 
 registerExtractor(TorrentFile, TorrentMetadata)
 registerExtractor(TrueTypeFontFile, TTF_Metadata)

--- a/lib/hachoir_metadata/program.py
+++ b/lib/hachoir_metadata/program.py
@@ -61,7 +61,7 @@ class ExeMetadata(RootMetadata):
     @fault_tolerant
     def usePE_Header(self, hdr):
         self.creation_date = hdr["creation_date"].value
-        self.comment = "CPU: %s" % hdr["cpu"].display
+        self.comment = "CPU: {0!s}".format(hdr["cpu"].display)
         if hdr["is_dll"].value:
             self.format_version = u"Portable Executable: Dynamic-link library (DLL)"
         else:
@@ -69,7 +69,7 @@ class ExeMetadata(RootMetadata):
 
     @fault_tolerant
     def usePE_OptHeader(self, hdr):
-        self.comment = "Subsystem: %s" % hdr["subsystem"].display
+        self.comment = "Subsystem: {0!s}".format(hdr["subsystem"].display)
 
     def readVersionInfo(self, info):
         values = {}
@@ -94,7 +94,7 @@ class ExeMetadata(RootMetadata):
             if key in self.KEY_TO_ATTR:
                 setattr(self, self.KEY_TO_ATTR[key], value)
             elif key not in self.SKIP_KEY:
-                self.comment = "%s=%s" % (key, value)
+                self.comment = "{0!s}={1!s}".format(key, value)
 
 registerExtractor(ExeFile, ExeMetadata)
 

--- a/lib/hachoir_metadata/riff.py
+++ b/lib/hachoir_metadata/riff.py
@@ -45,7 +45,7 @@ class RiffMetadata(MultipleMetadata):
         value = chunk["text"].value
         tag = chunk["tag"].value
         if tag not in self.TAG_TO_KEY:
-            self.warning("Skip RIFF metadata %s: %s" % (tag, value))
+            self.warning("Skip RIFF metadata {0!s}: {1!s}".format(tag, value))
             return
         key = self.TAG_TO_KEY[tag]
         setattr(self, key, value)
@@ -84,8 +84,7 @@ class RiffMetadata(MultipleMetadata):
 
     @fault_tolerant
     def extractAVIVideo(self, header, meta):
-        meta.compression = "%s (fourcc:\"%s\")" \
-            % (header["fourcc"].display, makeUnicode(header["fourcc"].value))
+        meta.compression = "{0!s} (fourcc:\"{1!s}\")".format(header["fourcc"].display, makeUnicode(header["fourcc"].value))
         if header["rate"].value and header["scale"].value:
             fps = float(header["rate"].value) / header["scale"].value
             meta.frame_rate = fps
@@ -114,8 +113,7 @@ class RiffMetadata(MultipleMetadata):
                 frame_rate = float(header["rate"].value) / header["scale"].value
                 meta.duration = timedelta(seconds=float(header["length"].value) / frame_rate)
             if header["fourcc"].value != "":
-                meta.compression = "%s (fourcc:\"%s\")" \
-                    % (format["codec"].display, header["fourcc"].value)
+                meta.compression = "{0!s} (fourcc:\"{1!s}\")".format(format["codec"].display, header["fourcc"].value)
         if not meta.has("compression"):
             meta.compression = format["codec"].display
 
@@ -157,7 +155,7 @@ class RiffMetadata(MultipleMetadata):
                 if "stream_fmt" in stream:
                     meta = Metadata(self)
                     self.extractAVIAudio(stream["stream_fmt"], meta)
-                    self.addGroup("audio[%u]" % audio_index, meta, "Audio stream")
+                    self.addGroup("audio[{0:d}]".format(audio_index), meta, "Audio stream")
                     audio_index += 1
         if "avi_hdr" in headers:
             self.useAviHeader(headers["avi_hdr"])

--- a/lib/hachoir_metadata/safe.py
+++ b/lib/hachoir_metadata/safe.py
@@ -5,7 +5,7 @@ def fault_tolerant(func, *args):
         try:
             func(*args, **kw)
         except HACHOIR_ERRORS, err:
-            warning("Error when calling function %s(): %s" % (
+            warning("Error when calling function {0!s}(): {1!s}".format(
                 func.__name__, err))
     return safe_func
 
@@ -15,7 +15,7 @@ def getFieldAttribute(fieldset, key, attrname):
         if field.hasValue():
             return getattr(field, attrname)
     except HACHOIR_ERRORS, err:
-        warning("Unable to get %s of field %s/%s: %s" % (
+        warning("Unable to get {0!s} of field {1!s}/{2!s}: {3!s}".format(
             attrname, fieldset.path, key, err))
     return None
 

--- a/lib/hachoir_metadata/setter.py
+++ b/lib/hachoir_metadata/setter.py
@@ -149,7 +149,7 @@ def setTrackTotal(meta, key, total):
     try:
         return int(total)
     except ValueError:
-        meta.warning("Invalid track total: %r" % total)
+        meta.warning("Invalid track total: {0!r}".format(total))
         return None
 
 def setTrackNumber(meta, key, number):
@@ -161,7 +161,7 @@ def setTrackNumber(meta, key, number):
     try:
         return int(number)
     except ValueError:
-        meta.warning("Invalid track number: %r" % number)
+        meta.warning("Invalid track number: {0!r}".format(number))
         return None
 
 def normalizeString(text):

--- a/lib/hachoir_metadata/timezone.py
+++ b/lib/hachoir_metadata/timezone.py
@@ -20,7 +20,7 @@ class Timezone(TimezoneUTC):
     """Fixed offset in hour from UTC."""
     def __init__(self, offset):
         self._offset = timedelta(minutes=offset*60)
-        self._name = u"%+03u00" % offset
+        self._name = u"{0:+03d}00".format(offset)
 
     def utcoffset(self, dt):
         return self._offset
@@ -29,7 +29,7 @@ class Timezone(TimezoneUTC):
         return self._name
 
     def __repr__(self):
-        return "<Timezone delta=%s, name='%s'>" % (
+        return "<Timezone delta={0!s}, name='{1!s}'>".format(
             self._offset, self._name)
 
 UTC = TimezoneUTC()

--- a/lib/hachoir_metadata/video.py
+++ b/lib/hachoir_metadata/video.py
@@ -77,10 +77,10 @@ class MkvMetadata(MultipleMetadata):
         self.addGroup("video[]", video, "Video stream")
 
     def getDouble(self, field, parent):
-        float_key = '%s/float' % parent
+        float_key = '{0!s}/float'.format(parent)
         if float_key in field:
             return field[float_key].value
-        double_key = '%s/double' % parent
+        double_key = '{0!s}/double'.format(parent)
         if double_key in field:
             return field[double_key].value
         return None
@@ -279,7 +279,7 @@ class AsfMetadata(MultipleMetadata):
 
             # Have ToolName and ToolVersion? If yes, group them to producer key
             if "ToolName" in data and "ToolVersion" in data:
-                self.producer = "%s (version %s)" % (data["ToolName"], data["ToolVersion"])
+                self.producer = "{0!s} (version {1!s})".format(data["ToolName"], data["ToolVersion"])
                 del data["ToolName"]
                 del data["ToolVersion"]
 
@@ -295,7 +295,7 @@ class AsfMetadata(MultipleMetadata):
                 else:
                     if isinstance(key, str):
                         key = makePrintable(key, "ISO-8859-1", to_unicode=True)
-                    value = "%s=%s" % (key, value)
+                    value = "{0!s}={1!s}".format(key, value)
                     key = "comment"
                 setattr(self, key, value)
 
@@ -307,7 +307,7 @@ class AsfMetadata(MultipleMetadata):
                 if "name" in codec:
                     text = codec["name"].value
                     if "desc" in codec and codec["desc"].value:
-                        text = "%s (%s)" % (text, codec["desc"].value)
+                        text = "{0!s} ({1!s})".format(text, codec["desc"].value)
                     compression.append(text)
 
         audio_index = 1
@@ -317,13 +317,13 @@ class AsfMetadata(MultipleMetadata):
                 meta = Metadata(self)
                 self.streamProperty(header, index, meta)
                 self.streamAudioHeader(stream_prop["content/audio_header"], meta)
-                if self.addGroup("audio[%u]" % audio_index, meta, "Audio stream #%u" % audio_index):
+                if self.addGroup("audio[{0:d}]".format(audio_index), meta, "Audio stream #{0:d}".format(audio_index)):
                     audio_index += 1
             elif "content/video_header" in stream_prop:
                 meta = Metadata(self)
                 self.streamProperty(header, index, meta)
                 self.streamVideoHeader(stream_prop["content/video_header"], meta)
-                if self.addGroup("video[%u]" % video_index, meta, "Video stream #%u" % video_index):
+                if self.addGroup("video[{0:d}]".format(video_index), meta, "Video stream #{0:d}".format(video_index)):
                     video_index += 1
 
         if "metadata/content" in header:
@@ -380,15 +380,15 @@ class AsfMetadata(MultipleMetadata):
         value = prop["max_bitrate"].value
         text = prop["max_bitrate"].display
         if is_vbr is True:
-            text = "VBR (%s max)" % text
+            text = "VBR ({0!s} max)".format(text)
         elif is_vbr is False:
-            text = "%s (CBR)" % text
+            text = "{0!s} (CBR)".format(text)
         else:
-            text = "%s (max)" % text
+            text = "{0!s} (max)".format(text)
         self.bit_rate = (value, text)
 
     def streamProperty(self, header, index, meta):
-        key = "bit_rates/content/bit_rate[%u]/avg_bitrate" % index
+        key = "bit_rates/content/bit_rate[{0:d}]/avg_bitrate".format(index)
         if key in header:
             meta.bit_rate = header[key].value
 

--- a/lib/hachoir_parser/archive/ace.py
+++ b/lib/hachoir_parser/archive/ace.py
@@ -135,7 +135,7 @@ def fileBody(self):
         yield RawBytes(self, "compressed_data", size, "Compressed data")
 
 def fileDesc(self):
-    return "File entry: %s (%s)" % (self["filename"].value, self["compressed_size"].display)
+    return "File entry: {0!s} ({1!s})".format(self["filename"].value, self["compressed_size"].display)
 
 def recoveryHeader(self):
     yield filesizeHandler(UInt32(self, "rec_blk_size", "Size of recovery data"))
@@ -151,11 +151,11 @@ def recoveryHeader(self):
     # The ultimate data is the xor data of all those blocks
     size = self["size_blocks"].value
     for index in xrange(self["num_blocks"].value):
-        yield RawBytes(self, "data[]", size, "Recovery block %i" % index)
+        yield RawBytes(self, "data[]", size, "Recovery block {0:d}".format(index))
     yield RawBytes(self, "xor_data", size, "The XOR value of the above data blocks")
 
 def recoveryDesc(self):
-    return "Recovery block, size=%u" % self["body_size"].display
+    return "Recovery block, size={0:d}".format(self["body_size"].display)
 
 def newRecoveryHeader(self):
     """
@@ -211,7 +211,7 @@ class Block(FieldSet):
                 else:
                     self.desc_func = desc
         else:
-            self.warning("Processing as unknown block block of type %u" % type)
+            self.warning("Processing as unknown block block of type {0:d}".format(type))
         if not self.parseFlags:
             self.parseFlags = parseFlags
         if not self.parseHeader:
@@ -243,7 +243,7 @@ class Block(FieldSet):
         if self.desc_func:
             return self.desc_func(self)
         else:
-            return "Block: %s" % self["type"].display
+            return "Block: {0!s}".format(self["type"].display)
 
 class AceFile(Parser):
     endian = LITTLE_ENDIAN

--- a/lib/hachoir_parser/archive/ar.py
+++ b/lib/hachoir_parser/archive/ar.py
@@ -18,7 +18,7 @@ class ArchiveFileEntry(FieldSet):
             yield RawBytes(self, "content", size, "File data")
 
     def createDescription(self):
-        return "File entry (%s)" % self["header"].value.split()[0]
+        return "File entry ({0!s})".format(self["header"].value.split()[0])
 
 class ArchiveFile(Parser):
     endian = BIG_ENDIAN

--- a/lib/hachoir_parser/archive/bzip2_parser.py
+++ b/lib/hachoir_parser/archive/bzip2_parser.py
@@ -63,7 +63,7 @@ class Bzip2Bitmap(FieldSet):
 
     def createFields(self):
         for i in xrange(self.start_index, self.start_index+self.nb_items):
-            yield Bit(self, "symbol_used[%i]"%i, "Is the symbol %i (%r) used?"%(i, chr(i)))
+            yield Bit(self, "symbol_used[{0:d}]".format(i), "Is the symbol {0:d} ({1!r}) used?".format(i, chr(i)))
 
 class Bzip2Lengths(FieldSet):
     def __init__(self, parent, name, symbols, *args, **kwargs):
@@ -76,12 +76,12 @@ class Bzip2Lengths(FieldSet):
         lengths = []
         for i in xrange(self.symbols):
             while True:
-                bit = Bit(self, "change_length[%i][]"%i, "Should the length be changed for symbol %i?"%i)
+                bit = Bit(self, "change_length[{0:d}][]".format(i), "Should the length be changed for symbol {0:d}?".format(i))
                 yield bit
                 if not bit.value:
                     break
                 else:
-                    bit = Enum(Bit(self, "length_decrement[%i][]"%i, "Decrement the value?"), {True: "Decrement", False: "Increment"})
+                    bit = Enum(Bit(self, "length_decrement[{0:d}][]".format(i), "Decrement the value?"), {True: "Decrement", False: "Increment"})
                     yield bit
                     if bit.value:
                         length -= 1
@@ -101,7 +101,7 @@ class Bzip2Selectors(FieldSet):
             field = ZeroTerminatedNumber(self, "selector_list[]")
             move_to_front(self.groups, field.value)
             field.realvalue = self.groups[0]
-            field._description = "MTF'ed selector index: raw value %i, real value %i"%(field.value, field.realvalue)
+            field._description = "MTF'ed selector index: raw value {0:d}, real value {1:d}".format(field.value, field.realvalue)
             yield field
 
 class Bzip2Block(FieldSet):
@@ -117,7 +117,7 @@ class Bzip2Block(FieldSet):
         for index, block_used in enumerate(self["huffman_used_map"].array('block_used')):
             if block_used.value:
                 start_index = index*16
-                field = Bzip2Bitmap(self, "huffman_used_bitmap[%i]"%index, 16, start_index, "Bitmap for block %i (literals %i to %i) showing which symbols are in use"%(index, start_index, start_index + 15))
+                field = Bzip2Bitmap(self, "huffman_used_bitmap[{0:d}]".format(index), 16, start_index, "Bitmap for block {0:d} (literals {1:d} to {2:d}) showing which symbols are in use".format(index, start_index, start_index + 15))
                 yield field
                 for i, used in enumerate(field):
                     if used.value:
@@ -144,15 +144,15 @@ class Bzip2Block(FieldSet):
                     rle_power = 1
                 rle_run += (field.realvalue + 1) * rle_power
                 rle_power <<= 1
-                field._description = "RLE Run Code %i (for %r); Total accumulated run %i (Huffman Code %i)" % (field.realvalue, chr(symbols_used[0]), rle_run, field.value)
+                field._description = "RLE Run Code {0:d} (for {1!r}); Total accumulated run {2:d} (Huffman Code {3:d})".format(field.realvalue, chr(symbols_used[0]), rle_run, field.value)
             elif field.realvalue == len(symbols_used)+1:
-                field._description = "Block Terminator (%i) (Huffman Code %i)"%(field.realvalue, field.value)
+                field._description = "Block Terminator ({0:d}) (Huffman Code {1:d})".format(field.realvalue, field.value)
                 yield field
                 break
             else:
                 rle_run = 0
                 move_to_front(symbols_used, field.realvalue-1)
-                field._description = "Literal %r (value %i) (Huffman Code %i)"%(chr(symbols_used[0]), field.realvalue, field.value)
+                field._description = "Literal {0!r} (value {1:d}) (Huffman Code {2:d})".format(chr(symbols_used[0]), field.realvalue, field.value)
             yield field
             if field.realvalue == len(symbols_used)+1:
                 break
@@ -175,7 +175,7 @@ class Bzip2Stream(FieldSet):
                     yield PaddingBits(self, "padding[]", padding)
                 end = True
             else:
-                raise ParserError("Invalid marker 0x%02X!"%marker)
+                raise ParserError("Invalid marker 0x{0:02X}!".format(marker))
 
 class Bzip2Parser(Parser):
     PARSER_TAGS = {

--- a/lib/hachoir_parser/archive/cab.py
+++ b/lib/hachoir_parser/archive/cab.py
@@ -45,9 +45,9 @@ class Folder(FieldSet):
             yield RawBytes(self, "reserved_folder", self["../reserved_folder_size"].value, "Per-folder reserved area")
 
     def createDescription(self):
-        text= "Folder: compression %s" % self["compr_method"].display
+        text= "Folder: compression {0!s}".format(self["compr_method"].display)
         if self["compr_method"].value in [2, 3]: # Quantum or LZX use compression level
-            text += " (level %u: window size %u)" % (self["compr_level"].value, 2**self["compr_level"].value)
+            text += " (level {0:d}: window size {1:d})".format(self["compr_level"].value, 2**self["compr_level"].value)
         return text
 
 class CabFileAttributes(FieldSet):
@@ -67,7 +67,7 @@ class File(FieldSet):
         yield UInt32(self, "folder_offset", "File offset in uncompressed folder")
         yield Enum(UInt16(self, "folder_index", "Containing folder ID (index)"), {
             0xFFFD:"Folder continued from previous cabinet (real folder ID = 0)",
-            0xFFFE:"Folder continued to next cabinet (real folder ID = %i)" % (self["../nb_folder"].value - 1),
+            0xFFFE:"Folder continued to next cabinet (real folder ID = {0:d})".format((self["../nb_folder"].value - 1)),
             0xFFFF:"Folder spanning previous, current and next cabinets (real folder ID = 0)"})
         yield DateTimeMSDOS32(self, "timestamp")
         yield CabFileAttributes(self, "attributes")
@@ -77,7 +77,7 @@ class File(FieldSet):
             yield CString(self, "filename", charset="ASCII")
 
     def createDescription(self):
-        return "File %s (%s)" % (
+        return "File {0!s} ({1!s})".format(
             self["filename"].display, self["filesize"].display)
 
 class Flags(FieldSet):
@@ -210,9 +210,9 @@ class CabFile(Parser):
         if self.stream.readBytes(0, 4) != self.MAGIC:
             return "Invalid magic"
         if self["major_version"].value != 1 or self["minor_version"].value != 3:
-            return "Unknown version (%i.%i)" % (self["major_version"].value, self["minor_version"].value)
+            return "Unknown version ({0:d}.{1:d})".format(self["major_version"].value, self["minor_version"].value)
         if not (1 <= self["nb_folder"].value <= MAX_NB_FOLDER):
-            return "Invalid number of folder (%s)" % self["nb_folder"].value
+            return "Invalid number of folder ({0!s})".format(self["nb_folder"].value)
         return True
 
     def createFields(self):
@@ -269,7 +269,7 @@ class CabFile(Parser):
                 size = (self.size // 8) - folder["offset"].value
             else:
                 size = (folders[i+1][1]["offset"].value) - folder["offset"].value
-            yield FolderData(self, "folder_data[%i]" % index, folder, files, size=size*8)
+            yield FolderData(self, "folder_data[{0:d}]".format(index), folder, files, size=size*8)
 
         end = self.seekBit(self.size, "endraw")
         if end:

--- a/lib/hachoir_parser/archive/gzip_parser.py
+++ b/lib/hachoir_parser/archive/gzip_parser.py
@@ -52,7 +52,7 @@ class GzipParser(Parser):
         if self["signature"].value != '\x1F\x8B':
             return "Invalid signature"
         if self["compression"].value not in self.COMPRESSION_NAME:
-            return "Unknown compression method (%u)" % self["compression"].value
+            return "Unknown compression method ({0:d})".format(self["compression"].value)
         if self["reserved[0]"].value != 0:
             return "Invalid reserved[0] value"
         if self["reserved[1]"].value != 0:
@@ -120,10 +120,10 @@ class GzipParser(Parser):
         desc = u"gzip archive"
         info = []
         if "filename" in self:
-            info.append('filename "%s"' % self["filename"].value)
+            info.append('filename "{0!s}"'.format(self["filename"].value))
         if "size" in self:
-            info.append("was %s" % self["size"].display)
+            info.append("was {0!s}".format(self["size"].display))
         if self["mtime"].value:
             info.append(self["mtime"].display)
-        return "%s: %s" % (desc, ", ".join(info))
+        return "{0!s}: {1!s}".format(desc, ", ".join(info))
 

--- a/lib/hachoir_parser/archive/mar.py
+++ b/lib/hachoir_parser/archive/mar.py
@@ -22,7 +22,7 @@ class FileIndex(FieldSet):
         yield UInt32(self, "offset")
 
     def createDescription(self):
-        return "File %s (%s) at %s" % (
+        return "File {0!s} ({1!s}) at {2!s}".format(
             self["filename"].value, self["filesize"].display, self["offset"].value)
 
 class MarFile(Parser):
@@ -62,6 +62,6 @@ class MarFile(Parser):
             if padding:
                 yield padding
             size = index["filesize"].value
-            desc = "File %s" % index["filename"].value
+            desc = "File {0!s}".format(index["filename"].value)
             yield SubFile(self, "data[]", size, desc, filename=index["filename"].value)
 

--- a/lib/hachoir_parser/archive/mozilla_ar.py
+++ b/lib/hachoir_parser/archive/mozilla_ar.py
@@ -20,7 +20,7 @@ class IndexEntry(FieldSet):
         yield CString(self, "name", "Filename (byte array)")
 
     def createDescription(self):
-        return 'File %s, Size %s, Mode %s'%(
+        return 'File {0!s}, Size {1!s}, Mode {2!s}'.format(
             self["name"].display, self["length"].display, self["flags"].display)
 
 class MozillaArchive(HachoirParser, RootSeekableFieldSet):

--- a/lib/hachoir_parser/archive/rar.py
+++ b/lib/hachoir_parser/archive/rar.py
@@ -61,7 +61,7 @@ def formatRARVersion(field):
     """
     Decodes the RAR version stored on 1 byte
     """
-    return "%u.%u" % divmod(field.value, 10)
+    return "{0:d}.{1:d}".format(*divmod(field.value, 10))
 
 def commonFlags(s):
     yield Bit(s, "has_added_size", "Additional field indicating additional size")
@@ -204,8 +204,7 @@ def fileBody(s):
         yield RawBytes(s, "compressed_data", size, "File compressed data")
 
 def fileDescription(s):
-    return "File entry: %s (%s)" % \
-           (s["filename"].display, s["compressed_size"].display)
+    return "File entry: {0!s} ({1!s})".format(s["filename"].display, s["compressed_size"].display)
 
 def newSubHeader(s):
     return specialHeader(s, False)
@@ -263,7 +262,7 @@ class Block(FieldSet):
             if parseHeader   : self.parseHeader    = lambda: parseHeader(self)
             if parseBody     : self.parseBody      = lambda: parseBody(self)
         else:
-            self.info("Processing as unknown block block of type %u" % type)
+            self.info("Processing as unknown block block of type {0:d}".format(type))
 
         self._size = 8*self["block_size"].value
         if t == 0x74 or t == 0x7A:
@@ -299,7 +298,7 @@ class Block(FieldSet):
             yield field
 
     def createDescription(self):
-        return "Block entry: %s" % self["type"].display
+        return "Block entry: {0!s}".format(self["type"].display)
 
     def parseFlags(self):
         yield BlockFlags(self, "flags", "Block header flags")

--- a/lib/hachoir_parser/archive/rpm.py
+++ b/lib/hachoir_parser/archive/rpm.py
@@ -30,7 +30,7 @@ class ItemContent(FieldSet):
     def __init__(self, parent, name, item):
         FieldSet.__init__(self, parent, name, item.description)
         self.related_item = item
-        self._name = "content_%s" % item.name
+        self._name = "content_{0!s}".format(item.name)
 
     def createFields(self):
         item = self.related_item
@@ -94,7 +94,7 @@ class Item(FieldSet):
         yield UInt32(self, "count", "Count")
 
     def createDescription(self):
-        return "Item: %s (%s)" % (self["tag"].display, self["type"].display)
+        return "Item: {0!s} ({1!s})".format(self["tag"].display, self["type"].display)
 
 class ItemHeader(Item):
     tag_name = {
@@ -237,7 +237,7 @@ class RpmFile(Parser):
         if self["signature"].value != '\xED\xAB\xEE\xDB':
             return "Invalid signature"
         if self["major_ver"].value != 3:
-            return "Unknown major version (%u)" % self["major_ver"].value
+            return "Unknown major version ({0:d})".format(self["major_ver"].value)
         if self["type"].value not in self.TYPE_NAME:
             return "Invalid RPM type"
         return True

--- a/lib/hachoir_parser/archive/tar.py
+++ b/lib/hachoir_parser/archive/tar.py
@@ -78,8 +78,7 @@ class FileEntry(FieldSet):
         else:
             filename = self["name"].value
             filesize = humanFilesize(self.getOctal("size"))
-            desc = "(%s: %s, %s)" % \
-                (filename, self["type"].display, filesize)
+            desc = "({0!s}: {1!s}, {2!s})".format(filename, self["type"].display, filesize)
         return "Tar File " + desc
 
 class TarFile(Parser):

--- a/lib/hachoir_parser/archive/zip.py
+++ b/lib/hachoir_parser/archive/zip.py
@@ -46,7 +46,7 @@ COMPRESSION_METHOD = {
 }
 
 def ZipRevision(field):
-    return "%u.%u" % divmod(field.value, 10)
+    return "{0:d}.{1:d}".format(*divmod(field.value, 10))
 
 class ZipVersion(FieldSet):
     static_size = 16
@@ -191,7 +191,7 @@ class ZipCentralDirectory(FieldSet):
                          "Comment", charset=charset)
 
     def createDescription(self):
-        return "Central directory: %s" % self["filename"].display
+        return "Central directory: {0!s}".format(self["filename"].display)
 
 class Zip64EndCentralDirectory(FieldSet):
     HEADER = 0x06064b50
@@ -257,8 +257,8 @@ class FileEntry(FieldSet):
         size = self.stream.searchBytesLength(ZipDataDescriptor.HEADER_STRING, False,
                                             self.absolute_address+self.current_size)
         if size <= 0:
-            raise ParserError("Couldn't resync to %s" %
-                              ZipDataDescriptor.HEADER_STRING)
+            raise ParserError("Couldn't resync to {0!s}".format(
+                              ZipDataDescriptor.HEADER_STRING))
         yield self.data(size)
         yield textHandler(UInt32(self, "header[]", "Header"), hexadecimal)
         data_desc = ZipDataDescriptor(self, "data_desc", "Data descriptor")
@@ -268,8 +268,7 @@ class FileEntry(FieldSet):
         # than aborting
         if self["crc32"].value == 0 and \
             data_desc["file_compressed_size"].value != size:
-            raise ParserError("Bad resync: position=>%i but data_desc=>%i" %
-                              (size, data_desc["file_compressed_size"].value))
+            raise ParserError("Bad resync: position=>{0:d} but data_desc=>{1:d}".format(size, data_desc["file_compressed_size"].value))
 
     def createFields(self):
         for field in ZipStartCommonFields(self):
@@ -295,12 +294,11 @@ class FileEntry(FieldSet):
             yield ZipDataDescriptor(self, "data_desc", "Data descriptor")
 
     def createDescription(self):
-        return "File entry: %s (%s)" % \
-            (self["filename"].value, self["compressed_size"].display)
+        return "File entry: {0!s} ({1!s})".format(self["filename"].value, self["compressed_size"].display)
 
     def validate(self):
         if self["compression"].value not in COMPRESSION_METHOD:
-            return "Unknown compression method (%u)" % self["compression"].value
+            return "Unknown compression method ({0:d})".format(self["compression"].value)
         return ""
 
 class ZipSignature(FieldSet):
@@ -380,7 +378,7 @@ class ZipFile(Parser):
             return "Unable to get file #0"
         err = file0.validate()
         if err:
-            return "File #0: %s" % err
+            return "File #0: {0!s}".format(err)
         return True
 
     def createFields(self):
@@ -408,7 +406,7 @@ class ZipFile(Parser):
             elif header == Zip64EndCentralDirectoryLocator.HEADER:
                 yield Zip64EndCentralDirectoryLocator(self, "end_locator", "ZIP64 Enf of central directory locator")
             else:
-                raise ParserError("Error, unknown ZIP header (0x%08X)." % header)
+                raise ParserError("Error, unknown ZIP header (0x{0:08X}).".format(header))
 
     def createMimeType(self):
         if self["file[0]/filename"].value == "mimetype":

--- a/lib/hachoir_parser/archive/zlib.py
+++ b/lib/hachoir_parser/archive/zlib.py
@@ -166,7 +166,7 @@ class DeflateBlock(FieldSet):
             yield Bits(self, "huff_num_code_length_codes", 4, "Number of Code Length Codes, minus 4")
             code_length_code_lengths = [0]*19 # confusing variable name...
             for i in self.CODE_LENGTH_ORDER[:self["huff_num_code_length_codes"].value+4]:
-                field = Bits(self, "huff_code_length_code[%i]" % i, 3, "Code lengths for the code length alphabet")
+                field = Bits(self, "huff_code_length_code[{0:d}]".format(i), 3, "Code lengths for the code length alphabet")
                 yield field
                 code_length_code_lengths[i] = field.value
             code_length_tree = build_tree(code_length_code_lengths)
@@ -176,11 +176,11 @@ class DeflateBlock(FieldSet):
                 (self["huff_num_length_codes"].value + 257, "length", length_code_lengths),
                 (self["huff_num_distance_codes"].value + 1, "distance", distance_code_lengths)):
                 while len(lengths) < numcodes:
-                    field = HuffmanCode(self, "huff_%s_code[]" % name, code_length_tree)
+                    field = HuffmanCode(self, "huff_{0!s}_code[]".format(name), code_length_tree)
                     value = field.realvalue
                     if value < 16:
                         prev_value = value
-                        field._description = "Literal Code Length %i (Huffman Code %i)" % (value, field.value)
+                        field._description = "Literal Code Length {0:d} (Huffman Code {1:d})".format(value, field.value)
                         yield field
                         lengths.append(value)
                     else:
@@ -191,11 +191,11 @@ class DeflateBlock(FieldSet):
                             repvalue = prev_value
                         else:
                             repvalue = 0
-                        field._description = "Repeat Code %i, Repeating value (%i) %i to %i times (Huffman Code %i)" % (value, repvalue, info[0], info[1], field.value)
+                        field._description = "Repeat Code {0:d}, Repeating value ({1:d}) {2:d} to {3:d} times (Huffman Code {4:d})".format(value, repvalue, info[0], info[1], field.value)
                         yield field
-                        extrafield = Bits(self, "huff_%s_code_extra[%s" % (name, field.name.split('[')[1]), info[2])
+                        extrafield = Bits(self, "huff_{0!s}_code_extra[{1!s}".format(name, field.name.split('[')[1]), info[2])
                         num_repeats = extrafield.value+info[0]
-                        extrafield._description = "Repeat Extra Bits (%i), total repeats %i"%(extrafield.value, num_repeats)
+                        extrafield._description = "Repeat Extra Bits ({0:d}), total repeats {1:d}".format(extrafield.value, num_repeats)
                         yield extrafield
                         lengths += [repvalue]*num_repeats
             length_tree = build_tree(length_code_lengths)
@@ -206,39 +206,39 @@ class DeflateBlock(FieldSet):
             field = HuffmanCode(self, "length_code[]", length_tree)
             value = field.realvalue
             if value < 256:
-                field._description = "Literal Code %r (Huffman Code %i)" % (chr(value), field.value)
+                field._description = "Literal Code {0!r} (Huffman Code {1:d})".format(chr(value), field.value)
                 yield field
                 self.uncomp_data += chr(value)
             if value == 256:
-                field._description = "Block Terminator Code (256) (Huffman Code %i)" % field.value
+                field._description = "Block Terminator Code (256) (Huffman Code {0:d})".format(field.value)
                 yield field
                 break
             elif value > 256:
                 info = self.LENGTH_SYMBOLS[value]
                 if info[2] == 0:
-                    field._description = "Length Code %i, Value %i (Huffman Code %i)" % (value, info[0], field.value)
+                    field._description = "Length Code {0:d}, Value {1:d} (Huffman Code {2:d})".format(value, info[0], field.value)
                     length = info[0]
                     yield field
                 else:
-                    field._description = "Length Code %i, Values %i to %i (Huffman Code %i)" % (value, info[0], info[1], field.value)
+                    field._description = "Length Code {0:d}, Values {1:d} to {2:d} (Huffman Code {3:d})".format(value, info[0], info[1], field.value)
                     yield field
-                    extrafield = Bits(self, "length_extra[%s" % field.name.split('[')[1], info[2])
+                    extrafield = Bits(self, "length_extra[{0!s}".format(field.name.split('[')[1]), info[2])
                     length = extrafield.value + info[0]
-                    extrafield._description = "Length Extra Bits (%i), total length %i"%(extrafield.value, length)
+                    extrafield._description = "Length Extra Bits ({0:d}), total length {1:d}".format(extrafield.value, length)
                     yield extrafield
                 field = HuffmanCode(self, "distance_code[]", distance_tree)
                 value = field.realvalue
                 info = self.DISTANCE_SYMBOLS[value]
                 if info[2] == 0:
-                    field._description = "Distance Code %i, Value %i (Huffman Code %i)" % (value, info[0], field.value)
+                    field._description = "Distance Code {0:d}, Value {1:d} (Huffman Code {2:d})".format(value, info[0], field.value)
                     distance = info[0]
                     yield field
                 else:
-                    field._description = "Distance Code %i, Values %i to %i (Huffman Code %i)" % (value, info[0], info[1], field.value)
+                    field._description = "Distance Code {0:d}, Values {1:d} to {2:d} (Huffman Code {3:d})".format(value, info[0], info[1], field.value)
                     yield field
-                    extrafield = Bits(self, "distance_extra[%s" % field.name.split('[')[1], info[2])
+                    extrafield = Bits(self, "distance_extra[{0!s}".format(field.name.split('[')[1]), info[2])
                     distance = extrafield.value + info[0]
-                    extrafield._description = "Distance Extra Bits (%i), total length %i"%(extrafield.value, distance)
+                    extrafield._description = "Distance Extra Bits ({0:d}), total length {1:d}".format(extrafield.value, distance)
                     yield extrafield
                 self.uncomp_data = extend_data(self.uncomp_data, length, distance)
 

--- a/lib/hachoir_parser/audio/id3.py
+++ b/lib/hachoir_parser/audio/id3.py
@@ -209,7 +209,7 @@ class ID3v1(FieldSet):
 
     def createDescription(self):
         version = self.getVersion()
-        return "ID3 %s: author=%s, song=%s" % (
+        return "ID3 {0!s}: author={1!s}, song={2!s}".format(
             version, self["author"].value, self["song"].value)
 
 def getCharset(field):
@@ -217,7 +217,7 @@ def getCharset(field):
         key = field.value
         return ID3_StringCharset.charset_name[key]
     except KeyError:
-        raise ParserError("ID3v2: Invalid charset (%s)." % key)
+        raise ParserError("ID3v2: Invalid charset ({0!s}).".format(key))
 
 class ID3_String(FieldSet):
     STRIP = " \0"
@@ -441,7 +441,7 @@ class ID3_Chunk(FieldSet):
 
     def createDescription(self):
         if self["size"].value != 0:
-            return "ID3 Chunk: %s" % self["tag"].display
+            return "ID3 Chunk: {0!s}".format(self["tag"].display)
         else:
             return "ID3 Chunk: (terminator)"
 
@@ -466,8 +466,7 @@ class ID3v2(FieldSet):
             self._size = (self["size"].value + 10) * 8
 
     def createDescription(self):
-        return "ID3 v2.%s.%s" % \
-            (self["ver_major"].value, self["ver_minor"].value)
+        return "ID3 v2.{0!s}.{1!s}".format(self["ver_major"].value, self["ver_minor"].value)
 
     def createFields(self):
         # Signature + version
@@ -481,8 +480,7 @@ class ID3v2(FieldSet):
         if self["ver_major"].value not in self.VALID_MAJOR_VERSIONS \
         or self["ver_minor"].value != 0:
             raise MatchError(
-                "Unknown ID3 metadata version (2.%u.%u)"
-                % (self["ver_major"].value, self["ver_minor"].value))
+                "Unknown ID3 metadata version (2.{0:d}.{1:d})".format(self["ver_major"].value, self["ver_minor"].value))
 
         # Flags
         yield Bit(self, "unsync", "Unsynchronisation is used?")

--- a/lib/hachoir_parser/audio/midi.py
+++ b/lib/hachoir_parser/audio/midi.py
@@ -81,13 +81,13 @@ def parseTimeSignature(parser, size):
 class Command(FieldSet):
     COMMAND = {}
     for channel in xrange(16):
-        COMMAND[0x80+channel] = ("Note off (channel %u)" % channel, parseNote)
-        COMMAND[0x90+channel] = ("Note on (channel %u)" % channel, parseNote)
-        COMMAND[0xA0+channel] = ("Key after-touch (channel %u)" % channel, parseNote)
-        COMMAND[0xB0+channel] = ("Control change (channel %u)" % channel, parseControl)
-        COMMAND[0xC0+channel] = ("Program (patch) change (channel %u)" % channel, parsePatch)
-        COMMAND[0xD0+channel] = ("Channel after-touch (channel %u)" % channel, parseChannel)
-        COMMAND[0xE0+channel] = ("Pitch wheel change (channel %u)" % channel, parsePitch)
+        COMMAND[0x80+channel] = ("Note off (channel {0:d})".format(channel), parseNote)
+        COMMAND[0x90+channel] = ("Note on (channel {0:d})".format(channel), parseNote)
+        COMMAND[0xA0+channel] = ("Key after-touch (channel {0:d})".format(channel), parseNote)
+        COMMAND[0xB0+channel] = ("Control change (channel {0:d})".format(channel), parseControl)
+        COMMAND[0xC0+channel] = ("Program (patch) change (channel {0:d})".format(channel), parsePatch)
+        COMMAND[0xD0+channel] = ("Channel after-touch (channel {0:d})".format(channel), parseChannel)
+        COMMAND[0xE0+channel] = ("Pitch wheel change (channel {0:d})".format(channel), parsePitch)
     COMMAND_DESC = createDict(COMMAND, 0)
     COMMAND_PARSER = createDict(COMMAND, 1)
 
@@ -150,7 +150,7 @@ class Command(FieldSet):
                     yield RawBytes(self, "data", size)
         else:
             if self.command not in self.COMMAND_PARSER:
-                raise ParserError("Unknown command: %s" % self["command"].display)
+                raise ParserError("Unknown command: {0!s}".format(self["command"].display))
             parser = self.COMMAND_PARSER[self.command]
             for field in parser(self):
                 yield field
@@ -203,7 +203,7 @@ class Header(FieldSet):
         yield UInt16(self, "delta_time", "Delta-time ticks per quarter note")
 
     def createDescription(self):
-        return "%s; %s tracks" % (
+        return "{0!s}; {1!s} tracks".format(
             self["file_format"].display, self["nb_track"].value)
 
 class MidiFile(Parser):
@@ -233,11 +233,11 @@ class MidiFile(Parser):
             yield Track(self, "track[]")
 
     def createDescription(self):
-        return "MIDI audio: %s" % self["header"].description
+        return "MIDI audio: {0!s}".format(self["header"].description)
 
     def createContentSize(self):
         count = self["/header/nb_track"].value - 1
-        start = self["track[%u]" % count].absolute_address
+        start = self["track[{0:d}]".format(count)].absolute_address
         # Search "End of track" of last track
         end = self.stream.searchBytes("\xff\x2f\x00", start, MAX_FILESIZE*8)
         if end is not None:

--- a/lib/hachoir_parser/audio/mod.py
+++ b/lib/hachoir_parser/audio/mod.py
@@ -47,7 +47,7 @@ def getFineTune(val):
             "-8", "-7", "-6", "-5", "-4", "-3", "-2", "-1")[val.value]
 
 def getVolume(val):
-    return "%.1f dB" % (20.0*log10(val.value/64.0))
+    return "{0:.1f} dB".format((20.0*log10(val.value/64.0)))
 
 class SampleInfo(FieldSet):
     static_size = 30*8
@@ -119,8 +119,8 @@ class AmigaModule(Parser):
     def validate(self):
         t = self.stream.readBytes(1080*8, 4)
         if t not in MODULE_TYPE:
-            return "Invalid module type '%s'" % t
-        self.createValue = lambda t: "%s module, %u channels" % MODULE_TYPE[t]
+            return "Invalid module type '{0!s}'".format(t)
+        self.createValue = lambda t: "{0!s} module, {1:d} channels".format(*MODULE_TYPE[t])
         return True
 
     def createFields(self):
@@ -132,7 +132,7 @@ class AmigaModule(Parser):
         patterns = 0
         for index in xrange(128):
             patterns = max(patterns,
-                           header["patterns/position[%u]" % index].value)
+                           header["patterns/position[{0:d}]".format(index)].value)
         patterns += 1
 
         # Yield patterns
@@ -141,9 +141,9 @@ class AmigaModule(Parser):
 
         # Yield samples
         for index in xrange(31):
-            count = header["samples/info[%u]/sample_count" % index].value
+            count = header["samples/info[{0:d}]/sample_count".format(index)].value
             if count:
-                self.info("Yielding sample %u: %u samples" % (index, count))
+                self.info("Yielding sample {0:d}: {1:d} samples".format(index, count))
                 yield RawBytes(self, "sample_data[]", 2*count, \
-                               "Sample %u" % index)
+                               "Sample {0:d}".format(index))
 

--- a/lib/hachoir_parser/audio/modplug.py
+++ b/lib/hachoir_parser/audio/modplug.py
@@ -34,7 +34,7 @@ class Command(FieldSet):
         start = self.absolute_address
         size = self.stream.searchBytesLength("\0", False, start)
         if size > 0:
-            self.info("Command: %s" % self.stream.readBytes(start, size))
+            self.info("Command: {0!s}".format(self.stream.readBytes(start, size)))
             yield String(self, "command", size, strip='\0')
         yield RawBytes(self, "parameter", (self._size//8)-size)
 
@@ -219,14 +219,13 @@ class MPField(FieldSet):
                 yield cls(self, "value")
 
     def createDescription(self):
-        return "Element '%s', size %i" % \
-               (self["code"]._description, self["data_size"].value)
+        return "Element '{0!s}', size {1:d}".format(self["code"]._description, self["data_size"].value)
 
 def parseFields(parser):
     # Determine field names
     ext = EXTENSIONS[parser["block_type"].value]
     if ext == None:
-        raise ParserError("Unknown parent '%s'" % parser["block_type"].value)
+        raise ParserError("Unknown parent '{0!s}'".format(parser["block_type"].value))
 
     # Parse fields
     addr = parser.absolute_address + parser.current_size
@@ -236,8 +235,7 @@ def parseFields(parser):
         addr += field._size
 
     # Abort on unknown codes
-    parser.info("End of extension '%s' when finding '%s'" %
-           (parser["block_type"].value, parser.stream.readBytes(addr, 4)))
+    parser.info("End of extension '{0!s}' when finding '{1!s}'".format(parser["block_type"].value, parser.stream.readBytes(addr, 4)))
 
 class ModplugBlock(FieldSet):
     BLOCK_INFO = {

--- a/lib/hachoir_parser/audio/mpeg_audio.py
+++ b/lib/hachoir_parser/audio/mpeg_audio.py
@@ -73,7 +73,7 @@ class Frame(FieldSet):
         if not self._size:
             frame_size = self.getFrameSize()
             if not frame_size:
-                raise ParserError("MPEG audio: Invalid frame %s" % self.path)
+                raise ParserError("MPEG audio: Invalid frame {0!s}".format(self.path))
             self._size = min(frame_size * 8, self.parent.size - self.address)
 
     def createFields(self):
@@ -163,14 +163,14 @@ class Frame(FieldSet):
         return self.NB_CHANNEL[ self["channel_mode"].value ]
 
     def createDescription(self):
-        info = ["layer %s" % self["layer"].display]
+        info = ["layer {0!s}".format(self["layer"].display)]
         bit_rate = self.getBitRate()
         if bit_rate:
-            info.append("%s/sec" % humanBitSize(bit_rate))
+            info.append("{0!s}/sec".format(humanBitSize(bit_rate)))
         sampling_rate = self.getSampleRate()
         if sampling_rate:
             info.append(humanFrequency(sampling_rate))
-        return "MPEG-%s %s" % (self["version"].display, ", ".join(info))
+        return "MPEG-{0!s} {1!s}".format(self["version"].display, ", ".join(info))
 
 def findSynchronizeBits(parser, start, max_size):
     """
@@ -260,7 +260,7 @@ class Frames(FieldSet):
             text = "(looks like) Constant bit rate (CBR)"
         else:
             text = "Variable bit rate (VBR)"
-        return "Frames: %s" % text
+        return "Frames: {0!s}".format(text)
 
 def createMpegAudioMagic():
 
@@ -306,26 +306,26 @@ class MpegAudioFile(Parser):
         # Validate first 5 frames
         for index in xrange(5):
             try:
-                frame = self["frames/frame[%u]" % index]
+                frame = self["frames/frame[{0:d}]".format(index)]
             except MissingField:
                 # Require a least one valid frame
                 if (1 <= index) \
                 and self["frames"].done:
                     return True
-                return "Unable to get frame #%u" % index
+                return "Unable to get frame #{0:d}".format(index)
             except (InputStreamError, ParserError):
-                return "Unable to create frame #%u" % index
+                return "Unable to create frame #{0:d}".format(index)
 
             # Check first frame values
             if not frame.isValid():
-                return "Frame #%u is invalid" % index
+                return "Frame #{0:d} is invalid".format(index)
 
             # Check that all frames are similar
             if not index:
                 frame0 = frame
             else:
                 if frame0["channel_mode"].value != frame["channel_mode"].value:
-                    return "Frame #%u channel mode is different" % index
+                    return "Frame #{0:d} channel mode is different".format(index)
         return True
 
     def createFields(self):
@@ -357,7 +357,7 @@ class MpegAudioFile(Parser):
     def createDescription(self):
         if "frames" in self:
             frame = self["frames/frame[0]"]
-            return "%s, %s" % (frame.description, frame["channel_mode"].display)
+            return "{0!s}, {1!s}".format(frame.description, frame["channel_mode"].display)
         elif "id3v2" in self:
             return self["id3v2"].description
         elif "id3v1" in self:

--- a/lib/hachoir_parser/audio/real_audio.py
+++ b/lib/hachoir_parser/audio/real_audio.py
@@ -82,9 +82,9 @@ class RealAudioFile(Parser):
 
     def createDescription(self):
         if (self["version"].value == 3):
-            return "RealAudio v3 file, '%s' codec" % self["FourCC"].value
+            return "RealAudio v3 file, '{0!s}' codec".format(self["FourCC"].value)
         elif (self["version"].value == 4):
-            return "RealAudio v4 file, '%s' codec, %s, %u channels" % (
+            return "RealAudio v4 file, '{0!s}' codec, {1!s}, {2:d} channels".format(
                 self["FourCC"].value, self["sample_rate"].display, self["channels"].value)
         else:
             return "Real audio"

--- a/lib/hachoir_parser/common/tracker.py
+++ b/lib/hachoir_parser/common/tracker.py
@@ -6,5 +6,5 @@ NOTE_NAME = {}
 NOTES = ("C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "G#", "A", "A#", "B")
 for octave in xrange(10):
     for index, note in enumerate(NOTES):
-        NOTE_NAME[octave*12+index] = "%s (octave %s)" % (note, octave)
+        NOTE_NAME[octave*12+index] = "{0!s} (octave {1!s})".format(note, octave)
 

--- a/lib/hachoir_parser/common/win32.py
+++ b/lib/hachoir_parser/common/win32.py
@@ -121,14 +121,14 @@ class GUID(FieldSet):
         c = self.stream.readBits (addr + 48, 16, self.endian)
         d = self.stream.readBytes(addr + 64, 2)
         e = self.stream.readBytes(addr + 80, 6)
-        return "%08X-%04X-%04X-%s-%s" % (a, b, c, str2hex(d), str2hex(e))
+        return "{0:08X}-{1:04X}-{2:04X}-{3!s}-{4!s}".format(a, b, c, str2hex(d), str2hex(e))
 
     def createDisplay(self):
         value = self.value
         if value == self.NULL:
             name = "Null GUID: "
         else:
-            name = "GUID v%u (%s): " % (self.version, self["version"].display)
+            name = "GUID v{0:d} ({1!s}): ".format(self.version, self["version"].display)
         return name + value
 
     def createRawDisplay(self):
@@ -169,6 +169,5 @@ class BitmapInfoHeader(FieldSet):
         yield UInt32(self, "color_important", "Number of important colors")
 
     def createDescription(self):
-        return "Bitmap info header: %ux%u pixels, %u bits/pixel" % \
-            (self["width"].value, self["height"].value, self["bpp"].value)
+        return "Bitmap info header: {0:d}x{1:d} pixels, {2:d} bits/pixel".format(self["width"].value, self["height"].value, self["bpp"].value)
 

--- a/lib/hachoir_parser/container/action_script.py
+++ b/lib/hachoir_parser/container/action_script.py
@@ -359,7 +359,7 @@ def FindABC(field):
 def GetConstant(field, pool, index):
     if index == 0:
         return None
-    return FindABC(field)["constant_%s_pool/constant[%i]"%(pool, index)]
+    return FindABC(field)["constant_{0!s}_pool/constant[{1:d}]".format(pool, index)]
 
 def GetMultiname(field, index):
     fld = GetConstant(field, "multiname", index)
@@ -388,7 +388,7 @@ class ABCNSIndex(FlashU30):
 
 class ABCMethodIndex(FlashU30):
     def createDisplay(self):
-        fld = FindABC(self)["method_array/method[%i]"%self.value]
+        fld = FindABC(self)["method_array/method[{0:d}]".format(self.value)]
         if fld is None:
             return "*"
         return fld.description
@@ -399,13 +399,13 @@ class ABCMultinameIndex(FlashU30):
 
 class ABCConstantPool(FieldSet):
     def __init__(self, parent, name, klass):
-        FieldSet.__init__(self, parent, 'constant_%s_pool'%name)
+        FieldSet.__init__(self, parent, 'constant_{0!s}_pool'.format(name))
         self.klass = klass
     def createFields(self):
         ctr = FlashU30(self, "count")
         yield ctr
         for i in xrange(ctr.value-1):
-            yield self.klass(self, "constant[%i]"%(i+1))
+            yield self.klass(self, "constant[{0:d}]".format((i+1)))
 
 class ABCObjectArray(FieldSet):
     def __init__(self, parent, name, klass):
@@ -461,7 +461,7 @@ class ABCConstantNamespace(FieldSet):
         yield ABCStringIndex(self, "name_index")
 
     def createDisplay(self):
-        return "%s %s"%(self["kind"].display, self["name_index"].display)
+        return "{0!s} {1!s}".format(self["kind"].display, self["name_index"].display)
 
     def createValue(self):
         return self["name_index"].value

--- a/lib/hachoir_parser/container/asn1.py
+++ b/lib/hachoir_parser/container/asn1.py
@@ -131,7 +131,7 @@ def readObjectID(self, content_size):
 
 def readBoolean(self, content_size):
     if content_size != 1:
-        raise ParserError("Overlong boolean: got %s bytes, expected 1 byte"%content_size)
+        raise ParserError("Overlong boolean: got {0!s} bytes, expected 1 byte".format(content_size))
     yield textHandler(UInt8(self, "value"), lambda field:str(bool(field.value)))
 
 def readInteger(self, content_size):
@@ -142,7 +142,7 @@ def readInteger(self, content_size):
 
 def formatFirstObjectID(field):
     value = field.value
-    return "%u.%u" % (value // 40, value % 40)
+    return "{0:d}.{1:d}".format(value // 40, value % 40)
 
 def formatValue(fieldset):
     return fieldset["value"].display
@@ -223,7 +223,7 @@ class Object(FieldSet):
             if key in self.TYPE_INFO:
                 self._name, self._handler, self._description, create_desc = self.TYPE_INFO[key]
                 if create_desc:
-                    self.createDescription = lambda: "%s: %s" % (self.TYPE_INFO[key][2], create_desc(self))
+                    self.createDescription = lambda: "{0!s}: {1!s}".format(self.TYPE_INFO[key][2], create_desc(self))
                     self._description = None
             elif key == 31:
                 raise ParserError("ASN.1 Object: tag bigger than 30 are not supported")
@@ -233,12 +233,12 @@ class Object(FieldSet):
             # constructed: treat as sequence
             self._name = 'seq[]'
             self._handler = readSequence
-            self._description = 'constructed object type %i' % key
+            self._description = 'constructed object type {0:d}'.format(key)
         else:
             # primitive, context/private
             self._name = 'raw[]'
             self._handler = readASCIIString
-            self._description = '%s object type %i' % (self['class'].display, key)
+            self._description = '{0!s} object type {1:d}'.format(self['class'].display, key)
         field = self["size"]
         self._size = field.address + field.size + field.value*8
 

--- a/lib/hachoir_parser/container/mkv.py
+++ b/lib/hachoir_parser/container/mkv.py
@@ -87,7 +87,7 @@ class AttachedFile(Bytes):
     def createDescription(self):
         filename = self._getFilename()
         if filename:
-            return 'File "%s"' % filename
+            return 'File "{0!s}"'.format(filename)
         return "('Filename' entry not found)"
     def _createInputStream(self, **args):
         tags = args.setdefault("tags",[])

--- a/lib/hachoir_parser/container/ogg.py
+++ b/lib/hachoir_parser/container/ogg.py
@@ -221,7 +221,7 @@ class OggPage(FieldSet):
     def createFields(self):
         yield String(self, 'capture_pattern', 4, charset="ASCII")
         if self['capture_pattern'].value != self.MAGIC:
-            self.warning('Invalid signature. An Ogg page must start with "%s".' % self.MAGIC)
+            self.warning('Invalid signature. An Ogg page must start with "{0!s}".'.format(self.MAGIC))
         yield UInt8(self, 'stream_structure_version')
         yield Bit(self, 'continued_packet')
         yield Bit(self, 'first_page')
@@ -240,7 +240,7 @@ class OggPage(FieldSet):
         if self['capture_pattern'].value != self.MAGIC:
             return "Wrong signature"
         if self['stream_structure_version'].value != 0:
-            return "Unknown structure version (%s)" % self['stream_structure_version'].value
+            return "Unknown structure version ({0!s})".format(self['stream_structure_version'].value)
         return ""
 
 class OggFile(Parser):
@@ -272,12 +272,12 @@ class OggFile(Parser):
             except MissingField:
                 if self.done:
                     return True
-                return "Unable to get page #%u" % index
+                return "Unable to get page #{0:d}".format(index)
             except (InputStreamError, ParserError):
-                return "Unable to create page #%u" % index
+                return "Unable to create page #{0:d}".format(index)
             err = page.validate()
             if err:
-                return "Invalid page #%s: %s" % (index, err)
+                return "Invalid page #{0!s}: {1!s}".format(index, err)
         return True
 
     def createMimeType(self):

--- a/lib/hachoir_parser/container/realmedia.py
+++ b/lib/hachoir_parser/container/realmedia.py
@@ -131,7 +131,7 @@ class Chunk(FieldSet):
                 yield RawBytes(self, "raw", size)
 
     def createDescription(self):
-        return "Chunk: %s" % self["tag"].display
+        return "Chunk: {0!s}".format(self["tag"].display)
 
 class RealMediaFile(Parser):
     MAGIC = '.RMF\0\0\0\x12\0\1'    # (magic, size=18, version=1)
@@ -157,7 +157,7 @@ class RealMediaFile(Parser):
         if self["header/size"].value != 18:
             return "Invalid header size"
         if self["header/version"].value not in (0, 1):
-            return "Unknown file format version (%s)" % self["header/version"].value
+            return "Unknown file format version ({0!s})".format(self["header/version"].value)
         return True
 
     def createFields(self):

--- a/lib/hachoir_parser/container/riff.py
+++ b/lib/hachoir_parser/container/riff.py
@@ -134,7 +134,7 @@ def formatSerialNumber(field):
     Eg. 0x00085C48 => "0008-5C48"
     """
     sn = field.value
-    return "%04X-%04X" % (sn >> 16, sn & 0xFFFF)
+    return "{0:04X}-{1:04X}".format(sn >> 16, sn & 0xFFFF)
 
 def parseCDDA(self):
     """
@@ -155,7 +155,7 @@ def parseCDDA(self):
 def parseWAVFormat(self):
     size = self["size"].value
     if size not in (16, 18):
-        self.warning("Format with size of %s bytes is not supported!" % size)
+        self.warning("Format with size of {0!s} bytes is not supported!".format(size))
     yield Enum(UInt16(self, "codec", "Audio codec"), audio_codec_name)
     yield UInt16(self, "nb_channel", "Number of audio channel")
     yield UInt32(self, "sample_per_sec", "Sample per second")
@@ -289,7 +289,7 @@ class Chunk(FieldSet):
 
     def createDescription(self):
         tag = self["tag"].display
-        return u"Chunk (tag %s)" % tag
+        return u"Chunk (tag {0!s})".format(tag)
 
 class ChunkAVI(Chunk):
     TAG_INFO = Chunk.TAG_INFO.copy()
@@ -318,7 +318,7 @@ class ChunkWAVE(Chunk):
 def parseAnimationHeader(self):
     yield UInt32(self, "hdr_size", "Size of header (36 bytes)")
     if self["hdr_size"].value != 36:
-        self.warning("Animation header with unknown size (%s)" % self["size"].value)
+        self.warning("Animation header with unknown size ({0!s})".format(self["size"].value))
     yield UInt32(self, "nb_frame", "Number of unique Icons in this cursor")
     yield UInt32(self, "nb_step", "Number of Blits before the animation cycles")
     yield UInt32(self, "cx")
@@ -413,10 +413,10 @@ class RiffFile(Parser):
             desc = u"Microsoft AVI video"
             if "headers/avi_hdr" in self:
                 header = self["headers/avi_hdr"]
-                desc += ": %ux%u pixels" % (header["width"].value, header["height"].value)
+                desc += ": {0:d}x{1:d} pixels".format(header["width"].value, header["height"].value)
                 microsec = header["microsec_per_frame"].value
                 if microsec:
-                    desc += ", %.1f fps" % (1000000.0 / microsec)
+                    desc += ", {0:.1f} fps".format((1000000.0 / microsec))
                     if "total_frame" in header and header["total_frame"].value:
                         delta = timedelta(seconds=float(header["total_frame"].value) * microsec)
                         desc += ", " + humanDuration(delta)

--- a/lib/hachoir_parser/container/swf.py
+++ b/lib/hachoir_parser/container/swf.py
@@ -53,7 +53,7 @@ class RECT(FieldSet):
         return math.ceil(float(self["ymax"].value) / TWIPS)
 
     def createDescription(self):
-        return "Rectangle: %ux%u" % (self.getWidth(), self.getHeight())
+        return "Rectangle: {0:d}x{1:d}".format(self.getWidth(), self.getHeight())
 
 class FixedFloat16(FieldSet):
     def createFields(self):
@@ -362,7 +362,7 @@ class Tag(FieldSet):
                 yield RawBytes(self, "data", size)
 
     def createDescription(self):
-        return "Tag: %s (%s)" % (self["code"].display, self["length"].display)
+        return "Tag: {0!s} ({1!s})".format(self["code"].display, self["length"].display)
 
 class SwfFile(Parser):
     VALID_VERSIONS = set(xrange(1, 10+1))
@@ -387,7 +387,7 @@ class SwfFile(Parser):
         if self["version"].value not in self.VALID_VERSIONS:
             return "Unknown version"
         if MAX_FILE_SIZE < self["filesize"].value:
-            return "File too big (%u)" % self["filesize"].value
+            return "File too big ({0:d})".format(self["filesize"].value)
         if self["signature"].value == "FWS":
             if self["rect/padding"].value != 0:
                 return "Unknown rectangle padding value"
@@ -419,10 +419,10 @@ class SwfFile(Parser):
                 yield Bytes(self, "compressed_data", size)
 
     def createDescription(self):
-        desc = ["version %u" % self["version"].value]
+        desc = ["version {0:d}".format(self["version"].value)]
         if self["signature"].value == "CWS":
             desc.append("compressed")
-        return u"Macromedia Flash data: %s" % (", ".join(desc))
+        return u"Macromedia Flash data: {0!s}".format((", ".join(desc)))
 
     def createContentSize(self):
         if self["signature"].value == "FWS":

--- a/lib/hachoir_parser/file_system/ext2.py
+++ b/lib/hachoir_parser/file_system/ext2.py
@@ -49,7 +49,7 @@ class DirectoryEntry(FieldSet):
     def createDescription(self):
         name = self["name"].value.strip("\0")
         if name:
-            return "Directory entry: %s" % name
+            return "Directory entry: {0!s}".format(name)
         else:
             return "Directory entry (empty)"
 
@@ -87,18 +87,18 @@ class Inode(FieldSet):
         self.uniq_id = 1+index
 
     def createDescription(self):
-        desc = "Inode %s: " % self.uniq_id
+        desc = "Inode {0!s}: ".format(self.uniq_id)
         size = self["size"].value
         if self["blocks"].value == 0:
             desc += "(unused)"
         elif 11 <= self.uniq_id:
             size = humanFilesize(size)
-            desc += "file, size=%s, mode=%s" % (size, self.getMode())
+            desc += "file, size={0!s}, mode={1!s}".format(size, self.getMode())
         else:
             if self.uniq_id in self.inode_type_name:
                 desc += self.inode_type_name[self.uniq_id]
                 if self.uniq_id == 2:
-                    desc += " (%s)" % self.getMode()
+                    desc += " ({0!s})".format(self.getMode())
             else:
                 desc += "special"
         return desc
@@ -175,13 +175,13 @@ class Inode(FieldSet):
 
 class Bitmap(FieldSet):
     def __init__(self, parent, name, start, size, description, **kw):
-        description = "%s: %s items" % (description, size)
+        description = "{0!s}: {1!s} items".format(description, size)
         FieldSet.__init__(self, parent, name, description, size=size, **kw)
         self.start = 1+start
 
     def createFields(self):
         for index in xrange(self._size):
-            yield Bit(self, "item[]", "Item %s" % (self.start+index))
+            yield Bit(self, "item[]", "Item {0!s}".format((self.start+index)))
 
 BlockBitmap = Bitmap
 InodeBitmap = Bitmap
@@ -197,7 +197,7 @@ class GroupDescriptor(FieldSet):
         blocks_per_group = self["/superblock/blocks_per_group"].value
         start = self.uniq_id * blocks_per_group
         end = start + blocks_per_group
-        return "Group descriptor: blocks %s-%s" % (start, end)
+        return "Group descriptor: blocks {0!s}-{1!s}".format(start, end)
 
     def createFields(self):
         yield UInt32(self, "block_bitmap", "Points to the blocks bitmap block")
@@ -238,7 +238,7 @@ class SuperBlock(FieldSet):
             fstype = "ext3"
         else:
             fstype = "ext2"
-        return "Superblock: %s file system" % fstype
+        return "Superblock: {0!s} file system".format(fstype)
 
     def createFields(self):
         yield UInt32(self, "inodes_count", "Inodes count")
@@ -302,7 +302,7 @@ class GroupDescriptors(FieldSet):
         self.count = count
 
     def createDescription(self):
-        return "Group descriptors: %s items" % self.count
+        return "Group descriptors: {0!s} items".format(self.count)
 
     def createFields(self):
         for index in range(0, self.count):
@@ -316,7 +316,7 @@ class InodeTable(FieldSet):
         self._size = self.count * self["/superblock/inode_size"].value * 8
 
     def createDescription(self):
-        return "Group descriptors: %s items" % self.count
+        return "Group descriptors: {0!s} items".format(self.count)
 
     def createFields(self):
         for index in range(self.start, self.start+self.count):
@@ -328,13 +328,13 @@ class Group(FieldSet):
         self.uniq_id = index
 
     def createDescription(self):
-        desc = "Group %s: %s" % (self.uniq_id, humanFilesize(self.size/8))
+        desc = "Group {0!s}: {1!s}".format(self.uniq_id, humanFilesize(self.size/8))
         if "superblock_copy" in self:
             desc += " (with superblock copy)"
         return desc
 
     def createFields(self):
-        group = self["../group_desc/group[%u]" % self.uniq_id]
+        group = self["../group_desc/group[{0:d}]".format(self.uniq_id)]
         superblock = self["/superblock"]
         block_size = self["/"].block_size
 
@@ -457,7 +457,7 @@ class EXT2_FS(Parser):
                 desc = "EXT3"
             else:
                 desc = "EXT2"
-        return desc + " file system: total=%s, used=%s, block=%s" % (
+        return desc + " file system: total={0!s}, used={1!s}, block={2!s}".format(
             humanFilesize(total), humanFilesize(used),
             humanFilesize(block_size))
 

--- a/lib/hachoir_parser/file_system/fat.py
+++ b/lib/hachoir_parser/file_system/fat.py
@@ -154,7 +154,7 @@ class InodeLink(Link):
             return Link.createValue(self)
 
     def createDisplay(self):
-        return "/%s[0]" % self._getTargetPath()
+        return "/{0!s}[0]".format(self._getTargetPath())
 
 
 class FileEntry(FieldSet):
@@ -199,9 +199,9 @@ class FileEntry(FieldSet):
             except ValueError:
                 pass
             seq_no = self["seq_no"].value
-            return "Long filename part: '%s' [%u]" % (name, seq_no)
+            return "Long filename part: '{0!s}' [{1:d}]".format(name, seq_no)
         else:
-            return "File: '%s'" % self.getFilename()
+            return "File: '{0!s}'".format(self.getFilename())
 
     def getCluster(self):
         cluster = self["cluster_lo"].value
@@ -294,7 +294,7 @@ class InodeGen:
                 return
             field = File(self.root, name, size=size)
             if prev.first is None:
-                field._description = 'File size: %s' % humanFilesize(self.filesize//8)
+                field._description = 'File size: {0!s}'.format(humanFilesize(self.filesize//8))
                 field.setSubIStream(self.createInputStream)
             field.datasize = min(self.filesize - self.done, size)
             self.done += field.datasize
@@ -302,7 +302,7 @@ class InodeGen:
             field = Directory(self.root, name, size=size)
         padding = self.root.getFieldByAddress(address, feed=False)
         if not isinstance(padding, (PaddingBytes, RawBytes)):
-            error("(FAT) address %u doesn't point to a padding field" % address)
+            error("(FAT) address {0:d} doesn't point to a padding field".format(address))
             return
         if last:
             next = None
@@ -322,8 +322,8 @@ class FAT_FS(Parser):
     }
 
     def _validate(self, type_offset):
-        if self.stream.readBytes(type_offset*8, 8) != ("FAT%-5u" % self.version):
-            return "Invalid FAT%u signature" % self.version
+        if self.stream.readBytes(type_offset*8, 8) != ("FAT{0:<5d}".format(self.version)):
+            return "Invalid FAT{0:d} signature".format(self.version)
         if self.stream.readBytes(510*8, 2) != "\x55\xAA":
             return "Invalid BIOS signature"
         return True

--- a/lib/hachoir_parser/file_system/linux_swap.py
+++ b/lib/hachoir_parser/file_system/linux_swap.py
@@ -34,7 +34,7 @@ class UUID(Bytes):
         Bytes.__init__(self, parent, name, 16)
     def createDisplay(self):
         text = str2hex(self.value, format=r"%02x")
-        return "%s-%s-%s-%s-%s" % (
+        return "{0!s}-{1!s}-{2!s}-{3!s}-{4!s}".format(
             text[:8], text[8:12], text[12:16], text[16:20], text[20:])
 
 class LinuxSwapFile(Parser):
@@ -57,7 +57,7 @@ class LinuxSwapFile(Parser):
         if magic not in ("SWAP-SPACE", "SWAPSPACE2", "S1SUSPEND\0"):
             return "Unknown magic string"
         if MAX_SWAP_BADPAGES < self["nb_badpage"].value:
-            return "Invalid number of bad page (%u)" % self["nb_badpage"].value
+            return "Invalid number of bad page ({0:d})".format(self["nb_badpage"].value)
         return True
 
     def getPageCount(self):
@@ -76,7 +76,7 @@ class LinuxSwapFile(Parser):
         else:
             text = "Linux swap file version 1"
         nb_page = self.getPageCount()
-        return "%s, page size: %s, %s pages" % (
+        return "{0!s}, page size: {1!s}, {2!s} pages".format(
             text, humanFilesize(PAGE_SIZE), nb_page)
 
     def createFields(self):
@@ -95,7 +95,7 @@ class LinuxSwapFile(Parser):
         count = self["nb_badpage"].value
         if count:
             if MAX_SWAP_BADPAGES < count:
-                raise ParserError("Invalid number of bad page (%u)" % count)
+                raise ParserError("Invalid number of bad page ({0:d})".format(count))
             yield GenericVector(self, "badpages", count, UInt32, "badpage")
 
         # Read magic

--- a/lib/hachoir_parser/file_system/mbr.py
+++ b/lib/hachoir_parser/file_system/mbr.py
@@ -155,7 +155,7 @@ class PartitionHeader(FieldSet):
         if self.isUsed():
             system = self["system"].display
             size = self["size"].value * BLOCK_SIZE
-            desc += "%s, %s" % (system, humanFilesize(size))
+            desc += "{0!s}, {1!s}".format(system, humanFilesize(size))
         else:
             desc += "(unused)"
         return desc
@@ -194,7 +194,7 @@ class Partition(FieldSet):
                 yield padding
 
             # Content of the partition
-            name = "partition[%u]" % index
+            name = "partition[{0:d}]".format(index)
             size = BLOCK_SIZE * header["size"].value
             desc = header["system"].display
             if header["system"].value == 5:

--- a/lib/hachoir_parser/file_system/ntfs.py
+++ b/lib/hachoir_parser/file_system/ntfs.py
@@ -46,11 +46,11 @@ class BiosParameterBlock(FieldSet):
 
     def validate(self):
         if self["bytes_per_sector"].value not in (256, 512, 1024, 2048, 4096):
-            return "Invalid sector size (%u bytes)" % \
-                self["bytes_per_sector"].value
+            return "Invalid sector size ({0:d} bytes)".format( \
+                self["bytes_per_sector"].value)
         if self["sectors_per_cluster"].value not in (1, 2, 4, 8, 16, 32, 64, 128):
-            return "Invalid cluster size (%u sectors)" % \
-                self["sectors_per_cluster"].value
+            return "Invalid cluster size ({0:d} sectors)".format( \
+                self["sectors_per_cluster"].value)
         return ""
 
 class MasterBootRecord(FieldSet):
@@ -79,7 +79,7 @@ class MasterBootRecord(FieldSet):
 
     def createDescription(self):
         size = self["nb_sectors"].value * self["bios/bytes_per_sector"].value
-        return "NTFS Master Boot Record (%s)" % humanFilesize(size)
+        return "NTFS Master Boot Record ({0!s})".format(humanFilesize(size))
 
 class MFT_Flags(FieldSet):
     static_size = 16
@@ -122,7 +122,7 @@ class Attribute(FieldSet):
             yield PaddingBytes(self, "end_padding", size)
 
     def createDescription(self):
-        return "Attribute %s" % self["type"].display
+        return "Attribute {0!s}".format(self["type"].display)
     FILENAME_NAMESPACE = {
         0: "POSIX",
         1: "Win32",
@@ -240,11 +240,11 @@ class File(FieldSet):
     def createDescription(self):
         text = "File"
         if "filename/filename" in self:
-            text += ' "%s"' % self["filename/filename"].value
+            text += ' "{0!s}"'.format(self["filename/filename"].value)
         if "filename/real_size" in self:
-            text += ' (%s)' % self["filename/real_size"].display
+            text += ' ({0!s})'.format(self["filename/real_size"].display)
         if "standard_info/file_attr" in self:
-            text += ', %s' % self["standard_info/file_attr"].display
+            text += ', {0!s}'.format(self["standard_info/file_attr"].display)
         return text
 
 class NTFS(Parser):

--- a/lib/hachoir_parser/file_system/reiser_fs.py
+++ b/lib/hachoir_parser/file_system/reiser_fs.py
@@ -43,7 +43,7 @@ class BlockState(Bit):
         self.__class__.block_nb += 1
 
     def createDescription(self):
-        return "State of the block %d" %  self.block_nb
+        return "State of the block {0:d}".format(self.block_nb)
 
     def createDisplay(self):
         return self.STATE[Bit.createValue(self)]

--- a/lib/hachoir_parser/game/blp.py
+++ b/lib/hachoir_parser/game/blp.py
@@ -20,7 +20,7 @@ from hachoir_core.tools import alignValue
 
 class PaletteIndex(UInt8):
     def createDescription(self):
-        return "Palette index %i (%s)" % (self.value, self["/palette/color[%i]" % self.value].description)
+        return "Palette index {0:d} ({1!s})".format(self.value, self["/palette/color[{0:d}]".format(self.value)].description)
 
 class Generic2DArray(FieldSet):
     def __init__(self, parent, name, width, height, item_class, row_name="row", item_name="item", *args, **kwargs):
@@ -91,11 +91,11 @@ class BLP1File(Parser):
             if padding:
                 yield padding
             if compression == 0:
-                yield RawBytes(self, "mipmap[%i]" % i, sizes[i].value, "JPEG data, append to header to recover complete image")
+                yield RawBytes(self, "mipmap[{0:d}]".format(i), sizes[i].value, "JPEG data, append to header to recover complete image")
             elif compression == 1:
-                yield Generic2DArray(self, "mipmap_indexes[%i]" % i, width, height, PaletteIndex, "row", "index", "Indexes into the palette")
+                yield Generic2DArray(self, "mipmap_indexes[{0:d}]".format(i), width, height, PaletteIndex, "row", "index", "Indexes into the palette")
                 if image_type in (3, 4):
-                    yield Generic2DArray(self, "mipmap_alphas[%i]" % i, width, height, UInt8, "row", "alpha", "Alpha values")
+                    yield Generic2DArray(self, "mipmap_alphas[{0:d}]".format(i), width, height, UInt8, "row", "alpha", "Alpha values")
             width /= 2
             height /= 2
 
@@ -118,7 +118,7 @@ def color_name(data, bits):
     """Color names in #RRGGBB format, given the number of bits for each component."""
     ret = ["#"]
     for i in range(3):
-        ret.append("%02X" % (data[i] << (8-bits[i])))
+        ret.append("{0:02X}".format((data[i] << (8-bits[i]))))
     return ''.join(ret)
 
 class DXT1(FieldSet):
@@ -133,28 +133,28 @@ class DXT1(FieldSet):
             yield Bits(self, "blue[]", 5)
             yield Bits(self, "green[]", 6)
             yield Bits(self, "red[]", 5)
-            values[i] = [self["red[%i]" % i].value,
-                         self["green[%i]" % i].value,
-                         self["blue[%i]" % i].value]
+            values[i] = [self["red[{0:d}]".format(i)].value,
+                         self["green[{0:d}]".format(i)].value,
+                         self["blue[{0:d}]".format(i)].value]
         if values[0] > values[1] or self.dxt2_mode:
             values += interp_avg(values[0], values[1], 3)
         else:
             values += interp_avg(values[0], values[1], 2)
             values.append(None) # transparent
         for i in xrange(16):
-            pixel = Bits(self, "pixel[%i][%i]" % divmod(i, 4), 2)
+            pixel = Bits(self, "pixel[{0:d}][{1:d}]".format(*divmod(i, 4)), 2)
             color = values[pixel.value]
             if color is None:
                 pixel._description = "Transparent"
             else:
-                pixel._description = "RGB color: %s" % color_name(color, [5, 6, 5])
+                pixel._description = "RGB color: {0!s}".format(color_name(color, [5, 6, 5]))
             yield pixel
 
 class DXT3Alpha(FieldSet):
     static_size = 64
     def createFields(self):
         for i in xrange(16):
-            yield Bits(self, "alpha[%i][%i]" % divmod(i, 4), 4)
+            yield Bits(self, "alpha[{0:d}][{1:d}]".format(*divmod(i, 4)), 4)
 
 class DXT3(FieldSet):
     static_size = 128
@@ -176,9 +176,9 @@ class DXT5Alpha(FieldSet):
             values += interp_avg(values[0], values[1], 5)
             values += [0, 255]
         for i in xrange(16):
-            pixel = Bits(self, "alpha[%i][%i]" % divmod(i, 4), 3)
+            pixel = Bits(self, "alpha[{0:d}][{1:d}]".format(*divmod(i, 4)), 3)
             alpha = values[pixel.value]
-            pixel._description = "Alpha value: %i" % alpha
+            pixel._description = "Alpha value: {0:d}".format(alpha)
             yield pixel
 
 class DXT5(FieldSet):
@@ -249,21 +249,21 @@ class BLP2File(Parser):
             if padding:
                 yield padding
             if compression == 0:
-                yield RawBytes(self, "mipmap[%i]" % i, sizes[i].value, "JPEG data, append to header to recover complete image")
+                yield RawBytes(self, "mipmap[{0:d}]".format(i), sizes[i].value, "JPEG data, append to header to recover complete image")
             elif compression == 1 and encoding == 1:
-                yield Generic2DArray(self, "mipmap_indexes[%i]" % i, height, width, PaletteIndex, "row", "index", "Indexes into the palette")
+                yield Generic2DArray(self, "mipmap_indexes[{0:d}]".format(i), height, width, PaletteIndex, "row", "index", "Indexes into the palette")
                 if alpha_depth == 1:
-                    yield GenericVector(self, "mipmap_alphas[%i]" % i, height, width, Bit, "row", "is_opaque", "Alpha values")
+                    yield GenericVector(self, "mipmap_alphas[{0:d}]".format(i), height, width, Bit, "row", "is_opaque", "Alpha values")
                 elif alpha_depth == 8:
-                    yield GenericVector(self, "mipmap_alphas[%i]" % i, height, width, UInt8, "row", "alpha", "Alpha values")
+                    yield GenericVector(self, "mipmap_alphas[{0:d}]".format(i), height, width, UInt8, "row", "alpha", "Alpha values")
             elif compression == 1 and encoding == 2:
                 block_height = alignValue(height, 4) // 4
                 block_width = alignValue(width, 4) // 4
                 if alpha_depth in [0, 1] and alpha_encoding == 0:
-                    yield Generic2DArray(self, "mipmap[%i]" % i, block_height, block_width, DXT1, "row", "block", "DXT1-compressed image blocks")
+                    yield Generic2DArray(self, "mipmap[{0:d}]".format(i), block_height, block_width, DXT1, "row", "block", "DXT1-compressed image blocks")
                 elif alpha_depth == 8 and alpha_encoding == 1:
-                    yield Generic2DArray(self, "mipmap[%i]" % i, block_height, block_width, DXT3, "row", "block", "DXT3-compressed image blocks")
+                    yield Generic2DArray(self, "mipmap[{0:d}]".format(i), block_height, block_width, DXT3, "row", "block", "DXT3-compressed image blocks")
                 elif alpha_depth == 8 and alpha_encoding == 7:
-                    yield Generic2DArray(self, "mipmap[%i]" % i, block_height, block_width, DXT5, "row", "block", "DXT5-compressed image blocks")
+                    yield Generic2DArray(self, "mipmap[{0:d}]".format(i), block_height, block_width, DXT5, "row", "block", "DXT5-compressed image blocks")
             width /= 2
             height /= 2

--- a/lib/hachoir_parser/game/laf.py
+++ b/lib/hachoir_parser/game/laf.py
@@ -57,13 +57,13 @@ class LafFile(Parser):
 
   def validate(self):
     if self["num_chars"].value != 256:
-        return "Invalid number of characters (%u)" % self["num_chars"].value
+        return "Invalid number of characters ({0:d})".format(self["num_chars"].value)
     if self["first_char_code"].value != 0:
-        return "Invalid of code of first character code (%u)" % self["first_char_code"].value
+        return "Invalid of code of first character code ({0:d})".format(self["first_char_code"].value)
     if self["last_char_code"].value != 255:
-        return "Invalid of code of last character code (%u)" % self["last_char_code"].value
+        return "Invalid of code of last character code ({0:d})".format(self["last_char_code"].value)
     if self["char_codes/char[0]"].value != 0:
-        return "Invalid character code #0 (%u)" % self["char_codes/char[0]"].value
+        return "Invalid character code #0 ({0:d})".format(self["char_codes/char[0]"].value)
     if self["chars/char[0]/data_offset"].value != 0:
         return "Invalid character #0 offset"
     return True

--- a/lib/hachoir_parser/game/spider_man_video.py
+++ b/lib/hachoir_parser/game/spider_man_video.py
@@ -32,7 +32,7 @@ class Chunk(FieldSet):
             self._name, self._parser, self._description = self.tag_info[fourcc]
         else:
             self._parser = None
-            self._description = "Unknown chunk: fourcc %s" % self["fourcc"].display
+            self._description = "Unknown chunk: fourcc {0!s}".format(self["fourcc"].display)
 
     def createFields(self):
         yield String(self, "fourcc", 4, "FourCC", charset="ASCII")

--- a/lib/hachoir_parser/game/zsnes.py
+++ b/lib/hachoir_parser/game/zsnes.py
@@ -223,7 +223,7 @@ class ZSNESFile(Parser):
         if temp[0:26] != "ZSNES Save State File V143":
             return "Wrong header"
         if ord(temp[27:28]) != 143: # extra...
-            return "Wrong save version %d <> 143" % temp[27:1]
+            return "Wrong save version {0:d} <> 143".format(temp[27:1])
         return True
 
     def seek(self, offset):

--- a/lib/hachoir_parser/image/bmp.py
+++ b/lib/hachoir_parser/image/bmp.py
@@ -44,7 +44,7 @@ class ImagePixels(FieldSet):
 
     def createFields(self):
         for y in xrange(self._height-1, -1, -1):
-            yield ImageLine(self, "line[%u]" % y, self._width, self._pixel)
+            yield ImageLine(self, "line[{0:d}]".format(y), self._width, self._pixel)
         size = (self.size - self.current_size) // 8
         if size:
             yield NullBytes(self, "padding", size)
@@ -151,7 +151,7 @@ class BmpFile(Parser):
         if self.stream.readBytes(0, 2) != 'BM':
             return "Wrong file signature"
         if self["header/header_size"].value not in (12, 40, 108):
-            return "Unknown header size (%s)" % self["header_size"].value
+            return "Unknown header size ({0!s})".format(self["header_size"].value)
         if self["header/nb_plan"].value != 1:
             return "Invalid number of planes"
         return True
@@ -188,7 +188,7 @@ class BmpFile(Parser):
         yield parseImageData(self, "pixels", size, header)
 
     def createDescription(self):
-        return u"Microsoft Bitmap version %s" % self["header"].getFormatVersion()
+        return u"Microsoft Bitmap version {0!s}".format(self["header"].getFormatVersion())
 
     def createContentSize(self):
         return self["file_size"].value * 8

--- a/lib/hachoir_parser/image/common.py
+++ b/lib/hachoir_parser/image/common.py
@@ -19,7 +19,7 @@ class RGB(FieldSet):
         rgb = self["red"].value, self["green"].value, self["blue"].value
         name = self.color_name.get(rgb)
         if not name:
-            name = "#%02X%02X%02X" % rgb
+            name = "#{0:02X}{1:02X}{2:02X}".format(*rgb)
         return "RGB color: " + name
 
 class RGBA(RGB):
@@ -34,16 +34,16 @@ class RGBA(RGB):
     def createDescription(self):
         description = RGB.createDescription(self)
         opacity = self["alpha"].value*100/255
-        return "%s (opacity: %s%%)" % (description, opacity)
+        return "{0!s} (opacity: {1!s}%)".format(description, opacity)
 
 class PaletteRGB(UserVector):
     item_class = RGB
     item_name = "color"
     def createDescription(self):
-        return "Palette of %u RGB colors" % len(self)
+        return "Palette of {0:d} RGB colors".format(len(self))
 
 class PaletteRGBA(PaletteRGB):
     item_class = RGBA
     def createDescription(self):
-        return "Palette of %u RGBA colors" % len(self)
+        return "Palette of {0:d} RGBA colors".format(len(self))
 

--- a/lib/hachoir_parser/image/exif.py
+++ b/lib/hachoir_parser/image/exif.py
@@ -84,7 +84,7 @@ class BasicIFDEntry(FieldSet):
 
         if not issubclass(self.value_cls, Bytes) \
           and self["count"].value > MAX_COUNT:
-            raise ParserError("EXIF: Invalid count value (%s)" % self["count"].value)
+            raise ParserError("EXIF: Invalid count value ({0!s})".format(self["count"].value))
 
         count = self['count'].value
         totalsize = self.value_size * count
@@ -326,12 +326,12 @@ class IFD(SeekableFieldSet):
             yield self.EntryClass(self, "entry[]")
         yield UInt32(self, "next", "Offset to next IFD")
         for i in xrange(count):
-            entry = self['entry[%d]'%i]
+            entry = self['entry[{0:d}]'.format(i)]
             if 'offset' not in entry:
                 continue
             self.seekByte(entry['offset'].value+self.base_addr//8, relative=False)
             count = entry['count'].value
-            name = "value[%s]"%i
+            name = "value[{0!s}]".format(i)
             if issubclass(entry.value_cls, Bytes):
                 yield entry.value_cls(self, name, count)
             else:
@@ -343,7 +343,7 @@ class IFD(SeekableFieldSet):
     def getEntryValues(self, entry):
         n = int(entry.name.rsplit('[',1)[1].strip(']'))
         if 'offset' in entry:
-            field = 'value[%d]'%n
+            field = 'value[{0:d}]'.format(n)
             base = self
         else:
             field = 'value'

--- a/lib/hachoir_parser/image/gif.py
+++ b/lib/hachoir_parser/image/gif.py
@@ -76,12 +76,12 @@ def rle_repr(l):
         if isinstance(previous, (list, tuple)):
             previous = rle_repr(previous)
         if runlen>1:
-            result.append('[%s]*%i'%(previous, runlen))
+            result.append('[{0!s}]*{1:d}'.format(previous, runlen))
         else:
             if result and '*' not in result[-1]:
-                result[-1] = '[%s, %s]'%(result[-1][1:-1], previous)
+                result[-1] = '[{0!s}, {1!s}]'.format(result[-1][1:-1], previous)
             else:
-                result.append('[%s]'%previous)
+                result.append('[{0!s}]'.format(previous))
     iterable = iter(l)
     runlen = 1
     result = []
@@ -125,11 +125,11 @@ class GifImageBlock(Parser):
                 dictionary = {}
                 compress_code = CLEAR_CODE + 2
                 obuf = []
-                code._description = "Reset Code (LZW code %i)" % code.value
+                code._description = "Reset Code (LZW code {0:d})".format(code.value)
                 yield code
                 continue
             elif code.value == END_CODE:
-                code._description = "End of Information Code (LZW code %i)" % code.value
+                code._description = "End of Information Code (LZW code {0:d})".format(code.value)
                 yield code
                 break
             if code.value < CLEAR_CODE: # literal
@@ -139,19 +139,19 @@ class GifImageBlock(Parser):
                     compress_code += 1
                 obuf = [code.value]
                 output.append(code.value)
-                code._description = "Literal Code %i" % code.value
+                code._description = "Literal Code {0:d}".format(code.value)
             elif code.value >= CLEAR_CODE + 2:
                 if code.value in dictionary:
                     chain = dictionary[code.value]
-                    code._description = "Compression Code %i (found in dictionary as %s)" % (code.value, rle_repr(chain))
+                    code._description = "Compression Code {0:d} (found in dictionary as {1!s})".format(code.value, rle_repr(chain))
                 else:
                     chain = obuf + [obuf[0]]
-                    code._description = "Compression Code %i (not found in dictionary; guessed to be %s)" % (code.value, rle_repr(chain))
+                    code._description = "Compression Code {0:d} (not found in dictionary; guessed to be {1!s})".format(code.value, rle_repr(chain))
                 dictionary[compress_code] = obuf + [chain[0]]
                 compress_code += 1
                 obuf = chain
                 output += chain
-            code._description += "; Current Decoded Length %i"%len(output)
+            code._description += "; Current Decoded Length {0:d}".format(len(output))
             yield code
         padding = paddingSize(self.current_size, 8)
         if padding:
@@ -186,7 +186,7 @@ class Image(FieldSet):
         yield NullBytes(self, "terminator", 1, "Terminator (0)")
 
     def createDescription(self):
-        return "Image: %ux%u pixels at (%u,%u)" % (
+        return "Image: {0:d}x{1:d} pixels at ({2:d},{3:d})".format(
             self["width"].value, self["height"].value,
             self["left"].value, self["top"].value)
 
@@ -285,7 +285,7 @@ class Extension(FieldSet):
             yield field
 
     def createDescription(self):
-        return "Extension: function %s" % self["func"].display
+        return "Extension: function {0!s}".format(self["func"].display)
 
 class ScreenDescriptor(FieldSet):
     def createFields(self):
@@ -298,15 +298,14 @@ class ScreenDescriptor(FieldSet):
         yield UInt8(self, "background", "Background color")
         field = UInt8(self, "pixel_aspect_ratio")
         if field.value:
-            field._description = "Pixel aspect ratio: %f (stored as %i)"%((field.value + 15)/64., field.value)
+            field._description = "Pixel aspect ratio: {0:f} (stored as {1:d})".format((field.value + 15)/64., field.value)
         else:
             field._description = "Pixel aspect ratio: not specified"
         yield field
 
     def createDescription(self):
         colors = 1 << (self["size_global_map"].value+1)
-        return "Screen descriptor: %ux%u pixels %u colors" \
-            % (self["width"].value, self["height"].value, colors)
+        return "Screen descriptor: {0:d}x{1:d} pixels {2:d} colors".format(self["width"].value, self["height"].value, colors)
 
 class GifFile(Parser):
     endian = LITTLE_ENDIAN
@@ -331,9 +330,9 @@ class GifFile(Parser):
         if self["screen/width"].value == 0 or self["screen/height"].value == 0:
             return "Invalid image size"
         if MAX_WIDTH < self["screen/width"].value:
-            return "Image width too big (%u)" % self["screen/width"].value
+            return "Image width too big ({0:d})".format(self["screen/width"].value)
         if MAX_HEIGHT < self["screen/height"].value:
-            return "Image height too big (%u)" % self["screen/height"].value
+            return "Image height too big ({0:d})".format(self["screen/height"].value)
         return True
 
     def createFields(self):
@@ -362,7 +361,7 @@ class GifFile(Parser):
                 # GIF Terminator
                 break
             else:
-                raise ParserError("Wrong GIF image separator: 0x%02X" % ord(code))
+                raise ParserError("Wrong GIF image separator: 0x{0:02X}".format(ord(code)))
 
     def createContentSize(self):
         field = self["image[0]"]

--- a/lib/hachoir_parser/image/ico.py
+++ b/lib/hachoir_parser/image/ico.py
@@ -23,8 +23,7 @@ class IconHeader(FieldSet):
         yield UInt32(self, "offset", "Data offset")
 
     def createDescription(self):
-        return "Icon: %ux%u pixels, %u bits/pixel" % \
-            (self["width"].value, self["height"].value, self["bpp"].value)
+        return "Icon: {0:d}x{1:d} pixels, {2:d} bits/pixel".format(self["width"].value, self["height"].value, self["bpp"].value)
 
     def isValid(self):
         if self["nb_color"].value == 0:
@@ -100,7 +99,7 @@ class IcoFile(Parser):
             if field.name.startswith("icon_header"):
                 index += 1
                 if not field.isValid():
-                    return "Invalid header #%u" % index
+                    return "Invalid header #{0:d}".format(index)
             elif 0 <= index:
                 break
         return True
@@ -120,13 +119,13 @@ class IcoFile(Parser):
             yield IconData(self, "icon_data[]", header)
 
     def createDescription(self):
-        desc = "Microsoft Windows %s" % self["type"].display
+        desc = "Microsoft Windows {0!s}".format(self["type"].display)
         size = []
         for header in self.array("icon_header"):
-            size.append("%ux%ux%u" % (header["width"].value,
+            size.append("{0:d}x{1:d}x{2:d}".format(header["width"].value,
                 header["height"].value, header["bpp"].value))
         if size:
-            return "%s: %s" % (desc, ", ".join(size))
+            return "{0!s}: {1!s}".format(desc, ", ".join(size))
         else:
             return desc
 
@@ -134,6 +133,6 @@ class IcoFile(Parser):
         count = self["nb_items"].value
         if not count:
             return None
-        field = self["icon_data[%u]" % (count-1)]
+        field = self["icon_data[{0:d}]".format((count-1))]
         return field.absolute_address + field.size
 

--- a/lib/hachoir_parser/image/png.py
+++ b/lib/hachoir_parser/image/png.py
@@ -59,26 +59,25 @@ def headerParse(parent):
     yield UInt8(parent, "interlace", "Interlace method")
 
 def headerDescription(parent):
-    return "Header: %ux%u pixels and %u bits/pixel" % \
-        (parent["width"].value, parent["height"].value, getBitsPerPixel(parent))
+    return "Header: {0:d}x{1:d} pixels and {2:d} bits/pixel".format(parent["width"].value, parent["height"].value, getBitsPerPixel(parent))
 
 def paletteParse(parent):
     size = parent["size"].value
     if (size % 3) != 0:
-        raise ParserError("Palette have invalid size (%s), should be 3*n!" % size)
+        raise ParserError("Palette have invalid size ({0!s}), should be 3*n!".format(size))
     nb_colors = size // 3
     for index in xrange(nb_colors):
         yield RGB(parent, "color[]")
 
 def paletteDescription(parent):
-    return "Palette: %u colors" % (parent["size"].value // 3)
+    return "Palette: {0:d} colors".format((parent["size"].value // 3))
 
 def gammaParse(parent):
     yield UInt32(parent, "gamma", "Gamma (x100,000)")
 def gammaValue(parent):
     return float(parent["gamma"].value) / 100000
 def gammaDescription(parent):
-    return "Gamma: %.3f" % parent.value
+    return "Gamma: {0:.3f}".format(parent.value)
 
 def textParse(parent):
     yield CString(parent, "keyword", "Keyword", charset="ISO-8859-1")
@@ -88,7 +87,7 @@ def textParse(parent):
 
 def textDescription(parent):
     if "text" in parent:
-        return u'Text: %s' % parent["text"].display
+        return u'Text: {0!s}'.format(parent["text"].display)
     else:
         return u'Text'
 
@@ -114,7 +113,7 @@ def physicalParse(parent):
 def physicalDescription(parent):
     x = parent["pixel_per_unit_x"].value
     y = parent["pixel_per_unit_y"].value
-    desc = "Physical: %ux%u pixels" % (x,y)
+    desc = "Physical: {0:d}x{1:d} pixels".format(x, y)
     if parent["unit"].value == 1:
         desc += " per meter"
     return desc
@@ -128,15 +127,15 @@ def backgroundColorDesc(parent):
     rgb = parent["red"].value, parent["green"].value, parent["blue"].value
     name = RGB.color_name.get(rgb)
     if not name:
-        name = "#%02X%02X%02X" % rgb
-    return "Background color: %s" % name
+        name = "#{0:02X}{1:02X}{2:02X}".format(*rgb)
+    return "Background color: {0!s}".format(name)
 
 
 class ImageData(Fragment):
     def __init__(self, parent, name="compressed_data"):
         Fragment.__init__(self, parent, name, None, 8*parent["size"].value)
         data = parent.name.split('[')
-        data, next = "../%s[%%u]" % data[0], int(data[1][:-1]) + 1
+        data, next = "../{0!s}[%u]".format(data[0]), int(data[1][:-1]) + 1
         first = parent.getField(data % 0)
         if first is parent:
             first = None
@@ -153,7 +152,7 @@ class ImageData(Fragment):
 
 def parseTransparency(parent):
     for i in range(parent["size"].value):
-        yield UInt8(parent, "alpha_value[]", "Alpha value for palette entry %i"%i)
+        yield UInt8(parent, "alpha_value[]", "Alpha value for palette entry {0:d}".format(i))
 
 def getBitsPerPixel(header):
     nr_component = 1
@@ -187,8 +186,7 @@ class Chunk(FieldSet):
         FieldSet.__init__(self, parent, name, description)
         self._size = (self["size"].value + 3*4) * 8
         if MAX_CHUNK_SIZE < (self._size//8):
-            raise ParserError("PNG: Chunk is too big (%s)"
-                % humanFilesize(self._size//8))
+            raise ParserError("PNG: Chunk is too big ({0!s})".format(humanFilesize(self._size//8)))
         tag = self["tag"].value
         self.desc_func = None
         self.value_func = None
@@ -223,7 +221,7 @@ class Chunk(FieldSet):
         if self.desc_func:
             return self.desc_func(self)
         else:
-            return "Chunk: %s" % self["tag"].display
+            return "Chunk: {0!s}".format(self["tag"].display)
 
 class PngFile(Parser):
     PARSER_TAGS = {
@@ -251,7 +249,7 @@ class PngFile(Parser):
 
     def createDescription(self):
         header = self["header"]
-        desc = "PNG picture: %ux%ux%u" % (
+        desc = "PNG picture: {0:d}x{1:d}x{2:d}".format(
             header["width"].value, header["height"].value, getBitsPerPixel(header))
         if header["has_alpha"].value:
             desc += " (alpha layer)"

--- a/lib/hachoir_parser/image/tga.py
+++ b/lib/hachoir_parser/image/tga.py
@@ -30,7 +30,7 @@ class Pixels(FieldSet):
         else:
             RANGE = xrange(self["/height"].value)
         for y in RANGE:
-            yield Line(self, "line[%u]" % y)
+            yield Line(self, "line[{0:d}]".format(y))
 
 class TargaFile(Parser):
     PARSER_TAGS = {

--- a/lib/hachoir_parser/image/tiff.py
+++ b/lib/hachoir_parser/image/tiff.py
@@ -54,7 +54,7 @@ class TiffFile(RootSeekableFieldSet, Parser):
     def validate(self):
         endian = self.stream.readBytes(0, 2)
         if endian not in ("MM", "II"):
-            return "Invalid endian (%r)" % endian
+            return "Invalid endian ({0!r})".format(endian)
         if self["version"].value != 42:
             return "Unknown TIFF version"
         return True

--- a/lib/hachoir_parser/image/wmf.py
+++ b/lib/hachoir_parser/image/wmf.py
@@ -110,7 +110,7 @@ class Point(FieldSet):
         yield Int16(self, "x")
         yield Int16(self, "y")
     def createDescription(self):
-        return "Point (%s, %s)" % (self["x"].value, self["y"].value)
+        return "Point ({0!s}, {1!s})".format(self["x"].value, self["y"].value)
 
 def parsePolygon(parser):
     yield UInt16(parser, "count")
@@ -225,7 +225,7 @@ class Point16(FieldSet):
         yield Int16(self, "x")
         yield Int16(self, "y")
     def createDescription(self):
-        return "Point16: (%i,%i)" % (self["x"].value, self["y"].value)
+        return "Point16: ({0:d},{1:d})".format(self["x"].value, self["y"].value)
 
 def parsePoint16array(parser):
     yield RECT32(parser, "bounds")
@@ -406,7 +406,7 @@ class Function(FieldSet):
         try:
             return META_DESC[self["function"].value]
         except KeyError:
-            return "Function %s" % self["function"].display
+            return "Function {0!s}".format(self["function"].display)
 
 class RECT16(StaticFieldSet):
     format = (
@@ -416,7 +416,7 @@ class RECT16(StaticFieldSet):
         (Int16, "bottom"),
     )
     def createDescription(self):
-        return "%s: %ux%u at (%u,%u)" % (
+        return "{0!s}: {1:d}x{2:d} at ({3:d},{4:d})".format(
             self.__class__.__name__,
             self["right"].value-self["left"].value,
             self["bottom"].value-self["top"].value,
@@ -538,17 +538,17 @@ class WMF_File(Parser):
         # Check first functions
         for index in xrange(5):
             try:
-                func = self["func[%u]" % index]
+                func = self["func[{0:d}]".format(index)]
             except MissingField:
                 if self.done:
                     return True
-                return "Unable to get function #%u" % index
+                return "Unable to get function #{0:d}".format(index)
             except ParserError:
-                return "Unable to create function #%u" % index
+                return "Unable to create function #{0:d}".format(index)
 
             # Check first frame values
             if not func.isValid():
-                return "Function #%u is invalid" % index
+                return "Function #{0:d} is invalid".format(index)
         return True
 
     def createFields(self):

--- a/lib/hachoir_parser/image/xcf.py
+++ b/lib/hachoir_parser/image/xcf.py
@@ -110,7 +110,7 @@ class XcfLevel(FieldSet):
         for chunk in data_offsets:
             data_offset = chunk.value
             size = data_offset - previous
-            yield RawBytes(self, "data[]", size, "Data content of %s" % chunk.name)
+            yield RawBytes(self, "data[]", size, "Data content of {0!s}".format(chunk.name))
             previous = data_offset
 
 class XcfHierarchy(FieldSet):
@@ -144,7 +144,7 @@ class XcfChannel(FieldSet):
         yield XcfHierarchy(self, "hierarchy", "Hierarchy")
 
     def createDescription(self):
-         return 'Channel "%s"' % self["name"].value
+         return 'Channel "{0!s}"'.format(self["name"].value)
 
 class XcfLayer(FieldSet):
     def createFields(self):
@@ -168,7 +168,7 @@ class XcfLayer(FieldSet):
         # TODO: Read layer mask if needed: self["mask_ofs"].value != 0
 
     def createDescription(self):
-        return 'Layer "%s"' % self["name"].value
+        return 'Layer "{0!s}"'.format(self["name"].value)
 
 class XcfParasites(FieldSet):
     def createFields(self):
@@ -244,7 +244,7 @@ class XcfProperty(FieldSet):
                 yield RawBytes(self, "data", size, "Data")
 
     def createDescription(self):
-        return "Property: %s" % self["type"].display
+        return "Property: {0!s}".format(self["type"].display)
 
 def readProperties(parser):
     while True:

--- a/lib/hachoir_parser/misc/bplist.py
+++ b/lib/hachoir_parser/misc/bplist.py
@@ -100,10 +100,10 @@ class BPListDict(FieldSet):
         return zip(self.array('keyref'),self.array('valref'))
 
     def createDisplay(self):
-        return '{' + ', '.join(['%s: %s'%(k.display,v.display) for k,v in self.value]) + '}'
+        return '{' + ', '.join(['{0!s}: {1!s}'.format(k.display, v.display) for k,v in self.value]) + '}'
 
     def createXML(self, prefix=''):
-        return prefix + '<dict>\n' + ''.join(['%s\t<key>%s</key>\n%s\n'%(prefix,k.getRef().value.encode('utf-8'),v.createXML(prefix + '\t')) for k,v in self.value]) + prefix + '</dict>'
+        return prefix + '<dict>\n' + ''.join(['{0!s}\t<key>{1!s}</key>\n{2!s}\n'.format(prefix, k.getRef().value.encode('utf-8'), v.createXML(prefix + '\t')) for k,v in self.value]) + prefix + '</dict>'
 
 class BPListObject(FieldSet):
     def createFields(self):
@@ -140,7 +140,7 @@ class BPListObject(FieldSet):
             # 8-bit (size=0), 16-bit (size=1) and 32-bit (size=2) numbers are unsigned
             # 64-bit (size=3) numbers are signed
             yield GenericInteger(self, "value", (size>=3), (2**size)*8)
-            self.xml=lambda prefix:prefix + "<integer>%s</integer>"%self['value'].value
+            self.xml=lambda prefix:prefix + "<integer>{0!s}</integer>".format(self['value'].value)
 
         elif markertype == 2:
             # Real
@@ -152,7 +152,7 @@ class BPListObject(FieldSet):
             else:
                 # FIXME: What is the format of the real?
                 yield Bits(self, "value", (2**self['size'].value)*8)
-            self.xml=lambda prefix:prefix + "<real>%s</real>"%self['value'].value
+            self.xml=lambda prefix:prefix + "<real>{0!s}</real>".format(self['value'].value)
 
         elif markertype == 3:
             # Date
@@ -166,14 +166,14 @@ class BPListObject(FieldSet):
                     return epoch1970 + v
                 return epoch2001 + v
             yield displayHandler(Float64(self, "value"),lambda x:humanDatetime(cvt_time(x)))
-            self.xml=lambda prefix:prefix + "<date>%sZ</date>"%(cvt_time(self['value'].value).isoformat())
+            self.xml=lambda prefix:prefix + "<date>{0!s}Z</date>".format((cvt_time(self['value'].value).isoformat()))
 
         elif markertype == 4:
             # Data
             yield BPListSize(self, "size")
             if self['size'].value:
                 yield Bytes(self, "value", self['size'].value)
-                self.xml=lambda prefix:prefix + "<data>\n%s\n%s</data>"%(self['value'].value.encode('base64').strip(),prefix)
+                self.xml=lambda prefix:prefix + "<data>\n{0!s}\n{1!s}</data>".format(self['value'].value.encode('base64').strip(), prefix)
             else:
                 self.xml=lambda prefix:prefix + '<data></data>'
 
@@ -182,7 +182,7 @@ class BPListObject(FieldSet):
             yield BPListSize(self, "size")
             if self['size'].value:
                 yield String(self, "value", self['size'].value, charset="ASCII")
-                self.xml=lambda prefix:prefix + "<string>%s</string>"%(self['value'].value.replace('&','&amp;').encode('iso-8859-1'))
+                self.xml=lambda prefix:prefix + "<string>{0!s}</string>".format((self['value'].value.replace('&','&amp;').encode('iso-8859-1')))
             else:
                 self.xml=lambda prefix:prefix + '<string></string>'
 
@@ -191,7 +191,7 @@ class BPListObject(FieldSet):
             yield BPListSize(self, "size")
             if self['size'].value:
                 yield String(self, "value", self['size'].value*2, charset="UTF-16-BE")
-                self.xml=lambda prefix:prefix + "<string>%s</string>"%(self['value'].value.replace('&','&amp;').encode('utf-8'))
+                self.xml=lambda prefix:prefix + "<string>{0!s}</string>".format((self['value'].value.replace('&','&amp;').encode('utf-8')))
             else:
                 self.xml=lambda prefix:prefix + '<string></string>'
 
@@ -244,7 +244,7 @@ class BPListObject(FieldSet):
         return ''
 
     def getFieldType(self):
-        return '%s<%s>'%(FieldSet.getFieldType(self), self['marker_type'].display)
+        return '{0!s}<{1!s}>'.format(FieldSet.getFieldType(self), self['marker_type'].display)
 
 class BPList(HachoirParser, RootSeekableFieldSet):
     endian = BIG_ENDIAN

--- a/lib/hachoir_parser/misc/chm.py
+++ b/lib/hachoir_parser/misc/chm.py
@@ -109,7 +109,7 @@ class PMGL_Entry(FieldSet):
         yield filesizeHandler(CWord(self, "length", "Length of the data"))
 
     def createDescription(self):
-        return "%s (%s)" % (self["name"].value, self["length"].display)
+        return "{0!s} ({1!s})".format(self["name"].value, self["length"].display)
 
 class PMGL(FieldSet):
     def createFields(self):
@@ -138,7 +138,7 @@ class PMGL(FieldSet):
         if padding:
             yield PaddingBytes(self, "padding", padding)
         for i in range(num_quickref*quickref_frequency, 0, -quickref_frequency):
-            yield UInt16(self, "quickref[%i]"%i)
+            yield UInt16(self, "quickref[{0:d}]".format(i))
         yield UInt16(self, "entry_count")
 
 class PMGI_Entry(FieldSet):
@@ -148,7 +148,7 @@ class PMGI_Entry(FieldSet):
         yield CWord(self, "page")
 
     def createDescription(self):
-        return "%s (page #%u)" % (self["name"].value, self["page"].value)
+        return "{0!s} (page #{1:d})".format(self["name"].value, self["page"].value)
 
 class PMGI(FieldSet):
     def createFields(self):
@@ -197,9 +197,9 @@ class ControlData(FieldSet):
         version=self["version"].value
         if version==1: block='bytes'
         else: block='32KB blocks'
-        yield UInt32(self, "reset_interval", "LZX: Reset interval in %s"%block)
-        yield UInt32(self, "window_size", "LZX: Window size in %s"%block)
-        yield UInt32(self, "cache_size", "LZX: Cache size in %s"%block)
+        yield UInt32(self, "reset_interval", "LZX: Reset interval in {0!s}".format(block))
+        yield UInt32(self, "window_size", "LZX: Window size in {0!s}".format(block))
+        yield UInt32(self, "cache_size", "LZX: Cache size in {0!s}".format(block))
         yield UInt32(self, "unknown[]")
 
 class ResetTable(FieldSet):
@@ -238,7 +238,7 @@ class SystemEntry(FieldSet):
         yield UInt16(self, "length", "Length of entry")
         yield RawBytes(self, "data", self["length"].value)
     def createDescription(self):
-        return '#SYSTEM Entry, Type %s'%self["type"].display
+        return '#SYSTEM Entry, Type {0!s}'.format(self["type"].display)
         
 class SystemFile(FieldSet):
     def createFields(self):
@@ -290,16 +290,16 @@ class ChmFile(HachoirParser, RootSeekableFieldSet):
                 elif name.startswith('::DataSpace/Storage/'):
                     sectname = str(name.split('/')[2])
                     if name.endswith('/SpanInfo'):
-                        yield UInt64(self, "%s_spaninfo"%sectname, "Size of uncompressed data in the %s section"%sectname)
+                        yield UInt64(self, "{0!s}_spaninfo".format(sectname), "Size of uncompressed data in the {0!s} section".format(sectname))
                     elif name.endswith('/ControlData'):
-                        yield ControlData(self, "%s_controldata"%sectname, "Data about the compression scheme", size=entry["length"].value*8)
+                        yield ControlData(self, "{0!s}_controldata".format(sectname), "Data about the compression scheme", size=entry["length"].value*8)
                     elif name.endswith('/Transform/List'):
-                        yield String(self, "%s_transform_list"%sectname, 38, description="Transform/List element", charset="UTF-16-LE")
+                        yield String(self, "{0!s}_transform_list".format(sectname), 38, description="Transform/List element", charset="UTF-16-LE")
                     elif name.endswith('/Transform/{7FC28940-9D31-11D0-9B27-00A0C91E9C7C}/InstanceData/ResetTable'):
-                        yield ResetTable(self, "%s_reset_table"%sectname, "LZX Reset Table", size=entry["length"].value*8)
+                        yield ResetTable(self, "{0!s}_reset_table".format(sectname), "LZX Reset Table", size=entry["length"].value*8)
                     elif name.endswith('/Content'):
                         # eventually, a LZX wrapper will appear here, we hope!
-                        yield RawBytes(self, "%s_content"%sectname, entry["length"].value, "Content for the %s section"%sectname)
+                        yield RawBytes(self, "{0!s}_content".format(sectname), entry["length"].value, "Content for the {0!s} section".format(sectname))
                     else:
                         yield RawBytes(self, "entry_data[]", entry["length"].value, name)
                 elif name=="/#SYSTEM":
@@ -313,11 +313,11 @@ class ChmFile(HachoirParser, RootSeekableFieldSet):
             for entry in self['/dir/pmgi'].array('entry'):
                 if entry['name'].value <= filename:
                     page=entry['page'].value
-        pmgl=self['/dir/pmgl[%i]'%page]
+        pmgl=self['/dir/pmgl[{0:d}]'.format(page)]
         for entry in pmgl.array('entry'):
             if entry['name'].value == filename:
                 return entry
-        raise ParserError("File '%s' not found!"%filename)
+        raise ParserError("File '{0!s}' not found!".format(filename))
 
     def createContentSize(self):
         return self["file_size/file_size"].value * 8

--- a/lib/hachoir_parser/misc/dsstore.py
+++ b/lib/hachoir_parser/misc/dsstore.py
@@ -117,7 +117,7 @@ class DSRecord(FieldSet):
         elif type == 'ustr':
             yield PascalString32UTF16(self, "value")
         else:
-            raise ParserError("Unknown record type %s"%type)
+            raise ParserError("Unknown record type {0!s}".format(type))
 
     def createValue(self):
         return (self['filename'].value, self['property'].value, self['value'].value)
@@ -127,7 +127,7 @@ class DSRecord(FieldSet):
 
 class BTNode(FieldSet):
     def linkValue(self, block):
-        return (lambda: self['/node[%d]'%block.value])
+        return (lambda: self['/node[{0:d}]'.format(block.value)])
 
     def createFields(self):
         yield UInt32(self, "last_block")
@@ -192,7 +192,7 @@ class DSStore(HachoirParser, RootSeekableFieldSet):
             block = blocks.pop()
             offs, size = self.getBlock(block)
             self.seekByte(offs+4)
-            node = BTNode(self, "node[%d]"%block, size=size*8)
+            node = BTNode(self, "node[{0:d}]".format(block), size=size*8)
             yield node
             if node['last_block'].value != 0:
                 new_blocks = []

--- a/lib/hachoir_parser/misc/file_3do.py
+++ b/lib/hachoir_parser/misc/file_3do.py
@@ -58,7 +58,7 @@ class Face(FieldSet):
             yield UInt32(self, "material_index", "material index")
 
     def createDescription(self):
-        return "Face: id=%s" % self["id"].value
+        return "Face: id={0!s}".format(self["id"].value)
 
 class Mesh(FieldSet):
     def __init__(self, *args):
@@ -99,7 +99,7 @@ class Mesh(FieldSet):
         yield Vertex(self, "unknown[]")
 
     def createDescription(self):
-        return 'Mesh "%s" (id %s)' % (self["name"].value, self["id"].value)
+        return 'Mesh "{0!s}" (id {1!s})'.format(self["name"].value, self["id"].value)
 
 class Geoset(FieldSet):
     def createFields(self):
@@ -108,7 +108,7 @@ class Geoset(FieldSet):
             yield Mesh(self, "mesh[]")
 
     def createDescription(self):
-        return "Set of %s meshes" % self["count"].value
+        return "Set of {0!s} meshes".format(self["count"].value)
 
 class Node(FieldSet):
     def __init__(self, *args):
@@ -149,7 +149,7 @@ class Node(FieldSet):
             yield UInt32(self, "next_sibling_id")
 
     def createDescription(self):
-        return 'Node "%s"' % self["name"].value
+        return 'Node "{0!s}"'.format(self["name"].value)
 
 class Nodes(FieldSet):
     def createFields(self):
@@ -158,7 +158,7 @@ class Nodes(FieldSet):
             yield Node(self, "node[]")
 
     def createDescription(self):
-        return 'Nodes (%s)' % self["count"].value
+        return 'Nodes ({0!s})'.format(self["count"].value)
 
 class Materials(FieldSet):
     def __init__(self, *args):
@@ -172,7 +172,7 @@ class Materials(FieldSet):
             yield String(self, "filename[]", 32, "Material file name", strip="\0")
 
     def createDescription(self):
-        return 'Material file names (%s)' % self["count"].value
+        return 'Material file names ({0!s})'.format(self["count"].value)
 
 class File3do(Parser):
     PARSER_TAGS = {

--- a/lib/hachoir_parser/misc/file_3ds.py
+++ b/lib/hachoir_parser/misc/file_3ds.py
@@ -123,14 +123,14 @@ class Chunk(FieldSet):
         FieldSet.__init__(self, *args)
 
         # Set description
-        self._description = "Chunk: %s" % self["type"].display
+        self._description = "Chunk: {0!s}".format(self["type"].display)
 
         # Set name based on type field
         type = self["type"].value
         if type in Chunk.chunk_id_by_type:
             self._name = Chunk.chunk_id_by_type[type]
         else:
-            self._name = "chunk_%04x" % type
+            self._name = "chunk_{0:04x}".format(type)
 
         # Guess chunk size
         self._size = self["size"].value * 8

--- a/lib/hachoir_parser/misc/gnome_keyring.py
+++ b/lib/hachoir_parser/misc/gnome_keyring.py
@@ -80,10 +80,10 @@ class Attribute(FieldSet):
         elif type == 1:
             yield UInt32(self, "value")
         else:
-            raise TypeError("Unknown attribute type (%s)" % type)
+            raise TypeError("Unknown attribute type ({0!s})".format(type))
 
     def createDescription(self):
-        return 'Attribute "%s"' % self["name"].value
+        return 'Attribute "{0!s}"'.format(self["name"].value)
 
 class ACL(FieldSet):
     def createFields(self):
@@ -102,7 +102,7 @@ class Item(FieldSet):
             yield Attribute(self, "attr[]")
 
     def createDescription(self):
-        return "Item #%s: %s attributes" % (self["id"].value, self["attr_count"].value)
+        return "Item #{0!s}: {1!s} attributes".format(self["id"].value, self["attr_count"].value)
 
 class Items(FieldSet):
     def createFields(self):
@@ -174,7 +174,7 @@ class GnomeKeyring(Parser):
         return True
 
     def createFields(self):
-        yield String(self, "magic", len(self.MAGIC), 'Magic string (%r)' % self.MAGIC, charset="ASCII")
+        yield String(self, "magic", len(self.MAGIC), 'Magic string ({0!r})'.format(self.MAGIC), charset="ASCII")
         yield UInt8(self, "major_version")
         yield UInt8(self, "minor_version")
         yield Enum(UInt8(self, "crypto"), self.CRYPTO_NAMES)

--- a/lib/hachoir_parser/misc/lnk.py
+++ b/lib/hachoir_parser/misc/lnk.py
@@ -174,7 +174,7 @@ class ItemId(FieldSet):
 
 def formatVolumeSerial(field):
     val = field.value
-    return '%04X-%04X'%(val>>16, val&0xFFFF)
+    return '{0:04X}-{1:04X}'.format(val>>16, val&0xFFFF)
 
 class LocalVolumeTable(FieldSet):
     VOLUME_TYPE={
@@ -298,7 +298,7 @@ class ColorRef(FieldSet):
         yield PaddingBytes(self, "pad", 1, "Padding (must be 0)")
     def createDescription(self):
         rgb = self["red"].value, self["green"].value, self["blue"].value
-        return "RGB Color: #%02X%02X%02X" % rgb
+        return "RGB Color: #{0:02X}{1:02X}{2:02X}".format(*rgb)
 
 class ColorTableIndex(Bits):
     def __init__(self, parent, name, size, description=None):
@@ -306,8 +306,8 @@ class ColorTableIndex(Bits):
         self.desc=description
     def createDescription(self):
         assert hasattr(self, 'parent') and hasattr(self, 'value')
-        return "%s: %s"%(self.desc,
-                         self.parent["color[%i]"%self.value].description)
+        return "{0!s}: {1!s}".format(self.desc,
+                         self.parent["color[{0:d}]".format(self.value)].description)
 
 class ExtraInfo(FieldSet):
     INFO_TYPE={
@@ -512,7 +512,7 @@ def text_hot_key(field):
     elif 0x60 <= val <= 0x69:
         return u'Numpad %c' % unichr(val-0x30)
     elif 0x70 <= val <= 0x87:
-        return 'F%i'%(val-0x6F)
+        return 'F{0:d}'.format((val-0x6F))
     elif val in HOT_KEYS:
         return HOT_KEYS[val]
     return str(val)

--- a/lib/hachoir_parser/misc/mapsforge_map.py
+++ b/lib/hachoir_parser/misc/mapsforge_map.py
@@ -84,7 +84,7 @@ class VbeString(FieldSet):
         yield String(self, "chars", self["length"].value, charset="UTF-8")
 
     def createDescription (self):
-        return '(%d B) "%s"' % (self["length"].value, self["chars"].value)
+        return '({0:d} B) "{1!s}"'.format(self["length"].value, self["chars"].value)
 
 
 class TagStringList(FieldSet):
@@ -94,7 +94,7 @@ class TagStringList(FieldSet):
             yield VbeString(self, "tag[]")
 
     def createDescription (self):
-        return "%d tag strings" % self["num_tags"].value
+        return "{0:d} tag strings".format(self["num_tags"].value)
 
 
 class ZoomIntervalCfg(FieldSet):
@@ -106,7 +106,7 @@ class ZoomIntervalCfg(FieldSet):
         yield UInt64(self, "subfile_size")
 
     def createDescription (self):
-        return "zoom level around %d (%d - %d)" % (self["base_zoom_level"].value,
+        return "zoom level around {0:d} ({1:d} - {2:d})".format(self["base_zoom_level"].value,
             self["min_zoom_level"].value, self["max_zoom_level"].value)
 
 
@@ -122,7 +122,7 @@ class TileZoomTable(FieldSet):
         yield UIntVbe(self, "num_ways")
 
     def createDescription (self):
-        return "%d POIs, %d ways" % (self["num_pois"].value, self["num_ways"].value)
+        return "{0:d} POIs, {1:d} ways".format(self["num_pois"].value, self["num_ways"].value)
 
 
 class TileHeader(FieldSet):
@@ -163,8 +163,8 @@ class POIData(FieldSet):
     def createDescription (self):
         s = "POI"
         if self["have_name"].value:
-            s += ' "%s"' % self["name"]["chars"].value
-        s += " @ %f/%f" % (self["lat_diff"].value / UDEG, self["lon_diff"].value / UDEG)
+            s += ' "{0!s}"'.format(self["name"]["chars"].value)
+        s += " @ {0:f}/{1:f}".format(self["lat_diff"].value / UDEG, self["lon_diff"].value / UDEG)
         return s
 
 
@@ -174,7 +174,7 @@ class SubTileBitmap(FieldSet):
     def createFields(self):
         for y in range(4):
             for x in range(4):
-                yield Bit(self, "is_used[%d,%d]" % (x,y))
+                yield Bit(self, "is_used[{0:d},{1:d}]".format(x, y))
 
 
 class WayProperties(FieldSet):
@@ -224,7 +224,7 @@ class WayPropertiesInner(FieldSet):
     def createDescription (self):
         s = "way"
         if self["have_name"].value:
-            s += ' "%s"' % self["name"]["chars"].value
+            s += ' "{0!s}"'.format(self["name"]["chars"].value)
         return s
 
 
@@ -255,14 +255,14 @@ class TileData(FieldSet):
 
         numLevels = int(self.zoomIntervalCfg["max_zoom_level"].value - self.zoomIntervalCfg["min_zoom_level"].value) +1
         for zoomLevel in range(numLevels):
-            zoomTableEntry = self["tile_header"]["zoom_table_entry[%d]" % zoomLevel]
+            zoomTableEntry = self["tile_header"]["zoom_table_entry[{0:d}]".format(zoomLevel)]
             for poiIndex in range(zoomTableEntry["num_pois"].value):
-                yield POIData(self, "poi_data[%d,%d]" % (zoomLevel, poiIndex))
+                yield POIData(self, "poi_data[{0:d},{1:d}]".format(zoomLevel, poiIndex))
 
         for zoomLevel in range(numLevels):
-            zoomTableEntry = self["tile_header"]["zoom_table_entry[%d]" % zoomLevel]
+            zoomTableEntry = self["tile_header"]["zoom_table_entry[{0:d}]".format(zoomLevel)]
             for wayIndex in range(zoomTableEntry["num_ways"].value):
-                yield WayProperties(self, "way_props[%d,%d]" % (zoomLevel, wayIndex))
+                yield WayProperties(self, "way_props[{0:d},{1:d}]".format(zoomLevel, wayIndex))
         
 
 
@@ -351,7 +351,7 @@ class MapsforgeMapFile(Parser, RootSeekableFieldSet):
             yield ZoomIntervalCfg(self, "zoom_interval_cfg[]")
 
         for i in range(self["num_zoom_intervals"].value):
-            zoomIntervalCfg = self["zoom_interval_cfg[%d]" % i]
+            zoomIntervalCfg = self["zoom_interval_cfg[{0:d}]".format(i)]
             self.seekByte(zoomIntervalCfg["subfile_start"].value, relative=False)
             yield ZoomSubFile(self, "subfile[]", size=zoomIntervalCfg["subfile_size"].value * 8, zoomIntervalCfg=zoomIntervalCfg)
 

--- a/lib/hachoir_parser/misc/msoffice.py
+++ b/lib/hachoir_parser/misc/msoffice.py
@@ -42,7 +42,7 @@ class RootEntry(OLE2FragmentParser):
             return
         if property["size"].value >= ole2["header/threshold"].value:
             return
-        name = "%s[]" % name_prefix
+        name = "{0!s}[]".format(name_prefix)
         first = None
         previous = None
         size = 0
@@ -66,8 +66,8 @@ class RootEntry(OLE2FragmentParser):
             if first is None:
                 break
             self.seekSBlock(first)
-            desc = "Small blocks %s..%s (%s)" % (first, previous, previous-first+1)
-            desc += " of %s bytes" % (ole2.ss_size//8)
+            desc = "Small blocks {0!s}..{1!s} ({2!s})".format(first, previous, previous-first+1)
+            desc += " of {0!s} bytes".format((ole2.ss_size//8))
             field = CustomFragment(self, name, size, parser, desc, fragment_group)
             yield field
             if not fragment_group:
@@ -385,8 +385,8 @@ class PowerPointDocument(OLE2FragmentParser):
                     yield RawBytes(self, "data", obj_len)
         def createDescription(self):
             if self["version"].value==0xF:
-                return "PowerPoint Object Container; instance %s, type %s"%(self["instance"].value,self["type"].display)
-            return "PowerPoint Object; version %s, instance %s, type %s"%(self["version"].value,self["instance"].value,self["type"].display)
+                return "PowerPoint Object Container; instance {0!s}, type {1!s}".format(self["instance"].value, self["type"].display)
+            return "PowerPoint Object; version {0!s}, instance {1!s}, type {2!s}".format(self["version"].value, self["instance"].value, self["type"].display)
     ENDIAN_CHECK=False
     OS_CHECK=False
     def createFields(self):
@@ -728,7 +728,7 @@ class ExcelWorkbook(OLE2FragmentParser):
             if self["length"].value:
                 yield RawBytes(self, "data", self["length"].value)
         def createDescription(self):
-            return "Excel BIFF; type %s"%self["type"].display
+            return "Excel BIFF; type {0!s}".format(self["type"].display)
     def createFields(self):
         pos=0
         while pos//8 < self.datasize:
@@ -748,7 +748,7 @@ class ThumbsCatalog(OLE2FragmentParser):
             if self.current_size // 8 != self['size'].value:
                 yield RawBytes(self, "padding", self['size'].value - self.current_size // 8)
         def createDescription(self):
-            return "Thumbnail entry for %s"%self["name"].display
+            return "Thumbnail entry for {0!s}".format(self["name"].display)
 
     def createFields(self):
         yield UInt16(self, "unknown[]")

--- a/lib/hachoir_parser/misc/msoffice_summary.py
+++ b/lib/hachoir_parser/misc/msoffice_summary.py
@@ -108,7 +108,7 @@ class PropertyIndex(FieldSet):
         yield UInt32(self, "offset")
 
     def createDescription(self):
-        return "Property: %s" % self["id"].display
+        return "Property: {0!s}".format(self["id"].display)
 
 class Bool(Int8):
     def createValue(self):
@@ -268,8 +268,7 @@ class PropertyContent(FieldSet):
         except LookupError:
             handler = None
         if not handler:
-            self.warning("OLE2: Unable to parse property of type %s" \
-                % self["type"].display)
+            self.warning("OLE2: Unable to parse property of type {0!s}".format(self["type"].display))
             # raise ParserError(
         elif self["is_vector"].value:
             yield UInt32(self, "count")
@@ -292,7 +291,7 @@ class SummarySection(SeekableFieldSet):
         for index in xrange(self["property_count"].value):
             yield PropertyIndex(self, "property_index[]")
         for index in xrange(self["property_count"].value):
-            findex = self["property_index[%u]" % index]
+            findex = self["property_index[{0:d}]".format(index)]
             self.seekByte(findex["offset"].value)
             field = PropertyContent(self, "property[]", findex["id"].display)
             yield field
@@ -302,7 +301,7 @@ class SummarySection(SeekableFieldSet):
                 if codepage in CODEPAGE_CHARSET:
                     self.osconfig.charset = CODEPAGE_CHARSET[codepage]
                 else:
-                    self.warning("Unknown codepage: %r" % codepage)
+                    self.warning("Unknown codepage: {0!r}".format(codepage))
 
 class SummaryIndex(FieldSet):
     static_size = 20*8
@@ -327,7 +326,7 @@ class Summary(OLE2FragmentParser):
         yield GUID(self, "format_id")
         yield UInt32(self, "section_count")
         if MAX_SECTION_COUNT < self["section_count"].value:
-            raise ParserError("OLE2: Too much sections (%s)" % self["section_count"].value)
+            raise ParserError("OLE2: Too much sections ({0!s})".format(self["section_count"].value))
 
         section_indexes = []
         for index in xrange(self["section_count"].value):

--- a/lib/hachoir_parser/misc/ole2_util.py
+++ b/lib/hachoir_parser/misc/ole2_util.py
@@ -24,7 +24,7 @@ class OLE2FragmentParser(HachoirParser,RootSeekableFieldSet):
     def validate(self):
         if self.ENDIAN_CHECK:
             if self["endian"].value not in ["\xFF\xFE", "\xFE\xFF"]:
-                return "Unknown endian value %s"%self["endian"].value.encode('hex')
+                return "Unknown endian value {0!s}".format(self["endian"].value.encode('hex'))
         return True
 
 class RawParser(OLE2FragmentParser):

--- a/lib/hachoir_parser/misc/pcf.py
+++ b/lib/hachoir_parser/misc/pcf.py
@@ -45,7 +45,7 @@ class TOC(FieldSet):
         yield UInt32(self, "offset")
 
     def createDescription(self):
-        return "%s at %s (%s)" % (
+        return "{0!s} at {1!s} ({2!s})".format(
             self["type"].display, self["offset"].value, self["size"].display)
 
 class PropertiesFormat(FieldSet):
@@ -66,8 +66,8 @@ class Property(FieldSet):
 
     def createDescription(self):
         # FIXME: Use link or any better way to read name value
-        name = self["../name[%s]" % (self.index-2)].value
-        return "Property %s" % name
+        name = self["../name[{0!s}]".format((self.index-2))].value
+        return "Property {0!s}".format(name)
 
 class GlyphNames(FieldSet):
     def __init__(self, parent, name, toc, description, size=None):
@@ -117,9 +117,9 @@ class Properties(GlyphNames):
             padding = self.seekByte(offset0+property["name_offset"].value)
             if padding:
                 yield padding
-            yield CString(self, "name[]", "Name of %s" % property.name)
+            yield CString(self, "name[]", "Name of {0!s}".format(property.name))
             if property["is_string"].value:
-                yield CString(self, "value[]", "Value of %s" % property.name)
+                yield CString(self, "value[]", "Value of {0!s}".format(property.name))
         padding = (self.size - self.current_size) // 8
         if padding:
             yield NullBytes(self, "end_padding", padding)
@@ -157,7 +157,7 @@ class PcfFile(Parser):
                 yield padding
             maxsize = (self.size-self.current_size)//8
             if maxsize < size:
-                self.warning("Truncate content of %s to %s bytes (was %s)" % (entry.path, maxsize, size))
+                self.warning("Truncate content of {0!s} to {1!s} bytes (was {2!s})".format(entry.path, maxsize, size))
                 size = maxsize
             if not size:
                 continue
@@ -166,5 +166,5 @@ class PcfFile(Parser):
             elif entry["type"].value == 128:
                 yield GlyphNames(self, "glyph_names", entry, "Glyph names", size=size*8)
             else:
-                yield RawBytes(self, "data[]", size, "Content of %s" % entry.path)
+                yield RawBytes(self, "data[]", size, "Content of {0!s}".format(entry.path))
 

--- a/lib/hachoir_parser/misc/pifv.py
+++ b/lib/hachoir_parser/misc/pifv.py
@@ -87,7 +87,7 @@ class BlockMap(FieldSet):
         yield UInt32(self, "len")
 
     def createDescription(self):
-        return "%d blocks of %s" % (
+        return "{0:d} blocks of {1!s}".format(
             self["num_blocks"].value, humanFilesize(self["len"].value))
 
 
@@ -174,7 +174,7 @@ class File(FieldSet):
             yield FileSection(self, "section[]")
 
     def createDescription(self):
-        return "%s: %s containing %d section(s)" % (
+        return "{0!s}: {1!s} containing {2:d} section(s)".format(
             self["name"].value,
             self["type"].display,
             len(self.array("section")))
@@ -213,7 +213,7 @@ class FirmwareVolume(FieldSet):
             yield File(self, "file[]")
 
     def createDescription(self):
-        return "Firmware Volume containing %d file(s)" % len(self.array("file"))
+        return "Firmware Volume containing {0:d} file(s)".format(len(self.array("file")))
 
 
 class PIFVFile(Parser):
@@ -224,7 +224,7 @@ class PIFVFile(Parser):
         "category": "program",
         "file_ext": ("bin", ""),
         "min_size": 64*8, # smallest possible header
-        "magic_regex": (("\0{16}.{24}%s" % MAGIC, 0), ),
+        "magic_regex": (("\0{{16}}.{{24}}{0!s}".format(MAGIC), 0), ),
         "description": "EFI Platform Initialization Firmware Volume",
     }
 

--- a/lib/hachoir_parser/misc/torrent.py
+++ b/lib/hachoir_parser/misc/torrent.py
@@ -56,10 +56,10 @@ class TorrentString(FieldSet):
         except ValueError:
             len = -1
         if len < 0:
-            raise ParserError("Invalid string length (%s)" % makePrintable(val.value, "ASCII", to_unicode=True))
+            raise ParserError("Invalid string length ({0!s})".format(makePrintable(val.value, "ASCII", to_unicode=True)))
         yield String(self, "separator", 1, "String length/value separator")
         if not len:
-            self.info("Empty string: len=%i" % len)
+            self.info("Empty string: len={0:d}".format(len))
             return
         if len<512:
             yield String(self, "value", len, "String value", charset="ISO-8859-1")
@@ -136,7 +136,7 @@ def Entry(parent, name):
     addr = parent.absolute_address + parent.current_size
     tag = parent.stream.readBytes(addr, 1)
     if tag not in TAGS:
-        raise ParserError("Torrent: Entry of type %r not handled" % type)
+        raise ParserError("Torrent: Entry of type {0!r} not handled".format(type))
     cls = TAGS[tag]
     return cls(parent, name)
 

--- a/lib/hachoir_parser/misc/ttf.py
+++ b/lib/hachoir_parser/misc/ttf.py
@@ -77,7 +77,7 @@ class TableHeader(FieldSet):
         yield filesizeHandler(UInt32(self, "size"))
 
     def createDescription(self):
-         return "Table entry: %s (%s)" % (self["tag"].display, self["size"].display)
+         return "Table entry: {0!s} ({1!s})".format(self["tag"].display, self["size"].display)
 
 class NameHeader(FieldSet):
     def createFields(self):
@@ -94,13 +94,13 @@ class NameHeader(FieldSet):
         try:
             return CHARSET_MAP[platform][encoding]
         except KeyError:
-            self.warning("TTF: Unknown charset (%s,%s)" % (platform, encoding))
+            self.warning("TTF: Unknown charset ({0!s},{1!s})".format(platform, encoding))
             return "ISO-8859-1"
 
     def createDescription(self):
         platform = self["platformID"].display
         name = self["nameID"].display
-        return "Name record: %s (%s)" % (name, platform)
+        return "Name record: {0!s} ({1!s})".format(name, platform)
 
 def parseFontHeader(self):
     yield UInt16(self, "maj_ver", "Major version")
@@ -160,12 +160,11 @@ def parseNames(self):
     # Read header
     yield UInt16(self, "format")
     if self["format"].value != 0:
-        raise ParserError("TTF (names): Invalid format (%u)" % self["format"].value)
+        raise ParserError("TTF (names): Invalid format ({0:d})".format(self["format"].value))
     yield UInt16(self, "count")
     yield UInt16(self, "offset")
     if MAX_NAME_COUNT < self["count"].value:
-        raise ParserError("Invalid number of names (%s)"
-            % self["count"].value)
+        raise ParserError("Invalid number of names ({0!s})".format(self["count"].value))
 
     # Read name index
     entries = []
@@ -183,14 +182,14 @@ def parseNames(self):
         # Skip duplicates values
         new = (entry["offset"].value, entry["length"].value)
         if last and last == new:
-            self.warning("Skip duplicate %s %s" % (entry.name, new))
+            self.warning("Skip duplicate {0!s} {1!s}".format(entry.name, new))
             continue
         last = (entry["offset"].value, entry["length"].value)
 
         # Skip negative offset
         offset = entry["offset"].value + self["offset"].value
         if offset < self.current_size//8:
-            self.warning("Skip value %s (negative offset)" % entry.name)
+            self.warning("Skip value {0!s} (negative offset)".format(entry.name))
             continue
 
         # Add padding if any
@@ -230,7 +229,7 @@ class Table(FieldSet):
             yield RawBytes(self, "content", self.size//8)
 
     def createDescription(self):
-        return "Table %s (%s)" % (self.table["tag"].value, self.table.path)
+        return "Table {0!s} ({1!s})".format(self.table["tag"].value, self.table.path)
 
 class TrueTypeFontFile(Parser):
     endian = BIG_ENDIAN
@@ -244,11 +243,11 @@ class TrueTypeFontFile(Parser):
 
     def validate(self):
         if self["maj_ver"].value != 1:
-            return "Invalid major version (%u)" % self["maj_ver"].value
+            return "Invalid major version ({0:d})".format(self["maj_ver"].value)
         if self["min_ver"].value != 0:
-            return "Invalid minor version (%u)" % self["min_ver"].value
+            return "Invalid minor version ({0:d})".format(self["min_ver"].value)
         if not (MIN_NB_TABLE <= self["nb_table"].value <= MAX_NB_TABLE):
-            return "Invalid number of table (%u)" % self["nb_table"].value
+            return "Invalid number of table ({0:d})".format(self["nb_table"].value)
         return True
 
     def createFields(self):

--- a/lib/hachoir_parser/misc/word_doc.py
+++ b/lib/hachoir_parser/misc/word_doc.py
@@ -49,7 +49,7 @@ def buildDateHandler(v):
     m,d=divmod(md,100)
     if y < 60: y=2000+y
     else: y=1900+y
-    return "%04i-%02i-%02i"%(y,m,d)
+    return "{0:04d}-{1:02d}-{2:02d}".format(y, m, d)
 
 class LongArray(FieldSet):
     def createFields(self):

--- a/lib/hachoir_parser/network/common.py
+++ b/lib/hachoir_parser/network/common.py
@@ -32,7 +32,7 @@ class IPv4_Address(Field):
 
     def createValue(self):
         value = self._parent.stream.readBytes(self.absolute_address, 4)
-        return ".".join(( "%u" % ord(byte) for byte in value ))
+        return ".".join(( "{0:d}".format(ord(byte)) for byte in value ))
 
     def createDisplay(self):
         return ip2name(self.value)
@@ -45,7 +45,7 @@ class IPv6_Address(Field):
         value = self._parent.stream.readBits(self.absolute_address, 128, self.parent.endian)
         parts = []
         for index in xrange(8):
-            part = "%04x" % (value & 0xffff)
+            part = "{0:04x}".format((value & 0xffff))
             value >>= 16
             parts.append(part)
         return ':'.join(reversed(parts))
@@ -77,7 +77,7 @@ class OrganizationallyUniqueIdentifier(Bits):
         a = value >> 16
         b = (value >> 8) & 0xFF
         c = value & 0xFF
-        return "%02X-%02X-%02X" % (a, b, c)
+        return "{0:02X}-{1:02X}-{2:02X}".format(a, b, c)
 
 class NIC24(Bits):
     static_size = 24
@@ -90,10 +90,10 @@ class NIC24(Bits):
         a = value >> 16
         b = (value >> 8) & 0xFF
         c = value & 0xFF
-        return "%02x:%02x:%02x" % (a, b, c)
+        return "{0:02x}:{1:02x}:{2:02x}".format(a, b, c)
 
     def createRawDisplay(self):
-        return "0x%06X" % self.value
+        return "0x{0:06X}".format(self.value)
 
 class MAC48_Address(FieldSet):
     """
@@ -114,5 +114,5 @@ class MAC48_Address(FieldSet):
         return str2hex(bytes, format="%02x:")[:-1]
 
     def createDisplay(self):
-        return "%s [%s]" % (self["organization"].display, self["nic"].display)
+        return "{0!s} [{1!s}]".format(self["organization"].display, self["nic"].display)
 

--- a/lib/hachoir_parser/network/tcpdump.py
+++ b/lib/hachoir_parser/network/tcpdump.py
@@ -50,14 +50,14 @@ class ARP(Layer):
         yield IPv4_Address(self, "dst_ip")
 
     def createDescription(self):
-        desc = "ARP: %s" % self["opcode"].display
+        desc = "ARP: {0!s}".format(self["opcode"].display)
         opcode = self["opcode"].value
         src_ip = self["src_ip"].display
         dst_ip = self["dst_ip"].display
         if opcode == 1:
-            desc += ", %s ask %s" % (dst_ip, src_ip)
+            desc += ", {0!s} ask {1!s}".format(dst_ip, src_ip)
         elif opcode == 2:
-            desc += " from %s" % src_ip
+            desc += " from {0!s}".format(src_ip)
         return desc
 
 class TCP_Option(FieldSet):
@@ -101,7 +101,7 @@ class TCP_Option(FieldSet):
                 yield RawBytes(self, "data", size)
 
     def createDescription(self):
-        return "TCP option: %s" % self["code"].display
+        return "TCP option: {0!s}".format(self["code"].display)
 
 class TCP(Layer):
     port_name = {
@@ -165,11 +165,11 @@ class TCP(Layer):
             dst = None
         desc = "TCP"
         if src != None and dst != None:
-            desc += " (%s->%s)" % (src, dst)
+            desc += " ({0!s}->{1!s})".format(src, dst)
         elif src != None:
-            desc += " (%s->)" % (src)
+            desc += " ({0!s}->)".format((src))
         elif dst != None:
-            desc += " (->%s)" % (dst)
+            desc += " (->{0!s})".format((dst))
 
         # Get flags
         flags = []
@@ -182,7 +182,7 @@ class TCP(Layer):
         if self["rst"].value:
             flags.append("RST")
         if flags:
-            desc += " [%s]" % (",".join(flags))
+            desc += " [{0!s}]".format((",".join(flags)))
         return desc
 
 class UDP(Layer):
@@ -205,7 +205,7 @@ class UDP(Layer):
         yield textHandler(UInt16(self, "checksum"), hexadecimal)
 
     def createDescription(self):
-        return "UDP (%s->%s)" % (self["src"].display, self["dst"].display)
+        return "UDP ({0!s}->{1!s})".format(self["src"].display, self["dst"].display)
 
 class ICMP(Layer):
     REJECT = 3
@@ -259,9 +259,9 @@ class ICMP(Layer):
     def createDescription(self):
         type = self["type"].value
         if type in (self.PING, self.PONG):
-            return "%s (num=%s)" % (self["type"].display, self["seq_num"].value)
+            return "{0!s} (num={1!s})".format(self["type"].display, self["seq_num"].value)
         else:
-            return "ICMP (%s)" % self["type"].display
+            return "ICMP ({0!s})".format(self["type"].display)
 
     def parseNext(self, parent):
         if self["type"].value == self.REJECT:
@@ -288,9 +288,9 @@ class ICMPv6(Layer):
 
     def createDescription(self):
         if self['type'].value in (self.ECHO_REQUEST, self.ECHO_REPLY):
-            return "%s (num=%s)" % (self["type"].display, self["sequence"].value)
+            return "{0!s} (num={1!s})".format(self["type"].display, self["sequence"].value)
         else:
-            return "ICMPv6 (%s)" % self["type"].display
+            return "ICMPv6 ({0!s})".format(self["type"].display)
 
 class IP(Layer):
     PROTOCOL_INFO = {
@@ -357,7 +357,7 @@ class IPv4(IP):
             yield RawBytes(self, "options", size)
 
     def createDescription(self):
-        return "IPv4 (%s>%s)" % (self["src"].display, self["dst"].display)
+        return "IPv4 ({0!s}>{1!s})".format(self["src"].display, self["dst"].display)
 
 class IPv6(IP):
     static_size = 40 * 8
@@ -374,7 +374,7 @@ class IPv6(IP):
         yield IPv6_Address(self, "dst")
 
     def createDescription(self):
-        return "IPv6 (%s>%s)" % (self["src"].display, self["dst"].display)
+        return "IPv6 ({0!s}>{1!s})".format(self["src"].display, self["dst"].display)
 
 class Layer2(Layer):
     PROTO_INFO = {
@@ -413,8 +413,7 @@ class Ethernet(Layer2):
         yield Enum(UInt16(self, "protocol"), self.PROTO_DESC)
 
     def createDescription(self):
-        return "Ethernet: %s>%s (%s)" % \
-            (self["src"].display, self["dst"].display, self["protocol"].display)
+        return "Ethernet: {0!s}>{1!s} ({2!s})".format(self["src"].display, self["dst"].display, self["protocol"].display)
 
 class Packet(FieldSet):
     endian = LITTLE_ENDIAN
@@ -452,7 +451,7 @@ class Packet(FieldSet):
 #        ts = max(self.getTimestamp() - t0, t0)
         ts = self.getTimestamp() - t0
         #text = ["%1.6f: " % ts]
-        text = ["%s: " % ts]
+        text = ["{0!s}: ".format(ts)]
         if "icmp" in self:
             text.append(self["icmp"].description)
         elif "tcp" in self:
@@ -498,7 +497,7 @@ class TcpdumpFile(Parser):
         yield Enum(UInt32(self, "link_type", "data link type"), self.LINK_TYPE_DESC)
         link = self["link_type"].value
         if link not in self.LINK_TYPE:
-            raise ParserError("Unknown link type: %s" % link)
+            raise ParserError("Unknown link type: {0!s}".format(link))
         name, parser = self.LINK_TYPE[link]
         while self.current_size < self.size:
             yield Packet(self, "packet[]", parser, name)

--- a/lib/hachoir_parser/parser.py
+++ b/lib/hachoir_parser/parser.py
@@ -39,7 +39,7 @@ class HachoirParser(object):
                     break
                 res = makeUnicode(res)
             else:
-                res = _("stream is smaller than %s.%s bytes" % divmod(nbits, 8))
+                res = _("stream is smaller than {0!s}.{1!s} bytes".format(*divmod(nbits, 8)))
             raise ValidateError(res or _("no reason given"))
         self._autofix = True
 
@@ -77,8 +77,7 @@ class HachoirParser(object):
                 if isinstance(self._description, str):
                     self._description = makeUnicode(self._description)
             except HACHOIR_ERRORS, err:
-                error("Error getting description of %s: %s" \
-                    % (self.path, unicode(err)))
+                error("Error getting description of {0!s}: {1!s}".format(self.path, unicode(err)))
                 self._description = self.PARSER_TAGS["description"]
         return self._description
     description = property(_getDescription,
@@ -89,7 +88,7 @@ class HachoirParser(object):
             try:
                 self._mime_type = self.createMimeType()
             except HACHOIR_ERRORS, err:
-                self.error("Error when creating MIME type: %s" % unicode(err))
+                self.error("Error when creating MIME type: {0!s}".format(unicode(err)))
             if not self._mime_type \
             and self.createMimeType != Parser.createMimeType:
                 self._mime_type = Parser.createMimeType(self)
@@ -105,7 +104,7 @@ class HachoirParser(object):
             try:
                 self._content_size = self.createContentSize()
             except HACHOIR_ERRORS, err:
-                error("Unable to compute %s content size: %s" % (self.__class__.__name__, err))
+                error("Unable to compute {0!s} content size: {1!s}".format(self.__class__.__name__, err))
                 self._content_size = None
         return self._content_size
     content_size = property(_getContentSize)
@@ -136,14 +135,14 @@ class HachoirParser(object):
     @classmethod
     def print_(cls, out, verbose):
         tags = cls.getParserTags()
-        print >>out, "- %s: %s" % (tags["id"], tags["description"])
+        print >>out, "- {0!s}: {1!s}".format(tags["id"], tags["description"])
         if verbose:
             if "mime" in tags:
-                print >>out, "  MIME type: %s" % (", ".join(tags["mime"]))
+                print >>out, "  MIME type: {0!s}".format((", ".join(tags["mime"])))
             if "file_ext" in tags:
                 file_ext = ", ".join(
-                    ".%s" % file_ext for file_ext in tags["file_ext"])
-                print >>out, "  File extension: %s" % file_ext
+                    ".{0!s}".format(file_ext) for file_ext in tags["file_ext"])
+                print >>out, "  File extension: {0!s}".format(file_ext)
 
     autofix = property(lambda self: self._autofix and config.autofix)
 

--- a/lib/hachoir_parser/parser_list.py
+++ b/lib/hachoir_parser/parser_list.py
@@ -25,14 +25,13 @@ class ParserList(object):
             return isinstance(value, (str, unicode)) and bool(value) or "Invalid description"
         elif name == "category":
             if value not in self.VALID_CATEGORY:
-                return "Invalid category: %r" % value
+                return "Invalid category: {0!r}".format(value)
         elif name == "id":
             if type(value) is not str or not self.ID_REGEX.match(value):
-                return "Invalid identifier: %r" % value
+                return "Invalid identifier: {0!r}".format(value)
             parser = self.bytag[name].get(value)
             if parser:
-                return "Duplicate parser id: %s already used by %s" % \
-                    (value, parser[0].__name__)
+                return "Duplicate parser id: {0!s} already used by {1!s}".format(value, parser[0].__name__)
         # TODO: lists should be forbidden
         if isinstance(value, list):
             value = tuple(value)
@@ -55,7 +54,7 @@ class ParserList(object):
             return "MIME type is not a tuple"
         for mime in mimes:
             if not isinstance(mime, unicode):
-                return "MIME type %r is not an unicode string" % mime
+                return "MIME type {0!r} is not an unicode string".format(mime)
 
         return ""
 
@@ -63,7 +62,7 @@ class ParserList(object):
         tags = parser.getParserTags()
         err = self.validParser(parser, tags)
         if err:
-            error("Skip parser %s: %s" % (parser.__name__, err))
+            error("Skip parser {0!s}: {1!s}".format(parser.__name__, err))
             return
 
         _tags = []
@@ -72,7 +71,7 @@ class ParserList(object):
             if isinstance(tag, tuple):
                 _tags.append(tag)
             elif tag is not True:
-                error("[%s] %s" % (parser.__name__, tag))
+                error("[{0!s}] {1!s}".format(parser.__name__, tag))
                 return
 
         self.parser_list.append(parser)
@@ -116,19 +115,19 @@ class ParserList(object):
             # Print list
             text = ", ".join( str(item) for item in extensions )
             if format == "file-ext":
-                print >>out, "File extensions: %s." % text
+                print >>out, "File extensions: {0!s}.".format(text)
                 print >>out
-                print >>out, "Total: %s file extensions." % len(extensions)
+                print >>out, "Total: {0!s} file extensions.".format(len(extensions))
             else:
-                print >>out, "MIME types: %s." % text
+                print >>out, "MIME types: {0!s}.".format(text)
                 print >>out
-                print >>out, "Total: %s MIME types." % len(extensions)
+                print >>out, "Total: {0!s} MIME types.".format(len(extensions))
             return
 
         if format == "trac":
             print >>out, "== List of parsers =="
             print >>out
-            print >>out, "Total: %s parsers" % len(self.parser_list)
+            print >>out, "Total: {0!s} parsers".format(len(self.parser_list))
             print >>out
         elif format == "one_line":
             if title:
@@ -143,35 +142,35 @@ class ParserList(object):
             if format == "one_line":
                 parser_list = [ parser.PARSER_TAGS["id"] for parser in bycategory[category] ]
                 parser_list.sort()
-                print >>out, "- %s: %s" % (category.title(), ", ".join(parser_list))
+                print >>out, "- {0!s}: {1!s}".format(category.title(), ", ".join(parser_list))
             else:
                 if format == "rest":
                     print >>out, category.replace("_", " ").title()
                     print >>out, "-" * len(category)
                     print >>out
                 elif format == "trac":
-                    print >>out, "=== %s ===" % category.replace("_", " ").title()
+                    print >>out, "=== {0!s} ===".format(category.replace("_", " ").title())
                     print >>out
                 else:
-                    print >>out, "[%s]" % category
+                    print >>out, "[{0!s}]".format(category)
                 parser_list = sorted(bycategory[category],
                     key=lambda parser: parser.PARSER_TAGS["id"])
                 if format == "rest":
                     for parser in parser_list:
                         tags = parser.getParserTags()
-                        print >>out, "* %s: %s" % (tags["id"], tags["description"])
+                        print >>out, "* {0!s}: {1!s}".format(tags["id"], tags["description"])
                 elif format == "trac":
                     for parser in parser_list:
                         tags = parser.getParserTags()
                         desc = tags["description"]
                         desc = re.sub(r"([A-Z][a-z]+[A-Z][^ ]+)", r"!\1", desc)
-                        print >>out, " * %s: %s" % (tags["id"], desc)
+                        print >>out, " * {0!s}: {1!s}".format(tags["id"], desc)
                 else:
                     for parser in parser_list:
                         parser.print_(out, verbose)
                 print >>out
         if format != "trac":
-            print >>out, "Total: %s parsers" % len(self.parser_list)
+            print >>out, "Total: {0!s} parsers".format(len(self.parser_list))
 
 
 class HachoirParserList(ParserList):

--- a/lib/hachoir_parser/program/elf.py
+++ b/lib/hachoir_parser/program/elf.py
@@ -130,7 +130,7 @@ class ElfHeader(FieldSet):
         if self["class"].value not in self.CLASS_NAME:
             return "Unknown class"
         if self["endian"].value not in self.ENDIAN_NAME:
-            return "Unknown endian (%s)" % self["endian"].value
+            return "Unknown endian ({0!s})".format(self["endian"].value)
         return ""
 
 class SectionFlags(FieldSet):
@@ -194,8 +194,7 @@ class SectionHeader32(FieldSet):
         yield UInt32(self, "entry_size", "Size of each entry in section")
 
     def createDescription(self):
-        return "Section header (name: %s, type: %s)" % \
-            (self["name"].display, self["type"].display)
+        return "Section header (name: {0!s}, type: {1!s})".format(self["name"].display, self["type"].display)
 
 class SectionHeader64(SectionHeader32):
     static_size = 64*8
@@ -259,7 +258,7 @@ class ProgramHeader32(FieldSet):
         yield UInt32(self, "align", "Alignment padding")
 
     def createDescription(self):
-        return "Program Header (%s)" % self["type"].display
+        return "Program Header ({0!s})".format(self["type"].display)
 
 class ProgramHeader64(ProgramHeader32):
     static_size = 56*8
@@ -336,6 +335,6 @@ class ElfFile(HachoirParser, RootSeekableFieldSet):
                 yield RawBytes(self, "section["+str(index)+"]", field['size'].value)
 
     def createDescription(self):
-        return "ELF Unix/BSD program/library: %s" % (
-            self["header/class"].display)
+        return "ELF Unix/BSD program/library: {0!s}".format((
+            self["header/class"].display))
 

--- a/lib/hachoir_parser/program/exe.py
+++ b/lib/hachoir_parser/program/exe.py
@@ -81,8 +81,7 @@ class ExeFile(HachoirParser, RootSeekableFieldSet):
             return "Invalid MSDOS header: "+err
         if self.isPE():
             if MAX_NB_SECTION < self["pe_header/nb_section"].value:
-                return "Invalid number of section (%s)" \
-                    % self["pe_header/nb_section"].value
+                return "Invalid number of section ({0!s})".format(self["pe_header/nb_section"].value)
         return True
 
     def createFields(self):
@@ -190,7 +189,7 @@ class ExeFile(HachoirParser, RootSeekableFieldSet):
                 info.append(hdr["subsystem"].display)
             if self["pe_header/is_stripped"].value:
                 info.append(u"stripped")
-            return u"%s: %s" % (text, ", ".join(info))
+            return u"{0!s}: {1!s}".format(text, ", ".join(info))
         elif self.isNE():
             return u"New-style Executable (NE) for Microsoft MS Windows 3.x"
         else:
@@ -200,7 +199,7 @@ class ExeFile(HachoirParser, RootSeekableFieldSet):
         if self.isPE():
             size = 0
             for index in xrange(self["pe_header/nb_section"].value):
-                section = self["section_hdr[%u]" % index]
+                section = self["section_hdr[{0:d}]".format(index)]
                 section_size = section["phys_size"].value
                 if not section_size:
                     continue

--- a/lib/hachoir_parser/program/exe_pe.py
+++ b/lib/hachoir_parser/program/exe_pe.py
@@ -54,8 +54,8 @@ class SectionHeader(FieldSet):
         rva = self["rva"].value
         size = self["mem_size"].value
         info = [
-            "rva=0x%08x..0x%08x" % (rva, rva+size),
-            "size=%s" % self["mem_size"].display,
+            "rva=0x{0:08x}..0x{1:08x}".format(rva, rva+size),
+            "size={0!s}".format(self["mem_size"].display),
         ]
         if self["is_executable"].value:
             info.append("exec")
@@ -63,13 +63,13 @@ class SectionHeader(FieldSet):
             info.append("read")
         if self["is_writable"].value:
             info.append("write")
-        return 'Section "%s": %s' % (self["name"].value, ", ".join(info))
+        return 'Section "{0!s}": {1!s}'.format(self["name"].value, ", ".join(info))
 
     def createSectionName(self):
         try:
             name = str(self["name"].value.strip("."))
             if name:
-                return "section_%s" % name
+                return "section_{0!s}".format(name)
         except HACHOIR_ERRORS, err:
             self.warning(unicode(err))
         return "section[]"
@@ -81,7 +81,7 @@ class DataDirectory(FieldSet):
 
     def createDescription(self):
         if self["size"].value:
-            return "Directory at %s (%s)" % (
+            return "Directory at {0!s} ({1!s})".format(
                 self["rva"].display, self["size"].display)
         else:
             return "(empty directory)"
@@ -211,11 +211,11 @@ class PE_OptHeader(FieldSet):
             try:
                 name = self.DIRECTORY_NAME[index]
             except KeyError:
-                name = "data_dir[%u]" % index
+                name = "data_dir[{0:d}]".format(index)
             yield DataDirectory(self, name)
 
     def createDescription(self):
-        return "PE optional header: %s, entry point %s" % (
+        return "PE optional header: {0!s}, entry point {1!s}".format(
             self["subsystem"].display,
             self["entry_point"].display)
 

--- a/lib/hachoir_parser/program/exe_res.py
+++ b/lib/hachoir_parser/program/exe_res.py
@@ -150,9 +150,9 @@ class VersionInfoNode(FieldSet):
 
 
     def createDescription(self):
-        text = "Version info node: %s" % self["name"].value
+        text = "Version info node: {0!s}".format(self["name"].value)
         if self["type"].value == self.TYPE_STRING and "value" in self:
-            text += "=%s" % self["value"].value
+            text += "={0!s}".format(self["value"].value)
         return text
 
 def parseVersionInfo(parent):
@@ -215,7 +215,7 @@ class Entry(FieldSet):
         yield NullBytes(self, "reserved", 4)
 
     def createDescription(self):
-        return "Entry #%u: offset=%s size=%s" % (
+        return "Entry #{0:d}: offset={1!s} size={2!s}".format(
             self.inode["offset"].value, self["rva"].display, self["size"].display)
 
 class NameOffset(FieldSet):
@@ -238,9 +238,9 @@ class IndexOffset(FieldSet):
 
     def createDescription(self):
         if self["is_subdir"].value:
-            return "Sub-directory: %s at %s" % (self["type"].display, self["offset"].value)
+            return "Sub-directory: {0!s} at {1!s}".format(self["type"].display, self["offset"].value)
         else:
-            return "Index: ID %s at %s" % (self["type"].display, self["offset"].value)
+            return "Index: ID {0!s} at {1!s}".format(self["type"].display, self["offset"].value)
 
 class ResourceContent(FieldSet):
     def __init__(self, parent, name, entry, size=None):
@@ -266,7 +266,7 @@ class ResourceContent(FieldSet):
             yield RawBytes(self, "content", self.size//8)
 
     def createDescription(self):
-        return "Resource #%u content: type=%s" % (
+        return "Resource #{0:d} content: type={1!s}".format(
             self.getResID(), self.getResType())
 
 class Header(FieldSet):
@@ -283,13 +283,13 @@ class Header(FieldSet):
         text = "Resource header"
         info = []
         if self["nb_name"].value:
-            info.append("%u name" % self["nb_name"].value)
+            info.append("{0:d} name".format(self["nb_name"].value))
         if self["nb_index"].value:
-            info.append("%u index" % self["nb_index"].value)
+            info.append("{0:d} index".format(self["nb_index"].value))
         if self["creation_date"].value:
             info.append(self["creation_date"].display)
         if info:
-            return "%s: %s" % (text, ", ".join(info))
+            return "{0!s}: {1!s}".format(text, ", ".join(info))
         else:
             return text
 
@@ -311,11 +311,9 @@ class Directory(FieldSet):
         yield Header(self, "header")
 
         if MAX_NAME_PER_HEADER < self["header/nb_name"].value:
-            raise ParserError("EXE resource: invalid number of name (%s)"
-                % self["header/nb_name"].value)
+            raise ParserError("EXE resource: invalid number of name ({0!s})".format(self["header/nb_name"].value))
         if MAX_INDEX_PER_HEADER < self["header/nb_index"].value:
-            raise ParserError("EXE resource: invalid number of index (%s)"
-                % self["header/nb_index"].value)
+            raise ParserError("EXE resource: invalid number of index ({0!s})".format(self["header/nb_index"].value))
 
         hdr = self["header"]
         for index in xrange(hdr["nb_name"].value):
@@ -356,18 +354,18 @@ class PE_Resource(SeekableFieldSet):
         while subdirs:
             depth += 1
             if MAX_DEPTH < depth:
-                self.error("EXE resource: depth too high (%s), stop parsing directories" % depth)
+                self.error("EXE resource: depth too high ({0!s}), stop parsing directories".format(depth))
                 break
             newsubdirs = []
             for index, subdir in enumerate(subdirs):
-                name = "directory[%u][%u][]" % (depth, index)
+                name = "directory[{0:d}][{1:d}][]".format(depth, index)
                 try:
                     for field in self.parseSub(subdir, name, depth):
                         if field.__class__ == Directory:
                             newsubdirs.append(field)
                         yield field
                 except HACHOIR_ERRORS, err:
-                    self.error("Unable to create directory %s: %s" % (name, err))
+                    self.error("Unable to create directory {0!s}: {1!s}".format(name, err))
             subdirs = newsubdirs
             alldirs.extend(subdirs)
 
@@ -399,7 +397,7 @@ class PE_Resource(SeekableFieldSet):
                     yield padding
                 yield ResourceContent(self, "content[]", entry)
             except HACHOIR_ERRORS, err:
-                self.warning("Error when parsing entry %s: %s" % (entry.path, err))
+                self.warning("Error when parsing entry {0!s}: {1!s}".format(entry.path, err))
 
         size = (self.size - self.current_size) // 8
         if size:
@@ -438,7 +436,7 @@ class NE_VersionInfoNode(FieldSet):
 
 
     def createDescription(self):
-        text = "Version info node: %s" % self["name"].value
+        text = "Version info node: {0!s}".format(self["name"].value)
 #        if self["type"].value == self.TYPE_STRING and "value" in self:
 #            text += "=%s" % self["value"].value
         return text

--- a/lib/hachoir_parser/program/java.py
+++ b/lib/hachoir_parser/program/java.py
@@ -120,7 +120,7 @@ def eat_descriptor(descr):
         try:
             type = code_to_type_name[descr[0]]
         except KeyError:
-            raise ParserError("Not a valid descriptor string: %s" % descr)
+            raise ParserError("Not a valid descriptor string: {0!s}".format(descr))
     return (type.replace("/", ".") + array_dim * "[]", descr[1:])
 
 def parse_field_descriptor(descr, name=None):
@@ -151,9 +151,9 @@ def parse_method_descriptor(descr, name=None):
     assert not tail
     params = ", ".join(params_list)
     if name:
-        return "%s %s(%s)" % (type, name, params)
+        return "{0!s} {1!s}({2!s})".format(type, name, params)
     else:
-        return "%s (%s)" % (type, params)
+        return "{0!s} ({1!s})".format(type, params)
 
 def parse_any_descriptor(descr, name=None):
     """
@@ -186,7 +186,7 @@ class FieldArray(FieldSet):
 
     def createFields(self):
         for i in range(0, self.array_length):
-            yield self.array_elements_class(self, "%s[%d]" % (self.name, i),
+            yield self.array_elements_class(self, "{0!s}[{1:d}]".format(self.name, i),
                     **self.array_elements_extra_args)
 
 class ConstantPool(FieldSet):
@@ -201,7 +201,7 @@ class ConstantPool(FieldSet):
     def createFields(self):
         i = 1
         while i < self.constant_pool_length:
-            name = "%s[%d]" % (self.name, i)
+            name = "{0!s}[{1:d}]".format(self.name, i)
             yield CPInfo(self, name)
             i += 1
             if self[name].constant_type in ("Long", "Double"):
@@ -246,7 +246,7 @@ class CPIndex(UInt16):
         """
         assert self.value < self["/constant_pool_count"].value
         if self.allow_zero and not self.value: return None
-        cp_entry = self["/constant_pool/constant_pool[%d]" % self.value]
+        cp_entry = self["/constant_pool/constant_pool[{0:d}]".format(self.value)]
         assert isinstance(cp_entry, CPInfo)
         if self.target_types:
             assert cp_entry.constant_type in self.target_types
@@ -279,7 +279,7 @@ class OpcodeCPIndex(JavaOpcode):
         yield UInt8(self, "opcode")
         yield CPIndex(self, "index")
     def createDisplay(self):
-        return "%s(%i)"%(self.op, self["index"].value)
+        return "{0!s}({1:d})".format(self.op, self["index"].value)
         
 class OpcodeCPIndexShort(JavaOpcode):
     OPSIZE = 2
@@ -287,7 +287,7 @@ class OpcodeCPIndexShort(JavaOpcode):
         yield UInt8(self, "opcode")
         yield UInt8(self, "index")
     def createDisplay(self):
-        return "%s(%i)"%(self.op, self["index"].value)
+        return "{0!s}({1:d})".format(self.op, self["index"].value)
 
 class OpcodeIndex(JavaOpcode):
     OPSIZE = 2
@@ -295,7 +295,7 @@ class OpcodeIndex(JavaOpcode):
         yield UInt8(self, "opcode")
         yield UInt8(self, "index")
     def createDisplay(self):
-        return "%s(%i)"%(self.op, self["index"].value)
+        return "{0!s}({1:d})".format(self.op, self["index"].value)
 
 class OpcodeShortJump(JavaOpcode):
     OPSIZE = 3
@@ -303,7 +303,7 @@ class OpcodeShortJump(JavaOpcode):
         yield UInt8(self, "opcode")
         yield Int16(self, "offset")
     def createDisplay(self):
-        return "%s(%s)"%(self.op, self["offset"].value)
+        return "{0!s}({1!s})".format(self.op, self["offset"].value)
 
 class OpcodeLongJump(JavaOpcode):
     OPSIZE = 5
@@ -311,7 +311,7 @@ class OpcodeLongJump(JavaOpcode):
         yield UInt8(self, "opcode")
         yield Int32(self, "offset")
     def createDisplay(self):
-        return "%s(%s)"%(self.op, self["offset"].value)
+        return "{0!s}({1!s})".format(self.op, self["offset"].value)
 
 class OpcodeSpecial_bipush(JavaOpcode):
     OPSIZE = 2
@@ -319,7 +319,7 @@ class OpcodeSpecial_bipush(JavaOpcode):
         yield UInt8(self, "opcode")
         yield Int8(self, "value")
     def createDisplay(self):
-        return "%s(%s)"%(self.op, self["value"].value)
+        return "{0!s}({1!s})".format(self.op, self["value"].value)
 
 class OpcodeSpecial_sipush(JavaOpcode):
     OPSIZE = 3
@@ -327,7 +327,7 @@ class OpcodeSpecial_sipush(JavaOpcode):
         yield UInt8(self, "opcode")
         yield Int16(self, "value")
     def createDisplay(self):
-        return "%s(%s)"%(self.op, self["value"].value)
+        return "{0!s}({1!s})".format(self.op, self["value"].value)
 
 class OpcodeSpecial_iinc(JavaOpcode):
     OPSIZE = 3
@@ -336,7 +336,7 @@ class OpcodeSpecial_iinc(JavaOpcode):
         yield UInt8(self, "index")
         yield Int8(self, "value")
     def createDisplay(self):
-        return "%s(%i,%i)"%(self.op, self["index"].value, self["value"].value)
+        return "{0!s}({1:d},{2:d})".format(self.op, self["index"].value, self["value"].value)
 
 class OpcodeSpecial_wide(JavaOpcode):
     def createFields(self):
@@ -347,9 +347,9 @@ class OpcodeSpecial_wide(JavaOpcode):
         yield UInt16(self, "index")
         if op == "iinc":
             yield Int16(self, "value")
-            self.createDisplay = lambda self: "%s(%i,%i)"%(self.op, self["index"].value, self["value"].value)
+            self.createDisplay = lambda self: "{0!s}({1:d},{2:d})".format(self.op, self["index"].value, self["value"].value)
         else:
-            self.createDisplay = lambda self: "%s(%i)"%(self.op, self["index"].value)
+            self.createDisplay = lambda self: "{0!s}({1:d})".format(self.op, self["index"].value)
 
 class OpcodeSpecial_invokeinterface(JavaOpcode):
     OPSIZE = 5
@@ -359,7 +359,7 @@ class OpcodeSpecial_invokeinterface(JavaOpcode):
         yield UInt8(self, "count")
         yield UInt8(self, "zero", "Must be zero.")
     def createDisplay(self):
-        return "%s(%i,%i,%i)"%(self.op, self["index"].value, self["count"].value, self["zero"].value)
+        return "{0!s}({1:d},{2:d},{3:d})".format(self.op, self["index"].value, self["count"].value, self["zero"].value)
 
 class OpcodeSpecial_newarray(JavaOpcode):
     OPSIZE = 2
@@ -374,7 +374,7 @@ class OpcodeSpecial_newarray(JavaOpcode):
                                            10:"int",
                                            11:"long"})
     def createDisplay(self):
-        return "%s(%s)"%(self.op, self["atype"].createDisplay())
+        return "{0!s}({1!s})".format(self.op, self["atype"].createDisplay())
 
 class OpcodeSpecial_multianewarray(JavaOpcode):
     OPSIZE = 4
@@ -383,7 +383,7 @@ class OpcodeSpecial_multianewarray(JavaOpcode):
         yield CPIndex(self, "index")
         yield UInt8(self, "dimensions")
     def createDisplay(self):
-        return "%s(%i,%i)"%(self.op, self["index"].value, self["dimensions"].value)
+        return "{0!s}({1:d},{2:d})".format(self.op, self["index"].value, self["dimensions"].value)
 
 class OpcodeSpecial_tableswitch(JavaOpcode):
     def createFields(self):
@@ -399,7 +399,7 @@ class OpcodeSpecial_tableswitch(JavaOpcode):
         for i in range(high.value-low.value+1):
             yield Int32(self, "offset[]")
     def createDisplay(self):
-        return "%s(%i,%i,%i,...)"%(self.op, self["default"].value, self["low"].value, self["high"].value)
+        return "{0!s}({1:d},{2:d},{3:d},...)".format(self.op, self["default"].value, self["low"].value, self["high"].value)
 
 class OpcodeSpecial_lookupswitch(JavaOpcode):
     def createFields(self):
@@ -414,7 +414,7 @@ class OpcodeSpecial_lookupswitch(JavaOpcode):
             yield Int32(self, "match[]")
             yield Int32(self, "offset[]")
     def createDisplay(self):
-        return "%s(%i,%i,...)"%(self.op, self["default"].value, self["npairs"].value)
+        return "{0!s}({1:d},{2:d},...)".format(self.op, self["default"].value, self["npairs"].value)
 
 class JavaBytecode(FieldSet):
     OPCODE_TABLE = {
@@ -640,7 +640,7 @@ class CPInfo(FieldSet):
     def createFields(self):
         yield Enum(UInt8(self, "tag"), self.root.CONSTANT_TYPES)
         if self["tag"].value not in self.root.CONSTANT_TYPES:
-            raise ParserError("Java: unknown constant type (%s)" % self["tag"].value)
+            raise ParserError("Java: unknown constant type ({0!s})".format(self["tag"].value))
         self.constant_type = self.root.CONSTANT_TYPES[self["tag"].value]
         if self.constant_type == "Utf8":
             yield PascalString16(self, "bytes", charset="UTF-8")
@@ -688,11 +688,11 @@ class CPInfo(FieldSet):
         elif self.constant_type == "String":
             return str(self["string_index"].get_cp_entry())
         elif self.constant_type == "Fieldref":
-            return "%s (from %s)" % (self["name_and_type_index"], self["class_index"])
+            return "{0!s} (from {1!s})".format(self["name_and_type_index"], self["class_index"])
         elif self.constant_type == "Methodref":
-            return "%s (from %s)" % (self["name_and_type_index"], self["class_index"])
+            return "{0!s} (from {1!s})".format(self["name_and_type_index"], self["class_index"])
         elif self.constant_type == "InterfaceMethodref":
-             return "%s (from %s)" % (self["name_and_type_index"], self["class_index"])
+             return "{0!s} (from {1!s})".format(self["name_and_type_index"], self["class_index"])
         elif self.constant_type == "NameAndType":
             return parse_any_descriptor(
                     str(self["descriptor_index"].get_cp_entry()),
@@ -791,8 +791,7 @@ class AttributeInfo(FieldSet):
         # }
         if attr_name == "ConstantValue":
             if self["attribute_length"].value != 2:
-                    raise ParserError("Java: Invalid attribute %s length (%s)" \
-                        % (self.path, self["attribute_length"].value))
+                    raise ParserError("Java: Invalid attribute {0!s} length ({1!s})".format(self.path, self["attribute_length"].value))
             yield CPIndex(self, "constantvalue_index",
                     target_types=("Long","Float","Double","Integer","String"))
 
@@ -1036,17 +1035,17 @@ class JavaCompiledClassFile(Parser):
     def validate(self):
         if self["magic"].value != self.MAGIC:
             return "Wrong magic signature!"
-        version = "%d.%d" % (self["major_version"].value, self["minor_version"].value)
+        version = "{0:d}.{1:d}".format(self["major_version"].value, self["minor_version"].value)
         if version not in self.KNOWN_VERSIONS:
-            return "Unknown version (%s)" % version
+            return "Unknown version ({0!s})".format(version)
         return True
 
     def createDescription(self):
-        version = "%d.%d" % (self["major_version"].value, self["minor_version"].value)
+        version = "{0:d}.{1:d}".format(self["major_version"].value, self["minor_version"].value)
         if version in self.KNOWN_VERSIONS:
-            return "Compiled Java class, %s" % self.KNOWN_VERSIONS[version]
+            return "Compiled Java class, {0!s}".format(self.KNOWN_VERSIONS[version])
         else:
-            return "Compiled Java class, version %s" % version
+            return "Compiled Java class, version {0!s}".format(version)
 
     def createFields(self):
         yield textHandler(UInt32(self, "magic", "Java compiled class signature"),

--- a/lib/hachoir_parser/program/nds.py
+++ b/lib/hachoir_parser/program/nds.py
@@ -66,9 +66,9 @@ class Crc16(UInt16):
     def createDescription(self):
         crc = CRC16().checksum(self.targetBytes, 0xffff)
         if crc == self.value:
-            return "matches CRC of %d bytes" % len(self.targetBytes)
+            return "matches CRC of {0:d} bytes".format(len(self.targetBytes))
         else:
-            return "mismatch (calculated CRC %d for %d bytes)" % (crc, len(self.targetBytes))
+            return "mismatch (calculated CRC {0:d} for {1:d} bytes)".format(crc, len(self.targetBytes))
 
 
 class FileNameDirTable(FieldSet):
@@ -79,7 +79,7 @@ class FileNameDirTable(FieldSet):
         yield UInt16(self, "parent_id")
 
     def createDescription(self):
-        return "first file id: %d; parent directory id: %d (%d)" % (self["entry_file_id"].value, self["parent_id"].value, self["parent_id"].value & 0xFFF)
+        return "first file id: {0:d}; parent directory id: {1:d} ({2:d})".format(self["entry_file_id"].value, self["parent_id"].value, self["parent_id"].value & 0xFFF)
 
 class FileNameEntry(FieldSet):
     def createFields(self):
@@ -118,7 +118,7 @@ class FileNameTable(SeekableFieldSet):
             yield FileNameDirTable(self, "dir_table[]")
 
         for i in range(0, numDirs):
-            dt = self["dir_table[%d]" % i]
+            dt = self["dir_table[{0:d}]".format(i)]
             offset = self.startOffset + dt["entry_start"].value
             self.seekByte(offset, relative=False)
             yield Directory(self, "directory[]")
@@ -131,7 +131,7 @@ class FATFileEntry(FieldSet):
         yield UInt32(self, "end")
 
     def createDescription(self):
-        return "start: %d; size: %d" % (self["start"].value, self["end"].value - self["start"].value)
+        return "start: {0:d}; size: {1:d}".format(self["start"].value, self["end"].value - self["start"].value)
 
 class FATContent(FieldSet):
     def createFields(self):
@@ -146,14 +146,14 @@ class BannerTile(FieldSet):
     def createFields(self):
         for y in range(8):
             for x in range(8):
-                yield Bits(self, "pixel[%d,%d]" % (x,y), 4)
+                yield Bits(self, "pixel[{0:d},{1:d}]".format(x, y), 4)
 
 class BannerIcon(FieldSet):
     static_size = 16*32*8
     def createFields(self):
         for y in range(4):
             for x in range(4):
-                yield BannerTile(self, "tile[%d,%d]" % (x,y))
+                yield BannerTile(self, "tile[{0:d},{1:d}]".format(x, y))
 
 class NdsColor(FieldSet):
     static_size = 16
@@ -164,7 +164,7 @@ class NdsColor(FieldSet):
         yield NullBits(self, "pad", 1)
 
     def createDescription(self):
-        return "#%02x%02x%02x" % (self["red"].value << 3, self["green"].value << 3, self["blue"].value << 3)
+        return "#{0:02x}{1:02x}{2:02x}".format(self["red"].value << 3, self["green"].value << 3, self["blue"].value << 3)
 
 class Banner(FieldSet):
     static_size = 2112*8
@@ -197,7 +197,7 @@ class Overlay(FieldSet):
         yield RawBytes(self, "reserved[]", 4)
 
     def createDescription(self):
-        return "file #%d, %d (+%d) bytes to 0x%08x" % (
+        return "file #{0:d}, {1:d} (+{2:d}) bytes to 0x{3:08x}".format(
             self["file_id"].value, self["ram_size"].value, self["bss_size"].value, self["ram_address"].value)
 
 
@@ -216,7 +216,7 @@ class SecureArea(FieldSet):
 
 class DeviceSize(UInt8):
     def createDescription(self):
-        return "%d Mbit" % ((2**(20+self.value)) / (1024*1024))
+        return "{0:d} Mbit".format(((2**(20+self.value)) / (1024*1024)))
 
 class Header(FieldSet):
     def createFields(self):

--- a/lib/hachoir_parser/program/prc.py
+++ b/lib/hachoir_parser/program/prc.py
@@ -39,7 +39,7 @@ class ResourceHeader(FieldSet):
         yield UInt32(self, "offset", "Pointer to the resource data")
 
     def createDescription(self):
-        return "Resource Header (%s)" % self["name"]
+        return "Resource Header ({0!s})".format(self["name"])
 
 class PRCFile(Parser):
     PARSER_TAGS = {

--- a/lib/hachoir_parser/program/python.py
+++ b/lib/hachoir_parser/program/python.py
@@ -37,11 +37,11 @@ def parseString(parent):
             bc_off_delta=UInt8(parent, 'bytecode_offset_delta[]')
             yield bc_off_delta
             bytecode_offset+=bc_off_delta.value
-            bc_off_delta._description='Bytecode Offset %i'%bytecode_offset
+            bc_off_delta._description='Bytecode Offset {0:d}'.format(bytecode_offset)
             line_number_delta=UInt8(parent, 'line_number_delta[]')
             yield line_number_delta
             line_number+=line_number_delta.value
-            line_number_delta._description='Line Number %i'%line_number
+            line_number_delta._description='Line Number {0:d}'.format(line_number)
     elif 0 < length:
         yield RawBytes(parent, "text", length, "Content")
     if DISASSEMBLE and parent.name == "compiled_code":
@@ -50,7 +50,7 @@ def parseString(parent):
 def parseStringRef(parent):
     yield textHandler(UInt32(parent, "ref"), hexadecimal)
 def createStringRefDesc(parent):
-    return "String ref: %s" % parent["ref"].display
+    return "String ref: {0!s}".format(parent["ref"].display)
 
 # --- Integers ---
 def parseInt32(parent):
@@ -90,7 +90,7 @@ def parseTuple(parent):
 def createTupleDesc(parent):
     count = parent["count"].value
     items = ngettext("%s item", "%s items", count) % count
-    return "%s: %s" % (parent.code_info[2], items)
+    return "{0!s}: {1!s}".format(parent.code_info[2], items)
 
 
 # --- Dict ---
@@ -109,7 +109,7 @@ def parseDict(parent):
         parent.count += 1
 
 def createDictDesc(parent):
-    return "Dict: %s" % (ngettext("%s key", "%s keys", parent.count) % parent.count)
+    return "Dict: {0!s}".format((ngettext("%s key", "%s keys", parent.count) % parent.count))
 
 # --- Code ---
 def parseCode(parent):
@@ -178,7 +178,7 @@ class Object(FieldSet):
         FieldSet.__init__(self, parent, name, **kw)
         code = self["bytecode"].value
         if code not in self.bytecode_info:
-            raise ParserError('Unknown bytecode: "%s"' % code)
+            raise ParserError('Unknown bytecode: "{0!s}"'.format(code))
         self.code_info = self.bytecode_info[code]
         if not name:
             self._name = self.code_info[0]
@@ -221,7 +221,7 @@ class Object(FieldSet):
         total = 0
         for index in xrange(count-1, -1, -1):
             total <<= 15
-            total += self["digit[%u]" % index].value
+            total += self["digit[{0:d}]".format(index)].value
         if is_negative:
             total = -total
         return total
@@ -328,7 +328,7 @@ class PythonCompiledFile(Parser):
     def validate(self):
         signature = self.stream.readBits(0, 16, self.endian)
         if signature not in self.MAGIC:
-            return "Unknown version (%s)" % signature
+            return "Unknown version ({0!s})".format(signature)
         if self.stream.readBytes(2*8, 2) != "\r\n":
             return r"Wrong signature (\r\n)"
         if self.stream.readBytes(8*8, 1) != 'c':

--- a/lib/hachoir_parser/video/amf.py
+++ b/lib/hachoir_parser/video/amf.py
@@ -82,7 +82,7 @@ class AMFObject(FieldSet):
             if code == self.CODE_DATE:
                 self.createValue = self.createValueDate
         except KeyError:
-            raise ParserError("AMF: Unable to parse type %s" % code)
+            raise ParserError("AMF: Unable to parse type {0!s}".format(code))
 
     def createFields(self):
         yield UInt8(self, "type")
@@ -106,5 +106,5 @@ class Attribute(AMFObject):
             yield field
 
     def createDescription(self):
-        return 'Attribute "%s"' % self["key"].value
+        return 'Attribute "{0!s}"'.format(self["key"].value)
 

--- a/lib/hachoir_parser/video/asf.py
+++ b/lib/hachoir_parser/video/asf.py
@@ -323,7 +323,7 @@ class AsfFile(Parser):
             return "Invalid magic"
         header = self[0]
         if not(30 <= header["size"].value  <= MAX_HEADER_SIZE):
-            return "Invalid header size (%u)" % header["size"].value
+            return "Invalid header size ({0:d})".format(header["size"].value)
         return True
 
     def createMimeType(self):

--- a/lib/hachoir_parser/video/flv.py
+++ b/lib/hachoir_parser/video/flv.py
@@ -153,5 +153,5 @@ class FlvFile(Parser):
             yield UInt32(self, "prev_size[]", "Size of previous chunk")
 
     def createDescription(self):
-        return u"Macromedia Flash video version %s" % self["header/version"].value
+        return u"Macromedia Flash video version {0!s}".format(self["header/version"].value)
 

--- a/lib/hachoir_parser/video/mov.py
+++ b/lib/hachoir_parser/video/mov.py
@@ -353,7 +353,7 @@ class EditList(FieldSet):
         elif version == 1:
             UInt, Int = UInt64, Int64
         else:
-            raise ParserError("elst version %d not supported"%version)
+            raise ParserError("elst version {0:d} not supported".format(version))
         for i in xrange(self['count'].value):
             yield UInt(self, "duration[]", "Duration of this edit segment")
             yield Int(self, "time[]", "Starting time of this edit segment within the media (-1 = empty edit)")
@@ -427,38 +427,38 @@ class TrackFragmentRandomAccess(FieldSet):
         yield UInt32(self, "number_of_entry")
         for i in xrange(self['number_of_entry'].value):
             if self['version'].value == 1:
-                yield UInt64(self, "time[%i]" % i)
-                yield UInt64(self, "moof_offset[%i]" %i)
+                yield UInt64(self, "time[{0:d}]".format(i))
+                yield UInt64(self, "moof_offset[{0:d}]".format(i))
             else:
-                yield UInt32(self, "time[%i]" %i)
-                yield UInt32(self, "moof_offset[%i]" %i)
+                yield UInt32(self, "time[{0:d}]".format(i))
+                yield UInt32(self, "moof_offset[{0:d}]".format(i))
 
             if self['length_size_of_traf_num'].value == 3:
-                yield UInt64(self, "traf_number[%i]" %i) 
+                yield UInt64(self, "traf_number[{0:d}]".format(i)) 
             elif self['length_size_of_traf_num'].value == 2:
-                yield UInt32(self, "traf_number[%i]" %i) 
+                yield UInt32(self, "traf_number[{0:d}]".format(i)) 
             elif self['length_size_of_traf_num'].value == 1:
-                yield UInt16(self, "traf_number[%i]" %i) 
+                yield UInt16(self, "traf_number[{0:d}]".format(i)) 
             else:
-                yield UInt8(self, "traf_number[%i]" %i) 
+                yield UInt8(self, "traf_number[{0:d}]".format(i)) 
 
             if self['length_size_of_trun_num'].value == 3:
-                yield UInt64(self, "trun_number[%i]" %i) 
+                yield UInt64(self, "trun_number[{0:d}]".format(i)) 
             elif self['length_size_of_trun_num'].value == 2:
-                yield UInt32(self, "trun_number[%i]" %i) 
+                yield UInt32(self, "trun_number[{0:d}]".format(i)) 
             elif self['length_size_of_trun_num'].value == 1:
-                yield UInt16(self, "trun_number[%i]" %i) 
+                yield UInt16(self, "trun_number[{0:d}]".format(i)) 
             else:
-                yield UInt8(self, "trun_number[%i]" %i) 
+                yield UInt8(self, "trun_number[{0:d}]".format(i)) 
 
             if self['length_size_of_sample_num'].value == 3:
-                yield UInt64(self, "sample_number[%i]" %i) 
+                yield UInt64(self, "sample_number[{0:d}]".format(i)) 
             elif self['length_size_of_sample_num'].value == 2:
-                yield UInt32(self, "sample_number[%i]" %i) 
+                yield UInt32(self, "sample_number[{0:d}]".format(i)) 
             elif self['length_size_of_sample_num'].value == 1:
-                yield UInt16(self, "sample_number[%i]" %i) 
+                yield UInt16(self, "sample_number[{0:d}]".format(i)) 
             else:
-                yield UInt8(self, "sample_number[%i]" %i) 
+                yield UInt8(self, "sample_number[{0:d}]".format(i)) 
 
 class MovieFragmentRandomAccessOffset(FieldSet):
     def createFields(self):
@@ -822,7 +822,7 @@ class Atom(FieldSet):
     def createDescription(self):
         if self["tag"].value == "uuid":
             return "Atom: uuid: "+self["usertag"].value
-        return "Atom: %s" % self["tag"].value
+        return "Atom: {0!s}".format(self["tag"].value)
 
 class MovFile(Parser):
     PARSER_TAGS = {

--- a/lib/hachoir_parser/video/mpeg_ts.py
+++ b/lib/hachoir_parser/video/mpeg_ts.py
@@ -51,7 +51,7 @@ class Packet(FieldSet):
             yield RawBytes(self, "error_correction", 16)
 
     def createDescription(self):
-        text = "Packet: PID %s" % self["pid"].display
+        text = "Packet: PID {0!s}".format(self["pid"].display)
         if self["payload_unit_start"].value:
             text += ", start of payload"
         return text
@@ -61,7 +61,7 @@ class Packet(FieldSet):
             return u"No payload and no adaptation"
         pid = self["pid"].value
         if (0x0002 <= pid <= 0x000f) or (0x2000 <= pid):
-            return u"Invalid program identifier (%s)" % self["pid"].display
+            return u"Invalid program identifier ({0!s})".format(self["pid"].display)
         return ""
 
 class MPEG_TS(Parser):
@@ -80,15 +80,15 @@ class MPEG_TS(Parser):
             return "Unable to find synchronization byte"
         for index in xrange(5):
             try:
-                packet = self["packet[%u]" % index]
+                packet = self["packet[{0:d}]".format(index)]
             except (ParserError, MissingField):
                 if index and self.eof:
                     return True
                 else:
-                    return "Unable to get packet #%u" % index
+                    return "Unable to get packet #{0:d}".format(index)
             err = packet.isValid()
             if err:
-                return "Packet #%u is invalid: %s" % (index, err)
+                return "Packet #{0:d} is invalid: {1!s}".format(index, err)
         return True
 
     def createFields(self):

--- a/lib/hachoir_parser/video/mpeg_video.py
+++ b/lib/hachoir_parser/video/mpeg_video.py
@@ -494,11 +494,11 @@ class Chunk(FieldSet):
             if 0xC0 <= tag < 0xE0:
                 # audio
                 streamid = tag-0xC0
-                self._name, self.parser, self._description = ("audio[%i][]"%streamid, Stream, "Audio Stream %i Packet"%streamid)
+                self._name, self.parser, self._description = ("audio[{0:d}][]".format(streamid), Stream, "Audio Stream {0:d} Packet".format(streamid))
             elif 0xE0 <= tag < 0xF0:
                 # video
                 streamid = tag-0xE0
-                self._name, self.parser, self._description = ("video[%i][]"%streamid, Stream, "Video Stream %i Packet"%streamid)
+                self._name, self.parser, self._description = ("video[{0:d}][]".format(streamid), Stream, "Video Stream {0:d} Packet".format(streamid))
             else:
                 self._name, self.parser, self._description = ("stream[]", Stream, "Data Stream Packet")
         else:
@@ -520,7 +520,7 @@ class Chunk(FieldSet):
             yield self.parser(self, "content")
 
     def createDescription(self):
-        return "Chunk: tag %s" % self["tag"].display
+        return "Chunk: tag {0!s}".format(self["tag"].display)
 
 class MPEGVideoFile(Parser):
     PARSER_TAGS = {

--- a/lib/html5lib/filters/inject_meta_charset.py
+++ b/lib/html5lib/filters/inject_meta_charset.py
@@ -34,7 +34,7 @@ class Filter(_base.Filter):
                             has_http_equiv_content_type = True
                     else:
                         if has_http_equiv_content_type and (None, "content") in token["data"]:
-                            token["data"][(None, "content")] = 'text/html; charset=%s' % self.encoding
+                            token["data"][(None, "content")] = 'text/html; charset={0!s}'.format(self.encoding)
                             meta_found = True
 
                 elif token["name"].lower() == "head" and not meta_found:

--- a/lib/html5lib/filters/whitespace.py
+++ b/lib/html5lib/filters/whitespace.py
@@ -6,7 +6,7 @@ from . import _base
 from ..constants import rcdataElements, spaceCharacters
 spaceCharacters = "".join(spaceCharacters)
 
-SPACES_REGEX = re.compile("[%s]+" % spaceCharacters)
+SPACES_REGEX = re.compile("[{0!s}]+".format(spaceCharacters))
 
 
 class Filter(_base.Filter):

--- a/lib/html5lib/html5parser.py
+++ b/lib/html5lib/html5parser.py
@@ -772,7 +772,7 @@ def getPhases(debug):
 
         def endTagHead(self, token):
             node = self.parser.tree.openElements.pop()
-            assert node.name == "head", "Expected head got %s" % node.name
+            assert node.name == "head", "Expected head got {0!s}".format(node.name)
             self.parser.phase = self.parser.phases["afterHead"]
 
         def endTagHtmlBodyBr(self, token):
@@ -1601,7 +1601,7 @@ def getPhases(debug):
             return True
 
         def startTagOther(self, token):
-            assert False, "Tried to process start tag %s in RCDATA/RAWTEXT mode" % token['name']
+            assert False, "Tried to process start tag {0!s} in RCDATA/RAWTEXT mode".format(token['name'])
 
         def endTagScript(self, token):
             node = self.tree.openElements.pop()

--- a/lib/html5lib/ihatexml.py
+++ b/lib/html5lib/ihatexml.py
@@ -159,7 +159,7 @@ def listToRegexpStr(charList):
         else:
             rv.append(escapeRegexp(chr(item[0])) + "-" +
                       escapeRegexp(chr(item[1])))
-    return "[%s]" % "".join(rv)
+    return "[{0!s}]".format("".join(rv))
 
 
 def hexToInt(hex_str):
@@ -277,7 +277,7 @@ class InfosetFilter(object):
         return name
 
     def escapeChar(self, char):
-        replacement = "U%05X" % ord(char)
+        replacement = "U{0:05X}".format(ord(char))
         self.replaceCache[char] = replacement
         return replacement
 

--- a/lib/html5lib/inputstream.py
+++ b/lib/html5lib/inputstream.py
@@ -320,10 +320,10 @@ class HTMLUnicodeInputStream(object):
             if __debug__:
                 for c in characters:
                     assert(ord(c) < 128)
-            regex = "".join(["\\x%02x" % ord(c) for c in characters])
+            regex = "".join(["\\x{0:02x}".format(ord(c)) for c in characters])
             if not opposite:
-                regex = "^%s" % regex
-            chars = charsUntilRegEx[(characters, opposite)] = re.compile("[%s]+" % regex)
+                regex = "^{0!s}".format(regex)
+            chars = charsUntilRegEx[(characters, opposite)] = re.compile("[{0!s}]+".format(regex))
 
         rv = []
 
@@ -500,7 +500,7 @@ class HTMLBinaryInputStream(HTMLUnicodeInputStream):
             self.rawStream.seek(0)
             self.reset()
             self.charEncoding = (newEncoding, "certain")
-            raise ReparseException("Encoding changed from %s to %s" % (self.charEncoding[0], newEncoding))
+            raise ReparseException("Encoding changed from {0!s} to {1!s}".format(self.charEncoding[0], newEncoding))
 
     def detectBOM(self):
         """Attempts to detect at BOM at the start of the stream. If

--- a/lib/html5lib/sanitizer.py
+++ b/lib/html5lib/sanitizer.py
@@ -209,12 +209,12 @@ class HTMLSanitizerMixin(object):
 
     def disallowed_token(self, token, token_type):
         if token_type == tokenTypes["EndTag"]:
-            token["data"] = "</%s>" % token["name"]
+            token["data"] = "</{0!s}>".format(token["name"])
         elif token["data"]:
-            attrs = ''.join([' %s="%s"' % (k, escape(v)) for k, v in token["data"]])
-            token["data"] = "<%s%s>" % (token["name"], attrs)
+            attrs = ''.join([' {0!s}="{1!s}"'.format(k, escape(v)) for k, v in token["data"]])
+            token["data"] = "<{0!s}{1!s}>".format(token["name"], attrs)
         else:
-            token["data"] = "<%s>" % token["name"]
+            token["data"] = "<{0!s}>".format(token["name"])
         if token.get("selfClosing"):
             token["data"] = token["data"][:-1] + "/>"
 

--- a/lib/html5lib/serializer/htmlserializer.py
+++ b/lib/html5lib/serializer/htmlserializer.py
@@ -63,7 +63,7 @@ else:
                     if not e.endswith(";"):
                         res.append(";")
                 else:
-                    res.append("&#x%s;" % (hex(cp)[2:]))
+                    res.append("&#x{0!s};".format((hex(cp)[2:])))
             return ("".join(res), exc.end)
         else:
             return xmlcharrefreplace_errors(exc)
@@ -199,10 +199,10 @@ class HTMLSerializer(object):
         for token in treewalker:
             type = token["type"]
             if type == "Doctype":
-                doctype = "<!DOCTYPE %s" % token["name"]
+                doctype = "<!DOCTYPE {0!s}".format(token["name"])
 
                 if token["publicId"]:
-                    doctype += ' PUBLIC "%s"' % token["publicId"]
+                    doctype += ' PUBLIC "{0!s}"'.format(token["publicId"])
                 elif token["systemId"]:
                     doctype += " SYSTEM"
                 if token["systemId"]:
@@ -212,7 +212,7 @@ class HTMLSerializer(object):
                         quote_char = "'"
                     else:
                         quote_char = '"'
-                    doctype += " %s%s%s" % (quote_char, token["systemId"], quote_char)
+                    doctype += " {0!s}{1!s}{2!s}".format(quote_char, token["systemId"], quote_char)
 
                 doctype += ">"
                 yield self.encodeStrict(doctype)
@@ -227,7 +227,7 @@ class HTMLSerializer(object):
 
             elif type in ("StartTag", "EmptyTag"):
                 name = token["name"]
-                yield self.encodeStrict("<%s" % name)
+                yield self.encodeStrict("<{0!s}".format(name))
                 if name in rcdataElements and not self.escape_rcdata:
                     in_cdata = True
                 elif in_cdata:
@@ -280,23 +280,23 @@ class HTMLSerializer(object):
                     in_cdata = False
                 elif in_cdata:
                     self.serializeError(_("Unexpected child element of a CDATA element"))
-                yield self.encodeStrict("</%s>" % name)
+                yield self.encodeStrict("</{0!s}>".format(name))
 
             elif type == "Comment":
                 data = token["data"]
                 if data.find("--") >= 0:
                     self.serializeError(_("Comment contains --"))
-                yield self.encodeStrict("<!--%s-->" % token["data"])
+                yield self.encodeStrict("<!--{0!s}-->".format(token["data"]))
 
             elif type == "Entity":
                 name = token["name"]
                 key = name + ";"
                 if not key in entities:
-                    self.serializeError(_("Entity %s not recognized" % name))
+                    self.serializeError(_("Entity {0!s} not recognized".format(name)))
                 if self.resolve_entities and key not in xmlEntities:
                     data = entities[key]
                 else:
-                    data = "&%s;" % name
+                    data = "&{0!s};".format(name)
                 yield self.encodeStrict(data)
 
             else:

--- a/lib/html5lib/treebuilders/__init__.py
+++ b/lib/html5lib/treebuilders/__init__.py
@@ -72,5 +72,5 @@ def getTreeBuilder(treeType, implementation=None, **kwargs):
             # NEVER cache here, caching is done in the etree submodule
             return etree.getETreeModule(implementation, **kwargs).TreeBuilder
         else:
-            raise ValueError("""Unrecognised treebuilder "%s" """ % treeType)
+            raise ValueError("""Unrecognised treebuilder "{0!s}" """.format(treeType))
     return treeBuilderCache.get(treeType)

--- a/lib/html5lib/treebuilders/_base.py
+++ b/lib/html5lib/treebuilders/_base.py
@@ -40,16 +40,16 @@ class Node(object):
         self._flags = []
 
     def __str__(self):
-        attributesStr = " ".join(["%s=\"%s\"" % (name, value)
+        attributesStr = " ".join(["{0!s}=\"{1!s}\"".format(name, value)
                                   for name, value in
                                   self.attributes.items()])
         if attributesStr:
-            return "<%s %s>" % (self.name, attributesStr)
+            return "<{0!s} {1!s}>".format(self.name, attributesStr)
         else:
-            return "<%s>" % (self.name)
+            return "<{0!s}>".format((self.name))
 
     def __repr__(self):
-        return "<%s>" % (self.name)
+        return "<{0!s}>".format((self.name))
 
     def appendChild(self, node):
         """Insert node as a child of the current node
@@ -285,7 +285,7 @@ class TreeBuilder(object):
 
     def insertElementNormal(self, token):
         name = token["name"]
-        assert isinstance(name, text_type), "Element %s not unicode" % name
+        assert isinstance(name, text_type), "Element {0!s} not unicode".format(name)
         namespace = token.get("namespace", self.defaultNamespace)
         element = self.elementClass(name, namespace)
         element.attributes = token["data"]

--- a/lib/html5lib/treebuilders/dom.py
+++ b/lib/html5lib/treebuilders/dom.py
@@ -176,28 +176,27 @@ def getDomBuilder(DomImplementation):
                     if element.publicId or element.systemId:
                         publicId = element.publicId or ""
                         systemId = element.systemId or ""
-                        rv.append("""|%s<!DOCTYPE %s "%s" "%s">""" %
-                                  (' ' * indent, element.name, publicId, systemId))
+                        rv.append("""|{0!s}<!DOCTYPE {1!s} "{2!s}" "{3!s}">""".format(' ' * indent, element.name, publicId, systemId))
                     else:
-                        rv.append("|%s<!DOCTYPE %s>" % (' ' * indent, element.name))
+                        rv.append("|{0!s}<!DOCTYPE {1!s}>".format(' ' * indent, element.name))
                 else:
-                    rv.append("|%s<!DOCTYPE >" % (' ' * indent,))
+                    rv.append("|{0!s}<!DOCTYPE >".format(' ' * indent))
             elif element.nodeType == Node.DOCUMENT_NODE:
                 rv.append("#document")
             elif element.nodeType == Node.DOCUMENT_FRAGMENT_NODE:
                 rv.append("#document-fragment")
             elif element.nodeType == Node.COMMENT_NODE:
-                rv.append("|%s<!-- %s -->" % (' ' * indent, element.nodeValue))
+                rv.append("|{0!s}<!-- {1!s} -->".format(' ' * indent, element.nodeValue))
             elif element.nodeType == Node.TEXT_NODE:
-                rv.append("|%s\"%s\"" % (' ' * indent, element.nodeValue))
+                rv.append("|{0!s}\"{1!s}\"".format(' ' * indent, element.nodeValue))
             else:
                 if (hasattr(element, "namespaceURI") and
                         element.namespaceURI is not None):
-                    name = "%s %s" % (constants.prefixes[element.namespaceURI],
+                    name = "{0!s} {1!s}".format(constants.prefixes[element.namespaceURI],
                                       element.nodeName)
                 else:
                     name = element.nodeName
-                rv.append("|%s<%s>" % (' ' * indent, name))
+                rv.append("|{0!s}<{1!s}>".format(' ' * indent, name))
                 if element.hasAttributes():
                     attributes = []
                     for i in range(len(element.attributes)):
@@ -206,13 +205,13 @@ def getDomBuilder(DomImplementation):
                         value = attr.value
                         ns = attr.namespaceURI
                         if ns:
-                            name = "%s %s" % (constants.prefixes[ns], attr.localName)
+                            name = "{0!s} {1!s}".format(constants.prefixes[ns], attr.localName)
                         else:
                             name = attr.nodeName
                         attributes.append((name, value))
 
                     for name, value in sorted(attributes):
-                        rv.append('|%s%s="%s"' % (' ' * (indent + 2), name, value))
+                        rv.append('|{0!s}{1!s}="{2!s}"'.format(' ' * (indent + 2), name, value))
             indent += 2
             for child in element.childNodes:
                 serializeElement(child, indent)

--- a/lib/html5lib/treebuilders/etree.py
+++ b/lib/html5lib/treebuilders/etree.py
@@ -34,7 +34,7 @@ def getETreeBuilder(ElementTreeImplementation, fullTree=False):
             if namespace is None:
                 etree_tag = name
             else:
-                etree_tag = "{%s}%s" % (namespace, name)
+                etree_tag = "{{{0!s}}}{1!s}".format(namespace, name)
             return etree_tag
 
         def _setName(self, name):
@@ -65,7 +65,7 @@ def getETreeBuilder(ElementTreeImplementation, fullTree=False):
                 del self._element.attrib[key]
             for key, value in attributes.items():
                 if isinstance(key, tuple):
-                    name = "{%s}%s" % (key[2], key[1])
+                    name = "{{{0!s}}}{1!s}".format(key[2], key[1])
                 else:
                     name = key
                 self._element.set(name, value)
@@ -201,23 +201,22 @@ def getETreeBuilder(ElementTreeImplementation, fullTree=False):
                 if element.get("publicId") or element.get("systemId"):
                     publicId = element.get("publicId") or ""
                     systemId = element.get("systemId") or ""
-                    rv.append("""<!DOCTYPE %s "%s" "%s">""" %
-                              (element.text, publicId, systemId))
+                    rv.append("""<!DOCTYPE {0!s} "{1!s}" "{2!s}">""".format(element.text, publicId, systemId))
                 else:
-                    rv.append("<!DOCTYPE %s>" % (element.text,))
+                    rv.append("<!DOCTYPE {0!s}>".format(element.text))
             elif element.tag == "DOCUMENT_ROOT":
                 rv.append("#document")
                 if element.text is not None:
-                    rv.append("|%s\"%s\"" % (' ' * (indent + 2), element.text))
+                    rv.append("|{0!s}\"{1!s}\"".format(' ' * (indent + 2), element.text))
                 if element.tail is not None:
                     raise TypeError("Document node cannot have tail")
                 if hasattr(element, "attrib") and len(element.attrib):
                     raise TypeError("Document node cannot have attributes")
             elif element.tag == ElementTreeCommentType:
-                rv.append("|%s<!-- %s -->" % (' ' * indent, element.text))
+                rv.append("|{0!s}<!-- {1!s} -->".format(' ' * indent, element.text))
             else:
                 assert isinstance(element.tag, text_type), \
-                    "Expected unicode, got %s, %s" % (type(element.tag), element.tag)
+                    "Expected unicode, got {0!s}, {1!s}".format(type(element.tag), element.tag)
                 nsmatch = tag_regexp.match(element.tag)
 
                 if nsmatch is None:
@@ -225,8 +224,8 @@ def getETreeBuilder(ElementTreeImplementation, fullTree=False):
                 else:
                     ns, name = nsmatch.groups()
                     prefix = constants.prefixes[ns]
-                    name = "%s %s" % (prefix, name)
-                rv.append("|%s<%s>" % (' ' * indent, name))
+                    name = "{0!s} {1!s}".format(prefix, name)
+                rv.append("|{0!s}<{1!s}>".format(' ' * indent, name))
 
                 if hasattr(element, "attrib"):
                     attributes = []
@@ -235,20 +234,20 @@ def getETreeBuilder(ElementTreeImplementation, fullTree=False):
                         if nsmatch is not None:
                             ns, name = nsmatch.groups()
                             prefix = constants.prefixes[ns]
-                            attr_string = "%s %s" % (prefix, name)
+                            attr_string = "{0!s} {1!s}".format(prefix, name)
                         else:
                             attr_string = name
                         attributes.append((attr_string, value))
 
                     for name, value in sorted(attributes):
-                        rv.append('|%s%s="%s"' % (' ' * (indent + 2), name, value))
+                        rv.append('|{0!s}{1!s}="{2!s}"'.format(' ' * (indent + 2), name, value))
                 if element.text:
-                    rv.append("|%s\"%s\"" % (' ' * (indent + 2), element.text))
+                    rv.append("|{0!s}\"{1!s}\"".format(' ' * (indent + 2), element.text))
             indent += 2
             for child in element:
                 serializeElement(child, indent)
             if element.tail:
-                rv.append("|%s\"%s\"" % (' ' * (indent - 2), element.tail))
+                rv.append("|{0!s}\"{1!s}\"".format(' ' * (indent - 2), element.tail))
         serializeElement(element, 0)
 
         return "\n".join(rv)
@@ -266,10 +265,9 @@ def getETreeBuilder(ElementTreeImplementation, fullTree=False):
                 if element.get("publicId") or element.get("systemId"):
                     publicId = element.get("publicId") or ""
                     systemId = element.get("systemId") or ""
-                    rv.append("""<!DOCTYPE %s PUBLIC "%s" "%s">""" %
-                              (element.text, publicId, systemId))
+                    rv.append("""<!DOCTYPE {0!s} PUBLIC "{1!s}" "{2!s}">""".format(element.text, publicId, systemId))
                 else:
-                    rv.append("<!DOCTYPE %s>" % (element.text,))
+                    rv.append("<!DOCTYPE {0!s}>".format(element.text))
             elif element.tag == "DOCUMENT_ROOT":
                 if element.text is not None:
                     rv.append(element.text)
@@ -282,23 +280,23 @@ def getETreeBuilder(ElementTreeImplementation, fullTree=False):
                     serializeElement(child)
 
             elif element.tag == ElementTreeCommentType:
-                rv.append("<!--%s-->" % (element.text,))
+                rv.append("<!--{0!s}-->".format(element.text))
             else:
                 # This is assumed to be an ordinary element
                 if not element.attrib:
-                    rv.append("<%s>" % (filter.fromXmlName(element.tag),))
+                    rv.append("<{0!s}>".format(filter.fromXmlName(element.tag)))
                 else:
-                    attr = " ".join(["%s=\"%s\"" % (
+                    attr = " ".join(["{0!s}=\"{1!s}\"".format(
                         filter.fromXmlName(name), value)
                         for name, value in element.attrib.items()])
-                    rv.append("<%s %s>" % (element.tag, attr))
+                    rv.append("<{0!s} {1!s}>".format(element.tag, attr))
                 if element.text:
                     rv.append(element.text)
 
                 for child in element:
                     serializeElement(child)
 
-                rv.append("</%s>" % (element.tag,))
+                rv.append("</{0!s}>".format(element.tag))
 
             if element.tail:
                 rv.append(element.tail)
@@ -324,7 +322,7 @@ def getETreeBuilder(ElementTreeImplementation, fullTree=False):
             else:
                 if self.defaultNamespace is not None:
                     return self.document._element.find(
-                        "{%s}html" % self.defaultNamespace)
+                        "{{{0!s}}}html".format(self.defaultNamespace))
                 else:
                     return self.document._element.find("html")
 

--- a/lib/html5lib/treebuilders/etree_lxml.py
+++ b/lib/html5lib/treebuilders/etree_lxml.py
@@ -64,13 +64,13 @@ def testSerializer(element):
                 if element.docinfo.internalDTD:
                     if not (element.docinfo.public_id or
                             element.docinfo.system_url):
-                        dtd_str = "<!DOCTYPE %s>" % element.docinfo.root_name
+                        dtd_str = "<!DOCTYPE {0!s}>".format(element.docinfo.root_name)
                     else:
-                        dtd_str = """<!DOCTYPE %s "%s" "%s">""" % (
+                        dtd_str = """<!DOCTYPE {0!s} "{1!s}" "{2!s}">""".format(
                             element.docinfo.root_name,
                             element.docinfo.public_id,
                             element.docinfo.system_url)
-                    rv.append("|%s%s" % (' ' * (indent + 2), dtd_str))
+                    rv.append("|{0!s}{1!s}".format(' ' * (indent + 2), dtd_str))
                 next_element = element.getroot()
                 while next_element.getprevious() is not None:
                     next_element = next_element.getprevious()
@@ -80,16 +80,16 @@ def testSerializer(element):
             elif isinstance(element, str) or isinstance(element, bytes):
                 # Text in a fragment
                 assert isinstance(element, str) or sys.version_info.major == 2
-                rv.append("|%s\"%s\"" % (' ' * indent, element))
+                rv.append("|{0!s}\"{1!s}\"".format(' ' * indent, element))
             else:
                 # Fragment case
                 rv.append("#document-fragment")
                 for next_element in element:
                     serializeElement(next_element, indent + 2)
         elif element.tag == comment_type:
-            rv.append("|%s<!-- %s -->" % (' ' * indent, element.text))
+            rv.append("|{0!s}<!-- {1!s} -->".format(' ' * indent, element.text))
             if hasattr(element, "tail") and element.tail:
-                rv.append("|%s\"%s\"" % (' ' * indent, element.tail))
+                rv.append("|{0!s}\"{1!s}\"".format(' ' * indent, element.tail))
         else:
             assert isinstance(element, etree._Element)
             nsmatch = etree_builders.tag_regexp.match(element.tag)
@@ -97,10 +97,10 @@ def testSerializer(element):
                 ns = nsmatch.group(1)
                 tag = nsmatch.group(2)
                 prefix = constants.prefixes[ns]
-                rv.append("|%s<%s %s>" % (' ' * indent, prefix,
+                rv.append("|{0!s}<{1!s} {2!s}>".format(' ' * indent, prefix,
                                           infosetFilter.fromXmlName(tag)))
             else:
-                rv.append("|%s<%s>" % (' ' * indent,
+                rv.append("|{0!s}<{1!s}>".format(' ' * indent,
                                        infosetFilter.fromXmlName(element.tag)))
 
             if hasattr(element, "attrib"):
@@ -111,25 +111,25 @@ def testSerializer(element):
                         ns, name = nsmatch.groups()
                         name = infosetFilter.fromXmlName(name)
                         prefix = constants.prefixes[ns]
-                        attr_string = "%s %s" % (prefix, name)
+                        attr_string = "{0!s} {1!s}".format(prefix, name)
                     else:
                         attr_string = infosetFilter.fromXmlName(name)
                     attributes.append((attr_string, value))
 
                 for name, value in sorted(attributes):
-                    rv.append('|%s%s="%s"' % (' ' * (indent + 2), name, value))
+                    rv.append('|{0!s}{1!s}="{2!s}"'.format(' ' * (indent + 2), name, value))
 
             if element.text:
-                rv.append("|%s\"%s\"" % (' ' * (indent + 2), element.text))
+                rv.append("|{0!s}\"{1!s}\"".format(' ' * (indent + 2), element.text))
             indent += 2
             for child in element:
                 serializeElement(child, indent)
             if hasattr(element, "tail") and element.tail:
-                rv.append("|%s\"%s\"" % (' ' * (indent - 2), element.tail))
+                rv.append("|{0!s}\"{1!s}\"".format(' ' * (indent - 2), element.tail))
     serializeElement(element, 0)
 
     if finalText is not None:
-        rv.append("|%s\"%s\"" % (' ' * 2, finalText))
+        rv.append("|{0!s}\"{1!s}\"".format(' ' * 2, finalText))
 
     return "\n".join(rv)
 
@@ -145,28 +145,28 @@ def tostring(element):
                 if element.docinfo.doctype:
                     dtd_str = element.docinfo.doctype
                 else:
-                    dtd_str = "<!DOCTYPE %s>" % element.docinfo.root_name
+                    dtd_str = "<!DOCTYPE {0!s}>".format(element.docinfo.root_name)
                 rv.append(dtd_str)
             serializeElement(element.getroot())
 
         elif element.tag == comment_type:
-            rv.append("<!--%s-->" % (element.text,))
+            rv.append("<!--{0!s}-->".format(element.text))
 
         else:
             # This is assumed to be an ordinary element
             if not element.attrib:
-                rv.append("<%s>" % (element.tag,))
+                rv.append("<{0!s}>".format(element.tag))
             else:
-                attr = " ".join(["%s=\"%s\"" % (name, value)
+                attr = " ".join(["{0!s}=\"{1!s}\"".format(name, value)
                                  for name, value in element.attrib.items()])
-                rv.append("<%s %s>" % (element.tag, attr))
+                rv.append("<{0!s} {1!s}>".format(element.tag, attr))
             if element.text:
                 rv.append(element.text)
 
             for child in element:
                 serializeElement(child)
 
-            rv.append("</%s>" % (element.tag,))
+            rv.append("</{0!s}>".format(element.tag))
 
         if hasattr(element, "tail") and element.tail:
             rv.append(element.tail)
@@ -174,7 +174,7 @@ def tostring(element):
     serializeElement(element)
 
     if finalText is not None:
-        rv.append("%s\"" % (' ' * 2, finalText))
+        rv.append("{0!s}\"".format(' ' * 2, finalText))
 
     return "".join(rv)
 
@@ -198,7 +198,7 @@ class TreeBuilder(_base.TreeBuilder):
                 dict.__init__(self, value)
                 for key, value in self.items():
                     if isinstance(key, tuple):
-                        name = "{%s}%s" % (key[2], infosetFilter.coerceAttribute(key[1]))
+                        name = "{{{0!s}}}{1!s}".format(key[2], infosetFilter.coerceAttribute(key[1]))
                     else:
                         name = infosetFilter.coerceAttribute(key)
                     self._element._element.attrib[name] = value
@@ -206,7 +206,7 @@ class TreeBuilder(_base.TreeBuilder):
             def __setitem__(self, key, value):
                 dict.__setitem__(self, key, value)
                 if isinstance(key, tuple):
-                    name = "{%s}%s" % (key[2], infosetFilter.coerceAttribute(key[1]))
+                    name = "{{{0!s}}}{1!s}".format(key[2], infosetFilter.coerceAttribute(key[1]))
                 else:
                     name = infosetFilter.coerceAttribute(key)
                 self._element._element.attrib[name] = value
@@ -320,20 +320,20 @@ class TreeBuilder(_base.TreeBuilder):
         docStr = ""
         if self.doctype:
             assert self.doctype.name
-            docStr += "<!DOCTYPE %s" % self.doctype.name
+            docStr += "<!DOCTYPE {0!s}".format(self.doctype.name)
             if (self.doctype.publicId is not None or
                     self.doctype.systemId is not None):
-                docStr += (' PUBLIC "%s" ' %
-                           (self.infosetFilter.coercePubid(self.doctype.publicId or "")))
+                docStr += (' PUBLIC "{0!s}" '.format(
+                           (self.infosetFilter.coercePubid(self.doctype.publicId or ""))))
                 if self.doctype.systemId:
                     sysid = self.doctype.systemId
                     if sysid.find("'") >= 0 and sysid.find('"') >= 0:
                         warnings.warn("DOCTYPE system cannot contain single and double quotes", DataLossWarning)
                         sysid = sysid.replace("'", 'U00027')
                     if sysid.find("'") >= 0:
-                        docStr += '"%s"' % sysid
+                        docStr += '"{0!s}"'.format(sysid)
                     else:
-                        docStr += "'%s'" % sysid
+                        docStr += "'{0!s}'".format(sysid)
                 else:
                     docStr += "''"
             docStr += ">"
@@ -356,7 +356,7 @@ class TreeBuilder(_base.TreeBuilder):
         if namespace is None:
             etree_tag = name
         else:
-            etree_tag = "{%s}%s" % (namespace, name)
+            etree_tag = "{{{0!s}}}{1!s}".format(namespace, name)
         root.tag = etree_tag
 
         # Add the root element to the internal child/open data structures

--- a/lib/html5lib/treewalkers/__init__.py
+++ b/lib/html5lib/treewalkers/__init__.py
@@ -38,7 +38,7 @@ def getTreeWalker(treeType, implementation=None, **kwargs):
     treeType = treeType.lower()
     if treeType not in treeWalkerCache:
         if treeType in ("dom", "pulldom"):
-            name = "%s.%s" % (__name__, treeType)
+            name = "{0!s}.{1!s}".format(__name__, treeType)
             __import__(name)
             mod = sys.modules[name]
             treeWalkerCache[treeType] = mod.TreeWalker

--- a/lib/html5lib/utils.py
+++ b/lib/html5lib/utils.py
@@ -66,9 +66,9 @@ def moduleFactoryFactory(factory):
 
     def moduleFactory(baseModule, *args, **kwargs):
         if isinstance(ModuleType.__name__, type("")):
-            name = "_%s_factory" % baseModule.__name__
+            name = "_{0!s}_factory".format(baseModule.__name__)
         else:
-            name = b"_%s_factory" % baseModule.__name__
+            name = b"_{0!s}_factory".format(baseModule.__name__)
 
         if name in moduleCache:
             return moduleCache[name]

--- a/lib/httplib2/iri2uri.py
+++ b/lib/httplib2/iri2uri.py
@@ -57,7 +57,7 @@ def encode(c):
         if i < low:
             break
         if i >= low and i <= high:
-            retval = "".join(["%%%2X" % ord(o) for o in c.encode('utf-8')])
+            retval = "".join(["%{0:2X}".format(ord(o)) for o in c.encode('utf-8')])
             break
     return retval
 

--- a/lib/imdb/Character.py
+++ b/lib/imdb/Character.py
@@ -169,7 +169,7 @@ class Character(_Container):
 
     def __repr__(self):
         """String representation of a Character object."""
-        r = '<Character id:%s[%s] name:_%s_>' % (self.characterID,
+        r = '<Character id:{0!s}[{1!s}] name:_{2!s}_>'.format(self.characterID,
                                         self.accessSystem,
                                         self.get('name'))
         if isinstance(r, unicode): r = r.encode('utf_8', 'replace')
@@ -186,16 +186,16 @@ class Character(_Container):
     def summary(self):
         """Return a string with a pretty-printed summary for the character."""
         if not self: return u''
-        s = u'Character\n=====\nName: %s\n' % \
-                                self.get('name', u'')
+        s = u'Character\n=====\nName: {0!s}\n'.format( \
+                                self.get('name', u''))
         bio = self.get('biography')
         if bio:
-            s += u'Biography: %s\n' % bio[0]
+            s += u'Biography: {0!s}\n'.format(bio[0])
         filmo = self.get('filmography')
         if filmo:
             a_list = [x.get('long imdb canonical title', u'')
                         for x in filmo[:5]]
-            s += u'Last movies with this character: %s.\n' % u'; '.join(a_list)
+            s += u'Last movies with this character: {0!s}.\n'.format(u'; '.join(a_list))
         return s
 
 

--- a/lib/imdb/Company.py
+++ b/lib/imdb/Company.py
@@ -165,7 +165,7 @@ class Company(_Container):
 
     def __repr__(self):
         """String representation of a Company object."""
-        r = '<Company id:%s[%s] name:_%s_>' % (self.companyID,
+        r = '<Company id:{0!s}[{1!s}] name:_{2!s}_>'.format(self.companyID,
                                         self.accessSystem,
                                         self.get('long imdb name'))
         if isinstance(r, unicode): r = r.encode('utf_8', 'replace')
@@ -182,14 +182,13 @@ class Company(_Container):
     def summary(self):
         """Return a string with a pretty-printed summary for the company."""
         if not self: return u''
-        s = u'Company\n=======\nName: %s\n' % \
-                                self.get('name', u'')
+        s = u'Company\n=======\nName: {0!s}\n'.format( \
+                                self.get('name', u''))
         for k in ('distributor', 'production company', 'miscellaneous company',
                 'special effects company'):
             d = self.get(k, [])[:5]
             if not d: continue
-            s += u'Last movies from this company (%s): %s.\n' % \
-                    (k, u'; '.join([x.get('long imdb title', u'') for x in d]))
+            s += u'Last movies from this company ({0!s}): {1!s}.\n'.format(k, u'; '.join([x.get('long imdb title', u'') for x in d]))
         return s
 
 

--- a/lib/imdb/Movie.py
+++ b/lib/imdb/Movie.py
@@ -328,7 +328,7 @@ class Movie(_Container):
             title = self.get('long imdb episode title')
         else:
             title = self.get('long imdb title')
-        r = '<Movie id:%s[%s] title:_%s_>' % (self.movieID, self.accessSystem,
+        r = '<Movie id:{0!s}[{1!s}] title:_{2!s}_>'.format(self.movieID, self.accessSystem,
                                                 title)
         if isinstance(r, unicode): r = r.encode('utf_8', 'replace')
         return r
@@ -349,38 +349,38 @@ class Movie(_Container):
             nl = []
             for person in personList:
                 n = person.get('name', u'')
-                if person.currentRole: n += u' (%s)' % person.currentRole
+                if person.currentRole: n += u' ({0!s})'.format(person.currentRole)
                 nl.append(n)
             return joiner.join(nl)
-        s = u'Movie\n=====\nTitle: %s\n' % \
-                    self.get('long imdb canonical title', u'')
+        s = u'Movie\n=====\nTitle: {0!s}\n'.format( \
+                    self.get('long imdb canonical title', u''))
         genres = self.get('genres')
-        if genres: s += u'Genres: %s.\n' % u', '.join(genres)
+        if genres: s += u'Genres: {0!s}.\n'.format(u', '.join(genres))
         director = self.get('director')
         if director:
-            s += u'Director: %s.\n' % _nameAndRole(director)
+            s += u'Director: {0!s}.\n'.format(_nameAndRole(director))
         writer = self.get('writer')
         if writer:
-            s += u'Writer: %s.\n' % _nameAndRole(writer)
+            s += u'Writer: {0!s}.\n'.format(_nameAndRole(writer))
         cast = self.get('cast')
         if cast:
             cast = cast[:5]
-            s += u'Cast: %s.\n' % _nameAndRole(cast)
+            s += u'Cast: {0!s}.\n'.format(_nameAndRole(cast))
         runtime = self.get('runtimes')
         if runtime:
-            s += u'Runtime: %s.\n' % u', '.join(runtime)
+            s += u'Runtime: {0!s}.\n'.format(u', '.join(runtime))
         countries = self.get('countries')
         if countries:
-            s += u'Country: %s.\n' % u', '.join(countries)
+            s += u'Country: {0!s}.\n'.format(u', '.join(countries))
         lang = self.get('languages')
         if lang:
-            s += u'Language: %s.\n' % u', '.join(lang)
+            s += u'Language: {0!s}.\n'.format(u', '.join(lang))
         rating = self.get('rating')
         if rating:
-            s += u'Rating: %s' % rating
+            s += u'Rating: {0!s}'.format(rating)
             nr_votes = self.get('votes')
             if nr_votes:
-                s += u' (%s votes)' % nr_votes
+                s += u' ({0!s} votes)'.format(nr_votes)
             s += u'.\n'
         plot = self.get('plot')
         if not plot:
@@ -392,7 +392,7 @@ class Movie(_Container):
             i = plot.find('::')
             if i != -1:
                 plot = plot[:i]
-            s += u'Plot: %s' % plot
+            s += u'Plot: {0!s}'.format(plot)
         return s
 
 

--- a/lib/imdb/Person.py
+++ b/lib/imdb/Person.py
@@ -225,7 +225,7 @@ class Person(_Container):
     def __repr__(self):
         """String representation of a Person object."""
         # XXX: add also currentRole and notes, if present?
-        r = '<Person id:%s[%s] name:_%s_>' % (self.personID, self.accessSystem,
+        r = '<Person id:{0!s}[{1!s}] name:_{2!s}_>'.format(self.personID, self.accessSystem,
                                         self.get('long imdb canonical name'))
         if isinstance(r, unicode): r = r.encode('utf_8', 'replace')
         return r
@@ -241,35 +241,35 @@ class Person(_Container):
     def summary(self):
         """Return a string with a pretty-printed summary for the person."""
         if not self: return u''
-        s = u'Person\n=====\nName: %s\n' % \
-                                self.get('long imdb canonical name', u'')
+        s = u'Person\n=====\nName: {0!s}\n'.format( \
+                                self.get('long imdb canonical name', u''))
         bdate = self.get('birth date')
         if bdate:
-            s += u'Birth date: %s' % bdate
+            s += u'Birth date: {0!s}'.format(bdate)
             bnotes = self.get('birth notes')
             if bnotes:
-                s += u' (%s)' % bnotes
+                s += u' ({0!s})'.format(bnotes)
             s += u'.\n'
         ddate = self.get('death date')
         if ddate:
-            s += u'Death date: %s' % ddate
+            s += u'Death date: {0!s}'.format(ddate)
             dnotes = self.get('death notes')
             if dnotes:
-                s += u' (%s)' % dnotes
+                s += u' ({0!s})'.format(dnotes)
             s += u'.\n'
         bio = self.get('mini biography')
         if bio:
-            s += u'Biography: %s\n' % bio[0]
+            s += u'Biography: {0!s}\n'.format(bio[0])
         director = self.get('director')
         if director:
             d_list = [x.get('long imdb canonical title', u'')
                         for x in director[:3]]
-            s += u'Last movies directed: %s.\n' % u'; '.join(d_list)
+            s += u'Last movies directed: {0!s}.\n'.format(u'; '.join(d_list))
         act = self.get('actor') or self.get('actress')
         if act:
             a_list = [x.get('long imdb canonical title', u'')
                         for x in act[:5]]
-            s += u'Last movies acted: %s.\n' % u'; '.join(a_list)
+            s += u'Last movies acted: {0!s}.\n'.format(u'; '.join(a_list))
         return s
 
 

--- a/lib/imdb/__init__.py
+++ b/lib/imdb/__init__.py
@@ -48,19 +48,19 @@ imdbURL_base = 'http://akas.imdb.com/'
 #       please use the values in the 'urls' attribute
 #       of the IMDbBase subclass instance.
 # http://akas.imdb.com/title/
-imdbURL_movie_base = '%stitle/' % imdbURL_base
+imdbURL_movie_base = '{0!s}title/'.format(imdbURL_base)
 # http://akas.imdb.com/title/tt%s/
 imdbURL_movie_main = imdbURL_movie_base + 'tt%s/'
 # http://akas.imdb.com/name/
-imdbURL_person_base = '%sname/' % imdbURL_base
+imdbURL_person_base = '{0!s}name/'.format(imdbURL_base)
 # http://akas.imdb.com/name/nm%s/
 imdbURL_person_main = imdbURL_person_base + 'nm%s/'
 # http://akas.imdb.com/character/
-imdbURL_character_base = '%scharacter/' % imdbURL_base
+imdbURL_character_base = '{0!s}character/'.format(imdbURL_base)
 # http://akas.imdb.com/character/ch%s/
 imdbURL_character_main = imdbURL_character_base + 'ch%s/'
 # http://akas.imdb.com/company/
-imdbURL_company_base = '%scompany/' % imdbURL_base
+imdbURL_company_base = '{0!s}company/'.format(imdbURL_base)
 # http://akas.imdb.com/company/co%s/
 imdbURL_company_main = imdbURL_company_base + 'co%s/'
 # http://akas.imdb.com/keyword/%s/
@@ -104,7 +104,7 @@ class ConfigParserWithCase(ConfigParser.ConfigParser):
                 self.read(fname)
             except (ConfigParser.MissingSectionHeaderError,
                     ConfigParser.ParsingError), e:
-                _aux_logger.warn('Troubles reading config file: %s' % e)
+                _aux_logger.warn('Troubles reading config file: {0!s}'.format(e))
             # Stop at the first valid file.
             if self.has_section('imdbpy'):
                 break
@@ -199,8 +199,7 @@ def IMDb(accessSystem=None, *arguments, **keywords):
             raise IMDbError('the sql access system is not installed')
         return IMDbSqlAccessSystem(*arguments, **keywords)
     else:
-        raise IMDbError('unknown kind of data access system: "%s"' \
-                            % accessSystem)
+        raise IMDbError('unknown kind of data access system: "{0!s}"'.format(accessSystem))
 
 
 def available_access_systems():
@@ -282,23 +281,23 @@ class IMDbBase:
         """Set the urls used accessing the IMDb site."""
         imdbURL_base = imdbURL_base.strip().strip('"\'')
         if not imdbURL_base.startswith('http://'):
-            imdbURL_base = 'http://%s' % imdbURL_base
+            imdbURL_base = 'http://{0!s}'.format(imdbURL_base)
         if not imdbURL_base.endswith('/'):
-            imdbURL_base = '%s/' % imdbURL_base
+            imdbURL_base = '{0!s}/'.format(imdbURL_base)
         # http://akas.imdb.com/title/
-        imdbURL_movie_base='%stitle/' % imdbURL_base
+        imdbURL_movie_base='{0!s}title/'.format(imdbURL_base)
         # http://akas.imdb.com/title/tt%s/
         imdbURL_movie_main=imdbURL_movie_base + 'tt%s/'
         # http://akas.imdb.com/name/
-        imdbURL_person_base='%sname/' % imdbURL_base
+        imdbURL_person_base='{0!s}name/'.format(imdbURL_base)
         # http://akas.imdb.com/name/nm%s/
         imdbURL_person_main=imdbURL_person_base + 'nm%s/'
         # http://akas.imdb.com/character/
-        imdbURL_character_base='%scharacter/' % imdbURL_base
+        imdbURL_character_base='{0!s}character/'.format(imdbURL_base)
         # http://akas.imdb.com/character/ch%s/
         imdbURL_character_main=imdbURL_character_base + 'ch%s/'
         # http://akas.imdb.com/company/
-        imdbURL_company_base='%scompany/' % imdbURL_base
+        imdbURL_company_base='{0!s}company/'.format(imdbURL_base)
         # http://akas.imdb.com/company/co%s/
         imdbURL_company_main=imdbURL_company_base + 'co%s/'
         # http://akas.imdb.com/keyword/%s/
@@ -366,7 +365,7 @@ class IMDbBase:
     def _get_infoset(self, prefname):
         """Return methods with the name starting with prefname."""
         infoset = []
-        excludes = ('%sinfoset' % prefname,)
+        excludes = ('{0!s}infoset'.format(prefname),)
         preflen = len(prefname)
         for name in dir(self.__class__):
             if name.startswith(prefname) and name not in excludes:
@@ -762,8 +761,7 @@ class IMDbBase:
                 continue
             self._imdb_logger.debug('retrieving "%s" info set', i)
             try:
-                method = getattr(aSystem, 'get_%s_%s' %
-                                    (prefix, i.replace(' ', '_')))
+                method = getattr(aSystem, 'get_{0!s}_{1!s}'.format(prefix, i.replace(' ', '_')))
             except AttributeError:
                 self._imdb_logger.error('unknown information set "%s"', i)
                 # Keeps going.

--- a/lib/imdb/helpers.py
+++ b/lib/imdb/helpers.py
@@ -57,8 +57,8 @@ _re_hrefsub = _re_href.sub
 def makeCgiPrintEncoding(encoding):
     """Make a function to pretty-print strings for the web."""
     def cgiPrint(s):
-        """Encode the given string using the %s encoding, and replace
-        chars outside the given charset with XML char references.""" % encoding
+        """Encode the given string using the {0!s} encoding, and replace
+        chars outside the given charset with XML char references.""".format(encoding)
         s = escape(s, quote=1)
         if isinstance(s, unicode):
             s = s.encode(encoding, 'xmlcharrefreplace')
@@ -146,8 +146,7 @@ def makeObject2Txt(movieTxt=None, personTxt=None, characterTxt=None,
                                 for o in obj])
         elif isinstance(obj, dict):
             # XXX: not exactly nice, neither useful, I fear.
-            return joiner.join([u'%s::%s' %
-                            (object2txt(k, _limitRecursion=_limitRecursion),
+            return joiner.join([u'{0!s}::{1!s}'.format(object2txt(k, _limitRecursion=_limitRecursion),
                             object2txt(v, _limitRecursion=_limitRecursion))
                             for k, v in obj.items()])
         objData = {}
@@ -267,10 +266,10 @@ modHtmlLinksASCII = makeModCGILinks(movieTxt=_movieTxt, personTxt=_personTxt,
 everyentcharrefs = entcharrefs.copy()
 for k, v in {'lt':u'<','gt':u'>','amp':u'&','quot':u'"','apos':u'\''}.items():
     everyentcharrefs[k] = v
-    everyentcharrefs['#%s' % ord(v)] = v
+    everyentcharrefs['#{0!s}'.format(ord(v))] = v
 everyentcharrefsget = everyentcharrefs.get
-re_everyentcharrefs = re.compile('&(%s|\#160|\#\d{1,5});' %
-                            '|'.join(map(re.escape, everyentcharrefs)))
+re_everyentcharrefs = re.compile('&({0!s}|\#160|\#\d{{1,5}});'.format(
+                            '|'.join(map(re.escape, everyentcharrefs))))
 re_everyentcharrefssub = re_everyentcharrefs.sub
 
 def _replAllXMLRef(match):
@@ -506,7 +505,7 @@ def parseTags(tag, _topLevel=True, _as=None, _infoset2keys=None,
         if tag.notes:
             notes = (tag.notes.string or u'').strip()
             if notes:
-                tagStr += u'::%s' % notes
+                tagStr += u'::{0!s}'.format(notes)
         else:
             tagStr = _valueWithType(tag, tagStr)
         return tagStr

--- a/lib/imdb/locale/generatepot.py
+++ b/lib/imdb/locale/generatepot.py
@@ -50,7 +50,7 @@ msgstr ""
 """
 
 if len(sys.argv) != 2:
-    print "Usage: %s dtd_file" % sys.argv[0]
+    print "Usage: {0!s} dtd_file".format(sys.argv[0])
     sys.exit()
 
 dtdfilename = sys.argv[1]
@@ -64,10 +64,10 @@ print POT_HEADER_TEMPLATE % {
 }
 for element in sorted(elements):
     if element in DEFAULT_MESSAGES:
-        print '# Default: %s' % DEFAULT_MESSAGES[element]
+        print '# Default: {0!s}'.format(DEFAULT_MESSAGES[element])
     else:
-        print '# Default: %s' % element.replace('-', ' ').capitalize()
-    print 'msgid "%s"' % element
+        print '# Default: {0!s}'.format(element.replace('-', ' ').capitalize())
+    print 'msgid "{0!s}"'.format(element)
     print 'msgstr ""'
     # use this part instead of the line above to generate the po file for English
     #if element in DEFAULT_MESSAGES:

--- a/lib/imdb/locale/msgfmt.py
+++ b/lib/imdb/locale/msgfmt.py
@@ -99,7 +99,7 @@ class MsgFmt(object):
             elif section == STR:
                 msgstr += line
             else:
-                raise SyntaxErrorException('Syntax error on line %d, before:\n%s' % (line_no, line))
+                raise SyntaxErrorException('Syntax error on line {0:d}, before:\n{1!s}'.format(line_no, line))
         # Add last entry
         if section == STR:
             self.add(msgid, msgstr, fuzzy)

--- a/lib/imdb/locale/rebuildmo.py
+++ b/lib/imdb/locale/rebuildmo.py
@@ -45,5 +45,5 @@ def rebuildmo():
 
 if __name__ == '__main__':
     languages = rebuildmo()
-    print 'Created locale for: %s.' % ' '.join(languages)
+    print 'Created locale for: {0!s}.'.format(' '.join(languages))
 

--- a/lib/imdb/parser/http/__init__.py
+++ b/lib/imdb/parser/http/__init__.py
@@ -153,7 +153,7 @@ class IMDbURLopener(FancyURLopener):
         self.set_header('Accept-Language', 'en-us,en;q=0.5')
         # XXX: This class is used also to perform "Exact Primary
         #      [Title|Name]" searches, and so by default the cookie is set.
-        c_header = 'uu=%s; id=%s' % (_cookie_uu, _cookie_id)
+        c_header = 'uu={0!s}; id={1!s}'.format(_cookie_uu, _cookie_id)
         self.set_header('Cookie', c_header)
 
     def get_proxy(self):
@@ -167,7 +167,7 @@ class IMDbURLopener(FancyURLopener):
                 del self.proxies['http']
         else:
             if not proxy.lower().startswith('http://'):
-                proxy = 'http://%s' % proxy
+                proxy = 'http://{0!s}'.format(proxy)
             self.proxies['http'] = proxy
 
     def set_header(self, header, value, _overwrite=True):
@@ -198,7 +198,7 @@ class IMDbURLopener(FancyURLopener):
         encode = None
         try:
             if size != -1:
-                self.set_header('Range', 'bytes=0-%d' % size)
+                self.set_header('Range', 'bytes=0-{0:d}'.format(size))
             uopener = self.open(url)
             kwds = {}
             if PY_VERSION > (2, 3) and not IN_GAE:
@@ -247,7 +247,7 @@ class IMDbURLopener(FancyURLopener):
             self._logger.warn('404 code returned for %s: %s (headers: %s)',
                                 url, errmsg, headers)
             return _FakeURLOpener(url, headers)
-        raise IMDbDataAccessError({'url': 'http:%s' % url,
+        raise IMDbDataAccessError({'url': 'http:{0!s}'.format(url),
                                     'errcode': errcode,
                                     'errmsg': errmsg,
                                     'headers': headers,
@@ -341,32 +341,30 @@ class IMDbHTTPAccessSystem(IMDbBase):
     def _normalize_movieID(self, movieID):
         """Normalize the given movieID."""
         try:
-            return '%07d' % int(movieID)
+            return '{0:07d}'.format(int(movieID))
         except ValueError, e:
-            raise IMDbParserError('invalid movieID "%s": %s' % (movieID, e))
+            raise IMDbParserError('invalid movieID "{0!s}": {1!s}'.format(movieID, e))
 
     def _normalize_personID(self, personID):
         """Normalize the given personID."""
         try:
-            return '%07d' % int(personID)
+            return '{0:07d}'.format(int(personID))
         except ValueError, e:
-            raise IMDbParserError('invalid personID "%s": %s' % (personID, e))
+            raise IMDbParserError('invalid personID "{0!s}": {1!s}'.format(personID, e))
 
     def _normalize_characterID(self, characterID):
         """Normalize the given characterID."""
         try:
-            return '%07d' % int(characterID)
+            return '{0:07d}'.format(int(characterID))
         except ValueError, e:
-            raise IMDbParserError('invalid characterID "%s": %s' % \
-                    (characterID, e))
+            raise IMDbParserError('invalid characterID "{0!s}": {1!s}'.format(characterID, e))
 
     def _normalize_companyID(self, companyID):
         """Normalize the given companyID."""
         try:
-            return '%07d' % int(companyID)
+            return '{0:07d}'.format(int(companyID))
         except ValueError, e:
-            raise IMDbParserError('invalid companyID "%s": %s' % \
-                    (companyID, e))
+            raise IMDbParserError('invalid companyID "{0!s}": {1!s}'.format(companyID, e))
 
     def get_imdbMovieID(self, movieID):
         """Translate a movieID in an imdbID; in this implementation
@@ -418,7 +416,7 @@ class IMDbHTTPAccessSystem(IMDbBase):
 
     def set_cookies(self, cookie_id, cookie_uu):
         """Set a cookie to access an IMDb's account."""
-        c_header = 'id=%s; uu=%s' % (cookie_id, cookie_uu)
+        c_header = 'id={0!s}; uu={1!s}'.format(cookie_id, cookie_uu)
         self.urlOpener.set_header('Cookie', c_header)
 
     def del_cookies(self):
@@ -471,7 +469,7 @@ class IMDbHTTPAccessSystem(IMDbBase):
                 except Exception, e:
                     pass
         ##params = 'q=%s&%s=on&mx=%s' % (quote_plus(ton), kind, str(results))
-        params = 'q=%s&s=%s&mx=%s' % (quote_plus(ton), kind, str(results))
+        params = 'q={0!s}&s={1!s}&mx={2!s}'.format(quote_plus(ton), kind, str(results))
         if kind == 'ep':
             params = params.replace('s=ep&', 's=tt&ttype=ep&', 1)
         cont = self._retrieve(self.urls['find'] % params)
@@ -481,7 +479,7 @@ class IMDbHTTPAccessSystem(IMDbBase):
             return cont
         # The retrieved page contains no results, because too many
         # titles or names contain the string we're looking for.
-        params = 'q=%s&ls=%s&lm=0' % (quote_plus(ton), kind)
+        params = 'q={0!s}&ls={1!s}&lm=0'.format(quote_plus(ton), kind)
         size = 131072 + results * 512
         return self._retrieve(self.urls['find'] % params, size=size)
 

--- a/lib/imdb/parser/http/bsouplxml/_bsoup.py
+++ b/lib/imdb/parser/http/bsouplxml/_bsoup.py
@@ -424,7 +424,7 @@ class NavigableString(unicode, PageElement):
         if attr == 'string':
             return self
         else:
-            raise AttributeError, "'%s' object has no attribute '%s'" % (self.__class__.__name__, attr)
+            raise AttributeError, "'{0!s}' object has no attribute '{1!s}'".format(self.__class__.__name__, attr)
 
     def __unicode__(self):
         return str(self).decode(DEFAULT_OUTPUT_ENCODING)
@@ -438,22 +438,22 @@ class NavigableString(unicode, PageElement):
 class CData(NavigableString):
 
     def __str__(self, encoding=DEFAULT_OUTPUT_ENCODING):
-        return "<![CDATA[%s]]>" % NavigableString.__str__(self, encoding)
+        return "<![CDATA[{0!s}]]>".format(NavigableString.__str__(self, encoding))
 
 class ProcessingInstruction(NavigableString):
     def __str__(self, encoding=DEFAULT_OUTPUT_ENCODING):
         output = self
         if "%SOUP-ENCODING%" in output:
             output = self.substituteEncoding(output, encoding)
-        return "<?%s?>" % self.toEncoding(output, encoding)
+        return "<?{0!s}?>".format(self.toEncoding(output, encoding))
 
 class Comment(NavigableString):
     def __str__(self, encoding=DEFAULT_OUTPUT_ENCODING):
-        return "<!--%s-->" % NavigableString.__str__(self, encoding)
+        return "<!--{0!s}-->".format(NavigableString.__str__(self, encoding))
 
 class Declaration(NavigableString):
     def __str__(self, encoding=DEFAULT_OUTPUT_ENCODING):
-        return "<!%s>" % NavigableString.__str__(self, encoding)
+        return "<!{0!s}>".format(NavigableString.__str__(self, encoding))
 
 class Tag(PageElement):
 
@@ -486,7 +486,7 @@ class Tag(PageElement):
             if self.convertXMLEntities:
                 return self.XML_ENTITIES_TO_SPECIAL_CHARS[x]
             else:
-                return u'&%s;' % x
+                return u'&{0!s};'.format(x)
         elif len(x) > 0 and x[0] == '#':
             # Handle numeric entities
             if len(x) > 1 and x[1] == 'x':
@@ -495,9 +495,9 @@ class Tag(PageElement):
                 return unichr(int(x[1:]))
 
         elif self.escapeUnrecognizedEntities:
-            return u'&amp;%s;' % x
+            return u'&amp;{0!s};'.format(x)
         else:
-            return u'&%s;' % x
+            return u'&{0!s};'.format(x)
 
     def __init__(self, parser, name, attrs=None, parent=None,
                  previous=None):
@@ -592,7 +592,7 @@ class Tag(PageElement):
             return self.find(tag[:-3])
         elif tag.find('__') != 0:
             return self.find(tag)
-        raise AttributeError, "'%s' object has no attribute '%s'" % (self.__class__, tag)
+        raise AttributeError, "'{0!s}' object has no attribute '{1!s}'".format(self.__class__, tag)
 
     def __eq__(self, other):
         """Returns true iff this tag has the same name, the same attributes,
@@ -682,7 +682,7 @@ class Tag(PageElement):
         if self.isSelfClosing:
             close = ' /'
         else:
-            closeTag = '</%s>' % encodedName
+            closeTag = '</{0!s}>'.format(encodedName)
 
         indentTag, indentContents = 0, 0
         if prettyPrint:
@@ -699,7 +699,7 @@ class Tag(PageElement):
                 attributeString = ' ' + ' '.join(attrs)
             if prettyPrint:
                 s.append(space)
-            s.append('<%s%s%s>' % (encodedName, attributeString, close))
+            s.append('<{0!s}{1!s}{2!s}>'.format(encodedName, attributeString, close))
             if prettyPrint:
                 s.append("\n")
             s.append(contents)
@@ -842,7 +842,7 @@ class SoupStrainer:
         if self.text:
             return self.text
         else:
-            return "%s|%s" % (self.name, self.attrs)
+            return "{0!s}|{1!s}".format(self.name, self.attrs)
 
     def searchTag(self, markupName=None, markupAttrs={}):
         found = None
@@ -903,8 +903,7 @@ class SoupStrainer:
             if self._matches(markup, self.text):
                 found = markup
         else:
-            raise Exception, "I don't know how to match against a %s" \
-                  % markup.__class__
+            raise Exception, "I don't know how to match against a {0!s}".format(markup.__class__)
         return found
 
     def _matches(self, markup, matchAgainst):
@@ -1285,8 +1284,8 @@ class BeautifulStoneSoup(Tag, SGMLParser):
         if self.quoteStack:
             #This is not a real tag.
             #print "<%s> is not real!" % name
-            attrs = ''.join(map(lambda(x, y): ' %s="%s"' % (x, y), attrs))
-            self.handle_data('<%s%s>' % (name, attrs))
+            attrs = ''.join(map(lambda(x, y): ' {0!s}="{1!s}"'.format(x, y), attrs))
+            self.handle_data('<{0!s}{1!s}>'.format(name, attrs))
             return
         self.endData()
 
@@ -1315,7 +1314,7 @@ class BeautifulStoneSoup(Tag, SGMLParser):
         if self.quoteStack and self.quoteStack[-1] != name:
             #This is not a real end tag.
             #print "</%s> is not real!" % name
-            self.handle_data('</%s>' % name)
+            self.handle_data('</{0!s}>'.format(name))
             return
         self.endData()
         self._popToTag(name)
@@ -1350,7 +1349,7 @@ class BeautifulStoneSoup(Tag, SGMLParser):
         if self.convertEntities:
             data = unichr(int(ref))
         else:
-            data = '&#%s;' % ref
+            data = '&#{0!s};'.format(ref)
         self.handle_data(data)
 
     def handle_entityref(self, ref):
@@ -1385,7 +1384,7 @@ class BeautifulStoneSoup(Tag, SGMLParser):
                 #
                 # The more common case is a misplaced ampersand, so I
                 # escape the ampersand and omit the trailing semicolon.
-                data = "&amp;%s" % ref
+                data = "&amp;{0!s}".format(ref)
         if not data:
             # This case is different from the one above, because we
             # haven't already gone through a supposedly comprehensive
@@ -1393,7 +1392,7 @@ class BeautifulStoneSoup(Tag, SGMLParser):
             # have gone through any mapping at all. So the chances are
             # very high that this is a real entity, and not a
             # misplaced ampersand.
-            data = "&%s;" % ref
+            data = "&{0!s};".format(ref)
         self.handle_data(data)
 
     def handle_decl(self, data):
@@ -1759,9 +1758,9 @@ class UnicodeDammit:
         sub = self.MS_CHARS.get(orig)
         if type(sub) == types.TupleType:
             if self.smartQuotesTo == 'xml':
-                sub = '&#x%s;' % sub[1]
+                sub = '&#x{0!s};'.format(sub[1])
             else:
-                sub = '&%s;' % sub[0]
+                sub = '&{0!s};'.format(sub[0])
         return sub
 
     def _convertFrom(self, proposed):

--- a/lib/imdb/parser/http/bsouplxml/bsoupxpath.py
+++ b/lib/imdb/parser/http/bsouplxml/bsoupxpath.py
@@ -118,19 +118,16 @@ class PathStep:
     """A location step in a location path.
     """
 
-    AXIS_PATTERN          = r"""(%s)::|@""" % '|'.join(AXES)
+    AXIS_PATTERN          = r"""({0!s})::|@""".format('|'.join(AXES))
     NODE_TEST_PATTERN     = r"""\w+(\(\))?"""
     PREDICATE_PATTERN     = r"""\[(.*?)\]"""
-    LOCATION_STEP_PATTERN = r"""(%s)?(%s)((%s)*)""" \
-                          % (AXIS_PATTERN, NODE_TEST_PATTERN, PREDICATE_PATTERN)
+    LOCATION_STEP_PATTERN = r"""({0!s})?({1!s})(({2!s})*)""".format(AXIS_PATTERN, NODE_TEST_PATTERN, PREDICATE_PATTERN)
 
     _re_location_step = re.compile(LOCATION_STEP_PATTERN)
 
     PREDICATE_NOT_PATTERN = r"""not\((.*?)\)"""
-    PREDICATE_AXIS_PATTERN = r"""(%s)?(%s)(='(.*?)')?""" \
-                           % (AXIS_PATTERN, NODE_TEST_PATTERN)
-    PREDICATE_FUNCTION_PATTERN = r"""(%s)\(([^,]+(,\s*[^,]+)*)?\)(=(.*))?""" \
-                               % '|'.join(XPATH_FUNCTIONS)
+    PREDICATE_AXIS_PATTERN = r"""({0!s})?({1!s})(='(.*?)')?""".format(AXIS_PATTERN, NODE_TEST_PATTERN)
+    PREDICATE_FUNCTION_PATTERN = r"""({0!s})\(([^,]+(,\s*[^,]+)*)?\)(=(.*))?""".format('|'.join(XPATH_FUNCTIONS))
 
     _re_predicate_not = re.compile(PREDICATE_NOT_PATTERN)
     _re_predicate_axis = re.compile(PREDICATE_AXIS_PATTERN)

--- a/lib/imdb/parser/http/characterParser.py
+++ b/lib/imdb/parser/http/characterParser.py
@@ -125,7 +125,7 @@ class DOMHTMLCharacterBioParser(DOMParserBase):
                                 'info': "./preceding-sibling::h4[1]//text()",
                                 'text': ".//text()"
                             },
-                            postprocess=lambda x: u'%s: %s' % (
+                            postprocess=lambda x: u'{0!s}: {1!s}'.format(
                                 x.get('info').strip(),
                                 x.get('text').replace('\n',
                                     ' ').replace('||', '\n\n').strip()))),

--- a/lib/imdb/parser/http/companyParser.py
+++ b/lib/imdb/parser/http/companyParser.py
@@ -64,8 +64,7 @@ class DOMCompanyParser(DOMParserBase):
                                 'year': "./text()[1]"
                                 },
                             postprocess=lambda x:
-                                build_movie(u'%s %s' % \
-                                (x.get('title'), x.get('year').strip()),
+                                build_movie(u'{0!s} {1!s}'.format(x.get('title'), x.get('year').strip()),
                                 movieID=analyze_imdbid(x.get('link') or u''),
                                 _parsingCompany=True))),
             ]

--- a/lib/imdb/parser/http/movieParser.py
+++ b/lib/imdb/parser/http/movieParser.py
@@ -108,8 +108,7 @@ def _manageRoles(mo):
             roleID = u'/'
         else:
             roleID += u'/'
-        newRoles.append(u'<div class="_imdbpyrole" roleid="%s">%s</div>' % \
-                (roleID, role.strip()))
+        newRoles.append(u'<div class="_imdbpyrole" roleid="{0!s}">{1!s}</div>'.format(roleID, role.strip()))
     return firstHalf + u' / '.join(newRoles) + mo.group(3)
 
 
@@ -416,7 +415,7 @@ class DOMHTMLMovieParser(DOMParserBase):
             for a in self.xpath(b, "./following::h5/a[@class='glossary']"):
                 name = a.get('name')
                 if name:
-                    a.set('name', 'series %s' % name)
+                    a.set('name', 'series {0!s}'.format(name))
         # Remove links to IMDbPro.
         for proLink in self.xpath(dom, "//span[@class='pro-link']"):
             proLink.drop_tree()
@@ -486,7 +485,7 @@ class DOMHTMLMovieParser(DOMParserBase):
                 if episode or type(season) is type(0):
                     data['episode'] = episode
         for k in ('writer', 'director'):
-            t_k = 'thin %s' % k
+            t_k = 'thin {0!s}'.format(k)
             if t_k not in data:
                 continue
             if k not in data:
@@ -533,7 +532,7 @@ def _process_plotsummary(x):
     xauthor = x.get('author')
     xplot = x.get('plot', u'').strip()
     if xauthor:
-        xplot += u'::%s' % xauthor
+        xplot += u'::{0!s}'.format(xauthor)
     return xplot
 
 class DOMHTMLPlotParser(DOMParserBase):
@@ -968,7 +967,7 @@ class DOMHTMLReleaseinfoParser(DOMParserBase):
             date = date.strip()
             if not (country and date): continue
             notes = i['notes']
-            info = u'%s::%s' % (country, date)
+            info = u'{0!s}::{1!s}'.format(country, date)
             if notes:
                 info += notes
             rl.append(info)
@@ -987,7 +986,7 @@ class DOMHTMLReleaseinfoParser(DOMParserBase):
                 nakas.append(title)
             else:
                 for country in countries:
-                    nakas.append('%s::%s' % (title, country.strip()))
+                    nakas.append('{0!s}::{1!s}'.format(title, country.strip()))
         if akas:
             del data['akas']
         if nakas:
@@ -1132,10 +1131,10 @@ class DOMHTMLEpisodesRatings(DOMParserBase):
             except:
                 pass
             ept = ept.strip()
-            ept = u'%s {%s' % (title, ept)
+            ept = u'{0!s} {{{1!s}'.format(title, ept)
             nr = i['nr']
             if nr:
-                ept += u' (#%s)' % nr.strip()
+                ept += u' (#{0!s})'.format(nr.strip())
             ept += '}'
             if movieID is not None:
                 movieID = str(movieID)
@@ -1153,7 +1152,7 @@ def _normalize_href(href):
     if (href is not None) and (not href.lower().startswith('http://')):
         if href.startswith('/'): href = href[1:]
         # TODO: imdbURL_base may be set by the user!
-        href = '%s%s' % (imdbURL_base, href)
+        href = '{0!s}{1!s}'.format(imdbURL_base, href)
     return href
 
 class DOMHTMLCriticReviewsParser(DOMParserBase):
@@ -1271,7 +1270,7 @@ class DOMHTMLLocationsParser(DOMParserBase):
                                 path={'place': ".//text()",
                                         'note': "./following-sibling::dd[1]" \
                                                 "//text()"},
-                                postprocess=lambda x: (u'%s::%s' % (
+                                postprocess=lambda x: (u'{0!s}::{1!s}'.format(
                                     x['place'].strip(),
                                     (x['note'] or u'').strip())).strip(':')))]
 
@@ -1443,7 +1442,7 @@ def _parse_review(x):
     if x.get('item') is not None:
         item = x.get('item').strip()
         review = review[len(item):].strip()
-        review = "%s: %s" % (item, review)
+        review = "{0!s}: {1!s}".format(item, review)
     result['review'] = review
     return result
 
@@ -1486,7 +1485,7 @@ class DOMHTMLSeasonEpisodesParser(DOMParserBase):
                 path=".",
                 group="//div[@class='info']",
                 group_key=".//meta/@content",
-                group_key_normalize=lambda x: 'episode %s' % x,
+                group_key_normalize=lambda x: 'episode {0!s}'.format(x),
                 attrs=[Attribute(key=None,
                             multi=True,
                             path={
@@ -1516,9 +1515,9 @@ class DOMHTMLSeasonEpisodesParser(DOMParserBase):
         if 'episode -1' in data:
           counter = 1
           for episode in data['episode -1']:
-            while 'episode %d' % counter in data:
+            while 'episode {0:d}'.format(counter) in data:
               counter += 1
-            k = 'episode %d' % counter
+            k = 'episode {0:d}'.format(counter)
             data[k] = [episode]
           del data['episode -1']
         for episode_nr, episode in data.iteritems():
@@ -1692,7 +1691,7 @@ class DOMHTMLEpisodesParser(DOMParserBase):
                     if not isinstance(episode_key, int):
                         episode_key = ep_counter
                         ep_counter += 1
-                    cast_key = 'Season %s, Episode %s:' % (season_key,
+                    cast_key = 'Season {0!s}, Episode {1!s}:'.format(season_key,
                                                             episode_key)
                     if data.has_key(cast_key):
                         cast = data[cast_key]
@@ -1744,7 +1743,7 @@ class DOMHTMLFaqsParser(DOMParserBase):
                     'question': "./h3/a/span/text()",
                     'answer': "../following-sibling::div[1]//text()"
                 },
-                postprocess=lambda x: u'%s::%s' % (x.get('question').strip(),
+                postprocess=lambda x: u'{0!s}::{1!s}'.format(x.get('question').strip(),
                                     '\n\n'.join(x.get('answer').replace(
                                         '\n\n', '\n').strip().split('||')))))
         ]
@@ -1816,7 +1815,7 @@ class DOMHTMLAiringParser(DOMParserBase):
                         continue
                     epsID = seriesID
                 else:
-                    epsTitle = '%s {%s}' % (data['series title'],
+                    epsTitle = '{0!s} {{{1!s}}}'.format(data['series title'],
                                             airing['title'])
                     epsID = analyze_imdbid(airing['link'])
                 e = Movie(title=epsTitle, movieID=epsID)

--- a/lib/imdb/parser/http/personParser.py
+++ b/lib/imdb/parser/http/personParser.py
@@ -42,7 +42,7 @@ def build_date(date):
     day = date.get('day')
     year = date.get('year')
     if day and year:
-        return "%s %s" % (day, year)
+        return "{0!s} {1!s}".format(day, year)
     if day:
         return day
     if year:
@@ -261,8 +261,7 @@ class DOMHTMLBioParser(DOMParserBase):
                                 'bio': ".//text()",
                                 'by': ".//a[@name='ba']//text()"
                                 },
-                            postprocess=lambda x: "%s::%s" % \
-                                ((x.get('bio') or u'').split('- IMDb Mini Biography By:')[0].strip(),
+                            postprocess=lambda x: "{0!s}::{1!s}".format((x.get('bio') or u'').split('- IMDb Mini Biography By:')[0].strip(),
                                 (x.get('by') or u'').strip() or u'Anonymous'))),
             Extractor(label='spouse',
                         path="//div[h5='Spouse']/table/tr",
@@ -272,8 +271,7 @@ class DOMHTMLBioParser(DOMParserBase):
                                 'name': "./td[1]//text()",
                                 'info': "./td[2]//text()"
                                 },
-                            postprocess=lambda x: ("%s::%s" % \
-                                (x.get('name').strip(),
+                            postprocess=lambda x: ("{0!s}::{1!s}".format(x.get('name').strip(),
                                 (x.get('info') or u'').strip())).strip(':'))),
             Extractor(label='trade mark',
                         path="//div[h5='Trade Mark']/p",
@@ -301,8 +299,7 @@ class DOMHTMLBioParser(DOMParserBase):
                                 'title': "./td[1]//text()",
                                 'info': "./td[2]/text()",
                                 },
-                            postprocess=lambda x: "%s::%s" % \
-                                    (x.get('title').strip(),
+                            postprocess=lambda x: "{0!s}::{1!s}".format(x.get('title').strip(),
                                         x.get('info').strip()))),
             Extractor(label='where now',
                         path="//div[h5='Where Are They Now']/p",

--- a/lib/imdb/parser/http/searchKeywordParser.py
+++ b/lib/imdb/parser/http/searchKeywordParser.py
@@ -67,7 +67,7 @@ def custom_analyze_title4kwd(title, yearNote, outline):
     if not title:
         return {}
     if yearNote:
-        yearNote = '%s)' % yearNote.split(' ')[0]
+        yearNote = '{0!s})'.format(yearNote.split(' ')[0])
         title = title + ' ' + yearNote
     retDict = analyze_title(title)
     if outline:

--- a/lib/imdb/parser/http/searchMovieParser.py
+++ b/lib/imdb/parser/http/searchMovieParser.py
@@ -130,14 +130,14 @@ class DOMHTMLSearchMovieParser(DOMParserBase):
         if not res: return u''
         res = res['data']
         if not (res and res[0]): return u''
-        link = '%s%s' % (self._linkPrefix, res[0][0])
+        link = '{0!s}{1!s}'.format(self._linkPrefix, res[0][0])
         #    # Tries to cope with companies for which links to pro.imdb.com
         #    # are missing.
         #    link = self.url.replace(imdbURL_base[:-1], '')
         title = self._titleBuilder(res[0][1])
         if not (link and title): return u''
         link = link.replace('http://pro.imdb.com', '')
-        new_html = '<td class="result_text"><a href="%s">%s</a></td>' % (link,
+        new_html = '<td class="result_text"><a href="{0!s}">{1!s}</a></td>'.format(link,
                                                                     title)
         return new_html
 

--- a/lib/imdb/parser/http/utils.py
+++ b/lib/imdb/parser/http/utils.py
@@ -120,13 +120,13 @@ entcharrefs['#38'] = u'&amp;'
 entcharrefs['#x26'] = u'&amp;'
 entcharrefs['#x26'] = u'&amp;'
 
-re_entcharrefs = re.compile('&(%s|\#160|\#\d{1,5}|\#x[0-9a-f]{1,4});' %
-                            '|'.join(map(re.escape, entcharrefs)), re.I)
+re_entcharrefs = re.compile('&({0!s}|\#160|\#\d{{1,5}}|\#x[0-9a-f]{{1,4}});'.format(
+                            '|'.join(map(re.escape, entcharrefs))), re.I)
 re_entcharrefssub = re_entcharrefs.sub
 
 sgmlentity.update(dict([('#34', u'"'), ('#38', u'&'),
                         ('#60', u'<'), ('#62', u'>'), ('#39', u"'")]))
-re_sgmlref = re.compile('&(%s);' % '|'.join(map(re.escape, sgmlentity)))
+re_sgmlref = re.compile('&({0!s});'.format('|'.join(map(re.escape, sgmlentity))))
 re_sgmlrefsub = re_sgmlref.sub
 
 # Matches XML-only single tags, like <br/> ; they are invalid in HTML,
@@ -335,7 +335,7 @@ def build_movie(txt, movieID=None, roleID=None, status=None,
         # Else, in parentheses there are some notes.
         # XXX: should the notes in the role half be kept separated
         #      from the notes in the movie title half?
-        if notes: notes = '%s %s' % (title[nidx:], notes)
+        if notes: notes = '{0!s} {1!s}'.format(title[nidx:], notes)
         else: notes = title[nidx:]
         title = title[:nidx].rstrip()
     if year:
@@ -343,10 +343,10 @@ def build_movie(txt, movieID=None, roleID=None, status=None,
         if title[-1:] == ')':
             fpIdx = title.rfind('(')
             if fpIdx != -1:
-                if notes: notes = '%s %s' % (title[fpIdx:], notes)
+                if notes: notes = '{0!s} {1!s}'.format(title[fpIdx:], notes)
                 else: notes = title[fpIdx:]
                 title = title[:fpIdx].rstrip()
-        title = u'%s (%s)' % (title, year)
+        title = u'{0!s} ({1!s})'.format(title, year)
     if _parsingCharacter and roleID and not role:
         roleID = None
     if not roleID:
@@ -455,25 +455,24 @@ class DOMParserBase(object):
                     self._is_xml_unicode = True
                     self.usingModule = 'beautifulsoup'
                 else:
-                    self._logger.warn('unknown module "%s"' % mod)
+                    self._logger.warn('unknown module "{0!s}"'.format(mod))
                     continue
                 self.fromstring = fromstring
                 self._tostring = tostring
                 if _gotError:
-                    warnings.warn('falling back to "%s"' % mod)
+                    warnings.warn('falling back to "{0!s}"'.format(mod))
                 break
             except ImportError, e:
                 if idx+1 >= nrMods:
                     # Raise the exception, if we don't have any more
                     # options to try.
-                    raise IMDbError('unable to use any parser in %s: %s' % \
-                                    (str(useModule), str(e)))
+                    raise IMDbError('unable to use any parser in {0!s}: {1!s}'.format(str(useModule), str(e)))
                 else:
-                    warnings.warn('unable to use "%s": %s' % (mod, str(e)))
+                    warnings.warn('unable to use "{0!s}": {1!s}'.format(mod, str(e)))
                     _gotError = True
                 continue
         else:
-            raise IMDbError('unable to use parsers in %s' % str(useModule))
+            raise IMDbError('unable to use parsers in {0!s}'.format(str(useModule)))
         # Fall-back defaults.
         self._modFunct = None
         self._as = 'http'
@@ -737,16 +736,16 @@ class DOMParserBase(object):
     def add_refs(self, data):
         """Modify data according to the expected output."""
         if self.getRefs:
-            titl_re = ur'(%s)' % '|'.join([re.escape(x) for x
-                                            in self._titlesRefs.keys()])
+            titl_re = ur'({0!s})'.format('|'.join([re.escape(x) for x
+                                            in self._titlesRefs.keys()]))
             if titl_re != ur'()': re_titles = re.compile(titl_re, re.U)
             else: re_titles = None
-            nam_re = ur'(%s)' % '|'.join([re.escape(x) for x
-                                            in self._namesRefs.keys()])
+            nam_re = ur'({0!s})'.format('|'.join([re.escape(x) for x
+                                            in self._namesRefs.keys()]))
             if nam_re != ur'()': re_names = re.compile(nam_re, re.U)
             else: re_names = None
-            chr_re = ur'(%s)' % '|'.join([re.escape(x) for x
-                                            in self._charactersRefs.keys()])
+            chr_re = ur'({0!s})'.format('|'.join([re.escape(x) for x
+                                            in self._charactersRefs.keys()]))
             if chr_re != ur'()': re_characters = re.compile(chr_re, re.U)
             else: re_characters = None
             _putRefs(data, re_titles, re_names, re_characters)
@@ -815,7 +814,7 @@ def _parse_ref(text, link, info):
     if link.find('/title/tt') != -1:
         yearK = re_yearKind_index.match(info)
         if yearK and yearK.start() == 0:
-            text += ' %s' % info[:yearK.end()]
+            text += ' {0!s}'.format(info[:yearK.end()])
     return (text.replace('\n', ' '), link)
 
 

--- a/lib/imdb/parser/mobile/__init__.py
+++ b/lib/imdb/parser/mobile/__init__.py
@@ -83,7 +83,7 @@ def _getTagsWith(s, cont, toClosure=False, maxRes=None):
             else:
                 spaceidx = s[btag:].find(' ')
                 if spaceidx != -1:
-                    ctag = '</%s>' % s[btag+1:btag+spaceidx]
+                    ctag = '</{0!s}>'.format(s[btag+1:btag+spaceidx])
                     closeidx = s[bi:].find(ctag)
                     if closeidx != -1:
                         endidx = bi+closeidx+len(ctag)
@@ -242,7 +242,7 @@ class IMDbMobileAccessSystem(IMDbHTTPAccessSystem):
         cont = self._mretrieve(self.urls['movie_main'] % movieID + 'maindetails')
         title = _findBetween(cont, '<title>', '</title>', maxRes=1)
         if not title:
-            raise IMDbDataAccessError('unable to get movieID "%s"' % movieID)
+            raise IMDbDataAccessError('unable to get movieID "{0!s}"'.format(movieID))
         title = _unHtml(title[0])
         if title.endswith(' - IMDb'):
             title = title[:-7]
@@ -320,7 +320,7 @@ class IMDbMobileAccessSystem(IMDbHTTPAccessSystem):
                                         '<br/> <br/>'), maxRes=1)
             if creator:
                 creator = creator[0]
-                if creator.find('tn15more'): creator = '%s>' % creator
+                if creator.find('tn15more'): creator = '{0!s}>'.format(creator)
                 creator = self._getPersons(creator)
                 if creator: d['creator'] = creator
         writers = _findBetween(cont, '<h5>Writer', ('</div>', '<br/> <br/>'),
@@ -426,26 +426,26 @@ class IMDbMobileAccessSystem(IMDbHTTPAccessSystem):
         country = _findBetween(cont, 'Country:</h5>', '</div>', maxRes=1)
         if country:
             country[:] = country[0].split(' | ')
-            country[:] = ['<a %s' % x for x in country if x]
+            country[:] = ['<a {0!s}'.format(x) for x in country if x]
             country[:] = [_unHtml(x.replace(' <i>', '::')) for x in country]
             if country: d['countries'] = country
         lang = _findBetween(cont, 'Language:</h5>', '</div>', maxRes=1)
         if lang:
             lang[:] = lang[0].split(' | ')
-            lang[:] = ['<a %s' % x for x in lang if x]
+            lang[:] = ['<a {0!s}'.format(x) for x in lang if x]
             lang[:] = [_unHtml(x.replace(' <i>', '::')) for x in lang]
             if lang: d['languages'] = lang
         col = _findBetween(cont, '"/search/title?colors=', '</div>')
         if col:
             col[:] = col[0].split(' | ')
-            col[:] = ['<a %s' % x for x in col if x]
+            col[:] = ['<a {0!s}'.format(x) for x in col if x]
             col[:] = [_unHtml(x.replace(' <i>', '::')) for x in col]
             if col: d['color info'] = col
         sm = _findBetween(cont, '/search/title?sound_mixes=', '</div>',
                             maxRes=1)
         if sm:
             sm[:] = sm[0].split(' | ')
-            sm[:] = ['<a %s' % x for x in sm if x]
+            sm[:] = ['<a {0!s}'.format(x) for x in sm if x]
             sm[:] = [_unHtml(x.replace(' <i>', '::')) for x in sm]
             if sm: d['sound mix'] = sm
         cert = _findBetween(cont, 'Certification:</h5>', '</div>', maxRes=1)
@@ -475,8 +475,7 @@ class IMDbMobileAccessSystem(IMDbHTTPAccessSystem):
             p = plot[i]
             wbyidx = p.rfind(' Written by ')
             if wbyidx != -1:
-                plot[i] = '%s::%s' % \
-                        (p[:wbyidx].rstrip(),
+                plot[i] = '{0!s}::{1!s}'.format(p[:wbyidx].rstrip(),
                     p[wbyidx+12:].rstrip().replace('{','<').replace('}','>'))
         if plot: return {'data': {'plot': plot}}
         return {'data': {}}
@@ -538,7 +537,7 @@ class IMDbMobileAccessSystem(IMDbHTTPAccessSystem):
         if not name:
             if _parseChr: w = 'characterID'
             else: w = 'personID'
-            raise IMDbDataAccessError('unable to get %s "%s"' % (w, personID))
+            raise IMDbDataAccessError('unable to get {0!s} "{1!s}"'.format(w, personID))
         name = _unHtml(name[0].replace(' - IMDb', ''))
         if _parseChr:
             name = name.replace('(Character)', '').strip()
@@ -547,7 +546,7 @@ class IMDbMobileAccessSystem(IMDbHTTPAccessSystem):
             name = name.replace('- Filmography by', '').strip()
         r = analyze_name(name, canonical=not _parseChr)
         for dKind in ('Born', 'Died'):
-            date = _findBetween(s, '%s:</h4>' % dKind.capitalize(),
+            date = _findBetween(s, '{0!s}:</h4>'.format(dKind.capitalize()),
                                 ('<div class', '</div>', '<br/><br/>'), maxRes=1)
             if date:
                 date = _unHtml(date[0])
@@ -563,9 +562,9 @@ class IMDbMobileAccessSystem(IMDbHTTPAccessSystem):
                     if dKind == 'Died':
                         dtitle = 'death'
                     if date:
-                        r['%s date' % dtitle] = date
+                        r['{0!s} date'.format(dtitle)] = date
                     if notes:
-                        r['%s notes' % dtitle] = notes
+                        r['{0!s} notes'.format(dtitle)] = notes
         akas = _findBetween(s, 'Alternate Names:</h4>', ('</div>',
                             '<br/><br/>'), maxRes=1)
         if akas:
@@ -615,7 +614,7 @@ class IMDbMobileAccessSystem(IMDbHTTPAccessSystem):
             if _parseChr and sect == 'filmography':
                 inisect = s.find('<div class="filmo">')
             else:
-                inisect = s.find('<a name="%s' % sect)
+                inisect = s.find('<a name="{0!s}'.format(sect))
             if inisect != -1:
                 endsect = s[inisect:].find('<div id="filmo-head-')
                 if endsect == -1:
@@ -666,7 +665,7 @@ class IMDbMobileAccessSystem(IMDbHTTPAccessSystem):
                 year = _findBetween(m, 'year_column">', '</span>', maxRes=1)
                 if year:
                     year = year[0]
-                    m = m.replace('<span class="year_column">%s</span>' % year,
+                    m = m.replace('<span class="year_column">{0!s}</span>'.format(year),
                             '')
                 else:
                     year = None
@@ -761,7 +760,7 @@ class IMDbMobileAccessSystem(IMDbHTTPAccessSystem):
                         bioAuth = bio[:byidx].rstrip()
                     else:
                         bioAuth = 'Anonymous'
-                    bio = u'%s::%s' % (bioAuth, bio[byidx+23:].lstrip())
+                    bio = u'{0!s}::{1!s}'.format(bioAuth, bio[byidx+23:].lstrip())
                     ndata.append(bio)
                 data[:] = ndata
                 if 'mini biography' in d:
@@ -795,7 +794,7 @@ class IMDbMobileAccessSystem(IMDbHTTPAccessSystem):
             lis = _findBetween(cont, '<td class="result_text"',
                                 ['<small', '</td>', '<br'])
             for li in lis:
-                li = '<%s' % li
+                li = '<{0!s}'.format(li)
                 pid = re_imdbID.findall(li)
                 pname = _unHtml(li)
                 if not (pid and pname):

--- a/lib/imdb/parser/sql/__init__.py
+++ b/lib/imdb/parser/sql/__init__.py
@@ -180,7 +180,7 @@ def scan_names(name_list, name1, name2, name3, results=0, ro_thresold=None,
         if not _scan_character:
             nils = nil.split(', ', 1)
             surname = nils[0]
-            if len(nils) == 2: namesurname = '%s %s' % (nils[1], surname)
+            if len(nils) == 2: namesurname = '{0!s} {1!s}'.format(nils[1], surname)
         else:
             nils = nil.split(' ', 1)
             surname = nils[-1]
@@ -512,7 +512,7 @@ def getSingleInfo(table, movieID, infoType, notAList=False):
         info = r.info
         note = r.note
         if note:
-            info += u'::%s' % note
+            info += u'::{0!s}'.format(note)
         retList.append(info)
     if not retList:
         return {}
@@ -565,7 +565,7 @@ class IMDbSqlAccessSystem(IMDbBase):
                                                 setConnection, AND, OR, IN, \
                                                 ISNULL, CONTAINSSTRING, toUTF8
                 else:
-                    self._sql_logger.warn('unknown module "%s"' % mod)
+                    self._sql_logger.warn('unknown module "{0!s}"'.format(mod))
                     continue
                 self._sql_logger.info('using %s ORM', mod)
                 # XXX: look ma'... black magic!  It's used to make
@@ -581,19 +581,19 @@ class IMDbSqlAccessSystem(IMDbBase):
                 for t in DB_TABLES:
                     globals()[t._imdbpyName] = t
                 if _gotError:
-                    self._sql_logger.warn('falling back to "%s"' % mod)
+                    self._sql_logger.warn('falling back to "{0!s}"'.format(mod))
                 break
             except ImportError, e:
                 if idx+1 >= nrMods:
-                    raise IMDbError('unable to use any ORM in %s: %s' % (
+                    raise IMDbError('unable to use any ORM in {0!s}: {1!s}'.format(
                                                     str(useORM), str(e)))
                 else:
-                    self._sql_logger.warn('unable to use "%s": %s' % (mod,
+                    self._sql_logger.warn('unable to use "{0!s}": {1!s}'.format(mod,
                                                                     str(e)))
                     _gotError = True
                 continue
         else:
-            raise IMDbError('unable to use any ORM in %s' % str(useORM))
+            raise IMDbError('unable to use any ORM in {0!s}'.format(str(useORM)))
         # Set the connection to the database.
         self._sql_logger.debug('connecting to %s', uri)
         try:
@@ -601,7 +601,7 @@ class IMDbSqlAccessSystem(IMDbBase):
         except AssertionError, e:
             raise IMDbDataAccessError( \
                     'unable to connect to the database server; ' + \
-                    'complete message: "%s"' % str(e))
+                    'complete message: "{0!s}"'.format(str(e)))
         self.Error = self._connection.module.Error
         # Maps some IDs to the corresponding strings.
         self._kind = {}
@@ -793,32 +793,30 @@ class IMDbSqlAccessSystem(IMDbBase):
         try:
             return int(movieID)
         except (ValueError, OverflowError):
-            raise IMDbError('movieID "%s" can\'t be converted to integer' % \
-                            movieID)
+            raise IMDbError('movieID "{0!s}" can\'t be converted to integer'.format( \
+                            movieID))
 
     def _normalize_personID(self, personID):
         """Normalize the given personID."""
         try:
             return int(personID)
         except (ValueError, OverflowError):
-            raise IMDbError('personID "%s" can\'t be converted to integer' % \
-                            personID)
+            raise IMDbError('personID "{0!s}" can\'t be converted to integer'.format( \
+                            personID))
 
     def _normalize_characterID(self, characterID):
         """Normalize the given characterID."""
         try:
             return int(characterID)
         except (ValueError, OverflowError):
-            raise IMDbError('characterID "%s" can\'t be converted to integer' \
-                            % characterID)
+            raise IMDbError('characterID "{0!s}" can\'t be converted to integer'.format(characterID))
 
     def _normalize_companyID(self, companyID):
         """Normalize the given companyID."""
         try:
             return int(companyID)
         except (ValueError, OverflowError):
-            raise IMDbError('companyID "%s" can\'t be converted to integer' \
-                            % companyID)
+            raise IMDbError('companyID "{0!s}" can\'t be converted to integer'.format(companyID))
 
     def get_imdbMovieID(self, movieID):
         """Translate a movieID in an imdbID.
@@ -828,7 +826,7 @@ class IMDbSqlAccessSystem(IMDbBase):
         try: movie = Title.get(movieID)
         except NotFoundError: return None
         imdbID = movie.imdbID
-        if imdbID is not None: return '%07d' % imdbID
+        if imdbID is not None: return '{0:07d}'.format(imdbID)
         m_dict = get_movie_data(movie.id, self._kind)
         titline = build_title(m_dict, ptdf=0)
         imdbID = self.title2imdbID(titline, m_dict['kind'])
@@ -850,7 +848,7 @@ class IMDbSqlAccessSystem(IMDbBase):
         try: person = Name.get(personID)
         except NotFoundError: return None
         imdbID = person.imdbID
-        if imdbID is not None: return '%07d' % imdbID
+        if imdbID is not None: return '{0:07d}'.format(imdbID)
         n_dict = {'name': person.name, 'imdbIndex': person.imdbIndex}
         namline = build_name(n_dict, canonical=False)
         imdbID = self.name2imdbID(namline)
@@ -867,7 +865,7 @@ class IMDbSqlAccessSystem(IMDbBase):
         try: character = CharName.get(characterID)
         except NotFoundError: return None
         imdbID = character.imdbID
-        if imdbID is not None: return '%07d' % imdbID
+        if imdbID is not None: return '{0:07d}'.format(imdbID)
         n_dict = {'name': character.name, 'imdbIndex': character.imdbIndex}
         namline = build_name(n_dict, canonical=False)
         imdbID = self.character2imdbID(namline)
@@ -884,7 +882,7 @@ class IMDbSqlAccessSystem(IMDbBase):
         try: company = CompanyName.get(companyID)
         except NotFoundError: return None
         imdbID = company.imdbID
-        if imdbID is not None: return '%07d' % imdbID
+        if imdbID is not None: return '{0:07d}'.format(imdbID)
         n_dict = {'name': company.name, 'country': company.countryCode}
         namline = build_company_name(n_dict)
         imdbID = self.company2imdbID(namline)
@@ -985,7 +983,7 @@ class IMDbSqlAccessSystem(IMDbBase):
             qr += q2
         except NotFoundError, e:
             raise IMDbDataAccessError( \
-                    'unable to search the database: "%s"' % str(e))
+                    'unable to search the database: "{0!s}"'.format(str(e)))
 
         resultsST = results * 3
         res = scan_titles(qr, title1, title2, title3, resultsST,
@@ -1032,9 +1030,9 @@ class IMDbSqlAccessSystem(IMDbBase):
             res = get_movie_data(movieID, self._kind)
         except NotFoundError, e:
             raise IMDbDataAccessError( \
-                    'unable to get movieID "%s": "%s"' % (movieID, str(e)))
+                    'unable to get movieID "{0!s}": "{1!s}"'.format(movieID, str(e)))
         if not res:
-            raise IMDbDataAccessError('unable to get movieID "%s"' % movieID)
+            raise IMDbDataAccessError('unable to get movieID "{0!s}"'.format(movieID))
         # Collect cast information.
         castdata = [[cd.personID, cd.personRoleID, cd.note, cd.nrOrder,
                     self._role[cd.roleID]]
@@ -1078,7 +1076,7 @@ class IMDbSqlAccessSystem(IMDbBase):
             sect = group[0][0]
             for mdata in group:
                 data = mdata[1]
-                if mdata[2]: data += '::%s' % mdata[2]
+                if mdata[2]: data += '::{0!s}'.format(mdata[2])
                 res.setdefault(sect, []).append(data)
         # Companies info about a movie.
         cinfo = [(self._compType[m.companyTypeID], m.companyID, m.note) for m
@@ -1090,7 +1088,7 @@ class IMDbSqlAccessSystem(IMDbBase):
                 cDb = CompanyName.get(mdata[1])
                 cDbTxt = cDb.name
                 if cDb.countryCode:
-                    cDbTxt += ' %s' % cDb.countryCode
+                    cDbTxt += ' {0!s}'.format(cDb.countryCode)
                 company = Company(name=cDbTxt,
                                 companyID=mdata[1],
                                 notes=mdata[2] or u'',
@@ -1106,7 +1104,7 @@ class IMDbSqlAccessSystem(IMDbBase):
                 if note:
                     net = self._changeAKAencoding(note, nt)
                     if net is not None: nt = net
-                    nt += '::%s' % note
+                    nt += '::{0!s}'.format(note)
                 if nt not in res['akas']: res['akas'].append(nt)
         # Complete cast/crew.
         compcast = [(self._compcast[cc.subjectID], self._compcast[cc.statusID])
@@ -1114,7 +1112,7 @@ class IMDbSqlAccessSystem(IMDbBase):
         if compcast:
             for entry in compcast:
                 val = unicode(entry[1])
-                res[u'complete %s' % entry[0]] = val
+                res[u'complete {0!s}'.format(entry[0])] = val
         # Movie connections.
         mlinks = [[ml.linkedMovieID, self._link[ml.linkTypeID]]
                     for ml in MovieLink.select(MovieLink.q.movieID == movieID)]
@@ -1245,7 +1243,7 @@ class IMDbSqlAccessSystem(IMDbBase):
             qr += q2
         except NotFoundError, e:
             raise IMDbDataAccessError( \
-                    'unable to search the database: "%s"' % str(e))
+                    'unable to search the database: "{0!s}"'.format(str(e)))
 
         res = scan_names(qr, name1, name2, name3, results)
         res[:] = [x[1] for x in res]
@@ -1286,11 +1284,11 @@ class IMDbSqlAccessSystem(IMDbBase):
             p = Name.get(personID)
         except NotFoundError, e:
             raise IMDbDataAccessError( \
-                    'unable to get personID "%s": "%s"' % (personID, str(e)))
+                    'unable to get personID "{0!s}": "{1!s}"'.format(personID, str(e)))
         res = {'name': p.name, 'imdbIndex': p.imdbIndex}
         if res['imdbIndex'] is None: del res['imdbIndex']
         if not res:
-            raise IMDbDataAccessError('unable to get personID "%s"' % personID)
+            raise IMDbDataAccessError('unable to get personID "{0!s}"'.format(personID))
         # Collect cast information.
         castdata = [(cd.movieID, cd.personRoleID, cd.note,
                     self._role[cd.roleID],
@@ -1308,8 +1306,8 @@ class IMDbSqlAccessSystem(IMDbBase):
                 if 'episode of' in mdata[4]:
                     duty = 'episodes'
                     if orig_duty not in ('actor', 'actress'):
-                        if note: note = ' %s' % note
-                        note = '[%s]%s' % (orig_duty, note)
+                        if note: note = ' {0!s}'.format(note)
+                        note = '[{0!s}]{1!s}'.format(orig_duty, note)
                 curRole = mdata[1]
                 curRoleID = None
                 if curRole is not None:
@@ -1344,7 +1342,7 @@ class IMDbSqlAccessSystem(IMDbBase):
             sect = group[0][0]
             for pdata in group:
                 data = pdata[1]
-                if pdata[2]: data += '::%s' % pdata[2]
+                if pdata[2]: data += '::{0!s}'.format(pdata[2])
                 res.setdefault(sect, []).append(data)
         # AKA names.
         akan = [(an.name, an.imdbIndex)
@@ -1396,7 +1394,7 @@ class IMDbSqlAccessSystem(IMDbBase):
         soundexName2 = None
         nsplit = s_name.split()
         if len(nsplit) > 1:
-            name2 = '%s %s' % (nsplit[-1], ' '.join(nsplit[:-1]))
+            name2 = '{0!s} {1!s}'.format(nsplit[-1], ' '.join(nsplit[:-1]))
             if s_name == name2:
                 name2 = ''
             else:
@@ -1421,7 +1419,7 @@ class IMDbSqlAccessSystem(IMDbBase):
                     for q in CharName.select(condition)]
         except NotFoundError, e:
             raise IMDbDataAccessError( \
-                    'unable to search the database: "%s"' % str(e))
+                    'unable to search the database: "{0!s}"'.format(str(e)))
         res = scan_names(qr, s_name, name2, '', results,
                         _scan_character=True)
         res[:] = [x[1] for x in res]
@@ -1441,12 +1439,12 @@ class IMDbSqlAccessSystem(IMDbBase):
             c = CharName.get(characterID)
         except NotFoundError, e:
             raise IMDbDataAccessError( \
-                    'unable to get characterID "%s": "%s"' % (characterID, e))
+                    'unable to get characterID "{0!s}": "{1!s}"'.format(characterID, e))
         res = {'name': c.name, 'imdbIndex': c.imdbIndex}
         if res['imdbIndex'] is None: del res['imdbIndex']
         if not res:
-            raise IMDbDataAccessError('unable to get characterID "%s"' % \
-                                        characterID)
+            raise IMDbDataAccessError('unable to get characterID "{0!s}"'.format( \
+                                        characterID))
         # Collect filmography information.
         items = CastInfo.select(CastInfo.q.personRoleID == characterID)
         if results > 0:
@@ -1496,7 +1494,7 @@ class IMDbSqlAccessSystem(IMDbBase):
                     for q in CompanyName.select(condition)]
         except NotFoundError, e:
             raise IMDbDataAccessError( \
-                    'unable to search the database: "%s"' % str(e))
+                    'unable to search the database: "{0!s}"'.format(str(e)))
         qr[:] = [(x[0], build_company_name(x[1])) for x in qr]
         res = scan_company_names(qr, name, results)
         res[:] = [x[1] for x in res]
@@ -1517,12 +1515,12 @@ class IMDbSqlAccessSystem(IMDbBase):
             c = CompanyName.get(companyID)
         except NotFoundError, e:
             raise IMDbDataAccessError( \
-                    'unable to get companyID "%s": "%s"' % (companyID, e))
+                    'unable to get companyID "{0!s}": "{1!s}"'.format(companyID, e))
         res = {'name': c.name, 'country': c.countryCode}
         if res['country'] is None: del res['country']
         if not res:
-            raise IMDbDataAccessError('unable to get companyID "%s"' % \
-                                        companyID)
+            raise IMDbDataAccessError('unable to get companyID "{0!s}"'.format( \
+                                        companyID))
         # Collect filmography information.
         items = MovieCompanies.select(MovieCompanies.q.companyID == companyID)
         if results > 0:

--- a/lib/imdb/parser/sql/alchemyadapter.py
+++ b/lib/imdb/parser/sql/alchemyadapter.py
@@ -80,7 +80,7 @@ class DNNameObj(object):
         self.dbName = dbName
 
     def __repr__(self):
-        return '<DNNameObj(dbName=%s) [id=%s]>' % (self.dbName, id(self))
+        return '<DNNameObj(dbName={0!s}) [id={1!s}]>'.format(self.dbName, id(self))
 
 
 class DNNameDict(object):
@@ -92,7 +92,7 @@ class DNNameDict(object):
         return DNNameObj(self.colMap[key])
 
     def __repr__(self):
-        return '<DNNameDict(colMap=%s) [id=%s]>' % (self.colMap, id(self))
+        return '<DNNameDict(colMap={0!s}) [id={1!s}]>'.format(self.colMap, id(self))
 
 
 class SQLMetaAdapter(object):
@@ -114,8 +114,7 @@ class SQLMetaAdapter(object):
         return None
 
     def __repr__(self):
-        return '<SQLMetaAdapter(table=%s, colMap=%s) [id=%s]>' % \
-                (repr(self.table), repr(self.colMap), id(self))
+        return '<SQLMetaAdapter(table={0!s}, colMap={1!s}) [id={2!s}]>'.format(repr(self.table), repr(self.colMap), id(self))
 
 
 class QAdapter(object):
@@ -128,11 +127,10 @@ class QAdapter(object):
 
     def __getattr__(self, name):
         try: return getattr(self.table.c, self.colMap[name])
-        except KeyError, e: raise AttributeError("unable to get '%s'" % name)
+        except KeyError, e: raise AttributeError("unable to get '{0!s}'".format(name))
 
     def __repr__(self):
-        return '<QAdapter(table=%s, colMap=%s) [id=%s]>' % \
-                (repr(self.table), repr(self.colMap), id(self))
+        return '<QAdapter(table={0!s}, colMap={1!s}) [id={2!s}]>'.format(repr(self.table), repr(self.colMap), id(self))
 
 
 class RowAdapter(object):
@@ -150,7 +148,7 @@ class RowAdapter(object):
 
     def __getattr__(self, name):
         try: return getattr(self.row, self.colMap[name])
-        except KeyError, e: raise AttributeError("unable to get '%s'" % name)
+        except KeyError, e: raise AttributeError("unable to get '{0!s}'".format(name))
 
     def __setattr__(self, name, value):
         # FIXME: I can't even think about how much performances suffer,
@@ -176,8 +174,7 @@ class RowAdapter(object):
         object.__setattr__(self, name, value)
 
     def __repr__(self):
-        return '<RowAdapter(row=%s, table=%s, colMap=%s) [id=%s]>' % \
-                (repr(self.row), repr(self.table), repr(self.colMap), id(self))
+        return '<RowAdapter(row={0!s}, table={1!s}, colMap={2!s}) [id={3!s}]>'.format(repr(self.row), repr(self.table), repr(self.colMap), id(self))
 
 
 class ResultAdapter(object):
@@ -213,8 +210,7 @@ class ResultAdapter(object):
             yield RowAdapter(item, self.table, colMap=self.colMap)
 
     def __repr__(self):
-        return '<ResultAdapter(result=%s, table=%s, colMap=%s) [id=%s]>' % \
-                (repr(self.result), repr(self.table),
+        return '<ResultAdapter(result={0!s}, table={1!s}, colMap={2!s}) [id={3!s}]>'.format(repr(self.result), repr(self.table),
                     repr(self.colMap), id(self))
 
 
@@ -294,7 +290,7 @@ class TableAdapter(object):
         try:
             return result[0]
         except KeyError:
-            raise NotFoundError('no data for ID %s' % theID)
+            raise NotFoundError('no data for ID {0!s}'.format(theID))
 
     def dropTable(self, checkfirst=True):
         """Drop the table."""
@@ -326,7 +322,7 @@ class TableAdapter(object):
         #      indexes will be over the whole 255 chars strings...
         # NOTE: don't use a dot as a separator, or DB2 will do
         #       nasty things.
-        idx_name = '%s_%s' % (self.table.name, col.index or col.name)
+        idx_name = '{0!s}_{1!s}'.format(self.table.name, col.index or col.name)
         if checkfirst:
             for index in self.table.indexes:
                 if index.name == idx_name:
@@ -340,8 +336,7 @@ class TableAdapter(object):
         try:
             idx.create()
         except exc.OperationalError, e:
-            _alchemy_logger.warn('Skipping creation of the %s.%s index: %s' %
-                                (self.sqlmeta.table, col.name, e))
+            _alchemy_logger.warn('Skipping creation of the {0!s}.{1!s} index: {2!s}'.format(self.sqlmeta.table, col.name, e))
 
     def addIndexes(self, ifNotExists=True):
         """Create all required indexes."""
@@ -375,7 +370,7 @@ class TableAdapter(object):
             foreignCol = getattr(foreignTable.c, foreignColName)
             # Need to explicitly set an unique name, otherwise it will
             # explode, if two cols points to the same table.
-            fkName = 'fk_%s_%s_%d' % (foreignTable.name, foreignColName,
+            fkName = 'fk_{0!s}_{1!s}_{2:d}'.format(foreignTable.name, foreignColName,
                                         countCols)
             constrain = migrate.changeset.ForeignKeyConstraint([thisCol],
                                                         [foreignCol],
@@ -393,7 +388,7 @@ class TableAdapter(object):
         self._ta_insert.execute(*args, **taArgs)
 
     def __repr__(self):
-        return '<TableAdapter(table=%s) [id=%s]>' % (repr(self.table), id(self))
+        return '<TableAdapter(table={0!s}) [id={1!s}]>'.format(repr(self.table), id(self))
 
 
 # Module-level "cache" for SQLObject classes, to prevent
@@ -445,7 +440,7 @@ def ISNOTNULL(x):
 
 def CONTAINSSTRING(expr, pattern):
     """Emulate SQLObject's CONTAINSSTRING."""
-    return expr.like('%%%s%%' % pattern)
+    return expr.like('%{0!s}%'.format(pattern))
 
 
 def toUTF8(s):
@@ -474,7 +469,7 @@ def setConnection(uri, tables, encoding='utf8', debug=False):
             uri += '&'
         else:
             uri += '?'
-        uri += 'charset=%s' % encoding
+        uri += 'charset={0!s}'.format(encoding)
         
         # On some server configurations, we will need to explictly enable
         # loading data from local files

--- a/lib/imdb/parser/sql/dbschema.py
+++ b/lib/imdb/parser/sql/dbschema.py
@@ -59,38 +59,38 @@ class DBCol(object):
 
     def __str__(self):
         """Class representation."""
-        s = '<DBCol %s %s' % (self.name, _strMap[self.kind])
+        s = '<DBCol {0!s} {1!s}'.format(self.name, _strMap[self.kind])
         if self.index:
             s += ' INDEX'
             if self.indexLen:
-                s += '[:%d]' % self.indexLen
+                s += '[:{0:d}]'.format(self.indexLen)
         if self.foreignKey:
             s += ' FOREIGN'
         if 'default' in self.params:
             val = self.params['default']
             if val is not None:
-                val = '"%s"' % val
-            s += ' DEFAULT=%s' % val
+                val = '"{0!s}"'.format(val)
+            s += ' DEFAULT={0!s}'.format(val)
         for param in self.params:
             if param == 'default': continue
-            s += ' %s' % param.upper()
+            s += ' {0!s}'.format(param.upper())
         s += '>'
         return s
 
     def __repr__(self):
         """Class representation."""
-        s = '<DBCol(name="%s", %s' % (self.name, _strMap[self.kind])
+        s = '<DBCol(name="{0!s}", {1!s}'.format(self.name, _strMap[self.kind])
         if self.index:
-            s += ', index="%s"' % self.index
+            s += ', index="{0!s}"'.format(self.index)
         if self.indexLen:
-             s += ', indexLen=%d' % self.indexLen
+             s += ', indexLen={0:d}'.format(self.indexLen)
         if self.foreignKey:
-            s += ', foreignKey="%s"' % self.foreignKey
+            s += ', foreignKey="{0!s}"'.format(self.foreignKey)
         for param in self.params:
             val = self.params[param]
             if isinstance(val, (unicode, str)):
-                val = u'"%s"' % val
-            s += ', %s=%s' % (param, val)
+                val = u'"{0!s}"'.format(val)
+            s += ', {0!s}={1!s}'.format(param, val)
         s += ')>'
         return s
 
@@ -105,18 +105,18 @@ class DBTable(object):
 
     def __str__(self):
         """Class representation."""
-        return '<DBTable %s (%d cols, %d values)>' % (self.name,
+        return '<DBTable {0!s} ({1:d} cols, {2:d} values)>'.format(self.name,
                 len(self.cols), sum([len(v) for v in self.values.values()]))
 
     def __repr__(self):
         """Class representation."""
-        s = '<DBTable(name="%s"' % self.name
+        s = '<DBTable(name="{0!s}"'.format(self.name)
         col_s = ', '.join([repr(col).rstrip('>').lstrip('<')
                             for col in self.cols])
         if col_s:
-            s += ', %s' % col_s
+            s += ', {0!s}'.format(col_s)
         if self.values:
-            s += ', values=%s' % self.values
+            s += ', values={0!s}'.format(self.values)
         s += ')>'
         return s
 

--- a/lib/imdb/parser/sql/objectadapter.py
+++ b/lib/imdb/parser/sql/objectadapter.py
@@ -60,8 +60,7 @@ def addIndexes(cls, ifNotExists=True):
     try:
         cls.createIndexes(ifNotExists)
     except dberrors.OperationalError, e:
-        _object_logger.warn('Skipping creation of the %s.%s index: %s' %
-                            (cls.sqlmeta.table, col.name, e))
+        _object_logger.warn('Skipping creation of the {0!s}.{1!s} index: {2!s}'.format(cls.sqlmeta.table, col.name, e))
 addIndexes = classmethod(addIndexes)
 
 
@@ -107,7 +106,7 @@ def addForeignKeys(cls, mapTables, ifNotExists=True):
     # Do not even try, if there are no FK, in this table.
     if not filter(None, [col.foreignKey for col in cls._imdbpySchema.cols]):
         return
-    fakeTableName = 'myfaketable%s' % cls.sqlmeta.table
+    fakeTableName = 'myfaketable{0!s}'.format(cls.sqlmeta.table)
     if fakeTableName in FAKE_TABLES_REPOSITORY:
         newcls = FAKE_TABLES_REPOSITORY[fakeTableName]
     else:

--- a/lib/imdb/utils.py
+++ b/lib/imdb/utils.py
@@ -151,7 +151,7 @@ def analyze_name(name, canonical=None):
             # XXX: for the birth and death dates case like " (1926-2004)"
             name = re_parentheses.sub('', name).strip()
     if not name:
-        raise IMDbParserError('invalid name: "%s"' % original_n)
+        raise IMDbParserError('invalid name: "{0!s}"'.format(original_n))
     if canonical is not None:
         if canonical:
             name = canonicalName(name)
@@ -179,7 +179,7 @@ def build_name(name_dict, canonical=None):
             name = normalizeName(name)
     imdbIndex = name_dict.get('imdbIndex')
     if imdbIndex:
-        name += ' (%s)' % imdbIndex
+        name += ' ({0!s})'.format(imdbIndex)
     return name
 
 
@@ -207,7 +207,7 @@ def canonicalTitle(title, lang=None, imdbIndex=None):
         _format = '%s%s, %s'
     ltitle = title.lower()
     if imdbIndex:
-        imdbIndex = ' (%s)' % imdbIndex
+        imdbIndex = ' ({0!s})'.format(imdbIndex)
     else:
         imdbIndex = ''
     spArticles = linguistics.spArticlesForLang(lang)
@@ -448,7 +448,7 @@ def analyze_title(title, canonical=None, canonicalSeries=None,
         if last_yi[1]:
             imdbIndex = last_yi[1][1:]
             year = year[:-len(imdbIndex)-1]
-        i = title.rfind('(%s)' % last_yi[0])
+        i = title.rfind('({0!s})'.format(last_yi[0]))
         if i != -1:
             title = title[:i-1].rstrip()
     # This is a tv (mini) series: strip the '"' at the begin and at the end.
@@ -458,7 +458,7 @@ def analyze_title(title, canonical=None, canonicalSeries=None,
             kind = u'tv series'
         title = title[1:-1].strip()
     if not title:
-        raise IMDbParserError('invalid title: "%s"' % original_t)
+        raise IMDbParserError('invalid title: "{0!s}"'.format(original_t))
     if canonical is not None:
         if canonical:
             title = canonicalTitle(title)
@@ -494,13 +494,13 @@ def _convertTime(title, fromPTDFtoWEB=1, _emptyString=u''):
             from_format = _ptdf_format
             to_format = _web_format
         else:
-            from_format = u'Episode dated %s' % _web_format
+            from_format = u'Episode dated {0!s}'.format(_web_format)
             to_format = _ptdf_format
         t = strptime(title, from_format)
         title = strftime(to_format, t)
         if fromPTDFtoWEB:
             if title[0] == '0': title = title[1:]
-            title = u'Episode dated %s' % title
+            title = u'Episode dated {0!s}'.format(title)
     except ValueError:
         pass
     if isinstance(_emptyString, str):
@@ -565,16 +565,16 @@ def build_title(title_dict, canonical=None, canonicalSeries=None,
             oad = title_dict.get('original air date', _emptyString)
             if len(oad) == 10 and oad[4] == '-' and oad[7] == '-' and \
                         episode_title.find(oad) == -1:
-                episode_title += ' (%s)' % oad
+                episode_title += ' ({0!s})'.format(oad)
             seas = title_dict.get('season')
             if seas is not None:
-                episode_title += ' (#%s' % seas
+                episode_title += ' (#{0!s}'.format(seas)
                 episode = title_dict.get('episode')
                 if episode is not None:
-                    episode_title += '.%s' % episode
+                    episode_title += '.{0!s}'.format(episode)
                 episode_title += ')'
-            episode_title = '{%s}' % episode_title
-        return _emptyString + '%s %s' % (_emptyString + pre_title,
+            episode_title = '{{{0!s}}}'.format(episode_title)
+        return _emptyString + '{0!s} {1!s}'.format(_emptyString + pre_title,
                             _emptyString + episode_title)
     title = title_dict.get('title', '')
     imdbIndex = title_dict.get('imdbIndex', '')
@@ -585,9 +585,9 @@ def build_title(title_dict, canonical=None, canonicalSeries=None,
         else:
             title = normalizeTitle(title, lang=lang)
     if pre_title:
-        title = '%s %s' % (pre_title, title)
+        title = '{0!s} {1!s}'.format(pre_title, title)
     if kind in (u'tv series', u'tv mini series'):
-        title = '"%s"' % title
+        title = '"{0!s}"'.format(title)
     if _doYear:
         year = title_dict.get('year') or '????'
         if isinstance(_emptyString, str):
@@ -595,12 +595,12 @@ def build_title(title_dict, canonical=None, canonicalSeries=None,
         imdbIndex = title_dict.get('imdbIndex')
         if not ptdf:
             if imdbIndex and (canonical is None or canonical):
-                title += ' (%s)' % imdbIndex
-            title += ' (%s)' % year
+                title += ' ({0!s})'.format(imdbIndex)
+            title += ' ({0!s})'.format(year)
         else:
-            title += ' (%s' % year
+            title += ' ({0!s}'.format(year)
             if imdbIndex and (canonical is None or canonical):
-                title += '/%s' % imdbIndex
+                title += '/{0!s}'.format(imdbIndex)
             title += ')'
     if appendKind and kind:
         if kind == 'tv movie':
@@ -648,7 +648,7 @@ def analyze_company_name(name, stripNotes=False):
                 country = name[idx:]
                 name = name[:idx].rstrip()
     if not name:
-        raise IMDbParserError('invalid name: "%s"' % o_name)
+        raise IMDbParserError('invalid name: "{0!s}"'.format(o_name))
     result = {'name': name}
     if country:
         result['country'] = country
@@ -664,7 +664,7 @@ def build_company_name(name_dict, _emptyString=u''):
         return _emptyString
     country = name_dict.get('country')
     if country is not None:
-        name += ' %s' % country
+        name += ' {0!s}'.format(country)
     return name
 
 
@@ -916,7 +916,7 @@ def _handleTextNotes(s):
     ssplit = s.split('::', 1)
     if len(ssplit) == 1:
         return s
-    return u'%s<notes>%s</notes>' % (ssplit[0], ssplit[1])
+    return u'{0!s}<notes>{1!s}</notes>'.format(ssplit[0], ssplit[1])
 
 
 def _normalizeValue(value, withRefs=False, modFunct=None, titlesRefs=None,
@@ -968,29 +968,28 @@ def _tag4TON(ton, addAccessSystem=False, _containerOnly=False):
                             u'<name>%s</name></%s>' % (crTag, crID,
                                                         crValue, crTag)
             else:
-                extras += u'<current-role><%s><name>%s</name></%s>' % \
-                               (crTag, crValue, crTag)
+                extras += u'<current-role><{0!s}><name>{1!s}</name></{2!s}>'.format(crTag, crValue, crTag)
             if cr.notes:
-                extras += u'<notes>%s</notes>' % _normalizeValue(cr.notes)
+                extras += u'<notes>{0!s}</notes>'.format(_normalizeValue(cr.notes))
             extras += u'</current-role>'
     theID = ton.getID()
     if theID is not None:
-        beginTag = u'<%s id="%s"' % (tag, theID)
+        beginTag = u'<{0!s} id="{1!s}"'.format(tag, theID)
         if addAccessSystem and ton.accessSystem:
-            beginTag += ' access-system="%s"' % ton.accessSystem
+            beginTag += ' access-system="{0!s}"'.format(ton.accessSystem)
         if not _containerOnly:
-            beginTag += u'><%s>%s</%s>' % (what, value, what)
+            beginTag += u'><{0!s}>{1!s}</{2!s}>'.format(what, value, what)
         else:
             beginTag += u'>'
     else:
         if not _containerOnly:
-            beginTag = u'<%s><%s>%s</%s>' % (tag, what, value, what)
+            beginTag = u'<{0!s}><{1!s}>{2!s}</{3!s}>'.format(tag, what, value, what)
         else:
-            beginTag = u'<%s>' % tag
+            beginTag = u'<{0!s}>'.format(tag)
     beginTag += extras
     if ton.notes:
-        beginTag += u'<notes>%s</notes>' % _normalizeValue(ton.notes)
-    return (beginTag, u'</%s>' % tag)
+        beginTag += u'<notes>{0!s}</notes>'.format(_normalizeValue(ton.notes))
+    return (beginTag, u'</{0!s}>'.format(tag))
 
 
 TAGS_TO_MODIFY = {
@@ -1048,9 +1047,9 @@ def _tagAttr(key, fullpath):
         # This will proably break the DTD/schema, but at least it will
         # produce a valid XML.
         tagName = 'item'
-        _utils_logger.error('invalid tag: %s [%s]' % (_escapedKey, fullpath))
+        _utils_logger.error('invalid tag: {0!s} [{1!s}]'.format(_escapedKey, fullpath))
         attrs['key'] = _escapedKey
-    return tagName, u' '.join([u'%s="%s"' % i for i in attrs.items()])
+    return tagName, u' '.join([u'{0!s}="{1!s}"'.format(*i) for i in attrs.items()])
 
 
 def _seq2xml(seq, _l=None, withRefs=False, modFunct=None,
@@ -1071,34 +1070,34 @@ def _seq2xml(seq, _l=None, withRefs=False, modFunct=None,
                 tagName = key.__class__.__name__.lower()
             else:
                 tagName, attrs = _tagAttr(key, fullpath)
-                openTag = u'<%s' % tagName
+                openTag = u'<{0!s}'.format(tagName)
                 if attrs:
-                    openTag += ' %s' % attrs
+                    openTag += ' {0!s}'.format(attrs)
                 if _topLevel and key2infoset and key in key2infoset:
-                    openTag += u' infoset="%s"' % key2infoset[key]
+                    openTag += u' infoset="{0!s}"'.format(key2infoset[key])
                 if isinstance(value, int):
                     openTag += ' type="int"'
                 elif isinstance(value, float):
                     openTag += ' type="float"'
                 openTag += u'>'
-                closeTag = u'</%s>' % tagName
+                closeTag = u'</{0!s}>'.format(tagName)
             _l.append(openTag)
             _seq2xml(value, _l, withRefs, modFunct, titlesRefs,
                     namesRefs, charactersRefs, _topLevel=False,
-                    fullpath='%s.%s' % (fullpath, tagName))
+                    fullpath='{0!s}.{1!s}'.format(fullpath, tagName))
             _l.append(closeTag)
     elif isinstance(seq, (list, tuple)):
         tagName, attrs = _tagAttr('item', fullpath)
-        beginTag = u'<%s' % tagName
+        beginTag = u'<{0!s}'.format(tagName)
         if attrs:
-            beginTag += u' %s' % attrs
+            beginTag += u' {0!s}'.format(attrs)
         #beginTag += u'>'
-        closeTag = u'</%s>' % tagName
+        closeTag = u'</{0!s}>'.format(tagName)
         for item in seq:
             if isinstance(item, _Container):
                 _seq2xml(item, _l, withRefs, modFunct, titlesRefs,
                          namesRefs, charactersRefs, _topLevel=False,
-                         fullpath='%s.%s' % (fullpath,
+                         fullpath='{0!s}.{1!s}'.format(fullpath,
                                     item.__class__.__name__.lower()))
             else:
                 openTag = beginTag
@@ -1110,7 +1109,7 @@ def _seq2xml(seq, _l=None, withRefs=False, modFunct=None,
                 _l.append(openTag)
                 _seq2xml(item, _l, withRefs, modFunct, titlesRefs,
                         namesRefs, charactersRefs, _topLevel=False,
-                        fullpath='%s.%s' % (fullpath, tagName))
+                        fullpath='{0!s}.{1!s}'.format(fullpath, tagName))
                 _l.append(closeTag)
     else:
         if isinstance(seq, _Container):
@@ -1392,7 +1391,7 @@ class _Container(object):
             if acs in ('mobile', 'httpThin'):
                 acs = 'http'
             # There must be some indication of the kind of the object, too.
-            s4h = '%s:%s[%s]' % (self.__class__.__name__, theID, acs)
+            s4h = '{0!s}:{1!s}[{2!s}]'.format(self.__class__.__name__, theID, acs)
         else:
             s4h = repr(self)
         return hash(s4h)

--- a/lib/jsonrpclib/SimpleJSONRPCServer.py
+++ b/lib/jsonrpclib/SimpleJSONRPCServer.py
@@ -26,13 +26,13 @@ def get_version(request):
 def validate_request(request):
     if type(request) is not types.DictType:
         fault = Fault(
-            -32600, 'Request must be {}, not %s.' % type(request)
+            -32600, 'Request must be {{}}, not {0!s}.'.format(type(request))
         )
         return fault
     rpcid = request.get('id', None)
     version = get_version(request)
     if not version:
-        fault = Fault(-32600, 'Request %s invalid.' % request, rpcid=rpcid)
+        fault = Fault(-32600, 'Request {0!s} invalid.'.format(request), rpcid=rpcid)
         return fault        
     request.setdefault('params', [])
     method = request.get('method', None)
@@ -58,7 +58,7 @@ class SimpleJSONRPCDispatcher(SimpleXMLRPCServer.SimpleXMLRPCDispatcher):
         try:
             request = jsonrpclib.loads(data)
         except Exception, e:
-            fault = Fault(-32700, 'Request %s invalid. (%s)' % (data, e))
+            fault = Fault(-32700, 'Request {0!s} invalid. ({1!s})'.format(data, e))
             response = fault.response()
             return response
         if not request:
@@ -76,7 +76,7 @@ class SimpleJSONRPCDispatcher(SimpleXMLRPCServer.SimpleXMLRPCDispatcher):
                 if resp_entry is not None:
                     responses.append(resp_entry)
             if len(responses) > 0:
-                response = '[%s]' % ','.join(responses)
+                response = '[{0!s}]'.format(','.join(responses))
             else:
                 response = ''
         else:    
@@ -97,7 +97,7 @@ class SimpleJSONRPCDispatcher(SimpleXMLRPCServer.SimpleXMLRPCDispatcher):
             response = self._dispatch(method, params)
         except:
             exc_type, exc_value, exc_tb = sys.exc_info()
-            fault = Fault(-32603, '%s:%s' % (exc_type, exc_value))
+            fault = Fault(-32603, '{0!s}:{1!s}'.format(exc_type, exc_value))
             return fault.response()
         if 'id' not in request.keys() or request['id'] == None:
             # It's a notification
@@ -110,7 +110,7 @@ class SimpleJSONRPCDispatcher(SimpleXMLRPCServer.SimpleXMLRPCDispatcher):
             return response
         except:
             exc_type, exc_value, exc_tb = sys.exc_info()
-            fault = Fault(-32603, '%s:%s' % (exc_type, exc_value))
+            fault = Fault(-32603, '{0!s}:{1!s}'.format(exc_type, exc_value))
             return fault.response()
 
     def _dispatch(self, method, params):
@@ -141,12 +141,12 @@ class SimpleJSONRPCDispatcher(SimpleXMLRPCServer.SimpleXMLRPCDispatcher):
                 return Fault(-32602, 'Invalid parameters.')
             except:
                 err_lines = traceback.format_exc().splitlines()
-                trace_string = '%s | %s' % (err_lines[-3], err_lines[-1])
-                fault = jsonrpclib.Fault(-32603, 'Server error: %s' % 
-                                         trace_string)
+                trace_string = '{0!s} | {1!s}'.format(err_lines[-3], err_lines[-1])
+                fault = jsonrpclib.Fault(-32603, 'Server error: {0!s}'.format( 
+                                         trace_string))
                 return fault
         else:
-            return Fault(-32601, 'Method %s not supported.' % method)
+            return Fault(-32601, 'Method {0!s} not supported.'.format(method))
 
 class SimpleJSONRPCRequestHandler(
         SimpleXMLRPCServer.SimpleXMLRPCRequestHandler):
@@ -169,8 +169,8 @@ class SimpleJSONRPCRequestHandler(
         except Exception, e:
             self.send_response(500)
             err_lines = traceback.format_exc().splitlines()
-            trace_string = '%s | %s' % (err_lines[-3], err_lines[-1])
-            fault = jsonrpclib.Fault(-32603, 'Server error: %s' % trace_string)
+            trace_string = '{0!s} | {1!s}'.format(err_lines[-3], err_lines[-1])
+            fault = jsonrpclib.Fault(-32603, 'Server error: {0!s}'.format(trace_string))
             response = fault.response()
         if response == None:
             response = ''
@@ -222,7 +222,7 @@ class CGIJSONRPCRequestHandler(SimpleJSONRPCDispatcher):
     def handle_jsonrpc(self, request_text):
         response = self._marshaled_dispatch(request_text)
         print 'Content-Type: application/json-rpc'
-        print 'Content-Length: %d' % len(response)
+        print 'Content-Length: {0:d}'.format(len(response))
         print
         sys.stdout.write(response)
 

--- a/lib/jsonrpclib/config.py
+++ b/lib/jsonrpclib/config.py
@@ -26,8 +26,8 @@ class Config(object):
     # The list of classes to use for jsonclass translation.
     version = 2.0
     # Version of the JSON-RPC spec to support
-    user_agent = 'jsonrpclib/0.1 (Python %s)' % \
-        '.'.join([str(ver) for ver in sys.version_info[0:3]])
+    user_agent = 'jsonrpclib/0.1 (Python {0!s})'.format( \
+        '.'.join([str(ver) for ver in sys.version_info[0:3]]))
     # User agent to use for calls.
     _instance = None
     

--- a/lib/jsonrpclib/jsonclass.py
+++ b/lib/jsonrpclib/jsonclass.py
@@ -63,7 +63,7 @@ def dump(obj, serialize_method=None, ignore_attribute=None, ignore=[]):
     class_name = obj.__class__.__name__
     json_class = class_name
     if module_name not in ['', '__main__']:
-        json_class = '%s.%s' % (module_name, json_class)
+        json_class = '{0!s}.{1!s}'.format(module_name, json_class)
     return_obj = {"__jsonclass__":[json_class,]}
     # If a serialization method is defined..
     if serialize_method in dir(obj):
@@ -111,15 +111,15 @@ def load(obj):
         raise TranslationError('Module name empty.')
     json_module_clean = re.sub(invalid_module_chars, '', orig_module_name)
     if json_module_clean != orig_module_name:
-        raise TranslationError('Module name %s has invalid characters.' %
-                               orig_module_name)
+        raise TranslationError('Module name {0!s} has invalid characters.'.format(
+                               orig_module_name))
     json_module_parts = json_module_clean.split('.')
     json_class = None
     if len(json_module_parts) == 1:
         # Local class name -- probably means it won't work
         if json_module_parts[0] not in config.classes.keys():
-            raise TranslationError('Unknown class or module %s.' %
-                                   json_module_parts[0])
+            raise TranslationError('Unknown class or module {0!s}.'.format(
+                                   json_module_parts[0]))
         json_class = config.classes[json_module_parts[0]]
     else:
         json_class_name = json_module_parts.pop()
@@ -127,8 +127,7 @@ def load(obj):
         try:
             temp_module = __import__(json_module_tree)
         except ImportError:
-            raise TranslationError('Could not import %s from module %s.' %
-                                   (json_class_name, json_module_tree))
+            raise TranslationError('Could not import {0!s} from module {1!s}.'.format(json_class_name, json_module_tree))
         json_class = getattr(temp_module, json_class_name)
     # Creating the object...
     new_obj = None

--- a/lib/jsonrpclib/jsonrpc.py
+++ b/lib/jsonrpclib/jsonrpc.py
@@ -276,7 +276,7 @@ class _Method(XML_Method):
             return self.__send(self.__name, kwargs)
 
     def __getattr__(self, name):
-        self.__name = '%s.%s' % (self.__name, name)
+        self.__name = '{0!s}.{1!s}'.format(self.__name, name)
         return self
         # The old method returned a new instance, but this seemed wasteful.
         # The only thing that changes is the name.
@@ -312,10 +312,10 @@ class MultiCallMethod(object):
                      encoding=encoding, rpcid=rpcid, notify=self.notify)
 
     def __repr__(self):
-        return '%s' % self.request()
+        return '{0!s}'.format(self.request())
         
     def __getattr__(self, method):
-        new_method = '%s.%s' % (self.method, method)
+        new_method = '{0!s}.{1!s}'.format(self.method, method)
         self.method = new_method
         return self
 
@@ -357,8 +357,8 @@ class MultiCall(object):
         if len(self._job_list) < 1:
             # Should we alert? This /is/ pretty obvious.
             return
-        request_body = '[ %s ]' % ','.join([job.request() for
-                                          job in self._job_list])
+        request_body = '[ {0!s} ]'.format(','.join([job.request() for
+                                          job in self._job_list]))
         responses = self._server._run_request(request_body)
         del self._job_list[:]
         if not responses:
@@ -400,7 +400,7 @@ class Fault(object):
         )
 
     def __repr__(self):
-        return '<Fault %s: %s>' % (self.faultCode, self.faultString)
+        return '<Fault {0!s}: {1!s}>'.format(self.faultCode, self.faultString)
 
 def random_id(length=8):
     return_id = ''

--- a/lib/libgrowl/gntp.py
+++ b/lib/libgrowl/gntp.py
@@ -102,7 +102,7 @@ class _GNTPBase(object):
 		pointerEnd = pointerStart + dataLength
 		data = self.raw[pointerStart:pointerEnd]
 		if not len(data) == dataLength:
-			raise ParseError('INVALID_DATA_LENGTH Expected: %s Recieved %s'%(dataLength,len(data)))
+			raise ParseError('INVALID_DATA_LENGTH Expected: {0!s} Recieved {1!s}'.format(dataLength, len(data)))
 		return data
 	def validate_password(self,password):
 		'''
@@ -141,20 +141,20 @@ class _GNTPBase(object):
 		Generate info line for GNTP Message
 		@return: Info line string
 		'''
-		info = u'GNTP/%s %s'%(
+		info = u'GNTP/{0!s} {1!s}'.format(
 			self.info.get('version'),
-			self.info.get('messagetype'),
+			self.info.get('messagetype')
 		)
 		if self.info.get('encryptionAlgorithmID',None):
-			info += ' %s:%s'%(
+			info += ' {0!s}:{1!s}'.format(
 				self.info.get('encryptionAlgorithmID'),
-				self.info.get('ivValue'),
+				self.info.get('ivValue')
 			)
 		else:
 			info+=' NONE'
 		
 		if self.info.get('keyHashAlgorithmID',None):
-			info += ' %s:%s.%s'%(
+			info += ' {0!s}:{1!s}.{2!s}'.format(
 				self.info.get('keyHashAlgorithmID'),
 				self.info.get('keyHash'),
 				self.info.get('salt')

--- a/lib/libtrakt/trakt.py
+++ b/lib/libtrakt/trakt.py
@@ -100,7 +100,7 @@ class TraktAPI:
                     logger.log(u'Could not connect to Trakt. Error: {0}'.format(e), logger.DEBUG)
             elif code == 502:
                 # Retry the request, cloudflare had a proxying issue
-                logger.log(u'Retrying trakt api request: %s' % path, logger.DEBUG)
+                logger.log(u'Retrying trakt api request: {0!s}'.format(path), logger.DEBUG)
                 return self.traktRequest(path, data, headers, url, method)
             elif code == 401:
                 if self.traktToken(refresh=True, count=count):
@@ -111,7 +111,7 @@ class TraktAPI:
                 # http://docs.trakt.apiary.io/#introduction/status-codes
                 logger.log(u'Trakt may have some issues and it\'s unavailable. Try again later please', logger.DEBUG)
             elif code == 404:
-                logger.log(u'Trakt error (404) the resource does not exist: %s' % url + path, logger.DEBUG)
+                logger.log(u'Trakt error (404) the resource does not exist: {0!s}'.format(url) + path, logger.DEBUG)
             else:
                 logger.log(u'Could not connect to Trakt. Code error: {0}'.format(code), logger.ERROR)
             return {}

--- a/lib/lockfile/__init__.py
+++ b/lib/lockfile/__init__.py
@@ -198,7 +198,7 @@ class _SharedBase(object):
         self.release()
 
     def __repr__(self):
-        return "<%s: %r>" % (self.__class__.__name__, self.path)
+        return "<{0!s}: {1!r}>".format(self.__class__.__name__, self.path)
 
 class LockBase(_SharedBase):
     """Base class for platform-specific lock classes."""
@@ -216,7 +216,7 @@ class LockBase(_SharedBase):
             # Thread objects in Python 2.4 and earlier do not have ident
             # attrs.  Worm around that.
             ident = getattr(t, "ident", hash(t))
-            self.tname = "-%x" % (ident & 0xffffffff)
+            self.tname = "-{0:x}".format((ident & 0xffffffff))
         else:
             self.tname = ""
         dirname = os.path.dirname(self.lock_file)
@@ -229,7 +229,7 @@ class LockBase(_SharedBase):
         # gets unlocked, deleting both lock-file and unique file,
         # finally the last lock errors out upon releasing.
         self.unique_name = os.path.join(dirname,
-                                        "%s%s.%s%s" % (self.hostname,
+                                        "{0!s}{1!s}.{2!s}{3!s}".format(self.hostname,
                                                        self.tname,
                                                        self.pid,
                                                        hash(self.path)))
@@ -254,11 +254,11 @@ class LockBase(_SharedBase):
         raise NotImplemented("implement in subclass")
 
     def __repr__(self):
-        return "<%s: %r -- %r>" % (self.__class__.__name__, self.unique_name,
+        return "<{0!s}: {1!r} -- {2!r}>".format(self.__class__.__name__, self.unique_name,
                                    self.path)
 
 def _fl_helper(cls, mod, *args, **kwds):
-    warnings.warn("Import from %s module instead of lockfile package" % mod,
+    warnings.warn("Import from {0!s} module instead of lockfile package".format(mod),
                   DeprecationWarning, stacklevel=2)
     # This is a bit funky, but it's only for awhile.  The way the unit tests
     # are constructed this function winds up as an unbound method, so it

--- a/lib/lockfile/linklockfile.py
+++ b/lib/lockfile/linklockfile.py
@@ -17,7 +17,7 @@ class LinkLockFile(LockBase):
         try:
             open(self.unique_name, "wb").close()
         except IOError:
-            raise LockFailed("failed to create %s" % self.unique_name)
+            raise LockFailed("failed to create {0!s}".format(self.unique_name))
 
         timeout = timeout if timeout is not None else self.timeout
         end_time = time.time()
@@ -44,8 +44,8 @@ class LinkLockFile(LockBase):
                                               " lock for %s" %
                                               self.path)
                         else:
-                            raise AlreadyLocked("%s is already locked" %
-                                                self.path)
+                            raise AlreadyLocked("{0!s} is already locked".format(
+                                                self.path))
                     time.sleep(timeout is not None and timeout/10 or 0.1)
             else:
                 # Link creation succeeded.  We're good to go.
@@ -53,9 +53,9 @@ class LinkLockFile(LockBase):
 
     def release(self):
         if not self.is_locked():
-            raise NotLocked("%s is not locked" % self.path)
+            raise NotLocked("{0!s} is not locked".format(self.path))
         elif not os.path.exists(self.unique_name):
-            raise NotMyLock("%s is locked, but not by me" % self.path)
+            raise NotMyLock("{0!s} is locked, but not by me".format(self.path))
         os.unlink(self.unique_name)
         os.unlink(self.lock_file)
 

--- a/lib/lockfile/mkdirlockfile.py
+++ b/lib/lockfile/mkdirlockfile.py
@@ -19,7 +19,7 @@ class MkdirLockFile(LockBase):
         # Lock file itself is a directory.  Place the unique file name into
         # it.
         self.unique_name  = os.path.join(self.lock_file,
-                                         "%s.%s%s" % (self.hostname,
+                                         "{0!s}.{1!s}{2!s}".format(self.hostname,
                                                       self.tname,
                                                       self.pid))
 
@@ -51,21 +51,21 @@ class MkdirLockFile(LockBase):
                                               self.path)
                         else:
                             # Someone else has the lock.
-                            raise AlreadyLocked("%s is already locked" %
-                                                self.path)
+                            raise AlreadyLocked("{0!s} is already locked".format(
+                                                self.path))
                     time.sleep(wait)
                 else:
                     # Couldn't create the lock for some other reason
-                    raise LockFailed("failed to create %s" % self.lock_file)
+                    raise LockFailed("failed to create {0!s}".format(self.lock_file))
             else:
                 open(self.unique_name, "wb").close()
                 return
 
     def release(self):
         if not self.is_locked():
-            raise NotLocked("%s is not locked" % self.path)
+            raise NotLocked("{0!s} is not locked".format(self.path))
         elif not os.path.exists(self.unique_name):
-            raise NotMyLock("%s is locked, but not by me" % self.path)
+            raise NotMyLock("{0!s} is locked, but not by me".format(self.path))
         os.unlink(self.unique_name)
         os.rmdir(self.lock_file)
 

--- a/lib/lockfile/pidlockfile.py
+++ b/lib/lockfile/pidlockfile.py
@@ -87,11 +87,11 @@ class PIDLockFile(LockBase):
                                               " lock for %s" %
                                               self.path)
                         else:
-                            raise AlreadyLocked("%s is already locked" %
-                                                self.path)
+                            raise AlreadyLocked("{0!s} is already locked".format(
+                                                self.path))
                     time.sleep(timeout is not None and timeout/10 or 0.1)
                 else:
-                    raise LockFailed("failed to create %s" % self.path)
+                    raise LockFailed("failed to create {0!s}".format(self.path))
             else:
                 return
 
@@ -103,9 +103,9 @@ class PIDLockFile(LockBase):
 
             """
         if not self.is_locked():
-            raise NotLocked("%s is not locked" % self.path)
+            raise NotLocked("{0!s} is not locked".format(self.path))
         if not self.i_am_locking():
-            raise NotMyLock("%s is locked, but not by me" % self.path)
+            raise NotMyLock("{0!s} is locked, but not by me".format(self.path))
         remove_existing_pidfile(self.path)
 
     def break_lock(self):
@@ -171,7 +171,7 @@ def write_pid_to_pidfile(pidfile_path):
     #   would contain three characters: two, five, and newline.
 
     pid = os.getpid()
-    line = "%(pid)d\n" % vars()
+    line = "{pid:d}\n".format(**vars())
     pidfile.write(line)
     pidfile.close()
 

--- a/lib/lockfile/sqlitelockfile.py
+++ b/lib/lockfile/sqlitelockfile.py
@@ -107,17 +107,16 @@ class SQLiteLockFile(LockBase):
                                       self.path)
                 else:
                     # Someone else has the lock and we are impatient..
-                    raise AlreadyLocked("%s is already locked" % self.path)
+                    raise AlreadyLocked("{0!s} is already locked".format(self.path))
 
             # Well, okay.  We'll give it a bit longer.
             time.sleep(wait)
 
     def release(self):
         if not self.is_locked():
-            raise NotLocked("%s is not locked" % self.path)
+            raise NotLocked("{0!s} is not locked".format(self.path))
         if not self.i_am_locking():
-            raise NotMyLock("%s is locked, but not by me (by %s)" %
-                            (self.unique_name, self._who_is_locking()))
+            raise NotMyLock("{0!s} is locked, but not by me (by {1!s})".format(self.unique_name, self._who_is_locking()))
         cursor = self.connection.cursor()
         cursor.execute("delete from locks"
                        "  where unique_name = ?",

--- a/lib/lockfile/symlinklockfile.py
+++ b/lib/lockfile/symlinklockfile.py
@@ -43,8 +43,8 @@ class SymlinkLockFile(LockBase):
                                               " lock for %s" %
                                               self.path)
                         else:
-                            raise AlreadyLocked("%s is already locked" %
-                                                self.path)
+                            raise AlreadyLocked("{0!s} is already locked".format(
+                                                self.path))
                     time.sleep(timeout/10 if timeout is not None else 0.1)
             else:
                 # Link creation succeeded.  We're good to go.
@@ -52,9 +52,9 @@ class SymlinkLockFile(LockBase):
 
     def release(self):
         if not self.is_locked():
-            raise NotLocked("%s is not locked" % self.path)
+            raise NotLocked("{0!s} is not locked".format(self.path))
         elif not self.i_am_locking():
-            raise NotMyLock("%s is locked, but not by me" % self.path)
+            raise NotMyLock("{0!s} is locked, but not by me".format(self.path))
         os.unlink(self.lock_file)
 
     def is_locked(self):

--- a/lib/mako/_ast_util.py
+++ b/lib/mako/_ast_util.py
@@ -111,14 +111,14 @@ def dump(node):
     """
     def _format(node):
         if isinstance(node, AST):
-            return '%s(%s)' % (node.__class__.__name__,
-                               ', '.join('%s=%s' % (a, _format(b))
+            return '{0!s}({1!s})'.format(node.__class__.__name__,
+                               ', '.join('{0!s}={1!s}'.format(a, _format(b))
                                          for a, b in iter_fields(node)))
         elif isinstance(node, list):
-            return '[%s]' % ', '.join(_format(x) for x in node)
+            return '[{0!s}]'.format(', '.join(_format(x) for x in node))
         return repr(node)
     if not isinstance(node, AST):
-        raise TypeError('expected AST, got %r' % node.__class__.__name__)
+        raise TypeError('expected AST, got {0!r}'.format(node.__class__.__name__))
     return _format(node)
 
 
@@ -213,7 +213,7 @@ def get_compile_mode(node):
     node (`Expression`, `Module` etc.) a `TypeError` is thrown.
     """
     if not isinstance(node, mod):
-        raise TypeError('expected mod node, got %r' % node.__class__.__name__)
+        raise TypeError('expected mod node, got {0!r}'.format(node.__class__.__name__))
     return {
         Expression: 'eval',
         Interactive: 'single'
@@ -227,7 +227,7 @@ def get_docstring(node):
     will be raised.
     """
     if not isinstance(node, (FunctionDef, ClassDef, Module)):
-        raise TypeError("%r can't have docstrings" % node.__class__.__name__)
+        raise TypeError("{0!r} can't have docstrings".format(node.__class__.__name__))
     if node.body and isinstance(node.body[0], Str):
         return node.body[0].s
 
@@ -437,7 +437,7 @@ class SourceGenerator(NodeVisitor):
 
     def visit_ImportFrom(self, node):
         self.newline()
-        self.write('from %s%s import ' % ('.' * node.level, node.module))
+        self.write('from {0!s}{1!s} import '.format('.' * node.level, node.module))
         for idx, item in enumerate(node.names):
             if idx:
                 self.write(', ')
@@ -457,7 +457,7 @@ class SourceGenerator(NodeVisitor):
         self.newline(n=2)
         self.decorators(node)
         self.newline()
-        self.write('def %s(' % node.name)
+        self.write('def {0!s}('.format(node.name))
         self.signature(node.args)
         self.write('):')
         self.body(node.body)
@@ -475,7 +475,7 @@ class SourceGenerator(NodeVisitor):
         self.newline(n=3)
         self.decorators(node)
         self.newline()
-        self.write('class %s' % node.name)
+        self.write('class {0!s}'.format(node.name))
         for base in node.bases:
             paren_or_comma()
             self.visit(base)
@@ -716,7 +716,7 @@ class SourceGenerator(NodeVisitor):
     def visit_BinOp(self, node):
         self.write('(')
         self.visit(node.left)
-        self.write(' %s ' % BINOP_SYMBOLS[type(node.op)])
+        self.write(' {0!s} '.format(BINOP_SYMBOLS[type(node.op)]))
         self.visit(node.right)
         self.write(')')
 
@@ -724,7 +724,7 @@ class SourceGenerator(NodeVisitor):
         self.write('(')
         for idx, value in enumerate(node.values):
             if idx:
-                self.write(' %s ' % BOOLOP_SYMBOLS[type(node.op)])
+                self.write(' {0!s} '.format(BOOLOP_SYMBOLS[type(node.op)]))
             self.visit(value)
         self.write(')')
 
@@ -732,7 +732,7 @@ class SourceGenerator(NodeVisitor):
         self.write('(')
         self.visit(node.left)
         for op, right in zip(node.ops, node.comparators):
-            self.write(' %s ' % CMPOP_SYMBOLS[type(op)])
+            self.write(' {0!s} '.format(CMPOP_SYMBOLS[type(op)]))
             self.visit(right)
         self.write(')')
 

--- a/lib/mako/ast.py
+++ b/lib/mako/ast.py
@@ -83,8 +83,8 @@ class PythonFragment(PythonCode):
         m = re.match(r'^(\w+)(?:\s+(.*?))?:\s*(#|$)', code.strip(), re.S)
         if not m:
             raise exceptions.CompileException(
-                "Fragment '%s' is not a partial control statement" %
-                code, **exception_kwargs)
+                "Fragment '{0!s}' is not a partial control statement".format(
+                code), **exception_kwargs)
         if m.group(3):
             code = code[:m.start(3)]
         (keyword, expr) = m.group(1, 2)
@@ -100,8 +100,8 @@ class PythonFragment(PythonCode):
             code = code + "pass"
         else:
             raise exceptions.CompileException(
-                "Unsupported control keyword: '%s'" %
-                keyword, **exception_kwargs)
+                "Unsupported control keyword: '{0!s}'".format(
+                keyword), **exception_kwargs)
         super(PythonFragment, self).__init__(code, **exception_kwargs)
 
 
@@ -117,12 +117,12 @@ class FunctionDecl(object):
         f.visit(expr)
         if not hasattr(self, 'funcname'):
             raise exceptions.CompileException(
-                "Code '%s' is not a function declaration" % code,
+                "Code '{0!s}' is not a function declaration".format(code),
                 **exception_kwargs)
         if not allow_kwargs and self.kwargs:
             raise exceptions.CompileException(
-                "'**%s' keyword argument not allowed here" %
-                self.kwargnames[-1], **exception_kwargs)
+                "'**{0!s}' keyword argument not allowed here".format(
+                self.kwargnames[-1]), **exception_kwargs)
 
     def get_argument_expressions(self, as_call=False):
         """Return the argument declarations of this FunctionDecl as a printable
@@ -149,7 +149,7 @@ class FunctionDecl(object):
             # Keyword-only arguments must always be used by name, so even if
             # this is a call, print out `foo=foo`
             if as_call:
-                namedecls.append("%s=%s" % (name, name))
+                namedecls.append("{0!s}={1!s}".format(name, name))
             elif kwdefaults:
                 default = kwdefaults.pop(0)
                 if default is None:
@@ -157,7 +157,7 @@ class FunctionDecl(object):
                     # `def foo(*, a=1, b, c=3)`
                     namedecls.append(name)
                 else:
-                    namedecls.append("%s=%s" % (
+                    namedecls.append("{0!s}={1!s}".format(
                         name, pyparser.ExpressionGenerator(default).value()))
             else:
                 namedecls.append(name)
@@ -171,7 +171,7 @@ class FunctionDecl(object):
                 namedecls.append(name)
             else:
                 default = defaults.pop(0)
-                namedecls.append("%s=%s" % (
+                namedecls.append("{0!s}={1!s}".format(
                     name, pyparser.ExpressionGenerator(default).value()))
 
         namedecls.reverse()
@@ -187,5 +187,5 @@ class FunctionArgs(FunctionDecl):
     """the argument portion of a function declaration"""
 
     def __init__(self, code, **kwargs):
-        super(FunctionArgs, self).__init__("def ANON(%s):pass" % code,
+        super(FunctionArgs, self).__init__("def ANON({0!s}):pass".format(code),
                                            **kwargs)

--- a/lib/mako/cache.py
+++ b/lib/mako/cache.py
@@ -149,7 +149,7 @@ class Cache(object):
 
         """
 
-        self.invalidate('render_%s' % name, __M_defname='render_%s' % name)
+        self.invalidate('render_{0!s}'.format(name), __M_defname='render_{0!s}'.format(name))
 
     def invalidate_closure(self, name):
         """Invalidate a nested ``<%def>`` within this template.

--- a/lib/mako/cmd.py
+++ b/lib/mako/cmd.py
@@ -48,7 +48,7 @@ def cmdline(argv=None):
     else:
         filename = options.input
         if not isfile(filename):
-            raise SystemExit("error: can't find %s" % filename)
+            raise SystemExit("error: can't find {0!s}".format(filename))
         lookup_dirs = options.template_dir or [dirname(filename)]
         lookup = TemplateLookup(lookup_dirs)
         try:

--- a/lib/mako/codegen.py
+++ b/lib/mako/codegen.py
@@ -110,7 +110,7 @@ class _GenerateRenderMethod(object):
         self.in_def = isinstance(node, (parsetree.DefTag, parsetree.BlockTag))
 
         if self.in_def:
-            name = "render_%s" % node.funcname
+            name = "render_{0!s}".format(node.funcname)
             args = node.get_argument_expressions()
             filtered = len(node.filter_args.args) > 0
             buffered = eval(node.attributes.get('buffered', 'False'))
@@ -216,25 +216,24 @@ class _GenerateRenderMethod(object):
         # module-level names, python code
         if self.compiler.generate_magic_comment and \
                 self.compiler.source_encoding:
-            self.printer.writeline("# -*- coding:%s -*-" %
-                                   self.compiler.source_encoding)
+            self.printer.writeline("# -*- coding:{0!s} -*-".format(
+                                   self.compiler.source_encoding))
 
         if self.compiler.future_imports:
-            self.printer.writeline("from __future__ import %s" %
-                                   (", ".join(self.compiler.future_imports),))
+            self.printer.writeline("from __future__ import {0!s}".format(", ".join(self.compiler.future_imports)))
         self.printer.writeline("from mako import runtime, filters, cache")
         self.printer.writeline("UNDEFINED = runtime.UNDEFINED")
         self.printer.writeline("STOP_RENDERING = runtime.STOP_RENDERING")
         self.printer.writeline("__M_dict_builtin = dict")
         self.printer.writeline("__M_locals_builtin = locals")
-        self.printer.writeline("_magic_number = %r" % MAGIC_NUMBER)
-        self.printer.writeline("_modified_time = %r" % time.time())
-        self.printer.writeline("_enable_loop = %r" % self.compiler.enable_loop)
+        self.printer.writeline("_magic_number = {0!r}".format(MAGIC_NUMBER))
+        self.printer.writeline("_modified_time = {0!r}".format(time.time()))
+        self.printer.writeline("_enable_loop = {0!r}".format(self.compiler.enable_loop))
         self.printer.writeline(
-            "_template_filename = %r" % self.compiler.filename)
-        self.printer.writeline("_template_uri = %r" % self.compiler.uri)
+            "_template_filename = {0!r}".format(self.compiler.filename))
+        self.printer.writeline("_template_uri = {0!r}".format(self.compiler.uri))
         self.printer.writeline(
-            "_source_encoding = %r" % self.compiler.source_encoding)
+            "_source_encoding = {0!r}".format(self.compiler.source_encoding))
         if self.compiler.imports:
             buf = ''
             for imp in self.compiler.imports:
@@ -257,9 +256,9 @@ class _GenerateRenderMethod(object):
             module_identifiers.declared.update(impcode.declared_identifiers)
 
         self.compiler.identifiers = module_identifiers
-        self.printer.writeline("_exports = %r" %
+        self.printer.writeline("_exports = {0!r}".format(
                                [n.name for n in
-                                main_identifiers.topleveldefs.values()]
+                                main_identifiers.topleveldefs.values()])
                                )
         self.printer.write_blanks(2)
 
@@ -284,11 +283,11 @@ class _GenerateRenderMethod(object):
             decorator = node.decorator
             if decorator:
                 self.printer.writeline(
-                    "@runtime._decorate_toplevel(%s)" % decorator)
+                    "@runtime._decorate_toplevel({0!s})".format(decorator))
 
         self.printer.start_source(node.lineno)
         self.printer.writelines(
-            "def %s(%s):" % (name, ','.join(args)),
+            "def {0!s}({1!s}):".format(name, ','.join(args)),
             # push new frame, assign current frame to __M_caller
             "__M_caller = context.caller_stack._push_frame()",
             "try:"
@@ -305,11 +304,11 @@ class _GenerateRenderMethod(object):
             len(self.identifiers.locally_assigned) > 0 or
             len(self.identifiers.argument_declared) > 0
         ):
-            self.printer.writeline("__M_locals = __M_dict_builtin(%s)" %
+            self.printer.writeline("__M_locals = __M_dict_builtin({0!s})".format(
                                    ','.join([
-                                       "%s=%s" % (x, x) for x in
+                                       "{0!s}={1!s}".format(x, x) for x in
                                             self.identifiers.argument_declared
-                                            ]))
+                                            ])))
 
         self.write_variable_declares(self.identifiers, toplevel=True)
 
@@ -338,8 +337,8 @@ class _GenerateRenderMethod(object):
         self.printer.writelines(
             "def _mako_inherit(template, context):",
             "_mako_generate_namespaces(context)",
-            "return runtime._inherit_from(context, %s, _template_uri)" %
-            (node.parsed_attributes['file']),
+            "return runtime._inherit_from(context, {0!s}, _template_uri)".format(
+            (node.parsed_attributes['file'])),
             None
         )
 
@@ -386,7 +385,7 @@ class _GenerateRenderMethod(object):
                 vis = NSDefVisitor()
                 for n in node.nodes:
                     n.accept_visitor(vis)
-                self.printer.writeline("return [%s]" % (','.join(export)))
+                self.printer.writeline("return [{0!s}]".format((','.join(export))))
                 self.printer.writeline(None)
                 self.in_def = False
                 callable_name = "make_namespace()"
@@ -429,10 +428,10 @@ class _GenerateRenderMethod(object):
                     )
                 )
             if eval(node.attributes.get('inheritable', "False")):
-                self.printer.writeline("context['self'].%s = ns" % (node.name))
+                self.printer.writeline("context['self'].{0!s} = ns".format((node.name)))
 
             self.printer.writeline(
-                "context.namespaces[(__name__, %s)] = ns" % repr(node.name))
+                "context.namespaces[(__name__, {0!s})] = ns".format(repr(node.name)))
             self.printer.write_blanks(1)
         if not len(namespaces):
             self.printer.writeline("pass")
@@ -526,21 +525,19 @@ class _GenerateRenderMethod(object):
 
             elif ident in self.compiler.namespaces:
                 self.printer.writeline(
-                    "%s = _mako_get_namespace(context, %r)" %
-                    (ident, ident)
+                    "{0!s} = _mako_get_namespace(context, {1!r})".format(ident, ident)
                 )
             else:
                 if getattr(self.compiler, 'has_ns_imports', False):
                     if self.compiler.strict_undefined:
                         self.printer.writelines(
-                            "%s = _import_ns.get(%r, UNDEFINED)" %
-                            (ident, ident),
-                            "if %s is UNDEFINED:" % ident,
+                            "{0!s} = _import_ns.get({1!r}, UNDEFINED)".format(ident, ident),
+                            "if {0!s} is UNDEFINED:".format(ident),
                             "try:",
-                            "%s = context[%r]" % (ident, ident),
+                            "{0!s} = context[{1!r}]".format(ident, ident),
                             "except KeyError:",
-                            "raise NameError(\"'%s' is not defined\")" %
-                            ident,
+                            "raise NameError(\"'{0!s}' is not defined\")".format(
+                            ident),
                             None, None
                         )
                     else:
@@ -552,15 +549,15 @@ class _GenerateRenderMethod(object):
                     if self.compiler.strict_undefined:
                         self.printer.writelines(
                             "try:",
-                            "%s = context[%r]" % (ident, ident),
+                            "{0!s} = context[{1!r}]".format(ident, ident),
                             "except KeyError:",
-                            "raise NameError(\"'%s' is not defined\")" %
-                            ident,
+                            "raise NameError(\"'{0!s}' is not defined\")".format(
+                            ident),
                             None
                         )
                     else:
                         self.printer.writeline(
-                            "%s = context.get(%r, UNDEFINED)" % (ident, ident)
+                            "{0!s} = context.get({1!r}, UNDEFINED)".format(ident, ident)
                         )
 
         self.printer.writeline("__M_writer = context.writer()")
@@ -577,9 +574,9 @@ class _GenerateRenderMethod(object):
             nameargs.insert(0, 'context._locals(__M_locals)')
         else:
             nameargs.insert(0, 'context')
-        self.printer.writeline("def %s(%s):" % (funcname, ",".join(namedecls)))
+        self.printer.writeline("def {0!s}({1!s}):".format(funcname, ",".join(namedecls)))
         self.printer.writeline(
-            "return render_%s(%s)" % (funcname, ",".join(nameargs)))
+            "return render_{0!s}({1!s})".format(funcname, ",".join(nameargs)))
         self.printer.writeline(None)
 
     def write_inline_def(self, node, identifiers, nested):
@@ -590,9 +587,9 @@ class _GenerateRenderMethod(object):
         decorator = node.decorator
         if decorator:
             self.printer.writeline(
-                "@runtime._decorate_inline(context, %s)" % decorator)
+                "@runtime._decorate_inline(context, {0!s})".format(decorator))
         self.printer.writeline(
-            "def %s(%s):" % (node.funcname, ",".join(namedecls)))
+            "def {0!s}({1!s}):".format(node.funcname, ",".join(namedecls)))
         filtered = len(node.filter_args.args) > 0
         buffered = eval(node.attributes.get('buffered', 'False'))
         cached = eval(node.attributes.get('cached', 'False'))
@@ -669,10 +666,10 @@ class _GenerateRenderMethod(object):
                 s = self.create_filter_callable(self.compiler.buffer_filters,
                                                 s, False)
             if buffered or cached:
-                self.printer.writeline("return %s" % s)
+                self.printer.writeline("return {0!s}".format(s))
             else:
                 self.printer.writelines(
-                    "__M_writer(%s)" % s,
+                    "__M_writer({0!s})".format(s),
                     "return ''"
                 )
 
@@ -682,7 +679,7 @@ class _GenerateRenderMethod(object):
         """write a post-function decorator to replace a rendering
             callable with a cached version of itself."""
 
-        self.printer.writeline("__M_%s = %s" % (name, name))
+        self.printer.writeline("__M_{0!s} = {1!s}".format(name, name))
         cachekey = node_or_pagetag.parsed_attributes.get('cache_key',
                                                          repr(name))
 
@@ -706,11 +703,11 @@ class _GenerateRenderMethod(object):
         if 'timeout' in cache_args:
             cache_args['timeout'] = int(eval(cache_args['timeout']))
 
-        self.printer.writeline("def %s(%s):" % (name, ','.join(args)))
+        self.printer.writeline("def {0!s}({1!s}):".format(name, ','.join(args)))
 
         # form "arg1, arg2, arg3=arg3, arg4=arg4", etc.
         pass_args = [
-            "%s=%s" % ((a.split('=')[0],) * 2) if '=' in a else a
+            "{0!s}={1!s}".format(*((a.split('=')[0],) * 2)) if '=' in a else a
             for a in args
         ]
 
@@ -724,7 +721,7 @@ class _GenerateRenderMethod(object):
                 "cache._ctx_get_or_create("\
                 "%s, lambda:__M_%s(%s),  context, %s__M_defname=%r)" % (
                     cachekey, name, ','.join(pass_args),
-                    ''.join(["%s=%s, " % (k, v)
+                    ''.join(["{0!s}={1!s}, ".format(k, v)
                              for k, v in cache_args.items()]),
                     name
                 )
@@ -739,7 +736,7 @@ class _GenerateRenderMethod(object):
                 "%s, lambda:__M_%s(%s), context, %s__M_defname=%r))" %
                 (
                     cachekey, name, ','.join(pass_args),
-                    ''.join(["%s=%s, " % (k, v)
+                    ''.join(["{0!s}={1!s}, ".format(k, v)
                              for k, v in cache_args.items()]),
                     name,
                 ),
@@ -778,7 +775,7 @@ class _GenerateRenderMethod(object):
             else:
                 e = locate_encode(e)
                 assert e is not None
-            target = "%s(%s)" % (e, target)
+            target = "{0!s}({1!s})".format(e, target)
         return target
 
     def visitExpression(self, node):
@@ -791,10 +788,10 @@ class _GenerateRenderMethod(object):
                 len(self.compiler.default_filters):
 
             s = self.create_filter_callable(node.escapes_code.args,
-                                            "%s" % node.text, True)
-            self.printer.writeline("__M_writer(%s)" % s)
+                                            "{0!s}".format(node.text), True)
+            self.printer.writeline("__M_writer({0!s})".format(s))
         else:
-            self.printer.writeline("__M_writer(%s)" % node.text)
+            self.printer.writeline("__M_writer({0!s})".format(node.text))
 
     def visitControlLine(self, node):
         if node.isend:
@@ -827,7 +824,7 @@ class _GenerateRenderMethod(object):
 
     def visitText(self, node):
         self.printer.start_source(node.lineno)
-        self.printer.writeline("__M_writer(%s)" % repr(node.content))
+        self.printer.writeline("__M_writer({0!s})".format(repr(node.content)))
 
     def visitTextTag(self, node):
         filtered = len(node.filter_args.args) > 0
@@ -842,11 +839,11 @@ class _GenerateRenderMethod(object):
             self.printer.writelines(
                 "finally:",
                 "__M_buf, __M_writer = context._pop_buffer_and_writer()",
-                "__M_writer(%s)" %
+                "__M_writer({0!s})".format(
                 self.create_filter_callable(
                     node.filter_args.args,
                     "__M_buf.getvalue()",
-                    False),
+                    False)),
                 None
             )
 
@@ -873,12 +870,11 @@ class _GenerateRenderMethod(object):
         args = node.attributes.get('args')
         if args:
             self.printer.writeline(
-                "runtime._include_file(context, %s, _template_uri, %s)" %
-                (node.parsed_attributes['file'], args))
+                "runtime._include_file(context, {0!s}, _template_uri, {1!s})".format(node.parsed_attributes['file'], args))
         else:
             self.printer.writeline(
-                "runtime._include_file(context, %s, _template_uri)" %
-                (node.parsed_attributes['file']))
+                "runtime._include_file(context, {0!s}, _template_uri)".format(
+                (node.parsed_attributes['file'])))
 
     def visitNamespaceTag(self, node):
         pass
@@ -888,7 +884,7 @@ class _GenerateRenderMethod(object):
 
     def visitBlockTag(self, node):
         if node.is_anonymous:
-            self.printer.writeline("%s()" % node.funcname)
+            self.printer.writeline("{0!s}()".format(node.funcname))
         else:
             nameargs = node.get_argument_expressions(as_call=True)
             nameargs += ['**pageargs']
@@ -897,7 +893,7 @@ class _GenerateRenderMethod(object):
                 "not hasattr(context._data['parent'], '%s'):"
                 % node.funcname)
             self.printer.writeline(
-                "context['self'].%s(%s)" % (node.funcname, ",".join(nameargs)))
+                "context['self'].{0!s}({1!s})".format(node.funcname, ",".join(nameargs)))
             self.printer.writeline("\n")
 
     def visitCallNamespaceTag(self, node):
@@ -942,7 +938,7 @@ class _GenerateRenderMethod(object):
         self.identifier_stack.pop()
 
         bodyargs = node.body_decl.get_argument_expressions()
-        self.printer.writeline("def body(%s):" % ','.join(bodyargs))
+        self.printer.writeline("def body({0!s}):".format(','.join(bodyargs)))
 
         # TODO: figure out best way to specify
         # buffering/nonbuffering (at call time would be better)
@@ -962,7 +958,7 @@ class _GenerateRenderMethod(object):
         self.write_def_finish(node, buffered, False, False, callstack=False)
         self.printer.writelines(
             None,
-            "return [%s]" % (','.join(export)),
+            "return [{0!s}]".format((','.join(export))),
             None
         )
 
@@ -974,8 +970,8 @@ class _GenerateRenderMethod(object):
             "try:")
         self.printer.start_source(node.lineno)
         self.printer.writelines(
-            "__M_writer(%s)" % self.create_filter_callable(
-                [], node.expression, True),
+            "__M_writer({0!s})".format(self.create_filter_callable(
+                [], node.expression, True)),
             "finally:",
             "context.caller_stack.nextcaller = None",
             None
@@ -1046,8 +1042,8 @@ class _Identifiers(object):
             self.locally_declared)
         if illegal_names:
             raise exceptions.NameConflictError(
-                "Reserved words declared in template: %s" %
-                ", ".join(illegal_names))
+                "Reserved words declared in template: {0!s}".format(
+                ", ".join(illegal_names)))
 
     def branch(self, node, **kwargs):
         """create a new Identifiers for a new Node, with
@@ -1142,13 +1138,11 @@ class _Identifiers(object):
 
             if isinstance(self.node, parsetree.DefTag):
                 raise exceptions.CompileException(
-                    "Named block '%s' not allowed inside of def '%s'"
-                    % (node.name, self.node.name), **node.exception_kwargs)
+                    "Named block '{0!s}' not allowed inside of def '{1!s}'".format(node.name, self.node.name), **node.exception_kwargs)
             elif isinstance(self.node,
                             (parsetree.CallTag, parsetree.CallNamespaceTag)):
                 raise exceptions.CompileException(
-                    "Named block '%s' not allowed inside of <%%call> tag"
-                    % (node.name, ), **node.exception_kwargs)
+                    "Named block '{0!s}' not allowed inside of <%call> tag".format(node.name ), **node.exception_kwargs)
 
         for ident in node.undeclared_identifiers():
             if ident != 'context' and \
@@ -1218,13 +1212,13 @@ def mangle_mako_loop(node, printer):
         match = _FOR_LOOP.match(node.text)
         if match:
             printer.writelines(
-                'loop = __M_loop._enter(%s)' % match.group(2),
+                'loop = __M_loop._enter({0!s})'.format(match.group(2)),
                 'try:'
                 # 'with __M_loop(%s) as loop:' % match.group(2)
             )
-            text = 'for %s in loop:' % match.group(1)
+            text = 'for {0!s} in loop:'.format(match.group(1))
         else:
-            raise SyntaxError("Couldn't apply loop context: %s" % node.text)
+            raise SyntaxError("Couldn't apply loop context: {0!s}".format(node.text))
     else:
         text = node.text
     return text

--- a/lib/mako/compat.py
+++ b/lib/mako/compat.py
@@ -185,7 +185,7 @@ else:
 # Copyright (c) 2010-2012 Benjamin Peterson
 def with_metaclass(meta, base=object):
     """Create a base class with a metaclass."""
-    return meta("%sBase" % meta.__name__, (base,), {})
+    return meta("{0!s}Base".format(meta.__name__), (base,), {})
 ################################################
 
 

--- a/lib/mako/exceptions.py
+++ b/lib/mako/exceptions.py
@@ -21,9 +21,9 @@ class RuntimeException(MakoException):
 
 def _format_filepos(lineno, pos, filename):
     if filename is None:
-        return " at line: %d char: %d" % (lineno, pos)
+        return " at line: {0:d} char: {1:d}".format(lineno, pos)
     else:
-        return " in file '%s' at line: %d char: %d" % (filename, lineno, pos)
+        return " in file '{0!s}' at line: {1:d} char: {2:d}".format(filename, lineno, pos)
 
 
 class CompileException(MakoException):

--- a/lib/mako/filters.py
+++ b/lib/mako/filters.py
@@ -94,7 +94,7 @@ def is_ascii_str(text):
 class XMLEntityEscaper(object):
 
     def __init__(self, codepoint2name, name2codepoint):
-        self.codepoint2entity = dict([(c, compat.text_type('&%s;' % n))
+        self.codepoint2entity = dict([(c, compat.text_type('&{0!s};'.format(n)))
                                       for c, n in codepoint2name.items()])
         self.name2codepoint = name2codepoint
 
@@ -110,7 +110,7 @@ class XMLEntityEscaper(object):
         try:
             return self.codepoint2entity[codepoint]
         except (KeyError, IndexError):
-            return '&#x%X;' % codepoint
+            return '&#x{0:X};'.format(codepoint)
 
     __escapable = re.compile(r'["&<>]|[^\x00-\x7f]')
 

--- a/lib/mako/lexer.py
+++ b/lib/mako/lexer.py
@@ -107,7 +107,7 @@ class Lexer(object):
                                re.S)
             if match:
                 continue
-            match = self.match(r'(%s)' % text_re)
+            match = self.match(r'({0!s})'.format(text_re))
             if match:
                 if match.group(1) == '}' and brace_level > 0:
                     brace_level -= 1
@@ -116,14 +116,14 @@ class Lexer(object):
                     self.text[startpos:
                               self.match_position - len(match.group(1))],\
                     match.group(1)
-            match = self.match(r"(.*?)(?=\"|\'|#|%s)" % text_re, re.S)
+            match = self.match(r"(.*?)(?=\"|\'|#|{0!s})".format(text_re), re.S)
             if match:
                 brace_level += match.group(1).count('{')
                 brace_level -= match.group(1).count('}')
                 continue
             raise exceptions.SyntaxException(
-                "Expected: %s" %
-                ','.join(text),
+                "Expected: {0!s}".format(
+                ','.join(text)),
                 **self.exception_kwargs)
 
     def append_node(self, nodecls, *args, **kwargs):
@@ -164,8 +164,7 @@ class Lexer(object):
             elif self.control_line and \
                     not self.control_line[-1].is_ternary(node.keyword):
                 raise exceptions.SyntaxException(
-                    "Keyword '%s' not a legal ternary for keyword '%s'" %
-                    (node.keyword, self.control_line[-1].keyword),
+                    "Keyword '{0!s}' not a legal ternary for keyword '{1!s}'".format(node.keyword, self.control_line[-1].keyword),
                     **self.exception_kwargs)
 
     _coding_re = re.compile(r'#.*coding[:=]\s*([-\w.]+).*\r?\n')
@@ -203,8 +202,8 @@ class Lexer(object):
                 text = text.decode(parsed_encoding)
             except UnicodeDecodeError:
                 raise exceptions.CompileException(
-                    "Unicode decode operation of encoding '%s' failed" %
-                    parsed_encoding,
+                    "Unicode decode operation of encoding '{0!s}' failed".format(
+                    parsed_encoding),
                     text.decode('utf-8', 'ignore'),
                     0, 0, filename)
 
@@ -252,13 +251,13 @@ class Lexer(object):
             raise exceptions.CompileException("assertion failed")
 
         if len(self.tag):
-            raise exceptions.SyntaxException("Unclosed tag: <%%%s>" %
-                                             self.tag[-1].keyword,
+            raise exceptions.SyntaxException("Unclosed tag: <%{0!s}>".format(
+                                             self.tag[-1].keyword),
                                              **self.exception_kwargs)
         if len(self.control_line):
             raise exceptions.SyntaxException(
-                "Unterminated control keyword: '%s'" %
-                self.control_line[-1].keyword,
+                "Unterminated control keyword: '{0!s}'".format(
+                self.control_line[-1].keyword),
                 self.text,
                 self.control_line[-1].lineno,
                 self.control_line[-1].pos, self.filename)
@@ -300,8 +299,8 @@ class Lexer(object):
                     match = self.match(r'(.*?)(?=\</%text>)', re.S)
                     if not match:
                         raise exceptions.SyntaxException(
-                            "Unclosed tag: <%%%s>" %
-                            self.tag[-1].keyword,
+                            "Unclosed tag: <%{0!s}>".format(
+                            self.tag[-1].keyword),
                             **self.exception_kwargs)
                     self.append_node(parsetree.Text, match.group(1))
                     return self.match_tag_end()
@@ -314,13 +313,12 @@ class Lexer(object):
         if match:
             if not len(self.tag):
                 raise exceptions.SyntaxException(
-                    "Closing tag without opening tag: </%%%s>" %
-                    match.group(1),
+                    "Closing tag without opening tag: </%{0!s}>".format(
+                    match.group(1)),
                     **self.exception_kwargs)
             elif self.tag[-1].keyword != match.group(1):
                 raise exceptions.SyntaxException(
-                    "Closing tag </%%%s> does not match tag: <%%%s>" %
-                    (match.group(1), self.tag[-1].keyword),
+                    "Closing tag </%{0!s}> does not match tag: <%{1!s}>".format(match.group(1), self.tag[-1].keyword),
                     **self.exception_kwargs)
             self.tag.pop()
             return True
@@ -409,8 +407,8 @@ class Lexer(object):
                 m2 = re.match(r'(end)?(\w+)\s*(.*)', text)
                 if not m2:
                     raise exceptions.SyntaxException(
-                        "Invalid control line: '%s'" %
-                        text,
+                        "Invalid control line: '{0!s}'".format(
+                        text),
                         **self.exception_kwargs)
                 isend, keyword = m2.group(1, 2)
                 isend = (isend is not None)
@@ -418,13 +416,11 @@ class Lexer(object):
                 if isend:
                     if not len(self.control_line):
                         raise exceptions.SyntaxException(
-                            "No starting keyword '%s' for '%s'" %
-                            (keyword, text),
+                            "No starting keyword '{0!s}' for '{1!s}'".format(keyword, text),
                             **self.exception_kwargs)
                     elif self.control_line[-1].keyword != keyword:
                         raise exceptions.SyntaxException(
-                            "Keyword '%s' doesn't match keyword '%s'" %
-                            (text, self.control_line[-1].keyword),
+                            "Keyword '{0!s}' doesn't match keyword '{1!s}'".format(text, self.control_line[-1].keyword),
                             **self.exception_kwargs)
                 self.append_node(parsetree.ControlLine, keyword, isend, text)
             else:

--- a/lib/mako/lookup.py
+++ b/lib/mako/lookup.py
@@ -256,7 +256,7 @@ class TemplateLookup(TemplateCollection):
                     return self._load(srcfile, uri)
             else:
                 raise exceptions.TopLevelLookupException(
-                    "Cant locate template for uri %r" % uri)
+                    "Cant locate template for uri {0!r}".format(uri))
 
     def adjust_uri(self, uri, relativeto):
         """Adjust the given ``uri`` based on the given relative URI."""
@@ -344,7 +344,7 @@ class TemplateLookup(TemplateCollection):
         except OSError:
             self._collection.pop(uri, None)
             raise exceptions.TemplateLookupException(
-                "Cant locate template for uri %r" % uri)
+                "Cant locate template for uri {0!r}".format(uri))
 
     def put_string(self, uri, text):
         """Place a new :class:`.Template` object into this

--- a/lib/mako/parsetree.py
+++ b/lib/mako/parsetree.py
@@ -50,7 +50,7 @@ class TemplateNode(Node):
         return self.nodes
 
     def __repr__(self):
-        return "TemplateNode(%s, %r)" % (
+        return "TemplateNode({0!s}, {1!r})".format(
             util.sorted_dict_repr(self.page_attributes),
             self.nodes)
 
@@ -104,7 +104,7 @@ class ControlLine(Node):
         }.get(self.keyword, [])
 
     def __repr__(self):
-        return "ControlLine(%r, %r, %r, %r)" % (
+        return "ControlLine({0!r}, {1!r}, {2!r}, {3!r})".format(
             self.keyword,
             self.text,
             self.isend,
@@ -121,7 +121,7 @@ class Text(Node):
         self.content = content
 
     def __repr__(self):
-        return "Text(%r, %r)" % (self.content, (self.lineno, self.pos))
+        return "Text({0!r}, {1!r})".format(self.content, (self.lineno, self.pos))
 
 
 class Code(Node):
@@ -155,7 +155,7 @@ class Code(Node):
         return self.code.undeclared_identifiers
 
     def __repr__(self):
-        return "Code(%r, %r, %r)" % (
+        return "Code({0!r}, {1!r}, {2!r})".format(
             self.text,
             self.ismodule,
             (self.lineno, self.pos)
@@ -175,7 +175,7 @@ class Comment(Node):
         self.text = text
 
     def __repr__(self):
-        return "Comment(%r, %r)" % (self.text, (self.lineno, self.pos))
+        return "Comment({0!r}, {1!r})".format(self.text, (self.lineno, self.pos))
 
 
 class Expression(Node):
@@ -205,7 +205,7 @@ class Expression(Node):
         ).difference(self.code.declared_identifiers)
 
     def __repr__(self):
-        return "Expression(%r, %r, %r)" % (
+        return "Expression({0!r}, {1!r}, {2!r})".format(
             self.text,
             self.escapes_code.args,
             (self.lineno, self.pos)
@@ -234,7 +234,7 @@ class _TagMeta(type):
             cls = _TagMeta._classmap[keyword]
         except KeyError:
             raise exceptions.CompileException(
-                "No such tag: '%s'" % keyword,
+                "No such tag: '{0!s}'".format(keyword),
                 source=kwargs['source'],
                 lineno=kwargs['lineno'],
                 pos=kwargs['pos'],
@@ -284,8 +284,8 @@ class Tag(compat.with_metaclass(_TagMeta, Node)):
         missing = [r for r in required if r not in self.parsed_attributes]
         if len(missing):
             raise exceptions.CompileException(
-                "Missing attribute(s): %s" %
-                ",".join([repr(m) for m in missing]),
+                "Missing attribute(s): {0!s}".format(
+                ",".join([repr(m) for m in missing])),
                 **self.exception_kwargs)
         self.parent = None
         self.nodes = []
@@ -315,7 +315,7 @@ class Tag(compat.with_metaclass(_TagMeta, Node)):
                         undeclared_identifiers = \
                             undeclared_identifiers.union(
                                 code.undeclared_identifiers)
-                        expr.append('(%s)' % m.group(1))
+                        expr.append('({0!s})'.format(m.group(1)))
                     else:
                         if x:
                             expr.append(repr(x))
@@ -329,8 +329,7 @@ class Tag(compat.with_metaclass(_TagMeta, Node)):
                 self.parsed_attributes[key] = repr(self.attributes[key])
             else:
                 raise exceptions.CompileException(
-                    "Invalid attribute for tag '%s': '%s'" %
-                    (self.keyword, key),
+                    "Invalid attribute for tag '{0!s}': '{1!s}'".format(self.keyword, key),
                     **self.exception_kwargs)
         self.expression_undeclared_identifiers = undeclared_identifiers
 
@@ -341,7 +340,7 @@ class Tag(compat.with_metaclass(_TagMeta, Node)):
         return self.expression_undeclared_identifiers
 
     def __repr__(self):
-        return "%s(%r, %s, %r, %r)" % (self.__class__.__name__,
+        return "{0!s}({1!r}, {2!s}, {3!r}, {4!r})".format(self.__class__.__name__,
                                        self.keyword,
                                        util.sorted_dict_repr(self.attributes),
                                        (self.lineno, self.pos),
@@ -359,7 +358,7 @@ class IncludeTag(Tag):
             ('file', 'import', 'args'),
             (), ('file',), **kwargs)
         self.page_args = ast.PythonCode(
-            "__DUMMY(%s)" % attributes.get('args', ''),
+            "__DUMMY({0!s})".format(attributes.get('args', '')),
             **self.exception_kwargs)
 
     def declared_identifiers(self):
@@ -384,7 +383,7 @@ class NamespaceTag(Tag):
              'import', 'module'),
             (), **kwargs)
 
-        self.name = attributes.get('name', '__anon_%s' % hex(abs(id(self))))
+        self.name = attributes.get('name', '__anon_{0!s}'.format(hex(abs(id(self)))))
         if 'name' not in attributes and 'import' not in attributes:
             raise exceptions.CompileException(
                 "'name' and/or 'import' attributes are required "
@@ -517,7 +516,7 @@ class BlockTag(Tag):
 
     @property
     def funcname(self):
-        return self.name or "__M_anon_%d" % (self.lineno, )
+        return self.name or "__M_anon_{0:d}".format(self.lineno )
 
     def get_argument_expressions(self, **kw):
         return self.body_decl.get_argument_expressions(**kw)
@@ -562,10 +561,10 @@ class CallNamespaceTag(Tag):
             (),
             **kwargs)
 
-        self.expression = "%s.%s(%s)" % (
+        self.expression = "{0!s}.{1!s}({2!s})".format(
             namespace,
             defname,
-            ",".join(["%s=%s" % (k, v) for k, v in
+            ",".join(["{0!s}={1!s}".format(k, v) for k, v in
                       self.parsed_attributes.items()
                       if k != 'args'])
         )

--- a/lib/mako/pygen.py
+++ b/lib/mako/pygen.py
@@ -195,7 +195,7 @@ class PythonPrinter(object):
         stripspace is a string of space that will be truncated from the
         start of the line before indenting."""
 
-        return re.sub(r"^%s" % stripspace, self.indentstring
+        return re.sub(r"^{0!s}".format(stripspace), self.indentstring
                       * self.indent, line)
 
     def _reset_multi_line_flags(self):
@@ -267,11 +267,11 @@ def adjust_whitespace(text):
 
         while line:
             if state[triplequoted]:
-                m, line = match(r"%s" % state[triplequoted], line)
+                m, line = match(r"{0!s}".format(state[triplequoted]), line)
                 if m:
                     state[triplequoted] = False
                 else:
-                    m, line = match(r".*?(?=%s|$)" % state[triplequoted], line)
+                    m, line = match(r".*?(?={0!s}|$)".format(state[triplequoted]), line)
             else:
                 m, line = match(r'#', line)
                 if m:
@@ -287,7 +287,7 @@ def adjust_whitespace(text):
         return start_state
 
     def _indent_line(line, stripspace=''):
-        return re.sub(r"^%s" % stripspace, '', line)
+        return re.sub(r"^{0!s}".format(stripspace), '', line)
 
     lines = []
     stripspace = None

--- a/lib/mako/pyparser.py
+++ b/lib/mako/pyparser.py
@@ -41,7 +41,7 @@ def parse(code, mode='exec', **exception_kwargs):
         return _ast_util.parse(code, '<unknown>', mode)
     except Exception:
         raise exceptions.SyntaxException(
-            "(%s) %s (%r)" % (
+            "({0!s}) {1!s} ({2!r})".format(
                 compat.exception_as().__class__.__name__,
                 compat.exception_as(),
                 code[0:50]

--- a/lib/mako/runtime.py
+++ b/lib/mako/runtime.py
@@ -44,8 +44,8 @@ class Context(object):
         illegal_names = t.reserved_names.intersection(self._data)
         if illegal_names:
             raise exceptions.NameConflictError(
-                "Reserved words passed to render(): %s" %
-                ", ".join(illegal_names))
+                "Reserved words passed to render(): {0!s}".format(
+                ", ".join(illegal_names)))
 
     @property
     def lookup(self):
@@ -536,8 +536,7 @@ class Namespace(object):
             val = getattr(self.inherits, key)
         else:
             raise AttributeError(
-                "Namespace '%s' has no member '%s'" %
-                (self.name, key))
+                "Namespace '{0!s}' has no member '{1!s}'".format(self.name, key))
         setattr(self, key, val)
         return val
 
@@ -621,8 +620,7 @@ class TemplateNamespace(Namespace):
 
         else:
             raise AttributeError(
-                "Namespace '%s' has no member '%s'" %
-                (self.name, key))
+                "Namespace '{0!s}' has no member '{1!s}'".format(self.name, key))
         setattr(self, key, val)
         return val
 
@@ -672,8 +670,7 @@ class ModuleNamespace(Namespace):
             val = getattr(self.inherits, key)
         else:
             raise AttributeError(
-                "Namespace '%s' has no member '%s'" %
-                (self.name, key))
+                "Namespace '{0!s}' has no member '{1!s}'".format(self.name, key))
         setattr(self, key, val)
         return val
 
@@ -765,7 +762,7 @@ def _inherit_from(context, uri, calling_uri):
     while ih.inherits is not None:
         ih = ih.inherits
     lclcontext = context._locals({'next': ih})
-    ih.inherits = TemplateNamespace("self:%s" % template.uri,
+    ih.inherits = TemplateNamespace("self:{0!s}".format(template.uri),
                                     lclcontext,
                                     template=template,
                                     populate_self=False)
@@ -786,8 +783,8 @@ def _lookup_template(context, uri, relativeto):
     lookup = context._with_template.lookup
     if lookup is None:
         raise exceptions.TemplateLookupException(
-            "Template '%s' has no TemplateLookup associated" %
-            context._with_template.uri)
+            "Template '{0!s}' has no TemplateLookup associated".format(
+            context._with_template.uri))
     uri = lookup.adjust_uri(uri, relativeto)
     try:
         return lookup.get_template(uri)
@@ -797,7 +794,7 @@ def _lookup_template(context, uri, relativeto):
 
 def _populate_self_namespace(context, template, self_ns=None):
     if self_ns is None:
-        self_ns = TemplateNamespace('self:%s' % template.uri,
+        self_ns = TemplateNamespace('self:{0!s}'.format(template.uri),
                                     context, template=template,
                                     populate_self=False)
     context._data['self'] = context._data['local'] = self_ns

--- a/lib/mako/template.py
+++ b/lib/mako/template.py
@@ -468,15 +468,15 @@ class Template(object):
                                 **kwargs)
 
     def has_def(self, name):
-        return hasattr(self.module, "render_%s" % name)
+        return hasattr(self.module, "render_{0!s}".format(name))
 
     def get_def(self, name):
         """Return a def of this template as a :class:`.DefTemplate`."""
 
-        return DefTemplate(self, getattr(self.module, "render_%s" % name))
+        return DefTemplate(self, getattr(self.module, "render_{0!s}".format(name)))
 
     def _get_def_callable(self, name):
-        return getattr(self.module, "render_%s" % name)
+        return getattr(self.module, "render_{0!s}".format(name))
 
     @property
     def last_modified(self):

--- a/lib/mako/util.py
+++ b/lib/mako/util.py
@@ -37,8 +37,7 @@ class PluginLoader(object):
             else:
                 from mako import exceptions
                 raise exceptions.RuntimeException(
-                    "Can't load plugin %s %s" %
-                    (self.group, name))
+                    "Can't load plugin {0!s} {1!s}".format(self.group, name))
 
     def register(self, name, modulepath, objname):
         def load():
@@ -282,7 +281,7 @@ def sorted_dict_repr(d):
     """
     keys = list(d.keys())
     keys.sort()
-    return "{" + ", ".join(["%r: %r" % (k, d[k]) for k in keys]) + "}"
+    return "{" + ", ".join(["{0!r}: {1!r}".format(k, d[k]) for k in keys]) + "}"
 
 
 def restore__ast(_ast):

--- a/lib/markdown2.py
+++ b/lib/markdown2.py
@@ -234,7 +234,7 @@ class Markdown(object):
 
         self.link_patterns = link_patterns
         self.use_file_vars = use_file_vars
-        self._outdent_re = re.compile(r'^(\t|[ ]{1,%d})' % tab_width, re.M)
+        self._outdent_re = re.compile(r'^(\t|[ ]{{1,{0:d}}})'.format(tab_width), re.M)
 
         self._escape_table = g_escape_table.copy()
         if "smarty-pants" in self.extras:
@@ -549,14 +549,14 @@ class Markdown(object):
     _strict_tag_block_re = re.compile(r"""
         (                       # save in \1
             ^                   # start of line  (with re.M)
-            <(%s)               # start tag = \2
+            <({0!s})               # start tag = \2
             \b                  # word break
             (.*\n)*?            # any number of lines, minimally matching
             </\2>               # the matching end tag
             [ \t]*              # trailing spaces/tabs
             (?=\n+|\Z)          # followed by a newline or end of document
         )
-        """ % _block_tags_a,
+        """.format(_block_tags_a),
         re.X | re.M)
 
     _block_tags_b = 'p|div|h[1-6]|blockquote|pre|table|dl|ol|ul|script|noscript|form|fieldset|iframe|math'
@@ -565,14 +565,14 @@ class Markdown(object):
     _liberal_tag_block_re = re.compile(r"""
         (                       # save in \1
             ^                   # start of line  (with re.M)
-            <(%s)               # start tag = \2
+            <({0!s})               # start tag = \2
             \b                  # word break
             (.*\n)*?            # any number of lines, minimally matching
             .*</\2>             # the matching end tag
             [ \t]*              # trailing spaces/tabs
             (?=\n+|\Z)          # followed by a newline or end of document
         )
-        """ % _block_tags_b,
+        """.format(_block_tags_b),
         re.X | re.M)
 
     _html_markdown_attr_re = re.compile(
@@ -716,7 +716,7 @@ class Markdown(object):
         # Link defs are in the form:
         #   [id]: url "optional title"
         _link_def_re = re.compile(r"""
-            ^[ ]{0,%d}\[(.+)\]: # id = \1
+            ^[ ]{{0,{0:d}}}\[(.+)\]: # id = \1
               [ \t]*
               \n?               # maybe *one* newline
               [ \t]*
@@ -732,7 +732,7 @@ class Markdown(object):
                 [ \t]*
             )?  # title is optional
             (?:\n+|\Z)
-            """ % less_than_tab, re.X | re.M | re.U)
+            """.format(less_than_tab), re.X | re.M | re.U)
         return _link_def_re.sub(self._extract_link_def_sub, text)
 
     def _extract_link_def_sub(self, match):
@@ -769,19 +769,19 @@ class Markdown(object):
         """
         less_than_tab = self.tab_width - 1
         footnote_def_re = re.compile(r'''
-            ^[ ]{0,%d}\[\^(.+)\]:   # id = \1
+            ^[ ]{{0,{0:d}}}\[\^(.+)\]:   # id = \1
             [ \t]*
             (                       # footnote text = \2
               # First line need not start with the spaces.
               (?:\s*.*\n+)
               (?:
-                (?:[ ]{%d} | \t)  # Subsequent lines must be indented.
+                (?:[ ]{{{1:d}}} | \t)  # Subsequent lines must be indented.
                 .*\n+
               )*
             )
             # Lookahead for non-space at line-start, or end of doc.
-            (?:(?=^[ ]{0,%d}\S)|\Z)
-            ''' % (less_than_tab, self.tab_width, self.tab_width),
+            (?:(?=^[ ]{{0,{2:d}}}\S)|\Z)
+            '''.format(less_than_tab, self.tab_width, self.tab_width),
             re.X | re.M)
         return footnote_def_re.sub(self._extract_footnote_def_sub, text)
 
@@ -845,10 +845,10 @@ class Markdown(object):
 
         less_than_tab = self.tab_width - 1
         _pyshell_block_re = re.compile(r"""
-            ^([ ]{0,%d})>>>[ ].*\n   # first line
+            ^([ ]{{0,{0:d}}})>>>[ ].*\n   # first line
             ^(\1.*\S+.*\n)*         # any number of subsequent lines
             ^\n                     # ends with a blank line
-            """ % less_than_tab, re.M | re.X)
+            """.format(less_than_tab), re.M | re.X)
 
         return _pyshell_block_re.sub(self._pyshell_block_sub, text)
 
@@ -867,10 +867,10 @@ class Markdown(object):
                 align_from_col_idx[col_idx] = ' align="right"'
 
         # thead
-        hlines = ['<table%s>' % self._html_class_str_from_tag('table'), '<thead>', '<tr>']
+        hlines = ['<table{0!s}>'.format(self._html_class_str_from_tag('table')), '<thead>', '<tr>']
         cols = [cell.strip() for cell in head.strip('| \t\n').split('|')]
         for col_idx, col in enumerate(cols):
-            hlines.append('  <th%s>%s</th>' % (
+            hlines.append('  <th{0!s}>{1!s}</th>'.format(
                 align_from_col_idx.get(col_idx, ''),
                 self._run_span_gamut(col)
             ))
@@ -883,7 +883,7 @@ class Markdown(object):
             hlines.append('<tr>')
             cols = [cell.strip() for cell in line.strip('| \t\n').split('|')]
             for col_idx, col in enumerate(cols):
-                hlines.append('  <td%s>%s</td>' % (
+                hlines.append('  <td{0!s}>{1!s}</td>'.format(
                     align_from_col_idx.get(col_idx, ''),
                     self._run_span_gamut(col)
                 ))
@@ -901,10 +901,10 @@ class Markdown(object):
         table_re = re.compile(r'''
                 (?:(?<=\n\n)|\A\n?)             # leading blank line
 
-                ^[ ]{0,%d}                      # allowed whitespace
+                ^[ ]{{0,{0:d}}}                      # allowed whitespace
                 (.*[|].*)  \n                   # $1: header row (at least one pipe)
 
-                ^[ ]{0,%d}                      # allowed whitespace
+                ^[ ]{{0,{1:d}}}                      # allowed whitespace
                 (                               # $2: underline row
                     # underline row with leading bar
                     (?:  \|\ *:?-+:?\ *  )+  \|?  \n
@@ -915,11 +915,11 @@ class Markdown(object):
 
                 (                               # $3: data rows
                     (?:
-                        ^[ ]{0,%d}(?!\ )         # ensure line begins with 0 to less_than_tab spaces
+                        ^[ ]{{0,{2:d}}}(?!\ )         # ensure line begins with 0 to less_than_tab spaces
                         .*\|.*  \n
                     )+
                 )
-            ''' % (less_than_tab, less_than_tab, less_than_tab), re.M | re.X)
+            '''.format(less_than_tab, less_than_tab, less_than_tab), re.M | re.X)
         return table_re.sub(self._table_sub, text)
 
     def _wiki_table_sub(self, match):
@@ -931,7 +931,7 @@ class Markdown(object):
             row = [c.strip() for c in re.split(r'(?<!\\)\|\|', line)]
             rows.append(row)
         #pprint(rows)
-        hlines = ['<table%s>' % self._html_class_str_from_tag('table'), '<tbody>']
+        hlines = ['<table{0!s}>'.format(self._html_class_str_from_tag('table')), '<tbody>']
         for row in rows:
             hrow = ['<tr>']
             for cell in row:
@@ -951,9 +951,9 @@ class Markdown(object):
         less_than_tab = self.tab_width - 1
         wiki_table_re = re.compile(r'''
             (?:(?<=\n\n)|\A\n?)            # leading blank line
-            ^([ ]{0,%d})\|\|.+?\|\|[ ]*\n  # first line
+            ^([ ]{{0,{0:d}}})\|\|.+?\|\|[ ]*\n  # first line
             (^\1\|\|.+?\|\|\n)*        # any number of subsequent lines
-            ''' % less_than_tab, re.M | re.X)
+            '''.format(less_than_tab), re.M | re.X)
         return wiki_table_re.sub(self._wiki_table_sub, text)
 
     def _run_span_gamut(self, text):
@@ -984,9 +984,9 @@ class Markdown(object):
 
         # Do hard breaks:
         if "break-on-newline" in self.extras:
-            text = re.sub(r" *\n", "<br%s\n" % self.empty_element_suffix, text)
+            text = re.sub(r" *\n", "<br{0!s}\n".format(self.empty_element_suffix), text)
         else:
-            text = re.sub(r" {2,}\n", " <br%s\n" % self.empty_element_suffix, text)
+            text = re.sub(r" {2,}\n", " <br{0!s}\n".format(self.empty_element_suffix), text)
 
         return text
 
@@ -1234,16 +1234,15 @@ class Markdown(object):
                     url = url.replace('*', self._escape_table['*']) \
                              .replace('_', self._escape_table['_'])
                     if title:
-                        title_str = ' title="%s"' % (
+                        title_str = ' title="{0!s}"'.format((
                             _xml_escape_attr(title)
                                 .replace('*', self._escape_table['*'])
-                                .replace('_', self._escape_table['_']))
+                                .replace('_', self._escape_table['_'])))
                     else:
                         title_str = ''
                     if is_img:
                         img_class_str = self._html_class_str_from_tag("img")
-                        result = '<img src="%s" alt="%s"%s%s%s' \
-                            % (url.replace('"', '&quot;'),
+                        result = '<img src="{0!s}" alt="{1!s}"{2!s}{3!s}{4!s}'.format(url.replace('"', '&quot;'),
                                _xml_escape_attr(link_text),
                                title_str, img_class_str, self.empty_element_suffix)
                         if "smarty-pants" in self.extras:
@@ -1251,8 +1250,8 @@ class Markdown(object):
                         curr_pos = start_idx + len(result)
                         text = text[:start_idx] + result + text[url_end_idx:]
                     elif start_idx >= anchor_allowed_pos:
-                        result_head = '<a href="%s"%s>' % (url, title_str)
-                        result = '%s%s</a>' % (result_head, link_text)
+                        result_head = '<a href="{0!s}"{1!s}>'.format(url, title_str)
+                        result = '{0!s}{1!s}</a>'.format(result_head, link_text)
                         if "smarty-pants" in self.extras:
                             result = result.replace('"', self._escape_table['"'])
                         # <img> allowed from curr_pos on, <a> from
@@ -1288,13 +1287,12 @@ class Markdown(object):
                             title = _xml_escape_attr(title) \
                                 .replace('*', self._escape_table['*']) \
                                 .replace('_', self._escape_table['_'])
-                            title_str = ' title="%s"' % title
+                            title_str = ' title="{0!s}"'.format(title)
                         else:
                             title_str = ''
                         if is_img:
                             img_class_str = self._html_class_str_from_tag("img")
-                            result = '<img src="%s" alt="%s"%s%s%s' \
-                                % (url.replace('"', '&quot;'),
+                            result = '<img src="{0!s}" alt="{1!s}"{2!s}{3!s}{4!s}'.format(url.replace('"', '&quot;'),
                                    link_text.replace('"', '&quot;'),
                                    title_str, img_class_str, self.empty_element_suffix)
                             if "smarty-pants" in self.extras:
@@ -1302,10 +1300,9 @@ class Markdown(object):
                             curr_pos = start_idx + len(result)
                             text = text[:start_idx] + result + text[match.end():]
                         elif start_idx >= anchor_allowed_pos:
-                            result = '<a href="%s"%s>%s</a>' \
-                                % (url, title_str, link_text)
-                            result_head = '<a href="%s"%s>' % (url, title_str)
-                            result = '%s%s</a>' % (result_head, link_text)
+                            result = '<a href="{0!s}"{1!s}>{2!s}</a>'.format(url, title_str, link_text)
+                            result_head = '<a href="{0!s}"{1!s}>'.format(url, title_str)
+                            result = '{0!s}{1!s}</a>'.format(result_head, link_text)
                             if "smarty-pants" in self.extras:
                                 result = result.replace('"', self._escape_table['"'])
                             # <img> allowed from curr_pos on, <a> from
@@ -1346,7 +1343,7 @@ class Markdown(object):
             header_id = prefix + '-' + header_id
         if header_id in self._count_from_header_id:
             self._count_from_header_id[header_id] += 1
-            header_id += '-%s' % self._count_from_header_id[header_id]
+            header_id += '-{0!s}'.format(self._count_from_header_id[header_id])
         else:
             self._count_from_header_id[header_id] = 1
         return header_id
@@ -1391,11 +1388,11 @@ class Markdown(object):
             header_id = self.header_id_from_text(header_group,
                 self.extras["header-ids"], n)
             if header_id:
-                header_id_attr = ' id="%s"' % header_id
+                header_id_attr = ' id="{0!s}"'.format(header_id)
         html = self._run_span_gamut(header_group)
         if "toc" in self.extras and header_id:
             self._toc_add_entry(n, header_id, html)
-        return "<h%d%s>%s</h%d>\n\n" % (n, header_id_attr, html, n)
+        return "<h{0:d}{1!s}>{2!s}</h{3:d}>\n\n".format(n, header_id_attr, html, n)
 
     def _do_headers(self, text):
         # Setext-style headers:
@@ -1417,8 +1414,8 @@ class Markdown(object):
         return self._h_re.sub(self._h_sub, text)
 
     _marker_ul_chars  = '*+-'
-    _marker_any = r'(?:[%s]|\d+\.)' % _marker_ul_chars
-    _marker_ul = '(?:[%s])' % _marker_ul_chars
+    _marker_any = r'(?:[{0!s}]|\d+\.)'.format(_marker_ul_chars)
+    _marker_ul = '(?:[{0!s}])'.format(_marker_ul_chars)
     _marker_ol = r'(?:\d+\.)'
 
     def _list_sub(self, match):
@@ -1426,9 +1423,9 @@ class Markdown(object):
         lst_type = match.group(3) in self._marker_ul_chars and "ul" or "ol"
         result = self._process_list_items(lst)
         if self.list_level:
-            return "<%s>\n%s</%s>\n" % (lst_type, result, lst_type)
+            return "<{0!s}>\n{1!s}</{2!s}>\n".format(lst_type, result, lst_type)
         else:
-            return "<%s>\n%s</%s>\n\n" % (lst_type, result, lst_type)
+            return "<{0!s}>\n{1!s}</{2!s}>\n\n".format(lst_type, result, lst_type)
 
     def _do_lists(self, text):
         # Form HTML ordered (numbered) and unordered (bulleted) lists.
@@ -1445,8 +1442,8 @@ class Markdown(object):
                 whole_list = r'''
                     (                   # \1 = whole list
                       (                 # \2
-                        [ ]{0,%d}
-                        (%s)            # \3 = first list item marker
+                        [ ]{{0,{0:d}}}
+                        ({1!s})            # \3 = first list item marker
                         [ \t]+
                         (?!\ *\3\ )     # '- - - ...' isn't a list. See 'not_quite_a_list' test case.
                       )
@@ -1454,15 +1451,15 @@ class Markdown(object):
                       (                 # \4
                           \Z
                         |
-                          \n{2,}
+                          \n{{2,}}
                           (?=\S)
                           (?!           # Negative lookahead for another list item marker
                             [ \t]*
-                            %s[ \t]+
+                            {2!s}[ \t]+
                           )
                       )
                     )
-                ''' % (less_than_tab, marker_pat, marker_pat)
+                '''.format(less_than_tab, marker_pat, marker_pat)
                 if self.list_level:  # sub-list
                     list_re = re.compile("^"+whole_list, re.X | re.M | re.S)
                 else:
@@ -1485,11 +1482,11 @@ class Markdown(object):
     _list_item_re = re.compile(r'''
         (\n)?                   # leading line = \1
         (^[ \t]*)               # leading whitespace = \2
-        (?P<marker>%s) [ \t]+   # list marker = \3
+        (?P<marker>{0!s}) [ \t]+   # list marker = \3
         ((?:.+?)                # list item text = \4
-         (\n{1,2}))             # eols = \5
-        (?= \n* (\Z | \2 (?P<next_marker>%s) [ \t]+))
-        ''' % (_marker_any, _marker_any),
+         (\n{{1,2}}))             # eols = \5
+        (?= \n* (\Z | \2 (?P<next_marker>{1!s}) [ \t]+))
+        '''.format(_marker_any, _marker_any),
         re.M | re.X | re.S)
 
     _last_li_endswith_two_eols = False
@@ -1506,7 +1503,7 @@ class Markdown(object):
                 item = item[:-1]
             item = self._run_span_gamut(item)
         self._last_li_endswith_two_eols = (len(match.group(5)) == 2)
-        return "<li>%s</li>\n" % item
+        return "<li>{0!s}</li>\n".format(item)
 
     def _process_list_items(self, list_str):
         # Process the contents of a single ordered or unordered list,
@@ -1610,12 +1607,12 @@ class Markdown(object):
                 codeblock = unhash_code( codeblock )
                 colored = self._color_with_pygments(codeblock, lexer,
                                                     **formatter_opts)
-                return "\n\n%s\n\n" % colored
+                return "\n\n{0!s}\n\n".format(colored)
 
         codeblock = self._encode_code(codeblock)
         pre_class_str = self._html_class_str_from_tag("pre")
         code_class_str = self._html_class_str_from_tag("code")
-        return "\n\n<pre%s><code%s>%s\n</code></pre>\n\n" % (
+        return "\n\n<pre{0!s}><code{1!s}>{2!s}\n</code></pre>\n\n".format(
             pre_class_str, code_class_str, codeblock)
 
     def _html_class_str_from_tag(self, tag):
@@ -1630,7 +1627,7 @@ class Markdown(object):
             return ""
         else:
             if tag in html_classes_from_tag:
-                return ' class="%s"' % html_classes_from_tag[tag]
+                return ' class="{0!s}"'.format(html_classes_from_tag[tag])
         return ""
 
     def _do_code_blocks(self, text):
@@ -1639,15 +1636,15 @@ class Markdown(object):
             (?:\n\n|\A\n?)
             (               # $1 = the code block -- one or more lines, starting with a space/tab
               (?:
-                (?:[ ]{%d} | \t)  # Lines must start with a tab or a tab-width of spaces
+                (?:[ ]{{{0:d}}} | \t)  # Lines must start with a tab or a tab-width of spaces
                 .*\n+
               )+
             )
-            ((?=^[ ]{0,%d}\S)|\Z)   # Lookahead for non-space at line-start, or end of doc
+            ((?=^[ ]{{0,{1:d}}}\S)|\Z)   # Lookahead for non-space at line-start, or end of doc
             # Lookahead to make sure this block isn't already in a code block.
             # Needed when syntax highlighting is being used.
             (?![^<]*\</code\>)
-            ''' % (self.tab_width, self.tab_width),
+            '''.format(self.tab_width, self.tab_width),
             re.M | re.X)
         return code_block_re.sub(self._code_block_sub, text)
 
@@ -1686,7 +1683,7 @@ class Markdown(object):
     def _code_span_sub(self, match):
         c = match.group(2).strip(" \t")
         c = self._encode_code(c)
-        return "<code>%s</code>" % c
+        return "<code>{0!s}</code>".format(c)
 
     def _do_code_spans(self, text):
         #   *   Backtick quotes are used for <code></code> spans.
@@ -1756,9 +1753,9 @@ class Markdown(object):
     def _do_smart_contractions(self, text):
         text = self._apostrophe_year_re.sub(r"&#8217;\1", text)
         for c in self._contractions:
-            text = text.replace("'%s" % c, "&#8217;%s" % c)
-            text = text.replace("'%s" % c.capitalize(),
-                "&#8217;%s" % c.capitalize())
+            text = text.replace("'{0!s}".format(c), "&#8217;{0!s}".format(c))
+            text = text.replace("'{0!s}".format(c.capitalize()),
+                "&#8217;{0!s}".format(c.capitalize()))
         return text
 
     # Substitute double-quotes before single-quotes.
@@ -1828,9 +1825,9 @@ class Markdown(object):
         bq = self._html_pre_block_re.sub(self._dedent_two_spaces_sub, bq)
 
         if is_spoiler:
-            return '<blockquote class="spoiler">\n%s\n</blockquote>\n\n' % bq
+            return '<blockquote class="spoiler">\n{0!s}\n</blockquote>\n\n'.format(bq)
         else:
-            return '<blockquote>\n%s\n</blockquote>\n\n' % bq
+            return '<blockquote>\n{0!s}\n</blockquote>\n\n'.format(bq)
 
     def _do_block_quotes(self, text):
         if '>' not in text:
@@ -1887,7 +1884,7 @@ class Markdown(object):
             for i, id in enumerate(self.footnote_ids):
                 if i != 0:
                     footer.append('')
-                footer.append('<li id="fn-%s">' % id)
+                footer.append('<li id="fn-{0!s}">'.format(id))
                 footer.append(self._run_block_gamut(self.footnotes[id]))
                 backlink = ('<a href="#fnref-%s" '
                     'class="footnoteBackLink" '
@@ -1897,7 +1894,7 @@ class Markdown(object):
                     footer[-1] = footer[-1][:-len("</p>")] \
                         + '&#160;' + backlink + "</p>"
                 else:
-                    footer.append("\n<p>%s</p>" % backlink)
+                    footer.append("\n<p>{0!s}</p>".format(backlink))
                 footer.append('</li>')
             footer.append('</ol>')
             footer.append('</div>')
@@ -1933,7 +1930,7 @@ class Markdown(object):
     _auto_link_re = re.compile(r'<((https?|ftp):[^\'">\s]+)>', re.I)
     def _auto_link_sub(self, match):
         g1 = match.group(1)
-        return '<a href="%s">%s</a>' % (g1, g1)
+        return '<a href="{0!s}">{1!s}</a>'.format(g1, g1)
 
     _auto_email_link_re = re.compile(r"""
           <
@@ -1970,8 +1967,7 @@ class Markdown(object):
         chars = [_xml_encode_email_char_at_random(ch)
                  for ch in "mailto:" + addr]
         # Strip the mailto: from the visible part.
-        addr = '<a href="%s">%s</a>' \
-               % (''.join(chars), ''.join(chars[7:]))
+        addr = '<a href="{0!s}">{1!s}</a>'.format(''.join(chars), ''.join(chars[7:]))
         return addr
 
     def _do_link_patterns(self, text):
@@ -1997,7 +1993,7 @@ class Markdown(object):
                         # To avoid markdown <em> and <strong>:
                         .replace('*', self._escape_table['*'])
                         .replace('_', self._escape_table['_']))
-                link = '<a href="%s">%s</a>' % (escaped_href, text[start:end])
+                link = '<a href="{0!s}">{1!s}</a>'.format(escaped_href, text[start:end])
                 hash = _hash_text(link)
                 link_from_hash[hash] = link
                 text = text[:start] + hash + text[end:]
@@ -2054,7 +2050,7 @@ class UnicodeWithAttrs(unicode):
         h_stack = [0]   # stack of header-level numbers
         for level, id, name in self._toc:
             if level > h_stack[-1]:
-                lines.append("%s<ul>" % indent())
+                lines.append("{0!s}<ul>".format(indent()))
                 h_stack.append(level)
             elif level == h_stack[-1]:
                 lines[-1] += "</li>"
@@ -2063,14 +2059,14 @@ class UnicodeWithAttrs(unicode):
                     h_stack.pop()
                     if not lines[-1].endswith("</li>"):
                         lines[-1] += "</li>"
-                    lines.append("%s</ul></li>" % indent())
-            lines.append('%s<li><a href="#%s">%s</a>' % (
+                    lines.append("{0!s}</ul></li>".format(indent()))
+            lines.append('{0!s}<li><a href="#{1!s}">{2!s}</a>'.format(
                 indent(), id, name))
         while len(h_stack) > 1:
             h_stack.pop()
             if not lines[-1].endswith("</li>"):
                 lines[-1] += "</li>"
-            lines.append("%s</ul>" % indent())
+            lines.append("{0!s}</ul>".format(indent()))
         return '\n'.join(lines) + '\n'
     toc_html = property(toc_html)
 
@@ -2144,8 +2140,7 @@ def _dedentlines(lines, tabsize=8, skip_first_line=False):
     """
     DEBUG = False
     if DEBUG:
-        print("dedent: dedent(..., tabsize=%d, skip_first_line=%r)"\
-              % (tabsize, skip_first_line))
+        print("dedent: dedent(..., tabsize={0:d}, skip_first_line={1!r})".format(tabsize, skip_first_line))
     indents = []
     margin = None
     for i, line in enumerate(lines):
@@ -2162,12 +2157,12 @@ def _dedentlines(lines, tabsize=8, skip_first_line=False):
                 break
         else:
             continue # skip all-whitespace lines
-        if DEBUG: print("dedent: indent=%d: %r" % (indent, line))
+        if DEBUG: print("dedent: indent={0:d}: {1!r}".format(indent, line))
         if margin is None:
             margin = indent
         else:
             margin = min(margin, indent)
-    if DEBUG: print("dedent: margin=%r" % margin)
+    if DEBUG: print("dedent: margin={0!r}".format(margin))
 
     if margin is not None and margin > 0:
         for i, line in enumerate(lines):
@@ -2179,7 +2174,7 @@ def _dedentlines(lines, tabsize=8, skip_first_line=False):
                 elif ch == '\t':
                     removed += tabsize - (removed % tabsize)
                 elif ch in '\r\n':
-                    if DEBUG: print("dedent: %r: EOL -> strip up to EOL" % line)
+                    if DEBUG: print("dedent: {0!r}: EOL -> strip up to EOL".format(line))
                     lines[i] = lines[i][j:]
                     break
                 else:
@@ -2187,8 +2182,7 @@ def _dedentlines(lines, tabsize=8, skip_first_line=False):
                                      "line %r while removing %d-space margin"
                                      % (ch, line, margin))
                 if DEBUG:
-                    print("dedent: %r: %r -> removed %d/%d"\
-                          % (line, ch, removed, margin))
+                    print("dedent: {0!r}: {1!r} -> removed {2:d}/{3:d}".format(line, ch, removed, margin))
                 if removed == margin:
                     lines[i] = lines[i][j+1:]
                     break
@@ -2250,16 +2244,16 @@ def _xml_oneliner_re_from_tab_width(tab_width):
             \A\n?           # the beginning of the doc
         )
         (                           # save in $1
-            [ ]{0,%d}
+            [ ]{{0,{0:d}}}
             (?:
                 <\?\w+\b\s+.*?\?>   # XML processing instruction
                 |
                 <\w+:\w+\b\s+.*?/>  # namespaced single tag
             )
             [ \t]*
-            (?=\n{2,}|\Z)       # followed by a blank line or end of document
+            (?=\n{{2,}}|\Z)       # followed by a blank line or end of document
         )
-        """ % (tab_width - 1), re.X)
+        """.format((tab_width - 1)), re.X)
 _xml_oneliner_re_from_tab_width = _memoized(_xml_oneliner_re_from_tab_width)
 
 def _hr_tag_re_from_tab_width(tab_width):
@@ -2270,15 +2264,15 @@ def _hr_tag_re_from_tab_width(tab_width):
             \A\n?           # the beginning of the doc
         )
         (                       # save in \1
-            [ ]{0,%d}
+            [ ]{{0,{0:d}}}
             <(hr)               # start tag = \2
             \b                  # word break
             ([^<>])*?           #
             /?>                 # the matching end tag
             [ \t]*
-            (?=\n{2,}|\Z)       # followed by a blank line or end of document
+            (?=\n{{2,}}|\Z)       # followed by a blank line or end of document
         )
-        """ % (tab_width - 1), re.X)
+        """.format((tab_width - 1)), re.X)
 _hr_tag_re_from_tab_width = _memoized(_hr_tag_re_from_tab_width)
 
 
@@ -2307,9 +2301,9 @@ def _xml_encode_email_char_at_random(ch):
         return ch
     elif r < 0.45:
         # The [1:] is to drop leading '0': 0x63 -> x63
-        return '&#%s;' % hex(ord(ch))[1:]
+        return '&#{0!s};'.format(hex(ord(ch))[1:])
     else:
-        return '&#%s;' % ord(ch)
+        return '&#{0!s};'.format(ord(ch))
 
 
 
@@ -2394,8 +2388,7 @@ def main(argv=None):
                 try:
                     pat, href = line.rstrip().rsplit(None, 1)
                 except ValueError:
-                    raise MarkdownError("%s:%d: invalid link pattern line: %r"
-                                        % (opts.link_patterns_file, i+1, line))
+                    raise MarkdownError("{0!s}:{1:d}: invalid link pattern line: {2!r}".format(opts.link_patterns_file, i+1, line))
                 link_patterns.append(
                     (_regex_from_encoded_pattern(pat), href))
         finally:
@@ -2418,7 +2411,7 @@ def main(argv=None):
         if opts.compare:
             from subprocess import Popen, PIPE
             print("==== Markdown.pl ====")
-            p = Popen('perl %s' % markdown_pl, shell=True, stdin=PIPE, stdout=PIPE, close_fds=True)
+            p = Popen('perl {0!s}'.format(markdown_pl), shell=True, stdin=PIPE, stdout=PIPE, close_fds=True)
             p.stdin.write(text.encode('utf-8'))
             p.stdin.close()
             perl_html = p.stdout.read().decode('utf-8')
@@ -2451,7 +2444,7 @@ def main(argv=None):
             else:
                 norm_html = html
                 norm_perl_html = perl_html
-            print("==== match? %r ====" % (norm_perl_html == norm_html))
+            print("==== match? {0!r} ====".format((norm_perl_html == norm_html)))
 
 
 if __name__ == "__main__":

--- a/lib/markupsafe/__init__.py
+++ b/lib/markupsafe/__init__.py
@@ -101,7 +101,7 @@ class Markup(text_type):
         return self.__class__(text_type.__mod__(self, arg))
 
     def __repr__(self):
-        return '%s(%s)' % (
+        return '{0!s}({1!s})'.format(
             self.__class__.__name__,
             text_type.__repr__(self)
         )

--- a/lib/markupsafe/tests.py
+++ b/lib/markupsafe/tests.py
@@ -77,7 +77,7 @@ class MarkupTestCase(unittest.TestCase):
              '&lt;bar/&gt;'),
             (Markup('{0[1][bar]}').format([0, {'bar': Markup('<bar/>')}]),
              '<bar/>')):
-            assert actual == expected, "%r should be %r!" % (actual, expected)
+            assert actual == expected, "{0!r} should be {1!r}!".format(actual, expected)
 
     # This is new in 2.7
     if sys.version_info >= (2, 7):

--- a/lib/ndg/httpsclient/ssl_peer_verification.py
+++ b/lib/ndg/httpsclient/ssl_peer_verification.py
@@ -40,7 +40,7 @@ class ServerSSLCertVerification(object):
         'userid':                   'UID'
     }
     SUBJ_ALT_NAME_EXT_NAME = 'subjectAltName'
-    PARSER_RE_STR = '/(%s)=' % '|'.join(DN_LUT.keys() + DN_LUT.values())
+    PARSER_RE_STR = '/({0!s})='.format('|'.join(DN_LUT.keys() + DN_LUT.values()))
     PARSER_RE = re.compile(PARSER_RE_STR)
 
     __slots__ = ('__hostname', '__certDN', '__subj_alt_name_match')
@@ -201,7 +201,7 @@ class ServerSSLCertVerification(object):
 
             dnFields = self.__class__.PARSER_RE.split(certDN)
             if len(dnFields) < 2:
-                raise TypeError('Error parsing DN string: "%s"' % certDN)
+                raise TypeError('Error parsing DN string: "{0!s}"'.format(certDN))
 
             self.__certDN = zip(dnFields[1::2], dnFields[2::2])
             self.__certDN.sort()

--- a/lib/ndg/httpsclient/test/__init__.py
+++ b/lib/ndg/httpsclient/test/__init__.py
@@ -18,8 +18,8 @@ class Constants(object):
     PORT = 4443
     PORT2 = 4444
     HOSTNAME = 'localhost'
-    TEST_URI = 'https://%s:%d' % (HOSTNAME, PORT)
-    TEST_URI2 = 'https://%s:%d' % (HOSTNAME, PORT2)
+    TEST_URI = 'https://{0!s}:{1:d}'.format(HOSTNAME, PORT)
+    TEST_URI2 = 'https://{0!s}:{1:d}'.format(HOSTNAME, PORT2)
 
     UNITTEST_DIR = os.path.dirname(os.path.abspath(__file__))
     CACERT_DIR = os.path.join(UNITTEST_DIR, 'pki', 'ca')

--- a/lib/ndg/httpsclient/test/test_https.py
+++ b/lib/ndg/httpsclient/test/test_https.py
@@ -30,7 +30,7 @@ class TestHTTPSConnection(unittest.TestCase):
         conn.connect()
         conn.request('GET', '/')
         resp = conn.getresponse()
-        print('Response = %s' % resp.read())
+        print('Response = {0!s}'.format(resp.read()))
         conn.close()
 
     def test02_open_fails(self):
@@ -73,7 +73,7 @@ class TestHTTPSConnection(unittest.TestCase):
         conn.connect()
         conn.request('GET', '/')
         resp = conn.getresponse()
-        print('Response = %s' % resp.read())
+        print('Response = {0!s}'.format(resp.read()))
 
     def test04_ssl_verification_with_subj_alt_name(self):
         ctx = SSL.Context(SSL.SSLv3_METHOD)
@@ -91,7 +91,7 @@ class TestHTTPSConnection(unittest.TestCase):
         conn.connect()
         conn.request('GET', '/')
         resp = conn.getresponse()
-        print('Response = %s' % resp.read())
+        print('Response = {0!s}'.format(resp.read()))
 
     def test04_ssl_verification_with_subj_common_name(self):
         ctx = SSL.Context(SSL.SSLv3_METHOD)
@@ -112,7 +112,7 @@ class TestHTTPSConnection(unittest.TestCase):
         conn.connect()
         conn.request('GET', '/')
         resp = conn.getresponse()
-        print('Response = %s' % resp.read())
+        print('Response = {0!s}'.format(resp.read()))
 
         
 if __name__ == "__main__":

--- a/lib/ndg/httpsclient/test/test_urllib2.py
+++ b/lib/ndg/httpsclient/test/test_urllib2.py
@@ -28,7 +28,7 @@ class Urllib2TestCase(unittest.TestCase):
         opener = build_opener()
         res = opener.open(Constants.TEST_URI)
         self.assert_(res)
-        print("res = %s" % res.read())
+        print("res = {0!s}".format(res.read()))
 
     def test03_open_fails_unknown_loc(self):
         opener = build_opener()

--- a/lib/ndg/httpsclient/test/test_utils.py
+++ b/lib/ndg/httpsclient/test/test_utils.py
@@ -36,7 +36,7 @@ class TestUtilsModule(unittest.TestCase):
         config = Configuration(SSL.Context(SSL.SSLv3_METHOD), True)
         res = open_url(Constants.TEST_URI, config)
         self.assertEqual(res[0], 200, 
-                         'open_url for %r failed' % Constants.TEST_URI)
+                         'open_url for {0!r} failed'.format(Constants.TEST_URI))
         
     def test04__should_use_proxy(self):
         if 'no_proxy' in os.environ:

--- a/lib/ndg/httpsclient/utils.py
+++ b/lib/ndg/httpsclient/utils.py
@@ -183,7 +183,7 @@ def open_url(url, config, data=None, handlers=None):
         log.debug("Not using proxy")
     elif config.proxies:
         handlers.append(urllib2.ProxyHandler(config.proxies))
-        log.debug("Configuring proxies: %s" % config.proxies)
+        log.debug("Configuring proxies: {0!s}".format(config.proxies))
 
     opener = build_opener(*handlers, ssl_context=config.ssl_context)
     
@@ -207,12 +207,12 @@ def open_url(url, config, data=None, handlers=None):
                 
     except urllib2.HTTPError, exc:
         return_code = exc.code
-        return_message = "Error: %s" % exc.msg
+        return_message = "Error: {0!s}".format(exc.msg)
         if log.isEnabledFor(logging.DEBUG):
             log.debug("%s %s", exc.code, exc.msg)
             
     except Exception, exc:
-        return_message = "Error: %s" % exc.__str__()
+        return_message = "Error: {0!s}".format(exc.__str__())
         if log.isEnabledFor(logging.DEBUG):
             import traceback
             log.debug(traceback.format_exc())
@@ -251,8 +251,7 @@ def _url_as_string(url):
     elif isinstance(url, basestring):
         return url
     else:
-        raise TypeError("Expected type %r or %r" %
-                        (basestring, urllib2.Request))
+        raise TypeError("Expected type {0!r} or {1!r}".format(basestring, urllib2.Request))
 
 
 class Configuration(object):

--- a/lib/oauth2/__init__.py
+++ b/lib/oauth2/__init__.py
@@ -60,7 +60,7 @@ class MissingSignature(Error):
 
 def build_authenticate_header(realm=''):
     """Optional WWW-Authenticate header (401 error)"""
-    return {'WWW-Authenticate': 'OAuth realm="%s"' % realm}
+    return {'WWW-Authenticate': 'OAuth realm="{0!s}"'.format(realm)}
 
 
 def escape(s):
@@ -166,9 +166,9 @@ class Token(object):
             parts = urlparse.urlparse(self.callback)
             scheme, netloc, path, params, query, fragment = parts[:6]
             if query:
-                query = '%s&oauth_verifier=%s' % (query, self.verifier)
+                query = '{0!s}&oauth_verifier={1!s}'.format(query, self.verifier)
             else:
-                query = 'oauth_verifier=%s' % self.verifier
+                query = 'oauth_verifier={0!s}'.format(self.verifier)
             return urlparse.urlunparse((scheme, netloc, path, params,
                 query, fragment))
         return self.callback
@@ -276,9 +276,9 @@ class Request(dict):
             netloc = netloc[:-4]
 
         if scheme != 'http' and scheme != 'https':
-            raise ValueError("Unsupported URL %s (%s)." % (value, scheme))
+            raise ValueError("Unsupported URL {0!s} ({1!s}).".format(value, scheme))
 
-        value = '%s://%s%s' % (scheme, netloc, path)
+        value = '{0!s}://{1!s}{2!s}'.format(scheme, netloc, path)
         self.__dict__['url'] = value
  
     @setter
@@ -298,12 +298,12 @@ class Request(dict):
         oauth_params = ((k, v) for k, v in self.items() 
                             if k.startswith('oauth_'))
         stringy_params = ((k, escape(str(v))) for k, v in oauth_params)
-        header_params = ('%s="%s"' % (k, v) for k, v in stringy_params)
+        header_params = ('{0!s}="{1!s}"'.format(k, v) for k, v in stringy_params)
         params_header = ', '.join(header_params)
  
-        auth_header = 'OAuth realm="%s"' % realm
+        auth_header = 'OAuth realm="{0!s}"'.format(realm)
         if params_header:
-            auth_header = "%s, %s" % (auth_header, params_header)
+            auth_header = "{0!s}, {1!s}".format(auth_header, params_header)
  
         return {'Authorization': auth_header}
  
@@ -319,12 +319,12 @@ class Request(dict):
 
     def to_url(self):
         """Serialize as a URL for a GET request."""
-        return '%s?%s' % (self.url, self.to_postdata())
+        return '{0!s}?{1!s}'.format(self.url, self.to_postdata())
 
     def get_parameter(self, parameter):
         ret = self.get(parameter)
         if ret is None:
-            raise Error('Parameter not found: %s' % parameter)
+            raise Error('Parameter not found: {0!s}'.format(parameter))
 
         return ret
  
@@ -487,7 +487,7 @@ class Server(object):
 
     def build_authenticate_header(self, realm=''):
         """Optional support for the authenticate header."""
-        return {'WWW-Authenticate': 'OAuth realm="%s"' % realm}
+        return {'WWW-Authenticate': 'OAuth realm="{0!s}"'.format(realm)}
 
     def _get_version(self, request):
         """Verify the correct version request for this server."""
@@ -497,7 +497,7 @@ class Server(object):
             version = VERSION
 
         if version and version != self.version:
-            raise Error('OAuth version %s not supported.' % str(version))
+            raise Error('OAuth version {0!s} not supported.'.format(str(version)))
 
         return version
 
@@ -513,7 +513,7 @@ class Server(object):
             signature_method = self.signature_methods[signature_method]
         except:
             signature_method_names = ', '.join(self.signature_methods.keys())
-            raise Error('Signature method %s not supported try one of the following: %s' % (signature_method, signature_method_names))
+            raise Error('Signature method {0!s} not supported try one of the following: {1!s}'.format(signature_method, signature_method_names))
 
         return signature_method
 
@@ -665,7 +665,7 @@ class SignatureMethod_HMAC_SHA1(SignatureMethod):
             escape(request.get_normalized_parameters()),
         )
 
-        key = '%s&' % escape(consumer.secret)
+        key = '{0!s}&'.format(escape(consumer.secret))
         if token:
             key += escape(token.secret)
         raw = '&'.join(sig)
@@ -693,7 +693,7 @@ class SignatureMethod_PLAINTEXT(SignatureMethod):
     def signing_base(self, request, consumer, token):
         """Concatenates the consumer key and secret with the token's
         secret."""
-        sig = '%s&' % escape(consumer.secret)
+        sig = '{0!s}&'.format(escape(consumer.secret))
         if token:
             sig = sig + escape(token.secret)
         return sig, sig

--- a/lib/pkg_resources.py
+++ b/lib/pkg_resources.py
@@ -96,7 +96,7 @@ def get_supported_platform():
     plat = get_build_platform(); m = macosVersionString.match(plat)
     if m is not None and sys.platform == "darwin":
         try:
-            plat = 'macosx-%s-%s' % ('.'.join(_macosx_vers()[:2]), m.group(3))
+            plat = 'macosx-{0!s}-{1!s}'.format('.'.join(_macosx_vers()[:2]), m.group(3))
         except ValueError:
             pass    # not Mac OS X
     return plat
@@ -228,7 +228,7 @@ def get_build_platform():
         try:
             version = _macosx_vers()
             machine = os.uname()[4].replace(" ", "_")
-            return "macosx-%d.%d-%s" % (int(version[0]), int(version[1]),
+            return "macosx-{0:d}.{1:d}-{2!s}".format(int(version[0]), int(version[1]),
                 _macosx_arch(machine))
         except ValueError:
             # if someone is running a non-Mac darwin system, this will fall
@@ -271,7 +271,7 @@ def compatible_platforms(provided,required):
             provDarwin = darwinVersionString.match(provided)
             if provDarwin:
                 dversion = int(provDarwin.group(1))
-                macosversion = "%s.%s" % (reqMac.group(1), reqMac.group(2))
+                macosversion = "{0!s}.{1!s}".format(reqMac.group(1), reqMac.group(2))
                 if dversion == 7 and macosversion >= "10.3" or \
                     dversion == 8 and macosversion >= "10.4":
 
@@ -831,7 +831,7 @@ class Environment(object):
                 for dist in other[project]:
                     self.add(dist)
         else:
-            raise TypeError("Can't add %r to environment" % (other,))
+            raise TypeError("Can't add {0!r} to environment".format(other))
         return self
 
     def __add__(self, other):
@@ -915,16 +915,16 @@ class ResourceManager:
 The following error occurred while trying to extract file(s) to the Python egg
 cache:
 
-  %s
+  {0!s}
 
 The Python egg cache directory is currently set to:
 
-  %s
+  {1!s}
 
 Perhaps your account does not have write access to this directory?  You can
 change the cache directory by setting the PYTHON_EGG_CACHE environment
 variable to point to an accessible directory.
-"""         % (old_exc, cache_path)
+""".format(old_exc, cache_path)
         )
         err.manager        = self
         err.cache_path     = cache_path
@@ -1202,7 +1202,7 @@ class NullProvider:
     def run_script(self,script_name,namespace):
         script = 'scripts/'+script_name
         if not self.has_metadata(script):
-            raise ResolutionError("No script named %r" % script_name)
+            raise ResolutionError("No script named {0!r}".format(script_name))
         script_text = self.get_metadata(script).replace('\r\n','\n')
         script_text = script_text.replace('\r','\n')
         script_filename = self._fn(self.egg_info,script)
@@ -1330,7 +1330,7 @@ class ZipProvider(EggProvider):
         if fspath.startswith(self.zip_pre):
             return fspath[len(self.zip_pre):]
         raise AssertionError(
-            "%s is not a subpath of %s" % (fspath,self.zip_pre)
+            "{0!s} is not a subpath of {1!s}".format(fspath, self.zip_pre)
         )
 
     def _parts(self,zip_path):
@@ -1339,7 +1339,7 @@ class ZipProvider(EggProvider):
         if fspath.startswith(self.egg_root+os.sep):
             return fspath[len(self.egg_root)+1:].split(os.sep)
         raise AssertionError(
-            "%s is not a subpath of %s" % (fspath,self.egg_root)
+            "{0!s} is not a subpath of {1!s}".format(fspath, self.egg_root)
         )
 
     def get_resource_filename(self, manager, resource_name):
@@ -1939,19 +1939,19 @@ class EntryPoint(object):
         self.name = name
         self.module_name = module_name
         self.attrs = tuple(attrs)
-        self.extras = Requirement.parse(("x[%s]" % ','.join(extras))).extras
+        self.extras = Requirement.parse(("x[{0!s}]".format(','.join(extras)))).extras
         self.dist = dist
 
     def __str__(self):
-        s = "%s = %s" % (self.name, self.module_name)
+        s = "{0!s} = {1!s}".format(self.name, self.module_name)
         if self.attrs:
             s += ':' + '.'.join(self.attrs)
         if self.extras:
-            s += ' [%s]' % ','.join(self.extras)
+            s += ' [{0!s}]'.format(','.join(self.extras))
         return s
 
     def __repr__(self):
-        return "EntryPoint.parse(%r)" % str(self)
+        return "EntryPoint.parse({0!r})".format(str(self))
 
     def load(self, require=True, env=None, installer=None):
         if require: self.require(env, installer)
@@ -1960,7 +1960,7 @@ class EntryPoint(object):
             try:
                 entry = getattr(entry,attr)
             except AttributeError:
-                raise ImportError("%r has no %r attribute" % (entry,attr))
+                raise ImportError("{0!r} has no {1!r} attribute".format(entry, attr))
         return entry
 
     def require(self, env=None, installer=None):
@@ -2158,7 +2158,7 @@ class Distribution(object):
                 deps.extend(dm[safe_extra(ext)])
             except KeyError:
                 raise UnknownExtra(
-                    "%s has no such extra feature %r" % (self, ext)
+                    "{0!s} has no such extra feature {1!r}".format(self, ext)
                 )
         return deps
 
@@ -2178,7 +2178,7 @@ class Distribution(object):
 
     def egg_name(self):
         """Return what this distribution's standard .egg filename should be"""
-        filename = "%s-%s-py%s" % (
+        filename = "{0!s}-{1!s}-py{2!s}".format(
             to_filename(self.project_name), to_filename(self.version),
             self.py_version or PY_MAJOR
         )
@@ -2189,7 +2189,7 @@ class Distribution(object):
 
     def __repr__(self):
         if self.location:
-            return "%s (%s)" % (self,self.location)
+            return "{0!s} ({1!s})".format(self, self.location)
         else:
             return str(self)
 
@@ -2197,7 +2197,7 @@ class Distribution(object):
         try: version = getattr(self,'version',None)
         except ValueError: version = None
         version = version or "[unknown version]"
-        return "%s %s" % (self.project_name,version)
+        return "{0!s} {1!s}".format(self.project_name, version)
 
     def __getattr__(self,attr):
         """Delegate all unrecognized public attributes to .metadata provider"""
@@ -2215,13 +2215,13 @@ class Distribution(object):
 
     def as_requirement(self):
         """Return a ``Requirement`` that matches this distribution exactly"""
-        return Requirement.parse('%s==%s' % (self.project_name, self.version))
+        return Requirement.parse('{0!s}=={1!s}'.format(self.project_name, self.version))
 
     def load_entry_point(self, group, name):
         """Return the `name` entry point of `group` or raise ImportError"""
         ep = self.get_entry_info(group,name)
         if ep is None:
-            raise ImportError("Entry point %r not found" % ((group,name),))
+            raise ImportError("Entry point {0!r} not found".format((group,name)))
         return ep.load()
 
     def get_entry_map(self, group=None):
@@ -2481,8 +2481,8 @@ class Requirement:
     def __str__(self):
         specs = ','.join([''.join(s) for s in self.specs])
         extras = ','.join(self.extras)
-        if extras: extras = '[%s]' % extras
-        return '%s%s%s' % (self.project_name, extras, specs)
+        if extras: extras = '[{0!s}]'.format(extras)
+        return '{0!s}{1!s}{2!s}'.format(self.project_name, extras, specs)
 
     def __eq__(self,other):
         return isinstance(other,Requirement) and self.hashCmp==other.hashCmp
@@ -2507,7 +2507,7 @@ class Requirement:
     def __hash__(self):
         return self.__hash
 
-    def __repr__(self): return "Requirement.parse(%r)" % str(self)
+    def __repr__(self): return "Requirement.parse({0!r})".format(str(self))
 
     #@staticmethod
     def parse(s):

--- a/lib/profilehooks.py
+++ b/lib/profilehooks.py
@@ -207,8 +207,7 @@ def profile(fn=None, skip=0, filename=None, immediate=False, dirs=False,
             profiler_class = AVAILABLE_PROFILERS[p]
             break
     else:
-        raise ValueError('only these profilers are available: %s'
-                             % ', '.join(AVAILABLE_PROFILERS))
+        raise ValueError('only these profilers are available: {0!s}'.format(', '.join(AVAILABLE_PROFILERS)))
     fp = profiler_class(fn, skip=skip, filename=filename,
                         immediate=immediate, dirs=dirs,
                         sort=sort, entries=entries)
@@ -337,10 +336,10 @@ class FuncProfile(object):
         lineno = self.fn.func_code.co_firstlineno
         print
         print "*** PROFILER RESULTS ***"
-        print "%s (%s:%s)" % (funcname, filename, lineno)
-        print "function called %d times" % self.ncalls,
+        print "{0!s} ({1!s}:{2!s})".format(funcname, filename, lineno)
+        print "function called {0:d} times".format(self.ncalls),
         if self.skipped:
-            print "(%d calls not profiled)" % self.skipped
+            print "({0:d} calls not profiled)".format(self.skipped)
         else:
             print
         print
@@ -440,10 +439,10 @@ if hotshot is not None:
             lineno = self.fn.func_code.co_firstlineno
             print
             print "*** PROFILER RESULTS ***"
-            print "%s (%s:%s)" % (funcname, filename, lineno)
-            print "function called %d times" % self.ncalls,
+            print "{0!s} ({1!s}:{2!s})".format(funcname, filename, lineno)
+            print "function called {0:d} times".format(self.ncalls),
             if self.skipped:
-                print "(%d calls not profiled)" % self.skipped
+                print "({0:d} calls not profiled)".format(self.skipped)
             else:
                 print
             print
@@ -503,8 +502,8 @@ if hotshot is not None:
             lineno = self.fn.func_code.co_firstlineno
             print
             print "*** COVERAGE RESULTS ***"
-            print "%s (%s:%s)" % (funcname, filename, lineno)
-            print "function called %d times" % self.ncalls
+            print "{0!s} ({1!s}:{2!s})".format(funcname, filename, lineno)
+            print "function called {0:d} times".format(self.ncalls)
             print
             fs = FuncSource(self.fn)
             reader = hotshot.log.LogReader(self.logfilename)
@@ -577,8 +576,8 @@ class TraceFuncCoverage:
         lineno = self.fn.func_code.co_firstlineno
         print
         print "*** COVERAGE RESULTS ***"
-        print "%s (%s:%s)" % (funcname, filename, lineno)
-        print "function called %d times" % self.ncalls
+        print "{0!s} ({1!s}:{2!s})".format(funcname, filename, lineno)
+        print "function called {0:d} times".format(self.ncalls)
         print
         fs = FuncSource(self.fn)
         for (filename, lineno), count in self.tracer.counts.items():
@@ -588,7 +587,7 @@ class TraceFuncCoverage:
         print fs
         never_executed = fs.count_never_executed()
         if never_executed:
-            print "%d lines were not executed." % never_executed
+            print "{0:d} lines were not executed.".format(never_executed)
 
 
 class FuncSource:
@@ -647,7 +646,7 @@ class FuncSource:
                 else:
                     prefix = '>' * 6 + ' '
             else:
-                prefix = '%5d: ' % counter
+                prefix = '{0:5d}: '.format(counter)
             lines.append(prefix + line)
             lineno += 1
         return ''.join(lines)
@@ -718,7 +717,7 @@ class FuncTimer(object):
                 funcname = fn.__name__
                 filename = fn.func_code.co_filename
                 lineno = fn.func_code.co_firstlineno
-                print >> sys.stderr, "\n  %s (%s:%s):\n    %.3f seconds\n" % (
+                print >> sys.stderr, "\n  {0!s} ({1!s}:{2!s}):\n    {3:.3f} seconds\n".format(
                                         funcname, filename, lineno, duration)
     def atexit(self):
         if not self.ncalls:

--- a/lib/pyasn1/codec/ber/decoder.py
+++ b/lib/pyasn1/codec/ber/decoder.py
@@ -8,17 +8,17 @@ class AbstractDecoder:
     protoComponent = None
     def valueDecoder(self, fullSubstrate, substrate, asn1Spec, tagSet,
                      length, state, decodeFun, substrateFun):
-        raise error.PyAsn1Error('Decoder not implemented for %s' % (tagSet,))
+        raise error.PyAsn1Error('Decoder not implemented for {0!s}'.format(tagSet))
 
     def indefLenValueDecoder(self, fullSubstrate, substrate, asn1Spec, tagSet,
                      length, state, decodeFun, substrateFun):
-        raise error.PyAsn1Error('Indefinite length mode decoder not implemented for %s' % (tagSet,))
+        raise error.PyAsn1Error('Indefinite length mode decoder not implemented for {0!s}'.format(tagSet))
 
 class AbstractSimpleDecoder(AbstractDecoder):
     tagFormats = (tag.tagFormatSimple,)
     def _createComponent(self, asn1Spec, tagSet, value=None):
         if tagSet[0][1] not in self.tagFormats:
-            raise error.PyAsn1Error('Invalid tag format %r for %r' % (tagSet[0], self.protoComponent,))
+            raise error.PyAsn1Error('Invalid tag format {0!r} for {1!r}'.format(tagSet[0], self.protoComponent))
         if asn1Spec is None:
             return self.protoComponent.clone(value, tagSet)
         elif value is None:
@@ -30,7 +30,7 @@ class AbstractConstructedDecoder(AbstractDecoder):
     tagFormats = (tag.tagFormatConstructed,)
     def _createComponent(self, asn1Spec, tagSet, value=None):
         if tagSet[0][1] not in self.tagFormats:
-            raise error.PyAsn1Error('Invalid tag format %r for %r' % (tagSet[0], self.protoComponent,))
+            raise error.PyAsn1Error('Invalid tag format {0!r} for {1!r}'.format(tagSet[0], self.protoComponent))
         if asn1Spec is None:
             return self.protoComponent.clone(tagSet)
         else:
@@ -126,7 +126,7 @@ class BitStringDecoder(AbstractSimpleDecoder):
             trailingBits = oct2int(head[0])
             if trailingBits > 7:
                 raise error.PyAsn1Error(
-                    'Trailing bits overflow %s' % trailingBits
+                    'Trailing bits overflow {0!s}'.format(trailingBits)
                     )
             head = head[1:]
             lsb = p = 0; l = len(head)-1; b = ()
@@ -205,7 +205,7 @@ class NullDecoder(AbstractSimpleDecoder):
         head, tail = substrate[:length], substrate[length:]
         r = self._createComponent(asn1Spec, tagSet)
         if head:
-            raise error.PyAsn1Error('Unexpected %d-octet substrate for Null' % length)
+            raise error.PyAsn1Error('Unexpected {0:d}-octet substrate for Null'.format(length))
         return r, tail
 
 class ObjectIdentifierDecoder(AbstractSimpleDecoder):
@@ -238,7 +238,7 @@ class ObjectIdentifierDecoder(AbstractSimpleDecoder):
                     subId = (subId << 7) + (nextSubId & 0x7F)
                     if index >= substrateLen:
                         raise error.SubstrateUnderrunError(
-                            'Short substrate for sub-OID past %s' % (oid,)
+                            'Short substrate for sub-OID past {0!s}'.format(oid)
                             )
                     nextSubId = oct2int(head[index])
                     index = index + 1
@@ -286,7 +286,7 @@ class RealDecoder(AbstractSimpleDecoder):
                     value = float(head)
                 else:
                     raise error.SubstrateUnderrunError(
-                        'Unknown NR (tag %s)' % fo
+                        'Unknown NR (tag {0!s})'.format(fo)
                         )
             except ValueError:
                 raise error.SubstrateUnderrunError(
@@ -294,7 +294,7 @@ class RealDecoder(AbstractSimpleDecoder):
                     )
         else:
             raise error.SubstrateUnderrunError(
-                'Unknown encoding (tag %s)' % fo
+                'Unknown encoding (tag {0!s})'.format(fo)
                 )
         return self._createComponent(asn1Spec, tagSet, value), tail
         
@@ -586,7 +586,7 @@ class Decoder:
                  length=None, state=stDecodeTag, recursiveFlag=1,
                  substrateFun=None):
         if debug.logger & debug.flagDecoder:
-            debug.logger('decoder called at scope %s with state %d, working with up to %d octets of substrate: %s' % (debug.scope, state, len(substrate), debug.hexdump(substrate)))
+            debug.logger('decoder called at scope {0!s} with state {1:d}, working with up to {2:d} octets of substrate: {3!s}'.format(debug.scope, state, len(substrate), debug.hexdump(substrate)))
         fullSubstrate = substrate
         while state != stStop:
             if state == stDecodeTag:
@@ -637,7 +637,7 @@ class Decoder:
                 else:
                     tagSet = lastTag + tagSet
                 state = stDecodeLength
-                debug.logger and debug.logger & debug.flagDecoder and debug.logger('tag decoded into %r, decoding length' % tagSet)
+                debug.logger and debug.logger & debug.flagDecoder and debug.logger('tag decoded into {0!r}, decoding length'.format(tagSet))
             if state == stDecodeLength:
                 # Decode length
                 if not substrate:
@@ -659,8 +659,7 @@ class Decoder:
                     # problem, we can handle more than is possible
                     if len(lengthString) != size:
                         raise error.SubstrateUnderrunError(
-                            '%s<%s at %s' %
-                            (size, len(lengthString), tagSet)
+                            '{0!s}<{1!s} at {2!s}'.format(size, len(lengthString), tagSet)
                             )
                     for char in lengthString:
                         length = (length << 8) | oct2int(char)
@@ -668,10 +667,10 @@ class Decoder:
                 substrate = substrate[size:]
                 if length != -1 and len(substrate) < length:
                     raise error.SubstrateUnderrunError(
-                        '%d-octet short' % (length - len(substrate))
+                        '{0:d}-octet short'.format((length - len(substrate)))
                         )
                 state = stGetValueDecoder
-                debug.logger and debug.logger & debug.flagDecoder and debug.logger('value length decoded into %d, payload substrate is: %s' % (length, debug.hexdump(length == -1 and substrate or substrate[:length])))
+                debug.logger and debug.logger & debug.flagDecoder and debug.logger('value length decoded into {0:d}, payload substrate is: {1!s}'.format(length, debug.hexdump(length == -1 and substrate or substrate[:length])))
             if state == stGetValueDecoder:
                 if asn1Spec is None:
                     state = stGetValueDecoderByTag
@@ -711,7 +710,7 @@ class Decoder:
                     else:
                         state = stTryAsExplicitTag
                 if debug.logger and debug.logger & debug.flagDecoder:
-                    debug.logger('codec %s chosen by a built-in type, decoding %s' % (concreteDecoder and concreteDecoder.__class__.__name__ or "<none>", state == stDecodeValue and 'value' or 'as explicit tag'))
+                    debug.logger('codec {0!s} chosen by a built-in type, decoding {1!s}'.format(concreteDecoder and concreteDecoder.__class__.__name__ or "<none>", state == stDecodeValue and 'value' or 'as explicit tag'))
                     debug.scope.push(concreteDecoder is None and '?' or concreteDecoder.protoComponent.__class__.__name__)
             if state == stGetValueDecoderByAsn1Spec:
                 if isinstance(asn1Spec, (dict, tagmap.TagMap)):
@@ -722,15 +721,15 @@ class Decoder:
                     if debug.logger and debug.logger & debug.flagDecoder:
                         debug.logger('candidate ASN.1 spec is a map of:')
                         for t, v in asn1Spec.getPosMap().items():
-                            debug.logger('  %r -> %s' % (t, v.__class__.__name__))
+                            debug.logger('  {0!r} -> {1!s}'.format(t, v.__class__.__name__))
                         if asn1Spec.getNegMap():
                             debug.logger('but neither of: ')
                             for i in asn1Spec.getNegMap().items():
-                                debug.logger('  %r -> %s' % (t, v.__class__.__name__))
-                        debug.logger('new candidate ASN.1 spec is %s, chosen by %r' % (__chosenSpec is None and '<none>' or __chosenSpec.__class__.__name__, tagSet))
+                                debug.logger('  {0!r} -> {1!s}'.format(t, v.__class__.__name__))
+                        debug.logger('new candidate ASN.1 spec is {0!s}, chosen by {1!r}'.format(__chosenSpec is None and '<none>' or __chosenSpec.__class__.__name__, tagSet))
                 else:
                     __chosenSpec = asn1Spec
-                    debug.logger and debug.logger & debug.flagDecoder and debug.logger('candidate ASN.1 spec is %s' % asn1Spec.__class__.__name__)
+                    debug.logger and debug.logger & debug.flagDecoder and debug.logger('candidate ASN.1 spec is {0!s}'.format(asn1Spec.__class__.__name__))
                 if __chosenSpec is not None and (
                        tagSet == __chosenSpec.getTagSet() or \
                        tagSet in __chosenSpec.getTagMap()
@@ -741,11 +740,11 @@ class Decoder:
                            __chosenSpec.typeId in self.__typeMap:
                         # ambiguous type
                         concreteDecoder = self.__typeMap[__chosenSpec.typeId]
-                        debug.logger and debug.logger & debug.flagDecoder and debug.logger('value decoder chosen for an ambiguous type by type ID %s' % (__chosenSpec.typeId,))
+                        debug.logger and debug.logger & debug.flagDecoder and debug.logger('value decoder chosen for an ambiguous type by type ID {0!s}'.format(__chosenSpec.typeId))
                     elif baseTagSet in self.__tagMap:
                         # base type or tagged subtype
                         concreteDecoder = self.__tagMap[baseTagSet]
-                        debug.logger and debug.logger & debug.flagDecoder and debug.logger('value decoder chosen by base %r' % (baseTagSet,))
+                        debug.logger and debug.logger & debug.flagDecoder and debug.logger('value decoder chosen by base {0!r}'.format(baseTagSet))
                     else:
                         concreteDecoder = None
                     if concreteDecoder:
@@ -761,7 +760,7 @@ class Decoder:
                     concreteDecoder = None
                     state = stTryAsExplicitTag
                 if debug.logger and debug.logger & debug.flagDecoder:
-                    debug.logger('codec %s chosen by ASN.1 spec, decoding %s' % (state == stDecodeValue and concreteDecoder.__class__.__name__ or "<none>", state == stDecodeValue and 'value' or 'as explicit tag'))
+                    debug.logger('codec {0!s} chosen by ASN.1 spec, decoding {1!s}'.format(state == stDecodeValue and concreteDecoder.__class__.__name__ or "<none>", state == stDecodeValue and 'value' or 'as explicit tag'))
                     debug.scope.push(__chosenSpec is None and '?' or __chosenSpec.__class__.__name__)
             if state == stTryAsExplicitTag:
                 if tagSet and \
@@ -773,10 +772,10 @@ class Decoder:
                 else:                    
                     concreteDecoder = None
                     state = self.defaultErrorState
-                debug.logger and debug.logger & debug.flagDecoder and debug.logger('codec %s chosen, decoding %s' % (concreteDecoder and concreteDecoder.__class__.__name__ or "<none>", state == stDecodeValue and 'value' or 'as failure'))
+                debug.logger and debug.logger & debug.flagDecoder and debug.logger('codec {0!s} chosen, decoding {1!s}'.format(concreteDecoder and concreteDecoder.__class__.__name__ or "<none>", state == stDecodeValue and 'value' or 'as failure'))
             if state == stDumpRawValue:
                 concreteDecoder = self.defaultRawDecoder
-                debug.logger and debug.logger & debug.flagDecoder and debug.logger('codec %s chosen, decoding value' % concreteDecoder.__class__.__name__)
+                debug.logger and debug.logger & debug.flagDecoder and debug.logger('codec {0!s} chosen, decoding value'.format(concreteDecoder.__class__.__name__))
                 state = stDecodeValue
             if state == stDecodeValue:
                 if recursiveFlag == 0 and not substrateFun: # legacy
@@ -792,14 +791,14 @@ class Decoder:
                         stGetValueDecoder, self, substrateFun
                         )
                 state = stStop
-                debug.logger and debug.logger & debug.flagDecoder and debug.logger('codec %s yields type %s, value:\n%s\n...remaining substrate is: %s' % (concreteDecoder.__class__.__name__, value.__class__.__name__, value.prettyPrint(), substrate and debug.hexdump(substrate) or '<none>'))
+                debug.logger and debug.logger & debug.flagDecoder and debug.logger('codec {0!s} yields type {1!s}, value:\n{2!s}\n...remaining substrate is: {3!s}'.format(concreteDecoder.__class__.__name__, value.__class__.__name__, value.prettyPrint(), substrate and debug.hexdump(substrate) or '<none>'))
             if state == stErrorCondition:
                 raise error.PyAsn1Error(
-                    '%r not in asn1Spec: %r' % (tagSet, asn1Spec)
+                    '{0!r} not in asn1Spec: {1!r}'.format(tagSet, asn1Spec)
                     )
         if debug.logger and debug.logger & debug.flagDecoder:
             debug.scope.pop()
-            debug.logger('decoder left scope %s, call completed' % debug.scope)
+            debug.logger('decoder left scope {0!s}, call completed'.format(debug.scope))
         return value, substrate
             
 decode = Decoder(tagMap, typeMap)

--- a/lib/pyasn1/codec/ber/encoder.py
+++ b/lib/pyasn1/codec/ber/encoder.py
@@ -35,7 +35,7 @@ class AbstractItemEncoder:
                 length = length >> 8
             substrateLen = len(substrate)
             if substrateLen > 126:
-                raise Error('Length octets overflow (%d)' % substrateLen)
+                raise Error('Length octets overflow ({0:d})'.format(substrateLen))
             return int2oct(0x80 | substrateLen) + substrate
 
     def encodeValue(self, encodeFun, value, defMode, maxChunkSize):
@@ -164,12 +164,12 @@ class ObjectIdentifierEncoder(AbstractItemEncoder):
             index = 5
         else:
             if len(oid) < 2:
-                raise error.PyAsn1Error('Short OID %s' % (value,))
+                raise error.PyAsn1Error('Short OID {0!s}'.format(value))
 
             # Build the first twos
             if oid[0] > 6 or oid[1] > 39 or oid[0] == 6 and oid[1] > 15:
                 raise error.PyAsn1Error(
-                    'Initial sub-ID overflow %s in OID %s' % (oid[:2], value)
+                    'Initial sub-ID overflow {0!s} in OID {1!s}'.format(oid[:2], value)
                     )
             octets = (oid[0] * 40 + oid[1],)
             index = 2
@@ -181,7 +181,7 @@ class ObjectIdentifierEncoder(AbstractItemEncoder):
                 octets = octets + (subid & 0x7f,)
             elif subid < 0 or subid > 0xFFFFFFFF:
                 raise error.PyAsn1Error(
-                    'SubId overflow %s in %s' % (subid, value)
+                    'SubId overflow {0!s} in {1!s}'.format(subid, value)
                     )
             else:
                 # Pack large Sub-Object IDs
@@ -206,7 +206,7 @@ class RealEncoder(AbstractItemEncoder):
         if not m:
             return null, 0
         if b == 10:
-            return str2octs('\x03%dE%s%d' % (m, e == 0 and '+' or '', e)), 0
+            return str2octs('\x03{0:d}E{1!s}{2:d}'.format(m, e == 0 and '+' or '', e)), 0
         elif b == 2:
             fo = 0x80                 # binary enoding
             if m < 0:
@@ -243,7 +243,7 @@ class RealEncoder(AbstractItemEncoder):
             substrate = int2oct(fo) + eo + po
             return substrate, 0
         else:
-            raise error.PyAsn1Error('Prohibited Real base %s' % b)
+            raise error.PyAsn1Error('Prohibited Real base {0!s}'.format(b))
 
 class SequenceEncoder(AbstractItemEncoder):
     def encodeValue(self, encodeFun, value, defMode, maxChunkSize):
@@ -328,7 +328,7 @@ class Encoder:
         self.__typeMap = typeMap
 
     def __call__(self, value, defMode=1, maxChunkSize=0):
-        debug.logger & debug.flagEncoder and debug.logger('encoder called in %sdef mode, chunk size %s for type %s, value:\n%s' % (not defMode and 'in' or '', maxChunkSize, value.__class__.__name__, value.prettyPrint()))
+        debug.logger & debug.flagEncoder and debug.logger('encoder called in {0!s}def mode, chunk size {1!s} for type {2!s}, value:\n{3!s}'.format(not defMode and 'in' or '', maxChunkSize, value.__class__.__name__, value.prettyPrint()))
         tagSet = value.getTagSet()
         if len(tagSet) > 1:
             concreteEncoder = explicitlyTaggedItemEncoder
@@ -342,12 +342,12 @@ class Encoder:
                 if tagSet in self.__tagMap:
                     concreteEncoder = self.__tagMap[tagSet]
                 else:
-                    raise Error('No encoder for %s' % (value,))
-        debug.logger & debug.flagEncoder and debug.logger('using value codec %s chosen by %r' % (concreteEncoder.__class__.__name__, tagSet))
+                    raise Error('No encoder for {0!s}'.format(value))
+        debug.logger & debug.flagEncoder and debug.logger('using value codec {0!s} chosen by {1!r}'.format(concreteEncoder.__class__.__name__, tagSet))
         substrate = concreteEncoder.encode(
             self, value, defMode, maxChunkSize
             )
-        debug.logger & debug.flagEncoder and debug.logger('built %s octets of substrate: %s\nencoder completed' % (len(substrate), debug.hexdump(substrate)))
+        debug.logger & debug.flagEncoder and debug.logger('built {0!s} octets of substrate: {1!s}\nencoder completed'.format(len(substrate), debug.hexdump(substrate)))
         return substrate
 
 encode = Encoder(tagMap, typeMap)

--- a/lib/pyasn1/codec/cer/decoder.py
+++ b/lib/pyasn1/codec/cer/decoder.py
@@ -20,7 +20,7 @@ class BooleanDecoder(decoder.AbstractSimpleDecoder):
         elif byte == 0x00:
             value = 0
         else:
-            raise error.PyAsn1Error('Boolean CER violation: %s' % byte)
+            raise error.PyAsn1Error('Boolean CER violation: {0!s}'.format(byte))
         return self._createComponent(asn1Spec, tagSet, value), tail
 
 tagMap = decoder.tagMap.copy()

--- a/lib/pyasn1/debug.py
+++ b/lib/pyasn1/debug.py
@@ -19,18 +19,18 @@ class Debug:
     def __init__(self, *flags):
         self._flags = flagNone
         self._printer = self.defaultPrinter
-        self('running pyasn1 version %s' % __version__)
+        self('running pyasn1 version {0!s}'.format(__version__))
         for f in flags:
             if f not in flagMap:
-                raise error.PyAsn1Error('bad debug flag %s' % (f,))
+                raise error.PyAsn1Error('bad debug flag {0!s}'.format(f))
             self._flags = self._flags | flagMap[f]
-            self('debug category \'%s\' enabled' % f)
+            self('debug category \'{0!s}\' enabled'.format(f))
         
     def __str__(self):
-        return 'logger %s, flags %x' % (self._printer, self._flags)
+        return 'logger {0!s}, flags {1:x}'.format(self._printer, self._flags)
     
     def __call__(self, msg):
-        self._printer('DBG: %s\n' % msg)
+        self._printer('DBG: {0!s}\n'.format(msg))
 
     def __and__(self, flag):
         return self._flags & flag
@@ -46,7 +46,7 @@ def setLogger(l):
 
 def hexdump(octets):
     return ' '.join(
-            [ '%s%.2X' % (n%16 == 0 and ('\n%.5d: ' % n) or '', x) 
+            [ '{0!s}{1:.2X}'.format(n%16 == 0 and ('\n{0:.5d}: '.format(n)) or '', x) 
               for n,x in zip(range(len(octets)), octs2ints(octets)) ]
         )
 

--- a/lib/pyasn1/type/base.py
+++ b/lib/pyasn1/type/base.py
@@ -30,7 +30,7 @@ class Asn1ItemBase(Asn1Item):
             self._subtypeSpec(value, idx)
         except error.PyAsn1Error:
             c, i, t = sys.exc_info()
-            raise c('%s at %s' % (i, self.__class__.__name__))
+            raise c('{0!s} at {1!s}'.format(i, self.__class__.__name__))
         
     def getSubtypeSpec(self): return self._subtypeSpec
     
@@ -49,7 +49,7 @@ class Asn1ItemBase(Asn1Item):
 
 class __NoValue:
     def __getattr__(self, attr):
-        raise error.PyAsn1Error('No value for %s()' % attr)
+        raise error.PyAsn1Error('No value for {0!s}()'.format(attr))
     def __getitem__(self, i):
         raise error.PyAsn1Error('No value')
     
@@ -75,7 +75,7 @@ class AbstractSimpleAsn1Item(Asn1ItemBase):
         if self._value is noValue:
             return self.__class__.__name__ + '()'
         else:
-            return self.__class__.__name__ + '(%s)' % (self.prettyOut(self._value),)
+            return self.__class__.__name__ + '({0!s})'.format(self.prettyOut(self._value))
     def __str__(self): return str(self._value)
     def __eq__(self, other):
         return self is other and True or self._value == other
@@ -170,7 +170,7 @@ class AbstractConstructedAsn1Item(Asn1ItemBase):
         for idx in range(len(self._componentValues)):
             if self._componentValues[idx] is None:
                 continue
-            r = r + '.setComponentByPosition(%s, %r)' % (
+            r = r + '.setComponentByPosition({0!s}, {1!r})'.format(
                 idx, self._componentValues[idx]
                 )
         return r

--- a/lib/pyasn1/type/constraint.py
+++ b/lib/pyasn1/type/constraint.py
@@ -29,10 +29,10 @@ class AbstractConstraint:
             self._testValue(value, idx)
         except error.ValueConstraintError:
             raise error.ValueConstraintError(
-               '%s failed at: \"%s\"' % (self, sys.exc_info()[1])
+               '{0!s} failed at: \"{1!s}\"'.format(self, sys.exc_info()[1])
             )
     def __repr__(self):
-        return '%s(%s)' % (
+        return '{0!s}({1!s})'.format(
             self.__class__.__name__,
             ', '.join([repr(x) for x in self._values])
         )
@@ -88,12 +88,12 @@ class ValueRangeConstraint(AbstractConstraint):
     def _setValues(self, values):
         if len(values) != 2:
             raise error.PyAsn1Error(
-                '%s: bad constraint values' % (self.__class__.__name__,)
+                '{0!s}: bad constraint values'.format(self.__class__.__name__)
                 )
         self.start, self.stop = values
         if self.start > self.stop:
             raise error.PyAsn1Error(
-                '%s: screwed constraint values (start > stop): %s > %s' % (
+                '{0!s}: screwed constraint values (start > stop): {1!s} > {2!s}'.format(
                     self.__class__.__name__,
                     self.start, self.stop
                 )
@@ -193,7 +193,7 @@ class ConstraintsUnion(AbstractConstraintSet):
             else:
                 return
         raise error.ValueConstraintError(
-            'all of %s failed for \"%s\"' % (self._values, value)
+            'all of {0!s} failed for \"{1!s}\"'.format(self._values, value)
             )
 
 # XXX

--- a/lib/pyasn1/type/namedtype.py
+++ b/lib/pyasn1/type/namedtype.py
@@ -8,7 +8,7 @@ class NamedType:
     isDefaulted = 0
     def __init__(self, name, t):
         self.__name = name; self.__type = t
-    def __repr__(self): return '%s(%s, %s)' % (
+    def __repr__(self): return '{0!s}({1!s}, {2!s})'.format(
         self.__class__.__name__, self.__name, self.__type
         )
     def getType(self): return self.__type
@@ -33,9 +33,9 @@ class NamedTypes:
         self.__ambigiousTypes = {}
 
     def __repr__(self):
-        r = '%s(' % self.__class__.__name__
+        r = '{0!s}('.format(self.__class__.__name__)
         for n in self.__namedTypes:
-            r = r + '%r, ' % (n,)
+            r = r + '{0!r}, '.format(n)
         return r + ')'
     
     def __getitem__(self, idx): return self.__namedTypes[idx]
@@ -60,12 +60,12 @@ class NamedTypes:
                 tagMap = self.__namedTypes[idx].getType().getTagMap()
                 for t in tagMap.getPosMap():
                     if t in self.__tagToPosIdx:
-                        raise error.PyAsn1Error('Duplicate type %s' % (t,))
+                        raise error.PyAsn1Error('Duplicate type {0!s}'.format(t))
                     self.__tagToPosIdx[t] = idx
         try:
             return self.__tagToPosIdx[tagSet]
         except KeyError:
-            raise error.PyAsn1Error('Type %s not found' % (tagSet,))
+            raise error.PyAsn1Error('Type {0!s} not found'.format(tagSet))
         
     def getNameByPosition(self, idx):
         try:
@@ -79,12 +79,12 @@ class NamedTypes:
                 idx = idx - 1
                 n = self.__namedTypes[idx].getName()
                 if n in self.__nameToPosIdx:
-                    raise error.PyAsn1Error('Duplicate name %s' % (n,))
+                    raise error.PyAsn1Error('Duplicate name {0!s}'.format(n))
                 self.__nameToPosIdx[n] = idx
         try:
             return self.__nameToPosIdx[name]
         except KeyError:
-            raise error.PyAsn1Error('Name %s not found' % (name,))
+            raise error.PyAsn1Error('Name {0!s} not found'.format(name))
 
     def __buildAmbigiousTagMap(self):
         ambigiousTypes = ()

--- a/lib/pyasn1/type/namedval.py
+++ b/lib/pyasn1/type/namedval.py
@@ -15,10 +15,10 @@ class NamedValues:
                 name = namedValue
                 val = automaticVal
             if name in self.nameToValIdx:
-                raise error.PyAsn1Error('Duplicate name %s' % (name,))
+                raise error.PyAsn1Error('Duplicate name {0!s}'.format(name))
             self.nameToValIdx[name] = val
             if val in self.valToNameIdx:
-                raise error.PyAsn1Error('Duplicate value %s=%s' % (name, val))
+                raise error.PyAsn1Error('Duplicate value {0!s}={1!s}'.format(name, val))
             self.valToNameIdx[val] = name
             self.namedValues = self.namedValues + ((name, val),)
             automaticVal = automaticVal + 1

--- a/lib/pyasn1/type/tag.py
+++ b/lib/pyasn1/type/tag.py
@@ -18,16 +18,16 @@ class Tag:
     def __init__(self, tagClass, tagFormat, tagId):
         if tagId < 0:
             raise error.PyAsn1Error(
-                'Negative tag ID (%s) not allowed' % (tagId,)
+                'Negative tag ID ({0!s}) not allowed'.format(tagId)
                 )
         self.__tag = (tagClass, tagFormat, tagId)
         self.uniq = (tagClass, tagId)
         self.__hashedUniqTag = hash(self.uniq)
 
     def __repr__(self):
-        return '%s(tagClass=%s, tagFormat=%s, tagId=%s)' % (
+        return '{0!s}(tagClass={1!s}, tagFormat={2!s}, tagId={3!s})'.format(*(
             (self.__class__.__name__,) + self.__tag
-            )
+            ))
     # These is really a hotspot -- expose public "uniq" attribute to save on
     # function calls
     def __eq__(self, other): return self.uniq == other.uniq
@@ -64,7 +64,7 @@ class TagSet:
         self.__lenOfSuperTags = len(superTags)
         
     def __repr__(self):
-        return '%s(%s)' % (
+        return '{0!s}({1!s})'.format(
             self.__class__.__name__,
             ', '.join([repr(x) for x in self.__superTags])
             )

--- a/lib/pyasn1/type/tagmap.py
+++ b/lib/pyasn1/type/tagmap.py
@@ -21,14 +21,14 @@ class TagMap:
             raise KeyError()
 
     def __repr__(self):
-        s = '%r/%r' % (self.__posMap, self.__negMap)
+        s = '{0!r}/{1!r}'.format(self.__posMap, self.__negMap)
         if self.__defType is not None:
-            s = s + '/%r' % (self.__defType,)
+            s = s + '/{0!r}'.format(self.__defType)
         return s
 
     def clone(self, parentType, tagMap, uniq=False):
         if self.__defType is not None and tagMap.getDef() is not None:
-            raise error.PyAsn1Error('Duplicate default value at %s' % (self,))
+            raise error.PyAsn1Error('Duplicate default value at {0!s}'.format(self))
         if tagMap.getDef() is not None:
             defType = tagMap.getDef()
         else:
@@ -37,7 +37,7 @@ class TagMap:
         posMap = self.__posMap.copy()
         for k in tagMap.getPosMap():
             if uniq and k in posMap:
-                raise error.PyAsn1Error('Duplicate positive key %s' % (k,))
+                raise error.PyAsn1Error('Duplicate positive key {0!s}'.format(k))
             posMap[k] = parentType
 
         negMap = self.__negMap.copy()

--- a/lib/pyasn1/type/univ.py
+++ b/lib/pyasn1/type/univ.py
@@ -73,7 +73,7 @@ class Integer(base.AbstractSimpleAsn1Item):
                 return int(value)
             except:
                 raise error.PyAsn1Error(
-                    'Can\'t coerce %s into integer: %s' % (value, sys.exc_info()[1])
+                    'Can\'t coerce {0!s} into integer: {1!s}'.format(value, sys.exc_info()[1])
                     )
         r = self.__namedValues.getValue(value)
         if r is not None:
@@ -82,7 +82,7 @@ class Integer(base.AbstractSimpleAsn1Item):
             return int(value)
         except:
             raise error.PyAsn1Error(
-                'Can\'t coerce %s into integer: %s' % (value, sys.exc_info()[1])
+                'Can\'t coerce {0!s} into integer: {1!s}'.format(value, sys.exc_info()[1])
                 )
 
     def prettyOut(self, value):
@@ -216,7 +216,7 @@ class BitString(base.AbstractSimpleAsn1Item):
                             r.append(1)
                         else:
                             raise error.PyAsn1Error(
-                                'Non-binary BIT STRING initializer %s' % (v,)
+                                'Non-binary BIT STRING initializer {0!s}'.format(v)
                                 )
                     return tuple(r)
                 elif value[-2:] == '\'H':
@@ -229,14 +229,14 @@ class BitString(base.AbstractSimpleAsn1Item):
                     return tuple(r)
                 else:
                     raise error.PyAsn1Error(
-                        'Bad BIT STRING value notation %s' % (value,)
+                        'Bad BIT STRING value notation {0!s}'.format(value)
                         )                
             else:
                 for i in value.split(','):
                     j = self.__namedValues.getValue(i)
                     if j is None:
                         raise error.PyAsn1Error(
-                            'Unknown bit identifier \'%s\'' % (i,)
+                            'Unknown bit identifier \'{0!s}\''.format(i)
                             )
                     if j >= len(r):
                         r.extend([0]*(j-len(r)+1))
@@ -247,18 +247,18 @@ class BitString(base.AbstractSimpleAsn1Item):
             for b in r:
                 if b and b != 1:
                     raise error.PyAsn1Error(
-                        'Non-binary BitString initializer \'%s\'' % (r,)
+                        'Non-binary BitString initializer \'{0!s}\''.format(r)
                         )
             return r
         elif isinstance(value, BitString):
             return tuple(value)
         else:
             raise error.PyAsn1Error(
-                'Bad BitString initializer type \'%s\'' % (value,)
+                'Bad BitString initializer type \'{0!s}\''.format(value)
                 )
 
     def prettyOut(self, value):
-        return '\"\'%s\'B\"' % ''.join([str(x) for x in value])
+        return '\"\'{0!s}\'B\"'.format(''.join([str(x) for x in value]))
 
 class OctetString(base.AbstractSimpleAsn1Item):
     tagSet = baseTagSet = tag.initTagSet(
@@ -309,7 +309,7 @@ class OctetString(base.AbstractSimpleAsn1Item):
                     return ''.join([ chr(x) for x in value ])
                 except ValueError:
                     raise error.PyAsn1Error(
-                        'Bad OctetString initializer \'%s\'' % (value,)
+                        'Bad OctetString initializer \'{0!s}\''.format(value)
                         )                
             else:
                 return str(value)
@@ -324,14 +324,14 @@ class OctetString(base.AbstractSimpleAsn1Item):
                     return bytes(value)
                 except ValueError:
                     raise error.PyAsn1Error(
-                        'Bad OctetString initializer \'%s\'' % (value,)
+                        'Bad OctetString initializer \'{0!s}\''.format(value)
                         )
             else:
                 try:
                     return str(value).encode(self._encoding)
                 except UnicodeEncodeError:
                     raise error.PyAsn1Error(
-                        'Can\'t encode string \'%s\' with \'%s\' codec' % (value, self._encoding)
+                        'Can\'t encode string \'{0!s}\' with \'{1!s}\' codec'.format(value, self._encoding)
                         )
                         
 
@@ -350,7 +350,7 @@ class OctetString(base.AbstractSimpleAsn1Item):
                 v = 1
             else:
                 raise error.PyAsn1Error(
-                    'Non-binary OCTET STRING initializer %s' % (v,)
+                    'Non-binary OCTET STRING initializer {0!s}'.format(v)
                     )
             byte = byte | (v << bitNo)
         return octets.ints2octs(r + (byte,))
@@ -373,7 +373,7 @@ class OctetString(base.AbstractSimpleAsn1Item):
         else:
             numbers = tuple(value)
         if [ x for x in numbers if x < 32 or x > 126 ]:
-            return '0x' + ''.join([ '%.2x' % x for x in numbers ])
+            return '0x' + ''.join([ '{0:.2x}'.format(x) for x in numbers ])
         else:
             return str(value)
 
@@ -381,7 +381,7 @@ class OctetString(base.AbstractSimpleAsn1Item):
         if self._value is base.noValue:
             return self.__class__.__name__ + '()'
         if [ x for x in self.asNumbers() if x < 32 or x > 126 ]:
-            return self.__class__.__name__ + '(hexValue=\'' + ''.join([ '%.2x' % x for x in self.asNumbers() ])+'\')'
+            return self.__class__.__name__ + '(hexValue=\'' + ''.join([ '{0:.2x}'.format(x) for x in self.asNumbers() ])+'\')'
         else:
             return self.__class__.__name__ + '(\'' + self.prettyOut(self._value) + '\')'
                                 
@@ -480,8 +480,7 @@ class ObjectIdentifier(base.AbstractSimpleAsn1Item):
                     r.append(int(element, 0))
                 except ValueError:
                     raise error.PyAsn1Error(
-                        'Malformed Object ID %s at %s: %s' %
-                        (str(value), self.__class__.__name__, sys.exc_info()[1])
+                        'Malformed Object ID {0!s} at {1!s}: {2!s}'.format(str(value), self.__class__.__name__, sys.exc_info()[1])
                         )
             value = tuple(r)
         else:
@@ -489,14 +488,13 @@ class ObjectIdentifier(base.AbstractSimpleAsn1Item):
                 value = tuple(value)
             except TypeError:
                 raise error.PyAsn1Error(
-                        'Malformed Object ID %s at %s: %s' %
-                        (str(value), self.__class__.__name__,sys.exc_info()[1])
+                        'Malformed Object ID {0!s} at {1!s}: {2!s}'.format(str(value), self.__class__.__name__, sys.exc_info()[1])
                         )
 
         for x in value:
             if not isinstance(x, intTypes) or x < 0:
                 raise error.PyAsn1Error(
-                    'Invalid sub-ID in %s at %s' % (value, self.__class__.__name__)
+                    'Invalid sub-ID in {0!s} at {1!s}'.format(value, self.__class__.__name__)
                     )
     
         return value
@@ -529,11 +527,11 @@ class Real(base.AbstractSimpleAsn1Item):
             for d in value:
                 if not isinstance(d, intTypes):
                     raise error.PyAsn1Error(
-                        'Lame Real value syntax: %s' % (value,)
+                        'Lame Real value syntax: {0!s}'.format(value)
                         )
             if value[1] not in (2, 10):
                 raise error.PyAsn1Error(
-                    'Prohibited base for Real value: %s' % (value[1],)
+                    'Prohibited base for Real value: {0!s}'.format(value[1])
                     )
             if value[1] == 10:
                 value = self.__normalizeBase10(value)
@@ -557,12 +555,12 @@ class Real(base.AbstractSimpleAsn1Item):
             except ValueError:
                 pass
         raise error.PyAsn1Error(
-            'Bad real value syntax: %s' % (value,)
+            'Bad real value syntax: {0!s}'.format(value)
             )
         
     def prettyOut(self, value):
         if value in self._inf:
-            return '\'%s\'' % value
+            return '\'{0!s}\''.format(value)
         else:
             return str(value)
 
@@ -653,7 +651,7 @@ class SetOf(base.AbstractConstructedAsn1Item):
     def _verifyComponent(self, idx, value):
         if self._componentType is not None and \
                not self._componentType.isSuperTypeOf(value):
-            raise error.PyAsn1Error('Component type error %s' % (value,))
+            raise error.PyAsn1Error('Component type error {0!s}'.format(value))
 
     def getComponentByPosition(self, idx): return self._componentValues[idx]
     def setComponentByPosition(self, idx, value=None, verifyConstraints=True):
@@ -748,7 +746,7 @@ class SequenceAndSetBase(base.AbstractConstructedAsn1Item):
                 )
         t = self._componentType[idx].getType()
         if not t.isSuperTypeOf(value):
-            raise error.PyAsn1Error('Component type error %r vs %r' % (t, value))
+            raise error.PyAsn1Error('Component type error {0!r} vs {1!r}'.format(t, value))
 
     def getComponentByName(self, name):
         return self.getComponentByPosition(
@@ -815,7 +813,7 @@ class SequenceAndSetBase(base.AbstractConstructedAsn1Item):
             elif not self._componentType[idx].isOptional:
                 if self.getComponentByPosition(idx) is None:
                     raise error.PyAsn1Error(
-                        'Uninitialized component #%s at %r' % (idx, self)
+                        'Uninitialized component #{0!s} at {1!r}'.format(idx, self)
                         )
 
     def prettyPrint(self, scope=0):
@@ -829,7 +827,7 @@ class SequenceAndSetBase(base.AbstractConstructedAsn1Item):
                     r = r + '<no-name>'
                 else:
                     r = r + componentType.getNameByPosition(idx)
-                r = '%s=%s\n' % (
+                r = '{0!s}={1!s}\n'.format(
                     r, self._componentValues[idx].prettyPrint(scope)
                     )
         return r

--- a/lib/pynma/pynma.py
+++ b/lib/pynma/pynma.py
@@ -17,7 +17,7 @@ __version__ = "1.0"
 API_SERVER = 'www.notifymyandroid.com'
 ADD_PATH   = '/publicapi/notify'
 
-USER_AGENT="PyNMA/v%s"%__version__
+USER_AGENT="PyNMA/v{0!s}".format(__version__)
 
 def uniq_preserve(seq): # Dave Kirby
     # Order preserving

--- a/lib/pysrt/commands.py
+++ b/lib/pysrt/commands.py
@@ -15,7 +15,7 @@ from pysrt import SubRipFile, SubRipTime, VERSION_STRING
 
 
 def underline(string):
-    return "\033[4m%s\033[0m" % string
+    return "\033[4m{0!s}\033[0m".format(string)
 
 
 class TimeAwareArgumentParser(argparse.ArgumentParser):
@@ -105,7 +105,7 @@ class SubRipShifter(object):
             help="Edit file in-place, saving a backup as file.bak (do not works for the split command)")
         parser.add_argument('-e', '--output-encoding', metavar=underline('encoding'), action='store', dest='output_encoding',
             type=self.parse_encoding, help=self.ENCODING_HELP)
-        parser.add_argument('-v', '--version', action='version', version='%%(prog)s %s' % VERSION_STRING)
+        parser.add_argument('-v', '--version', action='version', version='%(prog)s {0!s}'.format(VERSION_STRING))
         subparsers = parser.add_subparsers(title='commands')
 
         shift_parser = subparsers.add_parser('shift', help="Shift subtitles by specified time offset", epilog=self.SHIFT_EPILOG, formatter_class=argparse.RawTextHelpFormatter)
@@ -164,7 +164,7 @@ class SubRipShifter(object):
         limits = [0] + self.arguments.limits + [self.input_file[-1].end.ordinal + 1]
         base_name, extension = os.path.splitext(self.arguments.file)
         for index, (start, end) in enumerate(zip(limits[:-1], limits[1:])):
-            file_name = '%s.%s%s' % (base_name, index + 1, extension)
+            file_name = '{0!s}.{1!s}{2!s}'.format(base_name, index + 1, extension)
             part_file = self.input_file.slice(ends_after=start, starts_before=end)
             part_file.shift(milliseconds=-start)
             part_file.clean_indexes()
@@ -178,7 +178,7 @@ class SubRipShifter(object):
         self.arguments.file = backup_file
 
     def break_lines(self):
-        split_re = re.compile(r'(.{,%i})(?:\s+|$)' % self.arguments.length)
+        split_re = re.compile(r'(.{{,{0:d}}})(?:\s+|$)'.format(self.arguments.length))
         for item in self.input_file:
             item.text = '\n'.join(split_re.split(item.text)[1::2])
         self.input_file.write_into(self.output_file)

--- a/lib/pysrt/srtfile.py
+++ b/lib/pysrt/srtfile.py
@@ -307,6 +307,6 @@ class SubRipFile(UserList, object):
             raise error
         if error_handling == cls.ERROR_LOG:
             name = type(error).__name__
-            sys.stderr.write('PySRT-%s(line %s): \n' % (name, index))
+            sys.stderr.write('PySRT-{0!s}(line {1!s}): \n'.format(name, index))
             sys.stderr.write(error.args[0].encode('ascii', 'replace'))
             sys.stderr.write('\n')

--- a/lib/pysrt/srtitem.py
+++ b/lib/pysrt/srtitem.py
@@ -51,7 +51,7 @@ class SubRipItem(ComparableMixin):
             return 0.0
 
     def __str__(self):
-        position = ' %s' % self.position if self.position.strip() else ''
+        position = ' {0!s}'.format(self.position) if self.position.strip() else ''
         return self.ITEM_PATTERN % (self.index, self.start, self.end,
                                     position, self.text)
     if is_py2:

--- a/lib/pythontwitter/__init__.py
+++ b/lib/pythontwitter/__init__.py
@@ -417,19 +417,19 @@ class Status(object):
         if delta < (1 * fudge):
             return 'about a second ago'
         elif delta < (60 * (1 / fudge)):
-            return 'about %d seconds ago' % (delta)
+            return 'about {0:d} seconds ago'.format((delta))
         elif delta < (60 * fudge):
             return 'about a minute ago'
         elif delta < (60 * 60 * (1 / fudge)):
-            return 'about %d minutes ago' % (delta / 60)
+            return 'about {0:d} minutes ago'.format((delta / 60))
         elif delta < (60 * 60 * fudge) or delta / (60 * 60) == 1:
             return 'about an hour ago'
         elif delta < (60 * 60 * 24 * (1 / fudge)):
-            return 'about %d hours ago' % (delta / (60 * 60))
+            return 'about {0:d} hours ago'.format((delta / (60 * 60)))
         elif delta < (60 * 60 * 24 * fudge) or delta / (60 * 60 * 24) == 1:
             return 'about a day ago'
         else:
-            return 'about %d days ago' % (delta / (60 * 60 * 24))
+            return 'about {0:d} days ago'.format((delta / (60 * 60 * 24)))
 
     relative_created_at = property(GetRelativeCreatedAt,
                                                                  doc = 'Get a human readable string representing '
@@ -2181,7 +2181,7 @@ class Trend(object):
         self.url = url
 
     def __str__(self):
-        return 'Name: %s\nQuery: %s\nTimestamp: %s\nSearch URL: %s\n' % (self.name, self.query, self.timestamp, self.url)
+        return 'Name: {0!s}\nQuery: {1!s}\nTimestamp: {2!s}\nSearch URL: {3!s}\n'.format(self.name, self.query, self.timestamp, self.url)
 
     def __ne__(self, other):
         return not self.__eq__(other)
@@ -2518,7 +2518,7 @@ class Api(object):
             parameters['result_type'] = result_type
 
         # Make and send requests
-        url = '%s/search/tweets.json' % self.base_url
+        url = '{0!s}/search/tweets.json'.format(self.base_url)
         json = self._FetchUrl(url, parameters = parameters)
         data = self._ParseAndCheckTwitter(json)
 
@@ -2566,7 +2566,7 @@ class Api(object):
             raise TwitterError("count must be an integer")
 
         # Make and send requests
-        url = '%s/users/search.json' % self.base_url
+        url = '{0!s}/users/search.json'.format(self.base_url)
         json = self._FetchUrl(url, parameters = parameters)
         data = self._ParseAndCheckTwitter(json)
         return [User.NewFromJsonDict(x) for x in data]
@@ -2598,7 +2598,7 @@ class Api(object):
         Returns:
             A list with 10 entries. Each entry contains a trend.
         '''
-        url = '%s/trends/place.json' % (self.base_url)
+        url = '{0!s}/trends/place.json'.format((self.base_url))
         parameters = {'id': id}
 
         if exclude:
@@ -2669,7 +2669,7 @@ class Api(object):
         Returns:
             A sequence of twitter.Status instances, one for each message
         '''
-        url = '%s/statuses/home_timeline.json' % self.base_url
+        url = '{0!s}/statuses/home_timeline.json'.format(self.base_url)
 
         if not self._oauth_consumer:
             raise TwitterError("API must be authenticated.")
@@ -2756,7 +2756,7 @@ class Api(object):
         '''
         parameters = {}
 
-        url = '%s/statuses/user_timeline.json' % (self.base_url)
+        url = '{0!s}/statuses/user_timeline.json'.format((self.base_url))
 
         if user_id:
             parameters['user_id'] = user_id
@@ -2824,7 +2824,7 @@ class Api(object):
         Returns:
             A twitter.Status instance representing that status message
         '''
-        url = '%s/statuses/show.json' % (self.base_url)
+        url = '{0!s}/statuses/show.json'.format((self.base_url))
 
         if not self._oauth_consumer:
             raise TwitterError("API must be authenticated.")
@@ -2867,7 +2867,7 @@ class Api(object):
             post_data = {'id': long(id)}
         except:
             raise TwitterError("id must be an integer")
-        url = '%s/statuses/destroy/%s.json' % (self.base_url, id)
+        url = '{0!s}/statuses/destroy/{1!s}.json'.format(self.base_url, id)
         if trim_user:
             post_data['trim_user'] = 1
         json = self._FetchUrl(url, post_data = post_data)
@@ -2876,7 +2876,7 @@ class Api(object):
 
     @classmethod
     def _calculate_status_length(cls, status, linksize = 19):
-        dummy_link_replacement = 'https://-%d-chars%s/' % (linksize, '-' * (linksize - 18))
+        dummy_link_replacement = 'https://-{0:d}-chars{1!s}/'.format(linksize, '-' * (linksize - 18))
         shortened = ' '.join([x if not (x.startswith('http://') or
                                                                         x.startswith('https://'))
                                                         else
@@ -2927,7 +2927,7 @@ class Api(object):
         if not self._oauth_consumer:
             raise TwitterError("The twitter.Api instance must be authenticated.")
 
-        url = '%s/statuses/update.json' % self.base_url
+        url = '{0!s}/statuses/update.json'.format(self.base_url)
 
         if isinstance(status, unicode) or self._input_encoding is None:
             u_status = status
@@ -3012,7 +3012,7 @@ class Api(object):
         except ValueError:
                 raise TwitterError("'original_id' must be an integer")
 
-        url = '%s/statuses/retweet/%s.json' % (self.base_url, original_id)
+        url = '{0!s}/statuses/retweet/{1!s}.json'.format(self.base_url, original_id)
 
         data = {'id': original_id}
         if trim_user:
@@ -3092,7 +3092,7 @@ class Api(object):
         '''
         if not self._oauth_consumer:
             raise TwitterError("The twitter.Api instsance must be authenticated.")
-        url = '%s/statuses/retweets/%s.json' % (self.base_url, statusid)
+        url = '{0!s}/statuses/retweets/{1!s}.json'.format(self.base_url, statusid)
         parameters = {}
         if trim_user:
             parameters['trim_user'] = 'true'
@@ -3132,7 +3132,7 @@ class Api(object):
         '''
         if not self._oauth_consumer:
             raise TwitterError("The twitter.Api instance must be authenticated.")
-        url = '%s/statuses/retweets_of_me.json' % self.base_url
+        url = '{0!s}/statuses/retweets_of_me.json'.format(self.base_url)
         parameters = {}
         if count is not None:
             try:
@@ -3182,7 +3182,7 @@ class Api(object):
         '''
         if not self._oauth_consumer:
             raise TwitterError("twitter.Api instance must be authenticated")
-        url = '%s/friends/list.json' % self.base_url
+        url = '{0!s}/friends/list.json'.format(self.base_url)
         result = []
         parameters = {}
         if user_id is not None:
@@ -3231,7 +3231,7 @@ class Api(object):
             Returns:
                 A list of integers, one for each user id.
             '''
-            url = '%s/friends/ids.json' % self.base_url
+            url = '{0!s}/friends/ids.json'.format(self.base_url)
             if not self._oauth_consumer:
                     raise TwitterError("twitter.Api instance must be authenticated")
             parameters = {}
@@ -3292,7 +3292,7 @@ class Api(object):
             Returns:
                 A list of integers, one for each user id.
             '''
-            url = '%s/followers/ids.json' % self.base_url
+            url = '{0!s}/followers/ids.json'.format(self.base_url)
             if not self._oauth_consumer:
                     raise TwitterError("twitter.Api instance must be authenticated")
             parameters = {}
@@ -3350,7 +3350,7 @@ class Api(object):
         '''
         if not self._oauth_consumer:
             raise TwitterError("twitter.Api instance must be authenticated")
-        url = '%s/followers/list.json' % self.base_url
+        url = '{0!s}/followers/list.json'.format(self.base_url)
         result = []
         parameters = {}
         if user_id is not None:
@@ -3407,7 +3407,7 @@ class Api(object):
             raise TwitterError("The twitter.Api instance must be authenticated.")
         if not user_id and not screen_name and not users:
             raise TwitterError("Specify at least one of user_id, screen_name, or users.")
-        url = '%s/users/lookup.json' % self.base_url
+        url = '{0!s}/users/lookup.json'.format(self.base_url)
         parameters = {}
         uids = list()
         if user_id:
@@ -3415,7 +3415,7 @@ class Api(object):
         if users:
             uids.extend([u.id for u in users])
         if len(uids):
-            parameters['user_id'] = ','.join(["%s" % u for u in uids])
+            parameters['user_id'] = ','.join(["{0!s}".format(u) for u in uids])
         if screen_name:
             parameters['screen_name'] = ','.join(screen_name)
         if not include_entities:
@@ -3454,7 +3454,7 @@ class Api(object):
         Returns:
             A twitter.User instance representing that user
         '''
-        url = '%s/users/show.json' % (self.base_url)
+        url = '{0!s}/users/show.json'.format((self.base_url))
         parameters = {}
 
         if not self._oauth_consumer:
@@ -3504,7 +3504,7 @@ class Api(object):
         Returns:
             A sequence of twitter.DirectMessage instances
         '''
-        url = '%s/direct_messages.json' % self.base_url
+        url = '{0!s}/direct_messages.json'.format(self.base_url)
         if not self._oauth_consumer:
             raise TwitterError("The twitter.Api instance must be authenticated.")
         parameters = {}
@@ -3555,7 +3555,7 @@ class Api(object):
         Returns:
             A sequence of twitter.DirectMessage instances
         '''
-        url = '%s/direct_messages/sent.json' % self.base_url
+        url = '{0!s}/direct_messages/sent.json'.format(self.base_url)
         if not self._oauth_consumer:
             raise TwitterError("The twitter.Api instance must be authenticated.")
         parameters = {}
@@ -3596,7 +3596,7 @@ class Api(object):
         '''
         if not self._oauth_consumer:
             raise TwitterError("The twitter.Api instance must be authenticated.")
-        url = '%s/direct_messages/new.json' % self.base_url
+        url = '{0!s}/direct_messages/new.json'.format(self.base_url)
         data = {'text': text}
         if user_id:
             data['user_id'] = user_id
@@ -3621,7 +3621,7 @@ class Api(object):
         Returns:
             A twitter.DirectMessage instance representing the message destroyed
         '''
-        url = '%s/direct_messages/destroy.json' % self.base_url
+        url = '{0!s}/direct_messages/destroy.json'.format(self.base_url)
         data = {'id': id}
         if not include_entities:
             data['include_entities'] = 'false'
@@ -3644,7 +3644,7 @@ class Api(object):
         Returns:
             A twitter.User instance representing the befriended user.
         '''
-        url = '%s/friendships/create.json' % (self.base_url)
+        url = '{0!s}/friendships/create.json'.format((self.base_url))
         data = {}
         if user_id:
             data['user_id'] = user_id
@@ -3673,7 +3673,7 @@ class Api(object):
         Returns:
             A twitter.User instance representing the discontinued friend.
         '''
-        url = '%s/friendships/destroy.json' % self.base_url
+        url = '{0!s}/friendships/destroy.json'.format(self.base_url)
         data = {}
         if user_id:
             data['user_id'] = user_id
@@ -3703,7 +3703,7 @@ class Api(object):
         Returns:
             A twitter.Status instance representing the newly-marked favorite.
         '''
-        url = '%s/favorites/create.json' % self.base_url
+        url = '{0!s}/favorites/create.json'.format(self.base_url)
         data = {}
         if id:
             data['id'] = id
@@ -3735,7 +3735,7 @@ class Api(object):
         Returns:
             A twitter.Status instance representing the newly-unmarked favorite.
         '''
-        url = '%s/favorites/destroy.json' % self.base_url
+        url = '{0!s}/favorites/destroy.json'.format(self.base_url)
         data = {}
         if id:
             data['id'] = id
@@ -3770,7 +3770,7 @@ class Api(object):
         '''
         parameters = {}
 
-        url = '%s/favorites/list.json' % self.base_url
+        url = '{0!s}/favorites/list.json'.format(self.base_url)
 
         if user_id:
             parameters['user_id'] = user_id
@@ -3843,7 +3843,7 @@ class Api(object):
             A sequence of twitter.Status instances, one for each mention of the user.
         '''
 
-        url = '%s/statuses/mentions_timeline.json' % self.base_url
+        url = '{0!s}/statuses/mentions_timeline.json'.format(self.base_url)
 
         if not self._oauth_consumer:
             raise TwitterError("The twitter.Api instance must be authenticated.")
@@ -3893,7 +3893,7 @@ class Api(object):
         Returns:
             A twitter.List instance representing the new list
         '''
-        url = '%s/lists/create.json' % self.base_url
+        url = '{0!s}/lists/create.json'.format(self.base_url)
 
         if not self._oauth_consumer:
             raise TwitterError("The twitter.Api instance must be authenticated.")
@@ -3931,7 +3931,7 @@ class Api(object):
         Returns:
             A twitter.List instance representing the removed list.
         '''
-        url = '%s/lists/destroy.json' % self.base_url
+        url = '{0!s}/lists/destroy.json'.format(self.base_url)
         data = {}
         if list_id:
             try:
@@ -3979,7 +3979,7 @@ class Api(object):
         Returns:
             A twitter.List instance representing the list subscribed to
         '''
-        url = '%s/lists/subscribers/create.json' % (self.base_url)
+        url = '{0!s}/lists/subscribers/create.json'.format((self.base_url))
         if not self._oauth_consumer:
             raise TwitterError("The twitter.Api instance must be authenticated.")
         data = {}
@@ -4028,7 +4028,7 @@ class Api(object):
         Returns:
             A twitter.List instance representing the removed list.
         '''
-        url = '%s/lists/subscribers/destroy.json' % (self.base_url)
+        url = '{0!s}/lists/subscribers/destroy.json'.format((self.base_url))
         if not self._oauth_consumer:
             raise TwitterError("The twitter.Api instance must be authenticated.")
         data = {}
@@ -4082,7 +4082,7 @@ class Api(object):
         if not self._oauth_consumer:
             raise TwitterError("twitter.Api instance must be authenticated")
 
-        url = '%s/lists/subscriptions.json' % (self.base_url)
+        url = '{0!s}/lists/subscriptions.json'.format((self.base_url))
         parameters = {}
 
         try:
@@ -4136,7 +4136,7 @@ class Api(object):
         if not self._oauth_consumer:
             raise TwitterError("twitter.Api instance must be authenticated")
 
-        url = '%s/lists/ownerships.json' % self.base_url
+        url = '{0!s}/lists/ownerships.json'.format(self.base_url)
         result = []
         parameters = {}
         if user_id is not None:
@@ -4174,7 +4174,7 @@ class Api(object):
         '''
         if not self._oauth_consumer:
             raise TwitterError("Api instance must first be given user credentials.")
-        url = '%s/account/verify_credentials.json' % self.base_url
+        url = '{0!s}/account/verify_credentials.json'.format(self.base_url)
         try:
             json = self._FetchUrl(url, no_cache = True)
         except urllib2.HTTPError, http_error:
@@ -4275,7 +4275,7 @@ class Api(object):
         if resources is not None:
             parameters['resources'] = resources
 
-        url = '%s/application/rate_limit_status.json' % self.base_url
+        url = '{0!s}/application/rate_limit_status.json'.format(self.base_url)
         json = self._FetchUrl(url, parameters = parameters, no_cache = True)
         data = self._ParseAndCheckTwitter(json)
         return data
@@ -4342,8 +4342,7 @@ class Api(object):
             self._request_headers = {}
 
     def _InitializeUserAgent(self):
-        user_agent = 'Python-urllib/%s (python-twitter/%s)' % \
-                                 (self._urllib.__version__, __version__)
+        user_agent = 'Python-urllib/{0!s} (python-twitter/{1!s})'.format(self._urllib.__version__, __version__)
         self.SetUserAgent(user_agent)
 
     def _InitializeDefaultParameters(self):
@@ -4581,14 +4580,13 @@ class _FileCache(object):
         if not os.path.exists(directory):
             os.makedirs(directory)
         if not os.path.isdir(directory):
-            raise _FileCacheError('%s exists but is not a directory' % directory)
+            raise _FileCacheError('{0!s} exists but is not a directory'.format(directory))
         temp_fd, temp_path = tempfile.mkstemp()
         temp_fp = os.fdopen(temp_fd, 'w')
         temp_fp.write(data)
         temp_fp.close()
         if not path.startswith(self._root_directory):
-            raise _FileCacheError('%s does not appear to live under %s' %
-                                                        (path, self._root_directory))
+            raise _FileCacheError('{0!s} does not appear to live under {1!s}'.format(path, self._root_directory))
         if os.path.exists(path):
             os.remove(path)
         os.rename(temp_path, path)
@@ -4596,8 +4594,7 @@ class _FileCache(object):
     def Remove(self, key):
         path = self._GetPath(key)
         if not path.startswith(self._root_directory):
-            raise _FileCacheError('%s does not appear to live under %s' %
-                                                        (path, self._root_directory))
+            raise _FileCacheError('{0!s} does not appear to live under {1!s}'.format(path, self._root_directory))
         if os.path.exists(path):
             os.remove(path)
 
@@ -4631,8 +4628,8 @@ class _FileCache(object):
         if not os.path.exists(root_directory):
             os.mkdir(root_directory)
         if not os.path.isdir(root_directory):
-            raise _FileCacheError('%s exists but is not a directory' %
-                                                        root_directory)
+            raise _FileCacheError('{0!s} exists but is not a directory'.format(
+                                                        root_directory))
         self._root_directory = root_directory
 
     def _GetPath(self, key):

--- a/lib/rarfile/__init__.py
+++ b/lib/rarfile/__init__.py
@@ -614,7 +614,7 @@ class RarFile(object):
         if inf.needs_password():
             psw = psw or self._password
             if psw is None:
-                raise PasswordRequired("File %s requires password" % inf.filename)
+                raise PasswordRequired("File {0!s} requires password".format(inf.filename))
         else:
             psw = None
 
@@ -1911,7 +1911,7 @@ def custom_popen(cmd):
     except OSError:
         ex = sys.exc_info()[1]
         if ex.errno == errno.ENOENT:
-            raise RarCannotExec("Unrar not installed? (rarfile.UNRAR_TOOL=%r)" % UNRAR_TOOL)
+            raise RarCannotExec("Unrar not installed? (rarfile.UNRAR_TOOL={0!r})".format(UNRAR_TOOL))
         raise
     return p
 
@@ -1957,9 +1957,9 @@ def check_returncode(p, out):
 
     # format message
     if out:
-        msg = "%s [%d]: %s" % (exc.__doc__, p.returncode, out)
+        msg = "{0!s} [{1:d}]: {2!s}".format(exc.__doc__, p.returncode, out)
     else:
-        msg = "%s [%d]" % (exc.__doc__, p.returncode)
+        msg = "{0!s} [{1:d}]".format(exc.__doc__, p.returncode)
 
     raise exc(msg)
 

--- a/lib/rarfile/dumprar.py
+++ b/lib/rarfile/dumprar.py
@@ -109,7 +109,7 @@ def render_flags(flags, bit_list):
     n = 0
     while unknown:
         if unknown & 1:
-            res.append("UNK_%04x" % (1 << n))
+            res.append("UNK_{0:04x}".format((1 << n)))
         unknown = unknown >> 1
         n += 1
 
@@ -134,7 +134,7 @@ def get_generic_flags(flags):
 def fmt_time(t):
     if isinstance(t, datetime):
         return t.isoformat(' ')
-    return "%04d-%02d-%02d %02d:%02d:%02d" % t
+    return "{0:04d}-{1:02d}-{2:02d} {3:02d}:{4:02d}:{5:02d}".format(*t)
 
 def show_item(h):
     st = rarType(h.type)
@@ -146,9 +146,9 @@ def show_item(h):
         xprint("  unknown: %s", hexlify(dat))
     if h.type in (rf.RAR_BLOCK_FILE, rf.RAR_BLOCK_SUB):
         if h.host_os == rf.RAR_OS_UNIX:
-            s_mode = "0%o" % h.mode
+            s_mode = "0{0:o}".format(h.mode)
         else:
-            s_mode = "0x%x" % h.mode
+            s_mode = "0x{0:x}".format(h.mode)
         xprint("  flags=0x%04x:%s", h.flags, get_file_flags(h.flags))
         if h.host_os >= 0 and h.host_os < len(os_list):
             s_os = os_list[h.host_os]

--- a/lib/rebulk/chain.py
+++ b/lib/rebulk/chain.py
@@ -266,7 +266,7 @@ class Chain(Pattern):
         defined = ""
         if self.defined_at:
             defined = "@" + six.text_type(self.defined_at)
-        return "<%s%s:%s>" % (self.__class__.__name__, defined, self.parts)
+        return "<{0!s}{1!s}:{2!s}>".format(self.__class__.__name__, defined, self.parts)
 
 
 class ChainPart(object):
@@ -395,4 +395,4 @@ class ChainPart(object):
         return self
 
     def __repr__(self):
-        return "%s({%s,%s})" % (self.pattern, self.repeater_start, self.repeater_end)
+        return "{0!s}({{{1!s},{2!s}}})".format(self.pattern, self.repeater_start, self.repeater_end)

--- a/lib/rebulk/debug.py
+++ b/lib/rebulk/debug.py
@@ -29,7 +29,7 @@ class Frame(namedtuple('Frame', ['lineno', 'package', 'name', 'filename'])):
     __slots__ = ()
 
     def __repr__(self):
-        return "%s#L%s" % (os.path.basename(self.filename), self.lineno)
+        return "{0!s}#L{1!s}".format(os.path.basename(self.filename), self.lineno)
 
 
 def defined_at():

--- a/lib/rebulk/match.py
+++ b/lib/rebulk/match.py
@@ -778,4 +778,4 @@ class Match(object):
             tags = "+tags=" + six.text_type(self.tags)
         if self.defined_at:
             defined += "@" + six.text_type(self.defined_at)
-        return "<%s:%s%s%s%s%s>" % (self.value, self.span, flags, name, tags, defined)
+        return "<{0!s}:{1!s}{2!s}{3!s}{4!s}{5!s}>".format(self.value, self.span, flags, name, tags, defined)

--- a/lib/rebulk/pattern.py
+++ b/lib/rebulk/pattern.py
@@ -255,7 +255,7 @@ class Pattern(object):
         defined = ""
         if self.defined_at:
             defined = "@" + six.text_type(self.defined_at)
-        return "<%s%s:%s>" % (self.__class__.__name__, defined, self.patterns)
+        return "<{0!s}{1!s}:{2!s}>".format(self.__class__.__name__, defined, self.patterns)
 
 
 class StringPattern(Pattern):

--- a/lib/rebulk/rules.py
+++ b/lib/rebulk/rules.py
@@ -94,7 +94,7 @@ class CustomRule(Condition, Consequence):
         defined = ""
         if self.defined_at:
             defined = "@" + six.text_type(self.defined_at)
-        return "<%s%s>" % (self.name if self.name else self.__class__.__name__, defined)
+        return "<{0!s}{1!s}>".format(self.name if self.name else self.__class__.__name__, defined)
 
     def __eq__(self, other):
         return self.__class__ == other.__class__
@@ -357,7 +357,7 @@ def toposort_rules(rules):
     class_dict = {}
     for rule in rules:
         if rule.__class__ in class_dict:
-            raise ValueError("Duplicate class rules are not allowed: %s" % rule.__class__)
+            raise ValueError("Duplicate class rules are not allowed: {0!s}".format(rule.__class__))
         class_dict[rule.__class__] = rule
     for rule in rules:
         if not is_iterable(rule.dependency) and rule.dependency:

--- a/lib/rebulk/utils.py
+++ b/lib/rebulk/utils.py
@@ -130,4 +130,4 @@ class IdentitySet(MutableSet):  # pragma: no cover
             self.add(elem)
 
     def __repr__(self):  # pragma: no cover
-        return "%s(%s)" % (type(self).__name__, list(self))
+        return "{0!s}({1!s})".format(type(self).__name__, list(self))

--- a/lib/requests/auth.py
+++ b/lib/requests/auth.py
@@ -28,7 +28,7 @@ def _basic_auth_str(username, password):
     """Returns a Basic Auth string."""
 
     authstr = 'Basic ' + to_native_string(
-        b64encode(('%s:%s' % (username, password)).encode('latin1')).strip()
+        b64encode(('{0!s}:{1!s}'.format(username, password)).encode('latin1')).strip()
     )
 
     return authstr
@@ -112,7 +112,7 @@ class HTTPDigestAuth(AuthBase):
                 return hashlib.sha1(x).hexdigest()
             hash_utf8 = sha_utf8
 
-        KD = lambda s, d: hash_utf8("%s:%s" % (s, d))
+        KD = lambda s, d: hash_utf8("{0!s}:{1!s}".format(s, d))
 
         if hash_utf8 is None:
             return None
@@ -125,8 +125,8 @@ class HTTPDigestAuth(AuthBase):
         if p_parsed.query:
             path += '?' + p_parsed.query
 
-        A1 = '%s:%s:%s' % (self.username, realm, self.password)
-        A2 = '%s:%s' % (method, path)
+        A1 = '{0!s}:{1!s}:{2!s}'.format(self.username, realm, self.password)
+        A2 = '{0!s}:{1!s}'.format(method, path)
 
         HA1 = hash_utf8(A1)
         HA2 = hash_utf8(A2)
@@ -135,7 +135,7 @@ class HTTPDigestAuth(AuthBase):
             self._thread_local.nonce_count += 1
         else:
             self._thread_local.nonce_count = 1
-        ncvalue = '%08x' % self._thread_local.nonce_count
+        ncvalue = '{0:08x}'.format(self._thread_local.nonce_count)
         s = str(self._thread_local.nonce_count).encode('utf-8')
         s += nonce.encode('utf-8')
         s += time.ctime().encode('utf-8')
@@ -143,12 +143,12 @@ class HTTPDigestAuth(AuthBase):
 
         cnonce = (hashlib.sha1(s).hexdigest()[:16])
         if _algorithm == 'MD5-SESS':
-            HA1 = hash_utf8('%s:%s:%s' % (HA1, nonce, cnonce))
+            HA1 = hash_utf8('{0!s}:{1!s}:{2!s}'.format(HA1, nonce, cnonce))
 
         if not qop:
-            respdig = KD(HA1, "%s:%s" % (nonce, HA2))
+            respdig = KD(HA1, "{0!s}:{1!s}".format(nonce, HA2))
         elif qop == 'auth' or 'auth' in qop.split(','):
-            noncebit = "%s:%s:%s:%s:%s" % (
+            noncebit = "{0!s}:{1!s}:{2!s}:{3!s}:{4!s}".format(
                 nonce, ncvalue, cnonce, 'auth', HA2
                 )
             respdig = KD(HA1, noncebit)
@@ -162,15 +162,15 @@ class HTTPDigestAuth(AuthBase):
         base = 'username="%s", realm="%s", nonce="%s", uri="%s", ' \
                'response="%s"' % (self.username, realm, nonce, path, respdig)
         if opaque:
-            base += ', opaque="%s"' % opaque
+            base += ', opaque="{0!s}"'.format(opaque)
         if algorithm:
-            base += ', algorithm="%s"' % algorithm
+            base += ', algorithm="{0!s}"'.format(algorithm)
         if entdig:
-            base += ', digest="%s"' % entdig
+            base += ', digest="{0!s}"'.format(entdig)
         if qop:
-            base += ', qop="auth", nc=%s, cnonce="%s"' % (ncvalue, cnonce)
+            base += ', qop="auth", nc={0!s}, cnonce="{1!s}"'.format(ncvalue, cnonce)
 
-        return 'Digest %s' % (base)
+        return 'Digest {0!s}'.format((base))
 
     def handle_redirect(self, r, **kwargs):
         """Reset num_401_calls counter on redirects."""

--- a/lib/requests/cookies.py
+++ b/lib/requests/cookies.py
@@ -329,7 +329,7 @@ class RequestsCookieJar(cookielib.CookieJar, collections.MutableMapping):
                     if path is None or cookie.path == path:
                         return cookie.value
 
-        raise KeyError('name=%r, domain=%r, path=%r' % (name, domain, path))
+        raise KeyError('name={0!r}, domain={1!r}, path={2!r}'.format(name, domain, path))
 
     def _find_no_duplicates(self, name, domain=None, path=None):
         """Both ``__get_item__`` and ``get`` call this function: it's never
@@ -343,12 +343,12 @@ class RequestsCookieJar(cookielib.CookieJar, collections.MutableMapping):
                 if domain is None or cookie.domain == domain:
                     if path is None or cookie.path == path:
                         if toReturn is not None:  # if there are multiple cookies that meet passed in criteria
-                            raise CookieConflictError('There are multiple cookies with name, %r' % (name))
+                            raise CookieConflictError('There are multiple cookies with name, {0!r}'.format((name)))
                         toReturn = cookie.value  # we will eventually return this as long as no cookie conflict
 
         if toReturn:
             return toReturn
-        raise KeyError('name=%r, domain=%r, path=%r' % (name, domain, path))
+        raise KeyError('name={0!r}, domain={1!r}, path={2!r}'.format(name, domain, path))
 
     def __getstate__(self):
         """Unlike a normal CookieJar, this class is pickleable."""
@@ -428,7 +428,7 @@ def morsel_to_cookie(morsel):
         try:
             expires = int(time.time() + int(morsel['max-age']))
         except ValueError:
-            raise TypeError('max-age: %s must be integer' % morsel['max-age'])
+            raise TypeError('max-age: {0!s} must be integer'.format(morsel['max-age']))
     elif morsel['expires']:
         time_template = '%a, %d-%b-%Y %H:%M:%S GMT'
         expires = calendar.timegm(

--- a/lib/requests/models.py
+++ b/lib/requests/models.py
@@ -163,7 +163,7 @@ class RequestHooksMixin(object):
         """Properly register a hook."""
 
         if event not in self.hooks:
-            raise ValueError('Unsupported event specified, with event name "%s"' % (event))
+            raise ValueError('Unsupported event specified, with event name "{0!s}"'.format((event)))
 
         if isinstance(hook, collections.Callable):
             self.hooks[event].append(hook)
@@ -231,7 +231,7 @@ class Request(RequestHooksMixin):
         self.cookies = cookies
 
     def __repr__(self):
-        return '<Request [%s]>' % (self.method)
+        return '<Request [{0!s}]>'.format((self.method))
 
     def prepare(self):
         """Constructs a :class:`PreparedRequest <PreparedRequest>` for transmission and returns it."""
@@ -303,7 +303,7 @@ class PreparedRequest(RequestEncodingMixin, RequestHooksMixin):
         self.prepare_hooks(hooks)
 
     def __repr__(self):
-        return '<PreparedRequest [%s]>' % (self.method)
+        return '<PreparedRequest [{0!s}]>'.format((self.method))
 
     def copy(self):
         p = PreparedRequest()
@@ -353,7 +353,7 @@ class PreparedRequest(RequestEncodingMixin, RequestHooksMixin):
             raise MissingSchema(error)
 
         if not host:
-            raise InvalidURL("Invalid URL %r: No host supplied" % url)
+            raise InvalidURL("Invalid URL {0!r}: No host supplied".format(url))
 
         # Only want to apply IDNA to the hostname
         try:
@@ -391,7 +391,7 @@ class PreparedRequest(RequestEncodingMixin, RequestHooksMixin):
         enc_params = self._encode_params(params)
         if enc_params:
             if query:
-                query = '%s&%s' % (query, enc_params)
+                query = '{0!s}&{1!s}'.format(query, enc_params)
             else:
                 query = enc_params
 
@@ -603,7 +603,7 @@ class Response(object):
         setattr(self, 'raw', None)
 
     def __repr__(self):
-        return '<Response [%s]>' % (self.status_code)
+        return '<Response [{0!s}]>'.format((self.status_code))
 
     def __bool__(self):
         """Returns true if :attr:`status_code` is 'OK'."""
@@ -831,10 +831,10 @@ class Response(object):
         http_error_msg = ''
 
         if 400 <= self.status_code < 500:
-            http_error_msg = '%s Client Error: %s for url: %s' % (self.status_code, self.reason, self.url)
+            http_error_msg = '{0!s} Client Error: {1!s} for url: {2!s}'.format(self.status_code, self.reason, self.url)
 
         elif 500 <= self.status_code < 600:
-            http_error_msg = '%s Server Error: %s for url: %s' % (self.status_code, self.reason, self.url)
+            http_error_msg = '{0!s} Server Error: {1!s} for url: {2!s}'.format(self.status_code, self.reason, self.url)
 
         if http_error_msg:
             raise HTTPError(http_error_msg, response=self)

--- a/lib/requests/packages/__init__.py
+++ b/lib/requests/packages/__init__.py
@@ -27,10 +27,10 @@ try:
     from . import urllib3
 except ImportError:
     import urllib3
-    sys.modules['%s.urllib3' % __name__] = urllib3
+    sys.modules['{0!s}.urllib3'.format(__name__)] = urllib3
 
 try:
     from . import chardet
 except ImportError:
     import chardet
-    sys.modules['%s.chardet' % __name__] = chardet
+    sys.modules['{0!s}.chardet'.format(__name__)] = chardet

--- a/lib/requests/packages/chardet/charsetgroupprober.py
+++ b/lib/requests/packages/chardet/charsetgroupprober.py
@@ -93,8 +93,7 @@ class CharSetGroupProber(CharSetProber):
                 continue
             cf = prober.get_confidence()
             if constants._debug:
-                sys.stderr.write('%s confidence = %s\n' %
-                                 (prober.get_charset_name(), cf))
+                sys.stderr.write('{0!s} confidence = {1!s}\n'.format(prober.get_charset_name(), cf))
             if bestConf < cf:
                 bestConf = cf
                 self._mBestGuessProber = prober

--- a/lib/requests/packages/chardet/universaldetector.py
+++ b/lib/requests/packages/chardet/universaldetector.py
@@ -165,6 +165,5 @@ class UniversalDetector:
             for prober in self._mCharSetProbers[0].mProbers:
                 if not prober:
                     continue
-                sys.stderr.write('%s confidence = %s\n' %
-                                 (prober.get_charset_name(),
+                sys.stderr.write('{0!s} confidence = {1!s}\n'.format(prober.get_charset_name(),
                                   prober.get_confidence()))

--- a/lib/requests/packages/urllib3/__init__.py
+++ b/lib/requests/packages/urllib3/__init__.py
@@ -68,7 +68,7 @@ def add_stderr_logger(level=logging.DEBUG):
     handler.setFormatter(logging.Formatter('%(asctime)s %(levelname)s %(message)s'))
     logger.addHandler(handler)
     logger.setLevel(level)
-    logger.debug('Added a stderr logging handler to logger: %s' % __name__)
+    logger.debug('Added a stderr logging handler to logger: {0!s}'.format(__name__))
     return handler
 
 # ... Clean up.

--- a/lib/requests/packages/urllib3/_collections.py
+++ b/lib/requests/packages/urllib3/_collections.py
@@ -273,7 +273,7 @@ class HTTPHeaderDict(MutableMapping):
     iget = getlist
 
     def __repr__(self):
-        return "%s(%s)" % (type(self).__name__, dict(self.itermerged()))
+        return "{0!s}({1!s})".format(type(self).__name__, dict(self.itermerged()))
 
     def _copy_from(self, other):
         for key in other:

--- a/lib/requests/packages/urllib3/connection.py
+++ b/lib/requests/packages/urllib3/connection.py
@@ -138,12 +138,11 @@ class HTTPConnection(_HTTPConnection, object):
 
         except SocketTimeout as e:
             raise ConnectTimeoutError(
-                self, "Connection to %s timed out. (connect timeout=%s)" %
-                (self.host, self.timeout))
+                self, "Connection to {0!s} timed out. (connect timeout={1!s})".format(self.host, self.timeout))
 
         except SocketError as e:
             raise NewConnectionError(
-                self, "Failed to establish a new connection: %s" % e)
+                self, "Failed to establish a new connection: {0!s}".format(e))
 
         return conn
 

--- a/lib/requests/packages/urllib3/connectionpool.py
+++ b/lib/requests/packages/urllib3/connectionpool.py
@@ -73,7 +73,7 @@ class ConnectionPool(object):
         self.port = port
 
     def __str__(self):
-        return '%s(host=%r, port=%r)' % (type(self).__name__,
+        return '{0!s}(host={1!r}, port={2!r})'.format(type(self).__name__,
                                          self.host, self.port)
 
     def __enter__(self):
@@ -203,8 +203,7 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
         Return a fresh :class:`HTTPConnection`.
         """
         self.num_connections += 1
-        log.info("Starting new HTTP connection (%d): %s" %
-                 (self.num_connections, self.host))
+        log.info("Starting new HTTP connection ({0:d}): {1!s}".format(self.num_connections, self.host))
 
         conn = self.ConnectionCls(host=self.host, port=self.port,
                                   timeout=self.timeout.connect_timeout,
@@ -239,7 +238,7 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
 
         # If this is a persistent connection, check if it got disconnected
         if conn and is_connection_dropped(conn):
-            log.info("Resetting dropped connection: %s" % self.host)
+            log.info("Resetting dropped connection: {0!s}".format(self.host))
             conn.close()
             if getattr(conn, 'auto_open', 1) == 0:
                 # This is a proxied connection that has been mutated by
@@ -272,8 +271,8 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
         except Full:
             # This should never happen if self.block == True
             log.warning(
-                "Connection pool is full, discarding connection: %s" %
-                self.host)
+                "Connection pool is full, discarding connection: {0!s}".format(
+                self.host))
 
         # Connection never got put back into the pool, close it.
         if conn:
@@ -305,18 +304,18 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
         """Is the error actually a timeout? Will raise a ReadTimeout or pass"""
 
         if isinstance(err, SocketTimeout):
-            raise ReadTimeoutError(self, url, "Read timed out. (read timeout=%s)" % timeout_value)
+            raise ReadTimeoutError(self, url, "Read timed out. (read timeout={0!s})".format(timeout_value))
 
         # See the above comment about EAGAIN in Python 3. In Python 2 we have
         # to specifically catch it and throw the timeout error
         if hasattr(err, 'errno') and err.errno in _blocking_errnos:
-            raise ReadTimeoutError(self, url, "Read timed out. (read timeout=%s)" % timeout_value)
+            raise ReadTimeoutError(self, url, "Read timed out. (read timeout={0!s})".format(timeout_value))
 
         # Catch possible read timeouts thrown as SSL errors. If not the
         # case, rethrow the original. We need to do this because of:
         # http://bugs.python.org/issue10272
         if 'timed out' in str(err) or 'did not complete (read)' in str(err):  # Python 2.6
-            raise ReadTimeoutError(self, url, "Read timed out. (read timeout=%s)" % timeout_value)
+            raise ReadTimeoutError(self, url, "Read timed out. (read timeout={0!s})".format(timeout_value))
 
     def _make_request(self, conn, method, url, timeout=_Default,
                       **httplib_request_kw):
@@ -364,7 +363,7 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
             # timeouts, check for a zero timeout before making the request.
             if read_timeout == 0:
                 raise ReadTimeoutError(
-                    self, url, "Read timed out. (read timeout=%s)" % read_timeout)
+                    self, url, "Read timed out. (read timeout={0!s})".format(read_timeout))
             if read_timeout is Timeout.DEFAULT_TIMEOUT:
                 conn.sock.settimeout(socket.getdefaulttimeout())
             else:  # None or a value
@@ -382,7 +381,7 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
 
         # AppEngine doesn't have a version attr.
         http_version = getattr(conn, '_http_vsn_str', 'HTTP/?')
-        log.debug("\"%s %s %s\" %s %s" % (method, url, http_version,
+        log.debug("\"{0!s} {1!s} {2!s}\" {3!s} {4!s}".format(method, url, http_version,
                                           httplib_response.status,
                                           httplib_response.length))
 
@@ -644,7 +643,7 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
                     raise
                 return response
 
-            log.info("Redirecting %s -> %s" % (url, redirect_location))
+            log.info("Redirecting {0!s} -> {1!s}".format(url, redirect_location))
             return self.urlopen(
                 method, redirect_location, body, headers,
                 retries=retries, redirect=redirect,
@@ -656,7 +655,7 @@ class HTTPConnectionPool(ConnectionPool, RequestMethods):
         if retries.is_forced_retry(method, status_code=response.status):
             retries = retries.increment(method, url, response=response, _pool=self)
             retries.sleep()
-            log.info("Forced retry: %s" % url)
+            log.info("Forced retry: {0!s}".format(url))
             return self.urlopen(
                 method, url, body, headers,
                 retries=retries, redirect=redirect,
@@ -754,8 +753,7 @@ class HTTPSConnectionPool(HTTPConnectionPool):
         Return a fresh :class:`httplib.HTTPSConnection`.
         """
         self.num_connections += 1
-        log.info("Starting new HTTPS connection (%d): %s"
-                 % (self.num_connections, self.host))
+        log.info("Starting new HTTPS connection ({0:d}): {1!s}".format(self.num_connections, self.host))
 
         if not self.ConnectionCls or self.ConnectionCls is DummyConnection:
             raise SSLError("Can't connect to HTTPS URL because the SSL "

--- a/lib/requests/packages/urllib3/contrib/appengine.py
+++ b/lib/requests/packages/urllib3/contrib/appengine.py
@@ -130,7 +130,7 @@ class AppEngineManager(RequestMethods):
 
         except urlfetch.InvalidMethodError as e:
             raise AppEnginePlatformError(
-                "URLFetch does not support method: %s" % method, e)
+                "URLFetch does not support method: {0!s}".format(method), e)
 
         http_response = self._urlfetch_response_to_http_response(
             response, **response_kw)
@@ -144,7 +144,7 @@ class AppEngineManager(RequestMethods):
         if retries.is_forced_retry(method, status_code=http_response.status):
             retries = retries.increment(
                 method, url, response=http_response, _pool=self)
-            log.info("Forced retry: %s" % url)
+            log.info("Forced retry: {0!s}".format(url))
             retries.sleep()
             return self.urlopen(
                 method, url,

--- a/lib/requests/packages/urllib3/contrib/ntlmpool.py
+++ b/lib/requests/packages/urllib3/contrib/ntlmpool.py
@@ -43,8 +43,7 @@ class NTLMConnectionPool(HTTPSConnectionPool):
         # Performs the NTLM handshake that secures the connection. The socket
         # must be kept open while requests are performed.
         self.num_connections += 1
-        log.debug('Starting NTLM HTTPS connection no. %d: https://%s%s' %
-                  (self.num_connections, self.host, self.authurl))
+        log.debug('Starting NTLM HTTPS connection no. {0:d}: https://{1!s}{2!s}'.format(self.num_connections, self.host, self.authurl))
 
         headers = {}
         headers['Connection'] = 'Keep-Alive'
@@ -55,14 +54,14 @@ class NTLMConnectionPool(HTTPSConnectionPool):
 
         # Send negotiation message
         headers[req_header] = (
-            'NTLM %s' % ntlm.create_NTLM_NEGOTIATE_MESSAGE(self.rawuser))
-        log.debug('Request headers: %s' % headers)
+            'NTLM {0!s}'.format(ntlm.create_NTLM_NEGOTIATE_MESSAGE(self.rawuser)))
+        log.debug('Request headers: {0!s}'.format(headers))
         conn.request('GET', self.authurl, None, headers)
         res = conn.getresponse()
         reshdr = dict(res.getheaders())
-        log.debug('Response status: %s %s' % (res.status, res.reason))
-        log.debug('Response headers: %s' % reshdr)
-        log.debug('Response data: %s [...]' % res.read(100))
+        log.debug('Response status: {0!s} {1!s}'.format(res.status, res.reason))
+        log.debug('Response headers: {0!s}'.format(reshdr))
+        log.debug('Response data: {0!s} [...]'.format(res.read(100)))
 
         # Remove the reference to the socket, so that it can not be closed by
         # the response object (we want to keep the socket open)
@@ -75,8 +74,7 @@ class NTLMConnectionPool(HTTPSConnectionPool):
             if s[:5] == 'NTLM ':
                 auth_header_value = s[5:]
         if auth_header_value is None:
-            raise Exception('Unexpected %s response header: %s' %
-                            (resp_header, reshdr[resp_header]))
+            raise Exception('Unexpected {0!s} response header: {1!s}'.format(resp_header, reshdr[resp_header]))
 
         # Send authentication message
         ServerChallenge, NegotiateFlags = \
@@ -86,19 +84,18 @@ class NTLMConnectionPool(HTTPSConnectionPool):
                                                          self.domain,
                                                          self.pw,
                                                          NegotiateFlags)
-        headers[req_header] = 'NTLM %s' % auth_msg
-        log.debug('Request headers: %s' % headers)
+        headers[req_header] = 'NTLM {0!s}'.format(auth_msg)
+        log.debug('Request headers: {0!s}'.format(headers))
         conn.request('GET', self.authurl, None, headers)
         res = conn.getresponse()
-        log.debug('Response status: %s %s' % (res.status, res.reason))
-        log.debug('Response headers: %s' % dict(res.getheaders()))
-        log.debug('Response data: %s [...]' % res.read()[:100])
+        log.debug('Response status: {0!s} {1!s}'.format(res.status, res.reason))
+        log.debug('Response headers: {0!s}'.format(dict(res.getheaders())))
+        log.debug('Response data: {0!s} [...]'.format(res.read()[:100]))
         if res.status != 200:
             if res.status == 401:
                 raise Exception('Server rejected request: wrong '
                                 'username or password')
-            raise Exception('Wrong server response: %s %s' %
-                            (res.status, res.reason))
+            raise Exception('Wrong server response: {0!s} {1!s}'.format(res.status, res.reason))
 
         res.fp = None
         log.debug('Connection established')

--- a/lib/requests/packages/urllib3/contrib/pyopenssl.py
+++ b/lib/requests/packages/urllib3/contrib/pyopenssl.py
@@ -281,7 +281,7 @@ def ssl_wrap_socket(sock, keyfile=None, certfile=None, cert_reqs=None,
         try:
             ctx.load_verify_locations(ca_certs, ca_cert_dir)
         except OpenSSL.SSL.Error as e:
-            raise ssl.SSLError('bad ca_certs: %r' % ca_certs, e)
+            raise ssl.SSLError('bad ca_certs: {0!r}'.format(ca_certs), e)
     else:
         ctx.set_default_verify_paths()
 
@@ -304,7 +304,7 @@ def ssl_wrap_socket(sock, keyfile=None, certfile=None, cert_reqs=None,
                 raise timeout('select timed out')
             continue
         except OpenSSL.SSL.Error as e:
-            raise ssl.SSLError('bad handshake: %r' % e)
+            raise ssl.SSLError('bad handshake: {0!r}'.format(e))
         break
 
     return WrappedSocket(cnx, sock)

--- a/lib/requests/packages/urllib3/exceptions.py
+++ b/lib/requests/packages/urllib3/exceptions.py
@@ -16,7 +16,7 @@ class PoolError(HTTPError):
     "Base exception for errors caused within a pool."
     def __init__(self, pool, message):
         self.pool = pool
-        HTTPError.__init__(self, "%s: %s" % (pool, message))
+        HTTPError.__init__(self, "{0!s}: {1!s}".format(pool, message))
 
     def __reduce__(self):
         # For pickling purposes.
@@ -73,7 +73,7 @@ class MaxRetryError(RequestError):
     def __init__(self, pool, url, reason=None):
         self.reason = reason
 
-        message = "Max retries exceeded with url: %s (Caused by %r)" % (
+        message = "Max retries exceeded with url: {0!s} (Caused by {1!r})".format(
             url, reason)
 
         RequestError.__init__(self, pool, url, message)
@@ -83,7 +83,7 @@ class HostChangedError(RequestError):
     "Raised when an existing pool gets a request for a foreign host."
 
     def __init__(self, pool, url, retries=3):
-        message = "Tried to open a foreign host with url: %s" % url
+        message = "Tried to open a foreign host with url: {0!s}".format(url)
         RequestError.__init__(self, pool, url, message)
         self.retries = retries
 
@@ -138,7 +138,7 @@ class LocationParseError(LocationValueError):
     "Raised when get_host or similar fails to parse the URL input."
 
     def __init__(self, location):
-        message = "Failed to parse: %s" % location
+        message = "Failed to parse: {0!s}".format(location)
         HTTPError.__init__(self, message)
 
         self.location = location
@@ -190,12 +190,12 @@ class ProxySchemeUnknown(AssertionError, ValueError):
     # TODO(t-8ch): Stop inheriting from AssertionError in v2.0.
 
     def __init__(self, scheme):
-        message = "Not supported proxy scheme %s" % scheme
+        message = "Not supported proxy scheme {0!s}".format(scheme)
         super(ProxySchemeUnknown, self).__init__(message)
 
 
 class HeaderParsingError(HTTPError):
     "Raised by assert_header_parsing, but we convert it to a log.warning statement."
     def __init__(self, defects, unparsed_data):
-        message = '%s, unparsed data: %r' % (defects or 'Unknown', unparsed_data)
+        message = '{0!s}, unparsed data: {1!r}'.format(defects or 'Unknown', unparsed_data)
         super(HeaderParsingError, self).__init__(message)

--- a/lib/requests/packages/urllib3/fields.py
+++ b/lib/requests/packages/urllib3/fields.py
@@ -33,7 +33,7 @@ def format_header_param(name, value):
         The value of the parameter, provided as a unicode string.
     """
     if not any(ch in value for ch in '"\\\r\n'):
-        result = '%s="%s"' % (name, value)
+        result = '{0!s}="{1!s}"'.format(name, value)
         try:
             result.encode('ascii')
         except UnicodeEncodeError:
@@ -43,7 +43,7 @@ def format_header_param(name, value):
     if not six.PY3:  # Python 2:
         value = value.encode('utf-8')
     value = email.utils.encode_rfc2231(value, 'utf-8')
-    value = '%s*=%s' % (name, value)
+    value = '{0!s}*={1!s}'.format(name, value)
     return value
 
 
@@ -144,12 +144,12 @@ class RequestField(object):
         sort_keys = ['Content-Disposition', 'Content-Type', 'Content-Location']
         for sort_key in sort_keys:
             if self.headers.get(sort_key, False):
-                lines.append('%s: %s' % (sort_key, self.headers[sort_key]))
+                lines.append('{0!s}: {1!s}'.format(sort_key, self.headers[sort_key]))
 
         for header_name, header_value in self.headers.items():
             if header_name not in sort_keys:
                 if header_value:
-                    lines.append('%s: %s' % (header_name, header_value))
+                    lines.append('{0!s}: {1!s}'.format(header_name, header_value))
 
         lines.append('\r\n')
         return '\r\n'.join(lines)

--- a/lib/requests/packages/urllib3/filepost.py
+++ b/lib/requests/packages/urllib3/filepost.py
@@ -72,7 +72,7 @@ def encode_multipart_formdata(fields, boundary=None):
         boundary = choose_boundary()
 
     for field in iter_field_objects(fields):
-        body.write(b('--%s\r\n' % (boundary)))
+        body.write(b('--{0!s}\r\n'.format((boundary))))
 
         writer(body).write(field.render_headers())
         data = field.data
@@ -87,8 +87,8 @@ def encode_multipart_formdata(fields, boundary=None):
 
         body.write(b'\r\n')
 
-    body.write(b('--%s--\r\n' % (boundary)))
+    body.write(b('--{0!s}--\r\n'.format((boundary))))
 
-    content_type = str('multipart/form-data; boundary=%s' % boundary)
+    content_type = str('multipart/form-data; boundary={0!s}'.format(boundary))
 
     return body.getvalue(), content_type

--- a/lib/requests/packages/urllib3/packages/ordered_dict.py
+++ b/lib/requests/packages/urllib3/packages/ordered_dict.py
@@ -32,7 +32,7 @@ class OrderedDict(dict):
 
         '''
         if len(args) > 1:
-            raise TypeError('expected at most 1 arguments, got %d' % len(args))
+            raise TypeError('expected at most 1 arguments, got {0:d}'.format(len(args)))
         try:
             self.__root
         except AttributeError:
@@ -202,8 +202,8 @@ class OrderedDict(dict):
         _repr_running[call_key] = 1
         try:
             if not self:
-                return '%s()' % (self.__class__.__name__,)
-            return '%s(%r)' % (self.__class__.__name__, self.items())
+                return '{0!s}()'.format(self.__class__.__name__)
+            return '{0!s}({1!r})'.format(self.__class__.__name__, self.items())
         finally:
             del _repr_running[call_key]
 

--- a/lib/requests/packages/urllib3/packages/six.py
+++ b/lib/requests/packages/urllib3/packages/six.py
@@ -199,7 +199,7 @@ def remove_move(name):
         try:
             del moves.__dict__[name]
         except KeyError:
-            raise AttributeError("no such move, %r" % (name,))
+            raise AttributeError("no such move, {0!r}".format(name))
 
 
 if PY3:

--- a/lib/requests/packages/urllib3/poolmanager.py
+++ b/lib/requests/packages/urllib3/poolmanager.py
@@ -186,7 +186,7 @@ class PoolManager(RequestMethods):
         kw['retries'] = retries
         kw['redirect'] = redirect
 
-        log.info("Redirecting %s -> %s" % (url, redirect_location))
+        log.info("Redirecting {0!s} -> {1!s}".format(url, redirect_location))
         return self.urlopen(method, redirect_location, **kw)
 
 
@@ -221,7 +221,7 @@ class ProxyManager(PoolManager):
                  proxy_headers=None, **connection_pool_kw):
 
         if isinstance(proxy_url, HTTPConnectionPool):
-            proxy_url = '%s://%s:%i' % (proxy_url.scheme, proxy_url.host,
+            proxy_url = '{0!s}://{1!s}:{2:d}'.format(proxy_url.scheme, proxy_url.host,
                                         proxy_url.port)
         proxy = parse_url(proxy_url)
         if not proxy.port:

--- a/lib/requests/packages/urllib3/response.py
+++ b/lib/requests/packages/urllib3/response.py
@@ -241,7 +241,7 @@ class HTTPResponse(io.IOBase):
 
             except (HTTPException, SocketError) as e:
                 # This includes IncompleteRead.
-                raise ProtocolError('Connection broken: %r' % e, e)
+                raise ProtocolError('Connection broken: {0!r}'.format(e), e)
 
         except Exception:
             # The response may not be closed but we're not going to use it anymore

--- a/lib/requests/packages/urllib3/util/retry.py
+++ b/lib/requests/packages/urllib3/util/retry.py
@@ -153,7 +153,7 @@ class Retry(object):
 
         redirect = bool(redirect) and None
         new_retries = cls(retries, redirect=redirect)
-        log.debug("Converted retries value: %r -> %r" % (retries, new_retries))
+        log.debug("Converted retries value: {0!r} -> {1!r}".format(retries, new_retries))
         return new_retries
 
     def get_backoff_time(self):
@@ -272,7 +272,7 @@ class Retry(object):
         if new_retry.is_exhausted():
             raise MaxRetryError(_pool, url, error or ResponseError(cause))
 
-        log.debug("Incremented Retry for (url='%s'): %r" % (url, new_retry))
+        log.debug("Incremented Retry for (url='{0!s}'): {1!r}".format(url, new_retry))
 
         return new_retry
 

--- a/lib/requests/packages/urllib3/util/timeout.py
+++ b/lib/requests/packages/urllib3/util/timeout.py
@@ -100,7 +100,7 @@ class Timeout(object):
         self._start_connect = None
 
     def __str__(self):
-        return '%s(connect=%r, read=%r, total=%r)' % (
+        return '{0!s}(connect={1!r}, read={2!r}, total={3!r})'.format(
             type(self).__name__, self._connect, self._read, self.total)
 
     @classmethod

--- a/lib/requests/packages/urllib3/util/url.py
+++ b/lib/requests/packages/urllib3/util/url.py
@@ -40,7 +40,7 @@ class Url(namedtuple('Url', url_attrs)):
     def netloc(self):
         """Network location including host and port"""
         if self.port:
-            return '%s:%d' % (self.host, self.port)
+            return '{0!s}:{1:d}'.format(self.host, self.port)
         return self.host
 
     @property

--- a/lib/requests/sessions.py
+++ b/lib/requests/sessions.py
@@ -110,7 +110,7 @@ class SessionRedirectMixin(object):
                 resp.raw.read(decode_content=False)
 
             if i >= self.max_redirects:
-                raise TooManyRedirects('Exceeded %s redirects.' % self.max_redirects, response=resp)
+                raise TooManyRedirects('Exceeded {0!s} redirects.'.format(self.max_redirects), response=resp)
 
             # Release the connection back into the pool.
             resp.close()
@@ -121,7 +121,7 @@ class SessionRedirectMixin(object):
             # Handle redirection without scheme (see: RFC 1808 Section 4)
             if url.startswith('//'):
                 parsed_rurl = urlparse(resp.url)
-                url = '%s:%s' % (parsed_rurl.scheme, url)
+                url = '{0!s}:{1!s}'.format(parsed_rurl.scheme, url)
 
             # The scheme should be lower case...
             parsed = urlparse(url)
@@ -643,7 +643,7 @@ class Session(SessionRedirectMixin):
                 return adapter
 
         # Nothing matches :-/
-        raise InvalidSchema("No connection adapters were found for '%s'" % url)
+        raise InvalidSchema("No connection adapters were found for '{0!s}'".format(url))
 
     def close(self):
         """Closes all adapters and as such the session"""

--- a/lib/requests/structures.py
+++ b/lib/requests/structures.py
@@ -93,7 +93,7 @@ class LookupDict(dict):
         super(LookupDict, self).__init__()
 
     def __repr__(self):
-        return '<lookup \'%s\'>' % (self.name)
+        return '<lookup \'{0!s}\'>'.format((self.name))
 
     def __getitem__(self, key):
         # We allow fall-through here, so values default to None

--- a/lib/requests/utils.py
+++ b/lib/requests/utils.py
@@ -436,7 +436,7 @@ def unquote_unreserved(uri):
             try:
                 c = chr(int(h, 16))
             except ValueError:
-                raise InvalidURL("Invalid percent-escape sequence: '%s'" % h)
+                raise InvalidURL("Invalid percent-escape sequence: '{0!s}'".format(h))
 
             if c in UNRESERVED_SET:
                 parts[i] = c + parts[i][2:]
@@ -586,7 +586,7 @@ def select_proxy(url, proxies):
 
 def default_user_agent(name="python-requests"):
     """Return a string representing the default user agent."""
-    return '%s/%s' % (name, __version__)
+    return '{0!s}/{1!s}'.format(name, __version__)
 
 
 def default_headers():

--- a/lib/rtorrent/lib/xmlrpc/basic_auth.py
+++ b/lib/rtorrent/lib/xmlrpc/basic_auth.py
@@ -34,10 +34,10 @@ class BasicAuthTransport(xmlrpclib.Transport):
 
     def send_auth(self, h):
         if self.username is not None and self.password is not None:
-            h.putheader('AUTHORIZATION', "Basic %s" % string.replace(
-                encodestring("%s:%s" % (self.username, self.password)),
+            h.putheader('AUTHORIZATION', "Basic {0!s}".format(string.replace(
+                encodestring("{0!s}:{1!s}".format(self.username, self.password)),
                 "\012", ""
-            ))
+            )))
 
     def single_request(self, host, handler, request_body, verbose=0):
         # issue XML-RPC request

--- a/lib/rtorrent/lib/xmlrpc/scgi.py
+++ b/lib/rtorrent/lib/xmlrpc/scgi.py
@@ -106,9 +106,9 @@ class SCGITransport(xmlrpclib.Transport):
     def single_request(self, host, handler, request_body, verbose=0):
         # Add SCGI headers to the request.
         headers = {'CONTENT_LENGTH': str(len(request_body)), 'SCGI': '1'}
-        header = '\x00'.join(('%s\x00%s' % item for item in headers.iteritems())) + '\x00'
-        header = '%d:%s' % (len(header), header)
-        request_body = '%s,%s' % (header, request_body)
+        header = '\x00'.join(('{0!s}\x00{1!s}'.format(*item) for item in headers.iteritems())) + '\x00'
+        header = '{0:d}:{1!s}'.format(len(header), header)
+        request_body = '{0!s},{1!s}'.format(header, request_body)
 
         sock = None
 
@@ -195,8 +195,7 @@ class SCGIServerProxy(xmlrpclib.ServerProxy):
 
     def __repr__(self):
         return (
-            "<SCGIServerProxy for %s%s>" %
-            (self.__host, self.__handler)
+            "<SCGIServerProxy for {0!s}{1!s}>".format(self.__host, self.__handler)
         )
 
     __str__ = __repr__
@@ -216,4 +215,4 @@ class SCGIServerProxy(xmlrpclib.ServerProxy):
             return self.__close
         elif attr == "transport":
             return self.__transport
-        raise AttributeError("Attribute %r not found" % (attr,))
+        raise AttributeError("Attribute {0!r} not found".format(attr))

--- a/lib/send2trash/plat_other.py
+++ b/lib/send2trash/plat_other.py
@@ -75,7 +75,7 @@ def trash_move(src, dst, topdir=None):
     destname = filename
     while op.exists(op.join(filespath, destname)) or op.exists(op.join(infopath, destname + INFO_SUFFIX)):
         counter += 1
-        destname = '%s %s%s' % (base_name, counter, ext)
+        destname = '{0!s} {1!s}{2!s}'.format(base_name, counter, ext)
     
     check_create(filespath)
     check_create(infopath)
@@ -137,11 +137,11 @@ def send2trash(path):
         path = str(path)
 
     if not op.exists(path):
-        raise OSError("File not found: %s" % path)
+        raise OSError("File not found: {0!s}".format(path))
     # ...should check whether the user has the necessary permissions to delete
     # it, before starting the trashing operation itself. [2]
     if not os.access(path, os.W_OK):
-        raise OSError("Permission denied: %s" % path)
+        raise OSError("Permission denied: {0!s}".format(path))
     # if the file to be trashed is on the same device as HOMETRASH we
     # want to move it there.
     path_dev = get_dev(path)
@@ -157,6 +157,6 @@ def send2trash(path):
         topdir = find_mount_point(path)
         trash_dev = get_dev(topdir)
         if trash_dev != path_dev:
-            raise OSError("Couldn't find mount point for %s" % path)
+            raise OSError("Couldn't find mount point for {0!s}".format(path))
         dest_trash = find_ext_volume_trash(topdir)
     trash_move(path, dest_trash, topdir)

--- a/lib/send2trash/plat_win.py
+++ b/lib/send2trash/plat_win.py
@@ -54,6 +54,6 @@ def send2trash(path):
     fileop.lpszProgressTitle = None
     result = SHFileOperationW(byref(fileop))
     if result:
-        msg = "Couldn't perform operation. Error code: %d" % result
+        msg = "Couldn't perform operation. Error code: {0:d}".format(result)
         raise OSError(msg)
 

--- a/lib/shutil_custom/__init__.py
+++ b/lib/shutil_custom/__init__.py
@@ -11,7 +11,7 @@ from shutil import _samefile
 def copyfile_custom(src, dst):
     """Copy data from src to dst"""
     if _samefile(src, dst):
-        raise Error("`%s` and `%s` are the same file" % (src, dst))
+        raise Error("`{0!s}` and `{1!s}` are the same file".format(src, dst))
 
     for fn in [src, dst]:
         try:
@@ -23,9 +23,9 @@ def copyfile_custom(src, dst):
             # XXX What about other special files? (sockets, devices...)
             if stat.S_ISFIFO(st.st_mode):
                 try:
-                    raise SpecialFileError("`%s` is a named pipe" % fn)
+                    raise SpecialFileError("`{0!s}` is a named pipe".format(fn))
                 except NameError:
-                    raise Error("`%s` is a named pipe" % fn)
+                    raise Error("`{0!s}` is a named pipe".format(fn))
 
     try:
         # Windows

--- a/lib/simplejson/decoder.py
+++ b/lib/simplejson/decoder.py
@@ -94,7 +94,7 @@ def py_scanstring(s, end, encoding=None, strict=True, _b=BACKSLASH, _m=STRINGCHU
             break
         elif terminator != '\\':
             if strict:
-                msg = "Invalid control character %r at" % (terminator,)
+                msg = "Invalid control character {0!r} at".format(terminator)
                 #msg = "Invalid control character {0!r} at".format(terminator)
                 raise ValueError(errmsg(msg, s, end))
             else:

--- a/lib/simplejson/encoder.py
+++ b/lib/simplejson/encoder.py
@@ -25,7 +25,7 @@ ESCAPE_DCT = {
 }
 for i in range(0x20):
     #ESCAPE_DCT.setdefault(chr(i), '\\u{0:04x}'.format(i))
-    ESCAPE_DCT.setdefault(chr(i), '\\u%04x' % (i,))
+    ESCAPE_DCT.setdefault(chr(i), '\\u{0:04x}'.format(i))
 
 # Assume this produces an infinity on all machines (probably not guaranteed)
 INFINITY = float('1e66666')
@@ -54,14 +54,14 @@ def py_encode_basestring_ascii(s):
             n = ord(s)
             if n < 0x10000:
                 #return '\\u{0:04x}'.format(n)
-                return '\\u%04x' % (n,)
+                return '\\u{0:04x}'.format(n)
             else:
                 # surrogate pair
                 n -= 0x10000
                 s1 = 0xd800 | ((n >> 10) & 0x3ff)
                 s2 = 0xdc00 | (n & 0x3ff)
                 #return '\\u{0:04x}\\u{1:04x}'.format(s1, s2)
-                return '\\u%04x\\u%04x' % (s1, s2)
+                return '\\u{0:04x}\\u{1:04x}'.format(s1, s2)
     return '"' + str(ESCAPE_ASCII.sub(replace, s)) + '"'
 
 

--- a/lib/six.py
+++ b/lib/six.py
@@ -479,7 +479,7 @@ def remove_move(name):
         try:
             del moves.__dict__[name]
         except KeyError:
-            raise AttributeError("no such move, %r" % (name,))
+            raise AttributeError("no such move, {0!r}".format(name))
 
 
 if PY3:

--- a/lib/sqlalchemy/connectors/pyodbc.py
+++ b/lib/sqlalchemy/connectors/pyodbc.py
@@ -67,22 +67,22 @@ class PyODBCConnector(Connector):
             dsn_connection = 'dsn' in keys or \
                             ('host' in keys and 'database' not in keys)
             if dsn_connection:
-                connectors = ['dsn=%s' % (keys.pop('host', '') or \
-                            keys.pop('dsn', ''))]
+                connectors = ['dsn={0!s}'.format((keys.pop('host', '') or \
+                            keys.pop('dsn', '')))]
             else:
                 port = ''
                 if 'port' in keys and not 'port' in query:
-                    port = ',%d' % int(keys.pop('port'))
+                    port = ',{0:d}'.format(int(keys.pop('port')))
 
-                connectors = ["DRIVER={%s}" %
-                                keys.pop('driver', self.pyodbc_driver_name),
-                              'Server=%s%s' % (keys.pop('host', ''), port),
-                              'Database=%s' % keys.pop('database', '')]
+                connectors = ["DRIVER={{{0!s}}}".format(
+                                keys.pop('driver', self.pyodbc_driver_name)),
+                              'Server={0!s}{1!s}'.format(keys.pop('host', ''), port),
+                              'Database={0!s}'.format(keys.pop('database', ''))]
 
             user = keys.pop("user", None)
             if user:
-                connectors.append("UID=%s" % user)
-                connectors.append("PWD=%s" % keys.pop('password', ''))
+                connectors.append("UID={0!s}".format(user))
+                connectors.append("PWD={0!s}".format(keys.pop('password', '')))
             else:
                 connectors.append("Trusted_Connection=Yes")
 
@@ -91,10 +91,10 @@ class PyODBCConnector(Connector):
             # client encoding.  This should obviously be set to 'No' if
             # you query a cp1253 encoded database from a latin1 client...
             if 'odbc_autotranslate' in keys:
-                connectors.append("AutoTranslate=%s" %
-                                    keys.pop("odbc_autotranslate"))
+                connectors.append("AutoTranslate={0!s}".format(
+                                    keys.pop("odbc_autotranslate")))
 
-            connectors.extend(['%s=%s' % (k, v) for k, v in keys.items()])
+            connectors.extend(['{0!s}={1!s}'.format(k, v) for k, v in keys.items()])
         return [[";".join(connectors)], connect_args]
 
     def is_disconnect(self, e, connection, cursor):

--- a/lib/sqlalchemy/connectors/zxJDBC.py
+++ b/lib/sqlalchemy/connectors/zxJDBC.py
@@ -33,9 +33,9 @@ class ZxJDBCConnector(Connector):
 
     def _create_jdbc_url(self, url):
         """Create a JDBC url from a :class:`~sqlalchemy.engine.url.URL`"""
-        return 'jdbc:%s://%s%s/%s' % (self.jdbc_db_name, url.host,
+        return 'jdbc:{0!s}://{1!s}{2!s}/{3!s}'.format(self.jdbc_db_name, url.host,
                                       url.port is not None
-                                        and ':%s' % url.port or '',
+                                        and ':{0!s}'.format(url.port) or '',
                                       url.database)
 
     def create_connect_args(self, url):

--- a/lib/sqlalchemy/dialects/__init__.py
+++ b/lib/sqlalchemy/dialects/__init__.py
@@ -30,7 +30,7 @@ def _auto_fn(name):
         dialect = name
         driver = "base"
     try:
-        module = __import__('sqlalchemy.dialects.%s' % (dialect, )).dialects
+        module = __import__('sqlalchemy.dialects.{0!s}'.format(dialect )).dialects
     except ImportError:
         return None
 

--- a/lib/sqlalchemy/dialects/drizzle/base.py
+++ b/lib/sqlalchemy/dialects/drizzle/base.py
@@ -360,7 +360,7 @@ class DrizzleCompiler(mysql_dialect.MySQLCompiler):
         if type_ is None:
             return self.process(cast.clause)
 
-        return 'CAST(%s AS %s)' % (self.process(cast.clause), type_)
+        return 'CAST({0!s} AS {1!s})'.format(self.process(cast.clause), type_)
 
 
 class DrizzleDDLCompiler(mysql_dialect.MySQLDDLCompiler):
@@ -381,7 +381,7 @@ class DrizzleTypeCompiler(mysql_dialect.MySQLTypeCompiler):
             return getattr(type_, name, defaults.get(name))
 
         if attr('collation'):
-            collation = 'COLLATE %s' % type_.collation
+            collation = 'COLLATE {0!s}'.format(type_.collation)
         elif attr('binary'):
             collation = 'BINARY'
         else:
@@ -398,7 +398,7 @@ class DrizzleTypeCompiler(mysql_dialect.MySQLTypeCompiler):
 
     def visit_FLOAT(self, type_):
         if type_.scale is not None and type_.precision is not None:
-            return "FLOAT(%s, %s)" % (type_.precision, type_.scale)
+            return "FLOAT({0!s}, {1!s})".format(type_.precision, type_.scale)
         else:
             return "FLOAT"
 
@@ -457,8 +457,8 @@ class DrizzleDialect(mysql_dialect.MySQLDialect):
             current_schema = self.default_schema_name
 
         charset = 'utf8'
-        rp = connection.execute("SHOW TABLES FROM %s" %
-            self.identifier_preparer.quote_identifier(current_schema))
+        rp = connection.execute("SHOW TABLES FROM {0!s}".format(
+            self.identifier_preparer.quote_identifier(current_schema)))
         return [row[0] for row in self._compat_fetchall(rp, charset=charset)]
 
     @reflection.cache

--- a/lib/sqlalchemy/dialects/firebird/fdb.py
+++ b/lib/sqlalchemy/dialects/firebird/fdb.py
@@ -84,7 +84,7 @@ class FBDialect_fdb(FBDialect_kinterbasdb):
     def create_connect_args(self, url):
         opts = url.translate_connect_args(username='user')
         if opts.get('port'):
-            opts['host'] = "%s/%s" % (opts['host'], opts['port'])
+            opts['host'] = "{0!s}/{1!s}".format(opts['host'], opts['port'])
             del opts['port']
         opts.update(url.query)
 

--- a/lib/sqlalchemy/dialects/firebird/kinterbasdb.py
+++ b/lib/sqlalchemy/dialects/firebird/kinterbasdb.py
@@ -114,7 +114,7 @@ class FBDialect_kinterbasdb(FBDialect):
     def create_connect_args(self, url):
         opts = url.translate_connect_args(username='user')
         if opts.get('port'):
-            opts['host'] = "%s/%s" % (opts['host'], opts['port'])
+            opts['host'] = "{0!s}/{1!s}".format(opts['host'], opts['port'])
             del opts['port']
         opts.update(url.query)
 
@@ -158,7 +158,7 @@ class FBDialect_kinterbasdb(FBDialect):
         m = match('\w+-V(\d+)\.(\d+)\.(\d+)\.(\d+)( \w+ (\d+)\.(\d+))?', version)
         if not m:
             raise AssertionError(
-                    "Could not determine version from string '%s'" % version)
+                    "Could not determine version from string '{0!s}'".format(version))
 
         if m.group(5) != None:
             return tuple([int(x) for x in m.group(6, 7, 4)] + ['firebird'])

--- a/lib/sqlalchemy/dialects/mssql/adodbapi.py
+++ b/lib/sqlalchemy/dialects/mssql/adodbapi.py
@@ -59,15 +59,14 @@ class MSDialect_adodbapi(MSDialect):
 
         connectors = ["Provider=SQLOLEDB"]
         if 'port' in keys:
-            connectors.append("Data Source=%s, %s" %
-                                (keys.get("host"), keys.get("port")))
+            connectors.append("Data Source={0!s}, {1!s}".format(keys.get("host"), keys.get("port")))
         else:
-            connectors.append("Data Source=%s" % keys.get("host"))
-        connectors.append("Initial Catalog=%s" % keys.get("database"))
+            connectors.append("Data Source={0!s}".format(keys.get("host")))
+        connectors.append("Initial Catalog={0!s}".format(keys.get("database")))
         user = keys.get("user")
         if user:
-            connectors.append("User Id=%s" % user)
-            connectors.append("Password=%s" % keys.get("password", ""))
+            connectors.append("User Id={0!s}".format(user))
+            connectors.append("Password={0!s}".format(keys.get("password", "")))
         else:
             connectors.append("Integrated Security=SSPI")
         return [[";".join(connectors)], {}]

--- a/lib/sqlalchemy/dialects/mssql/mxodbc.py
+++ b/lib/sqlalchemy/dialects/mssql/mxodbc.py
@@ -59,7 +59,7 @@ class _MSDate_mxodbc(_MSDate):
     def bind_processor(self, dialect):
         def process(value):
             if value is not None:
-                return "%s-%s-%s" % (value.year, value.month, value.day)
+                return "{0!s}-{1!s}-{2!s}".format(value.year, value.month, value.day)
             else:
                 return None
         return process
@@ -69,7 +69,7 @@ class _MSTime_mxodbc(_MSTime):
     def bind_processor(self, dialect):
         def process(value):
             if value is not None:
-                return "%s:%s:%s" % (value.hour, value.minute, value.second)
+                return "{0!s}:{1!s}:{2!s}".format(value.hour, value.minute, value.second)
             else:
                 return None
         return process

--- a/lib/sqlalchemy/dialects/mssql/pymssql.py
+++ b/lib/sqlalchemy/dialects/mssql/pymssql.py
@@ -72,7 +72,7 @@ class MSDialect_pymssql(MSDialect):
         opts.update(url.query)
         port = opts.pop('port', None)
         if port and 'host' in opts:
-            opts['host'] = "%s:%s" % (opts['host'], port)
+            opts['host'] = "{0!s}:{1!s}".format(opts['host'], port)
         return [[], opts]
 
     def is_disconnect(self, e, connection, cursor):

--- a/lib/sqlalchemy/dialects/mssql/pyodbc.py
+++ b/lib/sqlalchemy/dialects/mssql/pyodbc.py
@@ -153,7 +153,7 @@ class _ms_numeric_pyodbc(object):
     # as of 2.1.8 this logic is integrated.
 
     def _small_dec_to_string(self, value):
-        return "%s0.%s%s" % (
+        return "{0!s}0.{1!s}{2!s}".format(
                     (value < 0 and '-' or ''),
                     '0' * (abs(value.adjusted()) - 1),
                     "".join([str(nint) for nint in value.as_tuple()[1]]))
@@ -161,20 +161,20 @@ class _ms_numeric_pyodbc(object):
     def _large_dec_to_string(self, value):
         _int = value.as_tuple()[1]
         if 'E' in str(value):
-            result = "%s%s%s" % (
+            result = "{0!s}{1!s}{2!s}".format(
                     (value < 0 and '-' or ''),
                     "".join([str(s) for s in _int]),
                     "0" * (value.adjusted() - (len(_int) - 1)))
         else:
             if (len(_int) - 1) > value.adjusted():
-                result = "%s%s.%s" % (
+                result = "{0!s}{1!s}.{2!s}".format(
                 (value < 0 and '-' or ''),
                 "".join(
                     [str(s) for s in _int][0:value.adjusted() + 1]),
                 "".join(
                     [str(s) for s in _int][value.adjusted() + 1:]))
             else:
-                result = "%s%s" % (
+                result = "{0!s}{1!s}".format(
                 (value < 0 and '-' or ''),
                 "".join(
                     [str(s) for s in _int][0:value.adjusted() + 1]))

--- a/lib/sqlalchemy/dialects/mssql/zxjdbc.py
+++ b/lib/sqlalchemy/dialects/mssql/zxjdbc.py
@@ -47,7 +47,7 @@ class MSExecutionContext_zxjdbc(MSExecutionContext):
         if self._enable_identity_insert:
             table = self.dialect.identifier_preparer.format_table(
                                         self.compiled.statement.table)
-            self.cursor.execute("SET IDENTITY_INSERT %s OFF" % table)
+            self.cursor.execute("SET IDENTITY_INSERT {0!s} OFF".format(table))
 
 
 class MSDialect_zxjdbc(ZxJDBCConnector, MSDialect):

--- a/lib/sqlalchemy/dialects/mysql/mysqldb.py
+++ b/lib/sqlalchemy/dialects/mysql/mysqldb.py
@@ -74,8 +74,7 @@ class MySQLDialect_mysqldb(MySQLDBConnector, MySQLDialect):
         # specific issue w/ the utf8_bin collation and unicode returns
 
         has_utf8_bin = connection.scalar(
-                                "show collation where %s = 'utf8' and %s = 'utf8_bin'"
-                                    % (
+                                "show collation where {0!s} = 'utf8' and {1!s} = 'utf8_bin'".format(
                                     self.identifier_preparer.quote("Charset"),
                                     self.identifier_preparer.quote("Collation")
                                 ))

--- a/lib/sqlalchemy/dialects/mysql/oursql.py
+++ b/lib/sqlalchemy/dialects/mysql/oursql.py
@@ -95,7 +95,7 @@ class MySQLDialect_oursql(MySQLDialect):
         else:
             charset = self._connection_charset
             arg = connection.connection._escape_string(xid.encode(charset)).decode(charset)
-        arg = "'%s'" % arg
+        arg = "'{0!s}'".format(arg)
         connection.execution_options(_oursql_plain_query=True).execute(query % arg)
 
     # Because mysql is bad, these methods have to be

--- a/lib/sqlalchemy/dialects/oracle/cx_oracle.py
+++ b/lib/sqlalchemy/dialects/oracle/cx_oracle.py
@@ -298,7 +298,7 @@ class _OracleNumeric(sqltypes.Numeric):
 
         if dialect.supports_native_decimal:
             if self.asdecimal:
-                fstring = "%%.%df" % self._effective_decimal_return_scale
+                fstring = "%.{0:d}f".format(self._effective_decimal_return_scale)
 
                 def to_decimal(value):
                     if value is None:
@@ -450,7 +450,7 @@ class OracleCompiler_cx_oracle(OracleCompiler):
         quote = getattr(name, 'quote', None)
         if quote is True or quote is not False and \
             self.preparer._bindparam_requires_quotes(name):
-            quoted_name = '"%s"' % name
+            quoted_name = '"{0!s}"'.format(name)
             self._quoted_bind_names[name] = quoted_name
             return OracleCompiler.bindparam_string(self, quoted_name, **kw)
         else:
@@ -592,12 +592,12 @@ class ReturningResultProxy(_result.FullyBufferedResultProxy):
     def _cursor_description(self):
         returning = self.context.compiled.returning
         return [
-            ("ret_%d" % i, None)
+            ("ret_{0:d}".format(i), None)
             for i, col in enumerate(returning)
         ]
 
     def _buffer_rows(self):
-        return collections.deque([tuple(self._returning_params["ret_%d" % i]
+        return collections.deque([tuple(self._returning_params["ret_{0:d}".format(i)]
                     for i, c in enumerate(self._returning_params))])
 
 
@@ -908,7 +908,7 @@ class OracleDialect_cx_oracle(OracleDialect):
         do_commit_twophase().  its format is unspecified."""
 
         id = random.randint(0, 2 ** 128)
-        return (0x1234, "%032x" % id, "%032x" % 9)
+        return (0x1234, "{0:032x}".format(id), "{0:032x}".format(9))
 
     def do_executemany(self, cursor, statement, parameters, context=None):
         if isinstance(parameters, tuple):

--- a/lib/sqlalchemy/dialects/oracle/zxjdbc.py
+++ b/lib/sqlalchemy/dialects/oracle/zxjdbc.py
@@ -74,7 +74,7 @@ class OracleCompiler_zxjdbc(OracleCompiler):
             dbtype = col.type.dialect_impl(self.dialect).get_dbapi_type(self.dialect.dbapi)
             self.returning_parameters.append((i + 1, dbtype))
 
-            bindparam = sql.bindparam("ret_%d" % i, value=ReturningParam(dbtype))
+            bindparam = sql.bindparam("ret_{0:d}".format(i), value=ReturningParam(dbtype))
             self.binds[bindparam.key] = bindparam
             binds.append(self.bindparam_string(self._truncate_bindparam(bindparam)))
 
@@ -97,9 +97,9 @@ class OracleExecutionContext_zxjdbc(OracleExecutionContext):
                     rrs = self.statement.__statement__.getReturnResultSet()
                     next(rrs)
                 except SQLException as sqle:
-                    msg = '%s [SQLCode: %d]' % (sqle.getMessage(), sqle.getErrorCode())
+                    msg = '{0!s} [SQLCode: {1:d}]'.format(sqle.getMessage(), sqle.getErrorCode())
                     if sqle.getSQLState() is not None:
-                        msg += ' [SQLState: %s]' % sqle.getSQLState()
+                        msg += ' [SQLState: {0!s}]'.format(sqle.getSQLState())
                     raise zxJDBC.Error(msg)
                 else:
                     row = tuple(self.cursor.datahandler.getPyObject(rrs, index, dbtype)
@@ -164,7 +164,7 @@ class ReturningParam(object):
 
     def __repr__(self):
         kls = self.__class__
-        return '<%s.%s object at 0x%x type=%s>' % (kls.__module__, kls.__name__, id(self),
+        return '<{0!s}.{1!s} object at 0x{2:x} type={3!s}>'.format(kls.__module__, kls.__name__, id(self),
                                                    self.type)
 
 
@@ -209,7 +209,7 @@ class OracleDialect_zxjdbc(ZxJDBCConnector, OracleDialect):
         self.implicit_returning = connection.connection.driverversion >= '10.2'
 
     def _create_jdbc_url(self, url):
-        return 'jdbc:oracle:thin:@%s:%s:%s' % (url.host, url.port or 1521, url.database)
+        return 'jdbc:oracle:thin:@{0!s}:{1!s}:{2!s}'.format(url.host, url.port or 1521, url.database)
 
     def _get_server_version_info(self, connection):
         version = re.search(r'Release ([\d\.]+)', connection.connection.dbversion).group(1)

--- a/lib/sqlalchemy/dialects/postgresql/hstore.py
+++ b/lib/sqlalchemy/dialects/postgresql/hstore.py
@@ -47,7 +47,7 @@ def _parse_error(hstore_str, pos):
     if len(residual) > ctx:
         residual = residual[:-1] + '[...]'
 
-    return "After %r, could not parse residual at position %d: %r" % (
+    return "After {0!r}, could not parse residual at position {1:d}: {2!r}".format(
         parsed_tail, pos, residual)
 
 
@@ -98,12 +98,11 @@ def _serialize_hstore(val):
         if position == 'value' and s is None:
             return 'NULL'
         elif isinstance(s, util.string_types):
-            return '"%s"' % s.replace("\\", "\\\\").replace('"', r'\"')
+            return '"{0!s}"'.format(s.replace("\\", "\\\\").replace('"', r'\"'))
         else:
-            raise ValueError("%r in %s position is not a string." %
-                             (s, position))
+            raise ValueError("{0!r} in {1!s} position is not a string.".format(s, position))
 
-    return ', '.join('%s=>%s' % (esc(k, 'key'), esc(v, 'value'))
+    return ', '.join('{0!s}=>{1!s}'.format(esc(k, 'key'), esc(v, 'value'))
                      for k, v in val.items())
 
 

--- a/lib/sqlalchemy/dialects/postgresql/json.py
+++ b/lib/sqlalchemy/dialects/postgresql/json.py
@@ -36,7 +36,7 @@ class JSONElement(elements.BinaryExpression):
             if hasattr(right, '__iter__') and \
                 not isinstance(right, util.string_types):
                 opstring = "#>"
-                right = "{%s}" % (", ".join(util.text_type(elem) for elem in right))
+                right = "{{{0!s}}}".format((", ".join(util.text_type(elem) for elem in right)))
             else:
                 opstring = "->"
 

--- a/lib/sqlalchemy/dialects/postgresql/pg8000.py
+++ b/lib/sqlalchemy/dialects/postgresql/pg8000.py
@@ -47,7 +47,7 @@ class _PGNumeric(sqltypes.Numeric):
                 return None
             else:
                 raise exc.InvalidRequestError(
-                            "Unknown PG numeric type: %d" % coltype)
+                            "Unknown PG numeric type: {0:d}".format(coltype))
         else:
             if coltype in _FLOAT_TYPES:
                 # pg8000 returns float natively for 701
@@ -56,7 +56,7 @@ class _PGNumeric(sqltypes.Numeric):
                 return processors.to_float
             else:
                 raise exc.InvalidRequestError(
-                            "Unknown PG numeric type: %d" % coltype)
+                            "Unknown PG numeric type: {0:d}".format(coltype))
 
 
 class _PGNumericNoBind(_PGNumeric):

--- a/lib/sqlalchemy/dialects/postgresql/psycopg2.py
+++ b/lib/sqlalchemy/dialects/postgresql/psycopg2.py
@@ -227,7 +227,7 @@ class _PGNumeric(sqltypes.Numeric):
                 return None
             else:
                 raise exc.InvalidRequestError(
-                            "Unknown PG numeric type: %d" % coltype)
+                            "Unknown PG numeric type: {0:d}".format(coltype))
         else:
             if coltype in _FLOAT_TYPES:
                 # pg8000 returns float natively for 701
@@ -236,7 +236,7 @@ class _PGNumeric(sqltypes.Numeric):
                 return processors.to_float
             else:
                 raise exc.InvalidRequestError(
-                            "Unknown PG numeric type: %d" % coltype)
+                            "Unknown PG numeric type: {0:d}".format(coltype))
 
 
 class _PGEnum(ENUM):
@@ -302,7 +302,7 @@ class PGExecutionContext_psycopg2(PGExecutionContext):
         if is_server_side:
             # use server-side cursors:
             # http://lists.initd.org/pipermail/psycopg/2007-January/005251.html
-            ident = "c_%s_%s" % (hex(id(self))[2:], hex(_server_side_id())[2:])
+            ident = "c_{0!s}_{1!s}".format(hex(id(self))[2:], hex(_server_side_id())[2:])
             return self._dbapi_connection.cursor(ident)
         else:
             return self._dbapi_connection.cursor()

--- a/lib/sqlalchemy/engine/base.py
+++ b/lib/sqlalchemy/engine/base.py
@@ -534,7 +534,7 @@ class Connection(Connectable):
 
         if name is None:
             self.__savepoint_seq += 1
-            name = 'sa_savepoint_%s' % self.__savepoint_seq
+            name = 'sa_savepoint_{0!s}'.format(self.__savepoint_seq)
         if self._still_open_and_connection_is_valid:
             self.engine.dialect.do_savepoint(self, name)
             return name
@@ -714,8 +714,8 @@ class Connection(Connectable):
             meth = object._execute_on_connection
         except AttributeError:
             raise exc.InvalidRequestError(
-                                "Unexecutable object type: %s" %
-                                type(object))
+                                "Unexecutable object type: {0!s}".format(
+                                type(object)))
         else:
             return meth(self, multiparams, params)
 
@@ -1500,7 +1500,7 @@ class Engine(Connectable, log.Identified):
     echo = log.echo_property()
 
     def __repr__(self):
-        return 'Engine(%r)' % self.url
+        return 'Engine({0!r})'.format(self.url)
 
     def dispose(self):
         """Dispose of the connection pool used by this :class:`.Engine`.

--- a/lib/sqlalchemy/engine/default.py
+++ b/lib/sqlalchemy/engine/default.py
@@ -167,8 +167,8 @@ class DefaultDialect(interfaces.Dialect):
 
         if not getattr(self, 'ported_sqla_06', True):
             util.warn(
-                "The %s dialect is not yet ported to the 0.6 format" %
-                self.name)
+                "The {0!s} dialect is not yet ported to the 0.6 format".format(
+                self.name))
 
         self.convert_unicode = convert_unicode
         self.encoding = encoding
@@ -368,8 +368,7 @@ class DefaultDialect(interfaces.Dialect):
     def validate_identifier(self, ident):
         if len(ident) > self.max_identifier_length:
             raise exc.IdentifierError(
-                "Identifier '%s' exceeds maximum length of %d characters" %
-                (ident, self.max_identifier_length)
+                "Identifier '{0!s}' exceeds maximum length of {1:d} characters".format(ident, self.max_identifier_length)
             )
 
     def connect(self, *cargs, **cparams):
@@ -417,7 +416,7 @@ class DefaultDialect(interfaces.Dialect):
         do_commit_twophase().  Its format is unspecified.
         """
 
-        return "_sa_%032x" % random.randint(0, 2 ** 128)
+        return "_sa_{0:032x}".format(random.randint(0, 2 ** 128))
 
     def do_savepoint(self, connection, name):
         connection.execute(expression.SavepointClause(name))

--- a/lib/sqlalchemy/engine/reflection.py
+++ b/lib/sqlalchemy/engine/reflection.py
@@ -577,8 +577,7 @@ class Inspector(object):
             if include_columns and \
                             not set(columns).issubset(include_columns):
                 util.warn(
-                    "Omitting %s KEY for (%s), key covers omitted columns." %
-                    (flavor, ', '.join(columns)))
+                    "Omitting {0!s} KEY for ({1!s}), key covers omitted columns.".format(flavor, ', '.join(columns)))
                 continue
             # look for columns by orig name in cols_by_orig_name,
             # but support columns that are in-Python only as fallback

--- a/lib/sqlalchemy/engine/result.py
+++ b/lib/sqlalchemy/engine/result.py
@@ -328,8 +328,8 @@ class ResultMetaData(object):
         if result is None:
             if raiseerr:
                 raise exc.NoSuchColumnError(
-                    "Could not locate column in row for column '%s'" %
-                        expression._string_or_unprintable(key))
+                    "Could not locate column in row for column '{0!s}'".format(
+                        expression._string_or_unprintable(key)))
             else:
                 return None
         else:

--- a/lib/sqlalchemy/engine/strategies.py
+++ b/lib/sqlalchemy/engine/strategies.py
@@ -138,7 +138,7 @@ class DefaultEngineStrategy(EngineStrategy):
                 "Invalid argument(s) %s sent to create_engine(), "
                 "using configuration %s/%s/%s.  Please check that the "
                 "keyword arguments are appropriate for this combination "
-                "of components." % (','.join("'%s'" % k for k in kwargs),
+                "of components." % (','.join("'{0!s}'".format(k) for k in kwargs),
                                     dialect.__class__.__name__,
                                     pool.__class__.__name__,
                                     engineclass.__name__))

--- a/lib/sqlalchemy/engine/threadlocal.py
+++ b/lib/sqlalchemy/engine/threadlocal.py
@@ -131,4 +131,4 @@ class TLEngine(base.Engine):
             self._connections.trans = []
 
     def __repr__(self):
-        return 'TLEngine(%s)' % str(self.url)
+        return 'TLEngine({0!s})'.format(str(self.url))

--- a/lib/sqlalchemy/engine/url.py
+++ b/lib/sqlalchemy/engine/url.py
@@ -72,7 +72,7 @@ class URL(object):
             s += "@"
         if self.host is not None:
             if ':' in self.host:
-                s += "[%s]" % self.host
+                s += "[{0!s}]".format(self.host)
             else:
                 s += self.host
         if self.port is not None:
@@ -82,7 +82,7 @@ class URL(object):
         if self.query:
             keys = list(self.query)
             keys.sort()
-            s += '?' + "&".join("%s=%s" % (k, self.query[k]) for k in keys)
+            s += '?' + "&".join("{0!s}={1!s}".format(k, self.query[k]) for k in keys)
         return s
 
     def __str__(self):
@@ -208,11 +208,11 @@ def _parse_rfc1738_args(name):
         return URL(name, **components)
     else:
         raise exc.ArgumentError(
-            "Could not parse rfc1738 URL from string '%s'" % name)
+            "Could not parse rfc1738 URL from string '{0!s}'".format(name))
 
 
 def _rfc_1738_quote(text):
-    return re.sub(r'[:@/]', lambda m: "%%%X" % ord(m.group(0)), text)
+    return re.sub(r'[:@/]', lambda m: "%{0:X}".format(ord(m.group(0))), text)
 
 def _rfc_1738_unquote(text):
     return util.unquote(text)

--- a/lib/sqlalchemy/event/api.py
+++ b/lib/sqlalchemy/event/api.py
@@ -23,8 +23,7 @@ def _event_key(target, identifier, fn):
         if tgt is not None:
             return _EventKey(target, identifier, fn, tgt)
     else:
-        raise exc.InvalidRequestError("No such event '%s' for target '%s'" %
-                                (identifier, target))
+        raise exc.InvalidRequestError("No such event '{0!s}' for target '{1!s}'".format(identifier, target))
 
 def listen(target, identifier, fn, *args, **kw):
     """Register a listener function for the given target.

--- a/lib/sqlalchemy/event/base.py
+++ b/lib/sqlalchemy/event/base.py
@@ -79,7 +79,7 @@ class _Dispatch(object):
         """
         if '_joined_dispatch_cls' not in self.__class__.__dict__:
             cls = type(
-                    "Joined%s" % self.__class__.__name__,
+                    "Joined{0!s}".format(self.__class__.__name__),
                     (_JoinedDispatcher, self.__class__), {}
                 )
             for ls in _event_descriptors(self):
@@ -129,7 +129,7 @@ def _create_dispatcher_class(cls, classname, bases, dict_):
     # i.e. make a Dispatch class that shares the '_listen' method
     # of the Event class, this is the straight monkeypatch.
     dispatch_base = getattr(cls, 'dispatch', _Dispatch)
-    dispatch_cls = type("%sDispatch" % classname,
+    dispatch_cls = type("{0!s}Dispatch".format(classname),
                                         (dispatch_base, ), {})
     cls._set_dispatch(cls, dispatch_cls)
 

--- a/lib/sqlalchemy/event/legacy.py
+++ b/lib/sqlalchemy/event/legacy.py
@@ -55,7 +55,7 @@ def _indent(text, indent):
 def _standard_listen_example(dispatch_descriptor, sample_target, fn):
     example_kw_arg = _indent(
             "\n".join(
-                "%(arg)s = kw['%(arg)s']" % {"arg": arg}
+                "{arg!s} = kw['{arg!s}']".format(**{"arg": arg})
                 for arg in dispatch_descriptor.arg_names[0:2]
             ),
             "    ")
@@ -85,8 +85,8 @@ def _standard_listen_example(dispatch_descriptor, sample_target, fn):
         )
 
     text %= {
-                "current_since": " (arguments as of %s)" %
-                                current_since if current_since else "",
+                "current_since": " (arguments as of {0!s})".format(
+                                current_since) if current_since else "",
                 "event_name": fn.__name__,
                 "has_kw_arguments": ", **kw" if dispatch_descriptor.has_kw else "",
                 "named_event_arguments": ", ".join(dispatch_descriptor.arg_names),

--- a/lib/sqlalchemy/event/registry.py
+++ b/lib/sqlalchemy/event/registry.py
@@ -184,8 +184,7 @@ class _EventKey(object):
 
         if key not in _key_to_collection:
             raise exc.InvalidRequestError(
-                    "No listeners found for event %s / %r / %s " %
-                    (self.target, self.identifier, self.fn)
+                    "No listeners found for event {0!s} / {1!r} / {2!s} ".format(self.target, self.identifier, self.fn)
                 )
         dispatch_reg = _key_to_collection.pop(key)
 

--- a/lib/sqlalchemy/exc.py
+++ b/lib/sqlalchemy/exc.py
@@ -60,7 +60,7 @@ class CircularDependencyError(SQLAlchemyError):
     """
     def __init__(self, message, cycles, edges, msg=None):
         if msg is None:
-            message += " Cycles: %r all edges: %r" % (cycles, edges)
+            message += " Cycles: {0!r} all edges: {1!r}".format(cycles, edges)
         else:
             message = msg
         SQLAlchemyError.__init__(self, message)
@@ -85,8 +85,7 @@ class UnsupportedCompilationError(CompileError):
 
     def __init__(self, compiler, element_type):
         super(UnsupportedCompilationError, self).__init__(
-                    "Compiler %r can't render element of type %s" %
-                                (compiler, element_type))
+                    "Compiler {0!r} can't render element of type {1!s}".format(compiler, element_type))
 
 class IdentifierError(SQLAlchemyError):
     """Raised when a schema name is beyond the max character limit"""
@@ -236,7 +235,7 @@ class StatementError(SQLAlchemyError):
         params_repr = util._repr_params(self.params, 10)
 
         return ' '.join([
-                            "(%s)" % det for det in self.detail
+                            "({0!s})".format(det) for det in self.detail
                         ] + [
                             SQLAlchemyError.__str__(self),
                              repr(self.statement), repr(params_repr)
@@ -286,7 +285,7 @@ class DBAPIError(StatementError):
                 msg = traceback.format_exception_only(
                     orig.__class__, orig)[-1].strip()
                 return StatementError(
-                    "%s (original cause: %s)" % (str(orig), msg),
+                    "{0!s} (original cause: {1!s})".format(str(orig), msg),
                     statement, params, orig
                 )
 
@@ -309,7 +308,7 @@ class DBAPIError(StatementError):
             text = 'Error in str() of DB-API-generated exception: ' + str(e)
         StatementError.__init__(
                 self,
-                '(%s) %s' % (orig.__class__.__name__, text),
+                '({0!s}) {1!s}'.format(orig.__class__.__name__, text),
                 statement,
                 params,
                 orig

--- a/lib/sqlalchemy/ext/associationproxy.py
+++ b/lib/sqlalchemy/ext/associationproxy.py
@@ -146,7 +146,7 @@ class AssociationProxy(interfaces._InspectionAttr):
         self.proxy_bulk_set = proxy_bulk_set
 
         self.owning_class = None
-        self.key = '_%s_%s_%s' % (
+        self.key = '_{0!s}_{1!s}_{2!s}'.format(
             type(self).__name__, target_collection, id(self))
         self.collection_class = None
 
@@ -693,7 +693,7 @@ class _AssociationList(_AssociationCollection):
         return repr(list(self))
 
     def __hash__(self):
-        raise TypeError("%s objects are unhashable" % type(self).__name__)
+        raise TypeError("{0!s} objects are unhashable".format(type(self).__name__))
 
     for func_name, func in list(locals().items()):
         if (util.callable(func) and func.__name__ == func_name and
@@ -818,8 +818,8 @@ class _AssociationDict(_AssociationCollection):
 
     def update(self, *a, **kw):
         if len(a) > 1:
-            raise TypeError('update expected at most 1 arguments, got %i' %
-                            len(a))
+            raise TypeError('update expected at most 1 arguments, got {0:d}'.format(
+                            len(a)))
         elif len(a) == 1:
             seq_or_map = a[0]
             # discern dict from sequence - took the advice from
@@ -844,7 +844,7 @@ class _AssociationDict(_AssociationCollection):
         return dict(self.items())
 
     def __hash__(self):
-        raise TypeError("%s objects are unhashable" % type(self).__name__)
+        raise TypeError("{0!s} objects are unhashable".format(type(self).__name__))
 
     for func_name, func in list(locals().items()):
         if (util.callable(func) and func.__name__ == func_name and
@@ -1044,7 +1044,7 @@ class _AssociationSet(_AssociationCollection):
         return repr(set(self))
 
     def __hash__(self):
-        raise TypeError("%s objects are unhashable" % type(self).__name__)
+        raise TypeError("{0!s} objects are unhashable".format(type(self).__name__))
 
     for func_name, func in list(locals().items()):
         if (util.callable(func) and func.__name__ == func_name and

--- a/lib/sqlalchemy/ext/automap.py
+++ b/lib/sqlalchemy/ext/automap.py
@@ -566,7 +566,7 @@ def generate_relationship(base, direction, return_fn, attrname, local_cls, refer
     elif return_fn is relationship:
         return return_fn(referred_cls, **kw)
     else:
-        raise TypeError("Unknown relationship function: %s" % return_fn)
+        raise TypeError("Unknown relationship function: {0!s}".format(return_fn))
 
 class AutomapBase(object):
     """Base class for an "automap" schema.

--- a/lib/sqlalchemy/ext/declarative/base.py
+++ b/lib/sqlalchemy/ext/declarative/base.py
@@ -519,8 +519,7 @@ def _declarative_constructor(self, **kwargs):
     for k in kwargs:
         if not hasattr(cls_, k):
             raise TypeError(
-                "%r is an invalid keyword argument for %s" %
-                (k, cls_.__name__))
+                "{0!r} is an invalid keyword argument for {1!s}".format(k, cls_.__name__))
         setattr(self, k, kwargs[k])
 _declarative_constructor.__name__ = '__init__'
 

--- a/lib/sqlalchemy/ext/declarative/clsregistry.py
+++ b/lib/sqlalchemy/ext/declarative/clsregistry.py
@@ -193,8 +193,7 @@ class _GetColumns(object):
         if mp:
             if key not in mp.all_orm_descriptors:
                 raise exc.InvalidRequestError(
-                            "Class %r does not have a mapped column named %r"
-                            % (self.cls, key))
+                            "Class {0!r} does not have a mapped column named {1!r}".format(self.cls, key))
 
             desc = mp.all_orm_descriptors[key]
             if desc.extension_type is interfaces.NOT_EXTENSION:

--- a/lib/sqlalchemy/ext/orderinglist.py
+++ b/lib/sqlalchemy/ext/orderinglist.py
@@ -180,7 +180,7 @@ def count_from_n_factory(start):
     def f(index, collection):
         return index + start
     try:
-        f.__name__ = 'count_from_%i' % start
+        f.__name__ = 'count_from_{0:d}'.format(start)
     except TypeError:
         pass
     return f

--- a/lib/sqlalchemy/ext/serializer.py
+++ b/lib/sqlalchemy/ext/serializer.py
@@ -138,7 +138,7 @@ def Deserializer(file, metadata=None, scoped_session=None, engine=None):
             elif type_ == "engine":
                 return get_engine()
             else:
-                raise Exception("Unknown token: %s" % type_)
+                raise Exception("Unknown token: {0!s}".format(type_))
     unpickler.persistent_load = persistent_load
     return unpickler
 

--- a/lib/sqlalchemy/log.py
+++ b/lib/sqlalchemy/log.py
@@ -172,10 +172,10 @@ def instance_logger(instance, echoflag=None):
     """create a logger for an instance that implements :class:`.Identified`."""
 
     if instance.logging_name:
-        name = "%s.%s.%s" % (instance.__class__.__module__,
+        name = "{0!s}.{1!s}.{2!s}".format(instance.__class__.__module__,
                       instance.__class__.__name__, instance.logging_name)
     else:
-        name = "%s.%s" % (instance.__class__.__module__,
+        name = "{0!s}.{1!s}".format(instance.__class__.__module__,
                   instance.__class__.__name__)
 
     instance._echo = echoflag

--- a/lib/sqlalchemy/orm/attributes.py
+++ b/lib/sqlalchemy/orm/attributes.py
@@ -190,7 +190,7 @@ class QueryableAttribute(interfaces._MappedAttribute,
             )
 
     def __str__(self):
-        return "%s.%s" % (self.class_.__name__, self.key)
+        return "{0!s}.{1!s}".format(self.class_.__name__, self.key)
 
     @util.memoized_property
     def property(self):
@@ -287,7 +287,7 @@ def create_proxied_attribute(descriptor):
                 return self.descriptor.__get__(instance, owner)
 
         def __str__(self):
-            return "%s.%s" % (self.class_.__name__, self.key)
+            return "{0!s}.{1!s}".format(self.class_.__name__, self.key)
 
         def __getattr__(self, attribute):
             """Delegate __getattr__ to the original descriptor and/or
@@ -444,7 +444,7 @@ class AttributeImpl(object):
         self.expire_missing = expire_missing
 
     def __str__(self):
-        return "%s.%s" % (self.class_.__name__, self.key)
+        return "{0!s}.{1!s}".format(self.class_.__name__, self.key)
 
     def _get_active_history(self):
         """Backwards compat for impl.active_history"""
@@ -772,7 +772,7 @@ class ScalarObjectAttributeImpl(ScalarAttributeImpl):
                 return
             else:
                 raise ValueError(
-                    "Object %s not associated with %s on attribute '%s'" % (
+                    "Object {0!s} not associated with {1!s} on attribute '{2!s}'".format(
                     instance_str(check_old),
                    state_str(state),
                    self.key

--- a/lib/sqlalchemy/orm/base.py
+++ b/lib/sqlalchemy/orm/base.py
@@ -187,7 +187,7 @@ def state_str(state):
     if state is None:
         return "None"
     else:
-        return '<%s at 0x%x>' % (state.class_.__name__, id(state.obj()))
+        return '<{0!s} at 0x{1:x}>'.format(state.class_.__name__, id(state.obj()))
 
 def state_class_str(state):
     """Return a string describing an instance's class via its InstanceState."""
@@ -195,7 +195,7 @@ def state_class_str(state):
     if state is None:
         return "None"
     else:
-        return '<%s>' % (state.class_.__name__, )
+        return '<{0!s}>'.format(state.class_.__name__ )
 
 
 def attribute_str(instance, attribute):
@@ -338,8 +338,7 @@ def _entity_descriptor(entity, key):
         return getattr(entity, key)
     except AttributeError:
         raise sa_exc.InvalidRequestError(
-                    "Entity '%s' has no property '%s'" %
-                    (description, key)
+                    "Entity '{0!s}' has no property '{1!s}'".format(description, key)
                 )
 
 _state_mapper = util.dottedgetter('manager.mapper')
@@ -379,7 +378,7 @@ def class_mapper(class_, configure=True):
     if mapper is None:
         if not isinstance(class_, type):
             raise sa_exc.ArgumentError(
-                    "Class object expected, got '%r'." % (class_, ))
+                    "Class object expected, got '{0!r}'.".format(class_ ))
         raise exc.UnmappedClassError(class_)
     else:
         return mapper

--- a/lib/sqlalchemy/orm/collections.py
+++ b/lib/sqlalchemy/orm/collections.py
@@ -630,7 +630,7 @@ class CollectionAdapter(object):
                 wanted = receiving_type.__name__
 
             raise TypeError(
-                "Incompatible collection type: %s is not %s-like" % (
+                "Incompatible collection type: {0!s} is not {1!s}-like".format(
                 given, wanted))
 
         # If the object is an adapted collection, return the (iterable)
@@ -842,7 +842,7 @@ def __converting_factory(specimen_cls, original_factory):
         return instrumented_cls(collection)
 
     # often flawed but better than nothing
-    wrapper.__name__ = "%sWrapper" % original_factory.__name__
+    wrapper.__name__ = "{0!s}Wrapper".format(original_factory.__name__)
     wrapper.__doc__ = original_factory.__doc__
 
     return wrapper
@@ -939,7 +939,7 @@ def _instrument_class(cls):
                                                before, argument, after))
     # intern the role map
     for role, method_name in roles.items():
-        setattr(cls, '_sa_%s' % role, getattr(cls, method_name))
+        setattr(cls, '_sa_{0!s}'.format(role), getattr(cls, method_name))
 
     cls._sa_adapter = None
     if not hasattr(cls, '_sa_linker'):
@@ -970,7 +970,7 @@ def _instrument_membership_mutator(method, before, argument, after):
             if pos_arg is None:
                 if named_arg not in kw:
                     raise sa_exc.ArgumentError(
-                        "Missing argument %s" % argument)
+                        "Missing argument {0!s}".format(argument))
                 value = kw[named_arg]
             else:
                 if len(args) > pos_arg:
@@ -979,7 +979,7 @@ def _instrument_membership_mutator(method, before, argument, after):
                     value = kw[named_arg]
                 else:
                     raise sa_exc.ArgumentError(
-                        "Missing argument %s" % argument)
+                        "Missing argument {0!s}".format(argument))
 
         initiator = kw.pop('_sa_initiator', None)
         if initiator is False:

--- a/lib/sqlalchemy/orm/dependency.py
+++ b/lib/sqlalchemy/orm/dependency.py
@@ -311,7 +311,7 @@ class DependencyProcessor(object):
         raise NotImplementedError()
 
     def __repr__(self):
-        return "%s(%s)" % (self.__class__.__name__, self.prop)
+        return "{0!s}({1!s})".format(self.__class__.__name__, self.prop)
 
 
 class OneToManyDP(DependencyProcessor):

--- a/lib/sqlalchemy/orm/deprecated_interfaces.py
+++ b/lib/sqlalchemy/orm/deprecated_interfaces.py
@@ -113,7 +113,7 @@ class MapperExtension(object):
                     event.listen(self.class_manager, 'init_failure',
                                         go(ls_meth), raw=False, propagate=True)
                 else:
-                    event.listen(self, "%s" % meth, ls_meth,
+                    event.listen(self, "{0!s}".format(meth), ls_meth,
                                         raw=False, retval=True, propagate=True)
 
     def instrument_class(self, mapper, class_):

--- a/lib/sqlalchemy/orm/evaluator.py
+++ b/lib/sqlalchemy/orm/evaluator.py
@@ -26,10 +26,10 @@ _notimplemented_ops = set(getattr(operators, op)
 
 class EvaluatorCompiler(object):
     def process(self, clause):
-        meth = getattr(self, "visit_%s" % clause.__visit_name__, None)
+        meth = getattr(self, "visit_{0!s}".format(clause.__visit_name__), None)
         if not meth:
             raise UnevaluatableError(
-                "Cannot evaluate %s" % type(clause).__name__)
+                "Cannot evaluate {0!s}".format(type(clause).__name__))
         return meth(clause)
 
     def visit_grouping(self, clause):
@@ -77,8 +77,8 @@ class EvaluatorCompiler(object):
                 return True
         else:
             raise UnevaluatableError(
-                "Cannot evaluate clauselist with operator %s" %
-                clause.operator)
+                "Cannot evaluate clauselist with operator {0!s}".format(
+                clause.operator))
 
         return evaluate
 
@@ -101,8 +101,7 @@ class EvaluatorCompiler(object):
                 return operator(eval_left(obj), eval_right(obj))
         else:
             raise UnevaluatableError(
-                    "Cannot evaluate %s with operator %s" %
-                    (type(clause).__name__, clause.operator))
+                    "Cannot evaluate {0!s} with operator {1!s}".format(type(clause).__name__, clause.operator))
         return evaluate
 
     def visit_unary(self, clause):
@@ -115,8 +114,7 @@ class EvaluatorCompiler(object):
                 return not value
             return evaluate
         raise UnevaluatableError(
-                    "Cannot evaluate %s with operator %s" %
-                    (type(clause).__name__, clause.operator))
+                    "Cannot evaluate {0!s} with operator {1!s}".format(type(clause).__name__, clause.operator))
 
     def visit_bindparam(self, clause):
         val = clause.value

--- a/lib/sqlalchemy/orm/exc.py
+++ b/lib/sqlalchemy/orm/exc.py
@@ -160,4 +160,4 @@ def _default_unmapped(base, cls):
     name = _safe_cls_name(cls)
 
     if not mappers:
-        return "Class '%s' is not mapped" % name
+        return "Class '{0!s}' is not mapped".format(name)

--- a/lib/sqlalchemy/orm/instrumentation.py
+++ b/lib/sqlalchemy/orm/instrumentation.py
@@ -337,7 +337,7 @@ class ClassManager(dict):
     __nonzero__ = __bool__
 
     def __repr__(self):
-        return '<%s of %r at %x>' % (
+        return '<{0!s} of {1!r} at {2:x}>'.format(
             self.__class__.__name__, self.class_, id(self))
 
 class _SerializeManager(object):

--- a/lib/sqlalchemy/orm/interfaces.py
+++ b/lib/sqlalchemy/orm/interfaces.py
@@ -218,7 +218,7 @@ class MapperProperty(_MappedAttribute, _InspectionAttr):
         return operator(self.comparator, value)
 
     def __repr__(self):
-        return '<%s at 0x%x; %s>' % (
+        return '<{0!s} at 0x{1:x}; {2!s}>'.format(
             self.__class__.__name__,
             id(self), getattr(self, 'key', 'no key'))
 
@@ -317,7 +317,7 @@ class PropComparator(operators.ColumnOperators):
         self._adapt_to_entity = adapt_to_entity
 
     def __clause_element__(self):
-        raise NotImplementedError("%r" % self)
+        raise NotImplementedError("{0!r}".format(self))
 
     def _query_clause_element(self):
         return self.__clause_element__()
@@ -502,7 +502,7 @@ class StrategizedProperty(MapperProperty):
                     return strategies[key]
                 except KeyError:
                     pass
-        raise Exception("can't locate strategy for %s %s" % (cls, key))
+        raise Exception("can't locate strategy for {0!s} {1!s}".format(cls, key))
 
 
 class MapperOption(object):

--- a/lib/sqlalchemy/orm/loading.py
+++ b/lib/sqlalchemy/orm/loading.py
@@ -534,8 +534,8 @@ def _configure_subclass_mapper(mapper, context, path, adapter):
             sub_mapper = mapper.polymorphic_map[discriminator]
         except KeyError:
             raise AssertionError(
-                    "No such polymorphic_identity %r is defined" %
-                    discriminator)
+                    "No such polymorphic_identity {0!r} is defined".format(
+                    discriminator))
         if sub_mapper is mapper:
             return None
 

--- a/lib/sqlalchemy/orm/mapper.py
+++ b/lib/sqlalchemy/orm/mapper.py
@@ -890,8 +890,7 @@ class Mapper(_InspectionAttr):
                 self.inherits = class_mapper(self.inherits, configure=False)
             if not issubclass(self.class_, self.inherits.class_):
                 raise sa_exc.ArgumentError(
-                        "Class '%s' does not inherit from '%s'" %
-                        (self.class_.__name__, self.inherits.class_.__name__))
+                        "Class '{0!s}' does not inherit from '{1!s}'".format(self.class_.__name__, self.inherits.class_.__name__))
             if self.non_primary != self.inherits.non_primary:
                 np = not self.non_primary and "primary" or "non-primary"
                 raise sa_exc.ArgumentError(
@@ -975,8 +974,7 @@ class Mapper(_InspectionAttr):
 
         if self.mapped_table is None:
             raise sa_exc.ArgumentError(
-                    "Mapper '%s' does not have a mapped_table specified."
-                    % self)
+                    "Mapper '{0!s}' does not have a mapped_table specified.".format(self))
 
     def _set_with_polymorphic(self, with_polymorphic):
         if with_polymorphic == '*':
@@ -1598,8 +1596,7 @@ class Mapper(_InspectionAttr):
         column = columns[0]
         if not expression._is_column(column):
             raise sa_exc.ArgumentError(
-                    "%s=%r is not an instance of MapperProperty or Column"
-                    % (key, prop))
+                    "{0!s}={1!r} is not an instance of MapperProperty or Column".format(key, prop))
 
         prop = self._props.get(key, None)
 
@@ -1723,11 +1720,11 @@ class Mapper(_InspectionAttr):
         )
 
     def __repr__(self):
-        return '<Mapper at 0x%x; %s>' % (
+        return '<Mapper at 0x{0:x}; {1!s}>'.format(
             id(self), self.class_.__name__)
 
     def __str__(self):
-        return "Mapper|%s|%s%s" % (
+        return "Mapper|{0!s}|{1!s}{2!s}".format(
             self.class_.__name__,
             self.local_table is not None and
             self.local_table.description or None,
@@ -1767,7 +1764,7 @@ class Mapper(_InspectionAttr):
             return self._props[key]
         except KeyError:
             raise sa_exc.InvalidRequestError(
-                    "Mapper '%s' has no property '%s'" % (self, key))
+                    "Mapper '{0!s}' has no property '{1!s}'".format(self, key))
 
     def get_property_by_column(self, column):
         """Given a :class:`.Column` object, return the
@@ -1798,8 +1795,7 @@ class Mapper(_InspectionAttr):
                 m = _class_to_mapper(m)
                 if not m.isa(self):
                     raise sa_exc.InvalidRequestError(
-                                "%r does not inherit from %r" %
-                                (m, self))
+                                "{0!r} does not inherit from {1!r}".format(m, self))
 
                 if selectable is None:
                     mappers.update(m.iterate_to_root())
@@ -2143,7 +2139,7 @@ class Mapper(_InspectionAttr):
         if self.include_properties is not None and \
                 name not in self.include_properties and \
                 (column is None or column not in self.include_properties):
-            self._log("not including property %s" % (name))
+            self._log("not including property {0!s}".format((name)))
             return True
 
         if self.exclude_properties is not None and \
@@ -2151,7 +2147,7 @@ class Mapper(_InspectionAttr):
                 name in self.exclude_properties or \
                 (column is not None and column in self.exclude_properties)
             ):
-            self._log("excluding property %s" % (name))
+            self._log("excluding property {0!s}".format((name)))
             return True
 
         return False
@@ -2705,5 +2701,4 @@ class _ColumnMapping(dict):
                 "conflicting property '%s':%r" % (
                     column.table.name, column.name, column.key, prop))
         raise orm_exc.UnmappedColumnError(
-            "No column %s is configured on mapper %s..." %
-            (column, self.mapper))
+            "No column {0!s} is configured on mapper {1!s}...".format(column, self.mapper))

--- a/lib/sqlalchemy/orm/path_registry.py
+++ b/lib/sqlalchemy/orm/path_registry.py
@@ -127,7 +127,7 @@ class PathRegistry(object):
         elif token.endswith(":" + _DEFAULT_TOKEN):
             return TokenRegistry(self.root, token)
         else:
-            raise exc.ArgumentError("invalid token: %s" % token)
+            raise exc.ArgumentError("invalid token: {0!s}".format(token))
 
     def __add__(self, other):
         return util.reduce(
@@ -135,7 +135,7 @@ class PathRegistry(object):
                     other.path, self)
 
     def __repr__(self):
-        return "%s(%r)" % (self.__class__.__name__, self.path, )
+        return "{0!s}({1!r})".format(self.__class__.__name__, self.path )
 
 
 class RootRegistry(PathRegistry):
@@ -195,7 +195,7 @@ class PropRegistry(PathRegistry):
         """
         return ("loader",
                 self.parent.token(
-                    "%s:%s" % (self.prop.strategy_wildcard_key, _WILDCARD_TOKEN)
+                    "{0!s}:{1!s}".format(self.prop.strategy_wildcard_key, _WILDCARD_TOKEN)
                     ).path
                 )
 
@@ -203,7 +203,7 @@ class PropRegistry(PathRegistry):
     def _default_path_loader_key(self):
         return ("loader",
                 self.parent.token(
-                    "%s:%s" % (self.prop.strategy_wildcard_key, _DEFAULT_TOKEN)
+                    "{0!s}:{1!s}".format(self.prop.strategy_wildcard_key, _DEFAULT_TOKEN)
                     ).path
                 )
 

--- a/lib/sqlalchemy/orm/properties.py
+++ b/lib/sqlalchemy/orm/properties.py
@@ -137,7 +137,7 @@ class ColumnProperty(StrategizedProperty):
 
         if kwargs:
             raise TypeError(
-                "%s received unexpected keyword argument(s): %s" % (
+                "{0!s} received unexpected keyword argument(s): {1!s}".format(
                     self.__class__.__name__,
                     ', '.join(sorted(kwargs.keys()))))
 

--- a/lib/sqlalchemy/orm/query.py
+++ b/lib/sqlalchemy/orm/query.py
@@ -404,8 +404,7 @@ class Query(object):
         ):
             if getattr(self, attr) is not notset:
                 raise sa_exc.InvalidRequestError(
-                    "Can't call Query.%s() when %s has been called" %
-                    (meth, methname)
+                    "Can't call Query.{0!s}() when {1!s} has been called".format(meth, methname)
                 )
 
     def _get_options(self, populate_existing=None,
@@ -795,7 +794,7 @@ class Query(object):
             raise sa_exc.InvalidRequestError(
             "Incorrect number of values in identifier to formulate "
             "primary key for query.get(); primary key columns are %s" %
-            ','.join("'%s'" % c for c in mapper.primary_key))
+            ','.join("'{0!s}'".format(c) for c in mapper.primary_key))
 
         key = mapper.identity_key_from_primary_key(ident)
 
@@ -1691,8 +1690,8 @@ class Query(object):
         aliased, from_joinpoint = kwargs.pop('aliased', False),\
                                     kwargs.pop('from_joinpoint', False)
         if kwargs:
-            raise TypeError("unknown arguments: %s" %
-                                ','.join(kwargs.keys))
+            raise TypeError("unknown arguments: {0!s}".format(
+                                ','.join(kwargs.keys)))
         return self._join(props,
                             outerjoin=False, create_aliases=aliased,
                             from_joinpoint=from_joinpoint)
@@ -1707,8 +1706,8 @@ class Query(object):
         aliased, from_joinpoint = kwargs.pop('aliased', False), \
                                 kwargs.pop('from_joinpoint', False)
         if kwargs:
-            raise TypeError("unknown arguments: %s" %
-                    ','.join(kwargs))
+            raise TypeError("unknown arguments: {0!s}".format(
+                    ','.join(kwargs)))
         return self._join(props,
                             outerjoin=True, create_aliases=aliased,
                             from_joinpoint=from_joinpoint)
@@ -1880,8 +1879,8 @@ class Query(object):
 
         if overlap and l_info.selectable is r_info.selectable:
             raise sa_exc.InvalidRequestError(
-                    "Can't join table/selectable '%s' to itself" %
-                        l_info.selectable)
+                    "Can't join table/selectable '{0!s}' to itself".format(
+                        l_info.selectable))
 
         right, onclause = self._prepare_right_side(
                                 r_info, right, onclause,
@@ -1928,8 +1927,7 @@ class Query(object):
             if not right_selectable.is_derived_from(
                                     right_mapper.mapped_table):
                 raise sa_exc.InvalidRequestError(
-                    "Selectable '%s' is not derived from '%s'" %
-                    (right_selectable.description,
+                    "Selectable '{0!s}' is not derived from '{1!s}'".format(right_selectable.description,
                     right_mapper.mapped_table.description))
 
             if isinstance(right_selectable, expression.SelectBase):
@@ -2941,7 +2939,7 @@ class LockmodeArg(ForUpdateArg):
             read = False
         else:
             raise sa_exc.ArgumentError(
-                        "Unknown with_lockmode argument: %r" % mode)
+                        "Unknown with_lockmode argument: {0!r}".format(mode))
 
         return LockmodeArg(read=read, nowait=nowait)
 

--- a/lib/sqlalchemy/orm/relationships.py
+++ b/lib/sqlalchemy/orm/relationships.py
@@ -1867,19 +1867,19 @@ class JoinCondition(object):
         log.info('%s setup secondary join %s', self.prop,
                          self.secondaryjoin)
         log.info('%s synchronize pairs [%s]', self.prop,
-                         ','.join('(%s => %s)' % (l, r) for (l, r) in
+                         ','.join('({0!s} => {1!s})'.format(l, r) for (l, r) in
                          self.synchronize_pairs))
         log.info('%s secondary synchronize pairs [%s]', self.prop,
-                         ','.join('(%s => %s)' % (l, r) for (l, r) in
+                         ','.join('({0!s} => {1!s})'.format(l, r) for (l, r) in
                          self.secondary_synchronize_pairs or []))
         log.info('%s local/remote pairs [%s]', self.prop,
-                         ','.join('(%s / %s)' % (l, r) for (l, r) in
+                         ','.join('({0!s} / {1!s})'.format(l, r) for (l, r) in
                          self.local_remote_pairs))
         log.info('%s remote columns [%s]', self.prop,
-                        ','.join('%s' % col for col in self.remote_columns)
+                        ','.join('{0!s}'.format(col) for col in self.remote_columns)
             )
         log.info('%s local columns [%s]', self.prop,
-                        ','.join('%s' % col for col in self.local_columns)
+                        ','.join('{0!s}'.format(col) for col in self.local_columns)
             )
         log.info('%s relationship direction %s', self.prop,
                          self.direction)

--- a/lib/sqlalchemy/orm/session.py
+++ b/lib/sqlalchemy/orm/session.py
@@ -238,8 +238,8 @@ class SessionTransaction(object):
         else:
             if self._parent is None:
                 raise sa_exc.InvalidRequestError(
-                    "Transaction %s is not on the active transaction list" % (
-                    upto))
+                    "Transaction {0!s} is not on the active transaction list".format((
+                    upto)))
             return (self,) + self._parent._iterate_parents(upto)
 
     def _take_snapshot(self):
@@ -1137,13 +1137,13 @@ class Session(_SessionClassMethods):
 
         context = []
         if mapper is not None:
-            context.append('mapper %s' % c_mapper)
+            context.append('mapper {0!s}'.format(c_mapper))
         if clause is not None:
             context.append('SQL expression')
 
         raise sa_exc.UnboundExecutionError(
-            "Could not locate a bind configured on %s or this Session" % (
-            ', '.join(context)))
+            "Could not locate a bind configured on {0!s} or this Session".format((
+            ', '.join(context))))
 
     def query(self, *entities, **kwargs):
         """Return a new ``Query`` object corresponding to this ``Session``."""
@@ -1242,8 +1242,8 @@ class Session(_SessionClassMethods):
                 lockmode=lockmode,
                 only_load_props=attribute_names) is None:
             raise sa_exc.InvalidRequestError(
-                "Could not refresh instance '%s'" %
-                instance_str(instance))
+                "Could not refresh instance '{0!s}'".format(
+                instance_str(instance)))
 
     def expire_all(self):
         """Expires all persistent instances within this Session.
@@ -1369,8 +1369,8 @@ class Session(_SessionClassMethods):
             raise exc.UnmappedInstanceError(instance)
         if state.session_id is not self.hash_key:
             raise sa_exc.InvalidRequestError(
-                "Instance %s is not present in this Session" %
-                state_str(state))
+                "Instance {0!s} is not present in this Session".format(
+                state_str(state)))
 
         cascaded = list(state.manager.mapper.cascade_iterator(
                                     'expunge', state))
@@ -1512,8 +1512,8 @@ class Session(_SessionClassMethods):
 
         if state.key is None:
             raise sa_exc.InvalidRequestError(
-                "Instance '%s' is not persisted" %
-                state_str(state))
+                "Instance '{0!s}' is not persisted".format(
+                state_str(state)))
 
         if state in self._deleted:
             return
@@ -1700,8 +1700,8 @@ class Session(_SessionClassMethods):
     def _validate_persistent(self, state):
         if not self.identity_map.contains_state(state):
             raise sa_exc.InvalidRequestError(
-                "Instance '%s' is not persistent within this Session" %
-                state_str(state))
+                "Instance '{0!s}' is not persistent within this Session".format(
+                state_str(state)))
 
     def _save_impl(self, state):
         if state.key is not None:
@@ -1722,8 +1722,8 @@ class Session(_SessionClassMethods):
 
         if state.key is None:
             raise sa_exc.InvalidRequestError(
-                "Instance '%s' is not persisted" %
-                state_str(state))
+                "Instance '{0!s}' is not persisted".format(
+                state_str(state)))
 
         if state.deleted:
             raise sa_exc.InvalidRequestError(
@@ -2354,10 +2354,10 @@ class sessionmaker(_SessionClassMethods):
         self.kw.update(new_kw)
 
     def __repr__(self):
-        return "%s(class_=%r,%s)" % (
+        return "{0!s}(class_={1!r},{2!s})".format(
                     self.__class__.__name__,
                     self.class_.__name__,
-                    ", ".join("%s=%r" % (k, v) for k, v in self.kw.items())
+                    ", ".join("{0!s}={1!r}".format(k, v) for k, v in self.kw.items())
                 )
 
 

--- a/lib/sqlalchemy/orm/strategy_options.py
+++ b/lib/sqlalchemy/orm/strategy_options.py
@@ -119,7 +119,7 @@ class Load(Generative, MapperOption):
                 if default_token:
                     self.propagate_to_loaders = False
                 if wildcard_key:
-                    attr = "%s:%s" % (wildcard_key, attr)
+                    attr = "{0!s}:{1!s}".format(wildcard_key, attr)
                 return path.token(attr)
 
             try:
@@ -224,7 +224,7 @@ class Load(Generative, MapperOption):
 
                 if i == 0 and c_token.endswith(':' + _DEFAULT_TOKEN):
                     return to_chop
-                elif c_token != 'relationship:%s' % (_WILDCARD_TOKEN,) and c_token != p_token.key:
+                elif c_token != 'relationship:{0!s}'.format(_WILDCARD_TOKEN) and c_token != p_token.key:
                     return None
 
             if c_token is p_token:
@@ -259,7 +259,7 @@ class _UnboundLoad(Load):
                 attr in (_WILDCARD_TOKEN, _DEFAULT_TOKEN):
             if attr == _DEFAULT_TOKEN:
                 self.propagate_to_loaders = False
-            attr = "%s:%s" % (wildcard_key, attr)
+            attr = "{0!s}:{1!s}".format(wildcard_key, attr)
 
         return path + (attr, )
 
@@ -324,7 +324,7 @@ class _UnboundLoad(Load):
             if isinstance(c_token, util.string_types):
                 if i == 0 and c_token.endswith(':' + _DEFAULT_TOKEN):
                     return to_chop
-                elif c_token != 'relationship:%s' % (_WILDCARD_TOKEN,) and c_token != p_prop.key:
+                elif c_token != 'relationship:{0!s}'.format(_WILDCARD_TOKEN) and c_token != p_prop.key:
                     return None
             elif isinstance(c_token, PropComparator):
                 if c_token.property is not p_prop:
@@ -459,7 +459,7 @@ class loader_option(object):
         self.name = name = fn.__name__
         self.fn = fn
         if hasattr(Load, name):
-            raise TypeError("Load class already has a %s method." % (name))
+            raise TypeError("Load class already has a {0!s} method.".format((name)))
         setattr(Load, name, fn)
 
         return self
@@ -468,28 +468,28 @@ class loader_option(object):
         self._unbound_fn = fn
         fn_doc = self.fn.__doc__
         self.fn.__doc__ = """Produce a new :class:`.Load` object with the
-:func:`.orm.%(name)s` option applied.
+:func:`.orm.{name!s}` option applied.
 
-See :func:`.orm.%(name)s` for usage examples.
+See :func:`.orm.{name!s}` for usage examples.
 
-""" % {"name": self.name}
+""".format(**{"name": self.name})
 
         fn.__doc__ = fn_doc
         return self
 
     def _add_unbound_all_fn(self, fn):
         self._unbound_all_fn = fn
-        fn.__doc__ = """Produce a standalone "all" option for :func:`.orm.%(name)s`.
+        fn.__doc__ = """Produce a standalone "all" option for :func:`.orm.{name!s}`.
 
 .. deprecated:: 0.9.0
 
     The "_all()" style is replaced by method chaining, e.g.::
 
         session.query(MyClass).options(
-            %(name)s("someattribute").%(name)s("anotherattribute")
+            {name!s}("someattribute").{name!s}("anotherattribute")
         )
 
-""" % {"name": self.name}
+""".format(**{"name": self.name})
         return self
 
 @loader_option()

--- a/lib/sqlalchemy/orm/unitofwork.py
+++ b/lib/sqlalchemy/orm/unitofwork.py
@@ -457,7 +457,7 @@ class PostSortRec(object):
         self.execute(uow)
 
     def __repr__(self):
-        return "%s(%s)" % (
+        return "{0!s}({1!s})".format(
             self.__class__.__name__,
             ",".join(str(x) for x in self.__dict__.values())
         )
@@ -486,7 +486,7 @@ class ProcessAll(IterateMappersMixin, PostSortRec):
         return iter([])
 
     def __repr__(self):
-        return "%s(%s, delete=%s)" % (
+        return "{0!s}({1!s}, delete={2!s})".format(
             self.__class__.__name__,
             self.dependency_processor,
             self.delete
@@ -590,7 +590,7 @@ class ProcessState(PostSortRec):
             dependency_processor.process_saves(uow, states)
 
     def __repr__(self):
-        return "%s(%s, %s, delete=%s)" % (
+        return "{0!s}({1!s}, {2!s}, delete={3!s})".format(
             self.__class__.__name__,
             self.dependency_processor,
             orm_util.state_str(self.state),
@@ -616,7 +616,7 @@ class SaveUpdateState(PostSortRec):
                         uow)
 
     def __repr__(self):
-        return "%s(%s)" % (
+        return "{0!s}({1!s})".format(
             self.__class__.__name__,
             orm_util.state_str(self.state)
         )
@@ -640,7 +640,7 @@ class DeleteState(PostSortRec):
                         uow)
 
     def __repr__(self):
-        return "%s(%s)" % (
+        return "{0!s}({1!s})".format(
             self.__class__.__name__,
             orm_util.state_str(self.state)
         )

--- a/lib/sqlalchemy/orm/util.py
+++ b/lib/sqlalchemy/orm/util.py
@@ -38,11 +38,11 @@ class CascadeOptions(frozenset):
 
         if values.difference(cls._allowed_cascades):
             raise sa_exc.ArgumentError(
-                    "Invalid cascade option(s): %s" %
+                    "Invalid cascade option(s): {0!s}".format(
                     ", ".join([repr(x) for x in
                         sorted(
                             values.difference(cls._allowed_cascades)
-                    )])
+                    )]))
             )
 
         if "all" in values:
@@ -65,9 +65,9 @@ class CascadeOptions(frozenset):
         return self
 
     def __repr__(self):
-        return "CascadeOptions(%r)" % (
+        return "CascadeOptions({0!r})".format((
             ",".join([x for x in sorted(self)])
-        )
+        ))
 
 
 def _validator_events(desc, key, validator, include_removes, include_backrefs):
@@ -248,16 +248,14 @@ def identity_key(*args, **kwargs):
             raise sa_exc.ArgumentError("expected up to three "
                 "positional arguments, got %s" % len(args))
         if kwargs:
-            raise sa_exc.ArgumentError("unknown keyword arguments: %s"
-                % ", ".join(kwargs))
+            raise sa_exc.ArgumentError("unknown keyword arguments: {0!s}".format(", ".join(kwargs)))
         mapper = class_mapper(class_)
         if "ident" in locals():
             return mapper.identity_key_from_primary_key(util.to_list(ident))
         return mapper.identity_key_from_row(row)
     instance = kwargs.pop("instance")
     if kwargs:
-        raise sa_exc.ArgumentError("unknown keyword arguments: %s"
-            % ", ".join(kwargs.keys))
+        raise sa_exc.ArgumentError("unknown keyword arguments: {0!s}".format(", ".join(kwargs.keys)))
     mapper = object_mapper(instance)
     return mapper.identity_key_from_instance(instance)
 
@@ -360,7 +358,7 @@ class AliasedClass(object):
             adapt_on_names
         )
 
-        self.__name__ = 'AliasedClass_%s' % mapper.class_.__name__
+        self.__name__ = 'AliasedClass_{0!s}'.format(mapper.class_.__name__)
 
     def __getattr__(self, key):
         try:
@@ -398,7 +396,7 @@ class AliasedClass(object):
             return attr
 
     def __repr__(self):
-        return '<AliasedClass at 0x%x; %s>' % (
+        return '<AliasedClass at 0x{0:x}; {1!s}>'.format(
             id(self), self._aliased_insp._target.__name__)
 
 
@@ -522,10 +520,10 @@ class AliasedInsp(_InspectionAttr):
         elif mapper.isa(self.mapper):
             return self
         else:
-            assert False, "mapper %s doesn't correspond to %s" % (mapper, self)
+            assert False, "mapper {0!s} doesn't correspond to {1!s}".format(mapper, self)
 
     def __repr__(self):
-        return '<AliasedInsp at 0x%x; %s>' % (
+        return '<AliasedInsp at 0x{0:x}; {1!s}>'.format(
             id(self), self.class_.__name__)
 
 

--- a/lib/sqlalchemy/pool.py
+++ b/lib/sqlalchemy/pool.py
@@ -220,8 +220,7 @@ class Pool(log.Identified):
             self._reset_on_return = reset_commit
         else:
             raise exc.ArgumentError(
-                        "Invalid value for 'reset_on_return': %r"
-                                    % reset_on_return)
+                        "Invalid value for 'reset_on_return': {0!r}".format(reset_on_return))
 
         self.echo = echo
         if _dispatch:
@@ -841,8 +840,7 @@ class SingletonThreadPool(Pool):
             c.close()
 
     def status(self):
-        return "SingletonThreadPool id:%d size: %d" % \
-                            (id(self), len(self._all_conns))
+        return "SingletonThreadPool id:{0:d} size: {1:d}".format(id(self), len(self._all_conns))
 
     def _do_return_conn(self, conn):
         pass
@@ -1145,8 +1143,8 @@ class AssertionPool(Pool):
     def _do_get(self):
         if self._checked_out:
             if self._checkout_traceback:
-                suffix = ' at:\n%s' % ''.join(
-                    chop_traceback(self._checkout_traceback))
+                suffix = ' at:\n{0!s}'.format(''.join(
+                    chop_traceback(self._checkout_traceback)))
             else:
                 suffix = ''
             raise AssertionError("connection is already checked out" + suffix)

--- a/lib/sqlalchemy/processors.py
+++ b/lib/sqlalchemy/processors.py
@@ -83,7 +83,7 @@ def py_fallback():
         return process
 
     def to_decimal_processor_factory(target_class, scale):
-        fstring = "%%.%df" % scale
+        fstring = "%.{0:d}f".format(scale)
 
         def process(value):
             if value is None:
@@ -146,7 +146,7 @@ try:
         # For example, the Python implementation might return
         # Decimal('5.00000') whereas the C implementation will
         # return Decimal('5'). These are equivalent of course.
-        return DecimalResultProcessor(target_class, "%%.%df" % scale).process
+        return DecimalResultProcessor(target_class, "%.{0:d}f".format(scale)).process
 
 except ImportError:
     globals().update(py_fallback())

--- a/lib/sqlalchemy/sql/annotation.py
+++ b/lib/sqlalchemy/sql/annotation.py
@@ -177,9 +177,9 @@ def _new_annotation_type(cls, base_cls):
             break
 
     annotated_classes[cls] = anno_cls = type(
-                            "Annotated%s" % cls.__name__,
+                            "Annotated{0!s}".format(cls.__name__),
                             (base_cls, cls), {})
-    globals()["Annotated%s" % cls.__name__] = anno_cls
+    globals()["Annotated{0!s}".format(cls.__name__)] = anno_cls
     return anno_cls
 
 def _prepare_annotations(target_hierarchy, base_cls):

--- a/lib/sqlalchemy/sql/base.py
+++ b/lib/sqlalchemy/sql/base.py
@@ -89,7 +89,7 @@ class _DialectArgView(collections.MutableMapping):
 
     def __iter__(self):
         return (
-            "%s_%s" % (dialect_name, value_name)
+            "{0!s}_{1!s}".format(dialect_name, value_name)
             for dialect_name in self.obj.dialect_options
             for value_name in self.obj.dialect_options[dialect_name]._non_defaults
         )
@@ -610,9 +610,9 @@ def _bind_or_error(schemaitem, msg=None):
         label = getattr(schemaitem, 'fullname',
                         getattr(schemaitem, 'name', None))
         if label:
-            item = '%s object %r' % (name, label)
+            item = '{0!s} object {1!r}'.format(name, label)
         else:
-            item = '%s object' % name
+            item = '{0!s} object'.format(name)
         if msg is None:
             msg = "%s is not bound to an Engine or Connection.  "\
                    "Execution can not proceed without a database to execute "\

--- a/lib/sqlalchemy/sql/compiler.py
+++ b/lib/sqlalchemy/sql/compiler.py
@@ -449,8 +449,7 @@ class SQLCompiler(Compiled):
                             (bindparam.key, _group_number))
                     else:
                         raise exc.InvalidRequestError(
-                            "A value is required for bind parameter %r"
-                            % bindparam.key)
+                            "A value is required for bind parameter {0!r}".format(bindparam.key))
                 else:
                     pd[name] = bindparam.effective_value
             return pd
@@ -465,8 +464,7 @@ class SQLCompiler(Compiled):
                             (bindparam.key, _group_number))
                     else:
                         raise exc.InvalidRequestError(
-                            "A value is required for bind parameter %r"
-                            % bindparam.key)
+                            "A value is required for bind parameter {0!r}".format(bindparam.key))
                 pd[self.bind_names[bindparam]] = bindparam.effective_value
             return pd
 
@@ -622,7 +620,7 @@ class SQLCompiler(Compiled):
 
         text = self.process(taf.element, **kw)
         if asfrom and parens:
-            text = "(%s)" % text
+            text = "({0!s})".format(text)
         return text
 
 
@@ -698,15 +696,14 @@ class SQLCompiler(Compiled):
         return x
 
     def visit_cast(self, cast, **kwargs):
-        return "CAST(%s AS %s)" % \
-                    (cast.clause._compiler_dispatch(self, **kwargs),
+        return "CAST({0!s} AS {1!s})".format(cast.clause._compiler_dispatch(self, **kwargs),
                     cast.typeclause._compiler_dispatch(self, **kwargs))
 
     def visit_over(self, over, **kwargs):
-        return "%s OVER (%s)" % (
+        return "{0!s} OVER ({1!s})".format(
             over.func._compiler_dispatch(self, **kwargs),
             ' '.join(
-                 '%s BY %s' % (word, clause._compiler_dispatch(self, **kwargs))
+                 '{0!s} BY {1!s}'.format(word, clause._compiler_dispatch(self, **kwargs))
                  for word, clause in (
                      ('PARTITION', over.partition_by),
                      ('ORDER', over.order_by)
@@ -717,7 +714,7 @@ class SQLCompiler(Compiled):
 
     def visit_extract(self, extract, **kwargs):
         field = self.extract_map.get(extract.field, extract.field)
-        return "EXTRACT(%s FROM %s)" % (field,
+        return "EXTRACT({0!s} FROM {1!s})".format(field,
                             extract.expr._compiler_dispatch(self, **kwargs))
 
     def visit_function(self, func, add_to_result_map=None, **kwargs):
@@ -726,7 +723,7 @@ class SQLCompiler(Compiled):
                 func.name, func.name, (), func.type
             )
 
-        disp = getattr(self, "visit_%s_func" % func.name.lower(), None)
+        disp = getattr(self, "visit_{0!s}_func".format(func.name.lower()), None)
         if disp:
             return disp(func, **kwargs)
         else:
@@ -739,8 +736,8 @@ class SQLCompiler(Compiled):
 
     def visit_sequence(self, sequence):
         raise NotImplementedError(
-            "Dialect '%s' does not support sequence increments." %
-            self.dialect.name
+            "Dialect '{0!s}' does not support sequence increments.".format(
+            self.dialect.name)
         )
 
     def function_argspec(self, func, **kwargs):
@@ -793,16 +790,16 @@ class SQLCompiler(Compiled):
                 raise exc.CompileError(
                         "Unary expression does not support operator "
                         "and modifier simultaneously")
-            disp = getattr(self, "visit_%s_unary_operator" %
-                                    unary.operator.__name__, None)
+            disp = getattr(self, "visit_{0!s}_unary_operator".format(
+                                    unary.operator.__name__), None)
             if disp:
                 return disp(unary, unary.operator, **kw)
             else:
                 return self._generate_generic_unary_operator(unary,
                                     OPERATORS[unary.operator], **kw)
         elif unary.modifier:
-            disp = getattr(self, "visit_%s_unary_modifier" %
-                                    unary.modifier.__name__, None)
+            disp = getattr(self, "visit_{0!s}_unary_modifier".format(
+                                    unary.modifier.__name__), None)
             if disp:
                 return disp(unary, unary.modifier, **kw)
             else:
@@ -816,13 +813,13 @@ class SQLCompiler(Compiled):
         if self.dialect.supports_native_boolean:
             return self.process(element.element, **kw)
         else:
-            return "%s = 1" % self.process(element.element, **kw)
+            return "{0!s} = 1".format(self.process(element.element, **kw))
 
     def visit_isfalse_unary_operator(self, element, operator, **kw):
         if self.dialect.supports_native_boolean:
-            return "NOT %s" % self.process(element.element, **kw)
+            return "NOT {0!s}".format(self.process(element.element, **kw))
         else:
-            return "%s = 0" % self.process(element.element, **kw)
+            return "{0!s} = 0".format(self.process(element.element, **kw))
 
     def visit_binary(self, binary, **kw):
         # don't allow "? = ?" to render
@@ -832,7 +829,7 @@ class SQLCompiler(Compiled):
             kw['literal_binds'] = True
 
         operator = binary.operator
-        disp = getattr(self, "visit_%s_binary" % operator.__name__, None)
+        disp = getattr(self, "visit_{0!s}_binary".format(operator.__name__), None)
         if disp:
             return disp(binary, operator, **kw)
         else:
@@ -914,7 +911,7 @@ class SQLCompiler(Compiled):
         escape = binary.modifiers.get("escape", None)
 
         # TODO: use ternary here, not "and"/ "or"
-        return '%s LIKE %s' % (
+        return '{0!s} LIKE {1!s}'.format(
                             binary.left._compiler_dispatch(self, **kw),
                             binary.right._compiler_dispatch(self, **kw)) \
             + (
@@ -925,7 +922,7 @@ class SQLCompiler(Compiled):
 
     def visit_notlike_op_binary(self, binary, operator, **kw):
         escape = binary.modifiers.get("escape", None)
-        return '%s NOT LIKE %s' % (
+        return '{0!s} NOT LIKE {1!s}'.format(
                             binary.left._compiler_dispatch(self, **kw),
                             binary.right._compiler_dispatch(self, **kw)) \
             + (
@@ -936,7 +933,7 @@ class SQLCompiler(Compiled):
 
     def visit_ilike_op_binary(self, binary, operator, **kw):
         escape = binary.modifiers.get("escape", None)
-        return 'lower(%s) LIKE lower(%s)' % (
+        return 'lower({0!s}) LIKE lower({1!s})'.format(
                             binary.left._compiler_dispatch(self, **kw),
                             binary.right._compiler_dispatch(self, **kw)) \
             + (
@@ -947,7 +944,7 @@ class SQLCompiler(Compiled):
 
     def visit_notilike_op_binary(self, binary, operator, **kw):
         escape = binary.modifiers.get("escape", None)
-        return 'lower(%s) NOT LIKE lower(%s)' % (
+        return 'lower({0!s}) NOT LIKE lower({1!s})'.format(
                             binary.left._compiler_dispatch(self, **kw),
                             binary.right._compiler_dispatch(self, **kw)) \
             + (
@@ -1023,7 +1020,7 @@ class SQLCompiler(Compiled):
             return processor(value)
         else:
             raise NotImplementedError(
-                        "Don't know how to literal-quote value %r" % value)
+                        "Don't know how to literal-quote value {0!r}".format(value))
 
     def _truncate_bindparam(self, bindparam):
         if bindparam in self.bind_names:
@@ -1127,9 +1124,9 @@ class SQLCompiler(Compiled):
                             util.unique_list(col_source.inner_columns)
                                 if c is not None]
 
-                text += "(%s)" % (", ".join(
+                text += "({0!s})".format((", ".join(
                                     self.preparer.format_column(ident)
-                                    for ident in recur_cols))
+                                    for ident in recur_cols)))
             text += " AS \n" + \
                         cte.original._compiler_dispatch(
                                 self, asfrom=True, **kwargs
@@ -1698,8 +1695,8 @@ class SQLCompiler(Compiled):
         text += table_text
 
         if colparams_single or not supports_default_values:
-            text += " (%s)" % ', '.join([preparer.format_column(c[0])
-                       for c in colparams_single])
+            text += " ({0!s})".format(', '.join([preparer.format_column(c[0])
+                       for c in colparams_single]))
 
         if self.returning or insert_stmt._returning:
             self.returning = self.returning or insert_stmt._returning
@@ -1710,21 +1707,21 @@ class SQLCompiler(Compiled):
                 text += " " + returning_clause
 
         if insert_stmt.select is not None:
-            text += " %s" % self.process(insert_stmt.select, **kw)
+            text += " {0!s}".format(self.process(insert_stmt.select, **kw))
         elif not colparams and supports_default_values:
             text += " DEFAULT VALUES"
         elif insert_stmt._has_multi_parameters:
-            text += " VALUES %s" % (
+            text += " VALUES {0!s}".format((
                         ", ".join(
-                            "(%s)" % (
+                            "({0!s})".format((
                                 ', '.join(c[1] for c in colparam_set)
-                            )
+                            ))
                             for colparam_set in colparams
                             )
-                        )
+                        ))
         else:
-            text += " VALUES (%s)" % \
-                     ', '.join([c[1] for c in colparams])
+            text += " VALUES ({0!s})".format( \
+                     ', '.join([c[1] for c in colparams]))
 
         if self.returning and not self.returning_precedes_values:
             text += " " + returning_clause
@@ -1872,7 +1869,7 @@ class SQLCompiler(Compiled):
                     return col.key
             def _col_bind_name(col):
                 if col.table in _et:
-                    return "%s_%s" % (col.table.name, col.key)
+                    return "{0!s}_{1!s}".format(col.table.name, col.key)
                 else:
                     return col.key
 
@@ -2041,7 +2038,7 @@ class SQLCompiler(Compiled):
                                     c, value, required=value is REQUIRED,
                                     name=_col_bind_name(c)
                                         if not stmt._has_multi_parameters
-                                        else "%s_0" % _col_bind_name(c)
+                                        else "{0!s}_0".format(_col_bind_name(c))
                                     )
                 else:
                     if isinstance(value, elements.BindParameter) and \
@@ -2181,8 +2178,8 @@ class SQLCompiler(Compiled):
             ).difference(check_columns)
             if check:
                 raise exc.CompileError(
-                    "Unconsumed column names: %s" %
-                    (", ".join("%s" % c for c in check))
+                    "Unconsumed column names: {0!s}".format(
+                    (", ".join("{0!s}".format(c) for c in check)))
                 )
 
         if stmt._has_multi_parameters:
@@ -2195,7 +2192,7 @@ class SQLCompiler(Compiled):
                         c,
                             self._create_crud_bind_param(
                                     c, row[c.key],
-                                    name="%s_%d" % (c.key, i + 1)
+                                    name="{0!s}_{1:d}".format(c.key, i + 1)
                             )
                             if c.key in row else param
                     )
@@ -2261,15 +2258,15 @@ class SQLCompiler(Compiled):
         return text
 
     def visit_savepoint(self, savepoint_stmt):
-        return "SAVEPOINT %s" % self.preparer.format_savepoint(savepoint_stmt)
+        return "SAVEPOINT {0!s}".format(self.preparer.format_savepoint(savepoint_stmt))
 
     def visit_rollback_to_savepoint(self, savepoint_stmt):
-        return "ROLLBACK TO SAVEPOINT %s" % \
-                self.preparer.format_savepoint(savepoint_stmt)
+        return "ROLLBACK TO SAVEPOINT {0!s}".format( \
+                self.preparer.format_savepoint(savepoint_stmt))
 
     def visit_release_savepoint(self, savepoint_stmt):
-        return "RELEASE SAVEPOINT %s" % \
-                self.preparer.format_savepoint(savepoint_stmt)
+        return "RELEASE SAVEPOINT {0!s}".format( \
+                self.preparer.format_savepoint(savepoint_stmt))
 
 
 class DDLCompiler(Compiled):
@@ -2356,7 +2353,7 @@ class DDLCompiler(Compiled):
         if const:
             text += ", \n\t" + const
 
-        text += "\n)%s\n\n" % self.post_create_table(table)
+        text += "\n){0!s}\n\n".format(self.post_create_table(table))
         return text
 
     def visit_create_column(self, create, first_pk=False):
@@ -2420,8 +2417,7 @@ class DDLCompiler(Compiled):
         text = "CREATE "
         if index.unique:
             text += "UNIQUE "
-        text += "INDEX %s ON %s (%s)" \
-                    % (
+        text += "INDEX {0!s} ON {1!s} ({2!s})".format(
                         self._prepared_index_name(index,
                                 include_schema=include_schema),
                        preparer.format_table(index.table,
@@ -2462,26 +2458,26 @@ class DDLCompiler(Compiled):
         return index_name
 
     def visit_add_constraint(self, create):
-        return "ALTER TABLE %s ADD %s" % (
+        return "ALTER TABLE {0!s} ADD {1!s}".format(
             self.preparer.format_table(create.element.table),
             self.process(create.element)
         )
 
     def visit_create_sequence(self, create):
-        text = "CREATE SEQUENCE %s" % \
-                self.preparer.format_sequence(create.element)
+        text = "CREATE SEQUENCE {0!s}".format( \
+                self.preparer.format_sequence(create.element))
         if create.element.increment is not None:
-            text += " INCREMENT BY %d" % create.element.increment
+            text += " INCREMENT BY {0:d}".format(create.element.increment)
         if create.element.start is not None:
-            text += " START WITH %d" % create.element.start
+            text += " START WITH {0:d}".format(create.element.start)
         return text
 
     def visit_drop_sequence(self, drop):
-        return "DROP SEQUENCE %s" % \
-                self.preparer.format_sequence(drop.element)
+        return "DROP SEQUENCE {0!s}".format( \
+                self.preparer.format_sequence(drop.element))
 
     def visit_drop_constraint(self, drop):
-        return "ALTER TABLE %s DROP CONSTRAINT %s%s" % (
+        return "ALTER TABLE {0!s} DROP CONSTRAINT {1!s}{2!s}".format(
             self.preparer.format_table(drop.element.table),
             self.preparer.format_constraint(drop.element),
             drop.cascade and " CASCADE" or ""
@@ -2504,7 +2500,7 @@ class DDLCompiler(Compiled):
     def get_column_default_string(self, column):
         if isinstance(column.server_default, schema.DefaultClause):
             if isinstance(column.server_default.arg, util.string_types):
-                return "'%s'" % column.server_default.arg
+                return "'{0!s}'".format(column.server_default.arg)
             else:
                 return self.sql_compiler.process(column.server_default.arg)
         else:
@@ -2513,20 +2509,20 @@ class DDLCompiler(Compiled):
     def visit_check_constraint(self, constraint):
         text = ""
         if constraint.name is not None:
-            text += "CONSTRAINT %s " % \
-                        self.preparer.format_constraint(constraint)
-        text += "CHECK (%s)" % self.sql_compiler.process(constraint.sqltext,
+            text += "CONSTRAINT {0!s} ".format( \
+                        self.preparer.format_constraint(constraint))
+        text += "CHECK ({0!s})".format(self.sql_compiler.process(constraint.sqltext,
                                                             include_table=False,
-                                                            literal_binds=True)
+                                                            literal_binds=True))
         text += self.define_constraint_deferrability(constraint)
         return text
 
     def visit_column_check_constraint(self, constraint):
         text = ""
         if constraint.name is not None:
-            text += "CONSTRAINT %s " % \
-                        self.preparer.format_constraint(constraint)
-        text += "CHECK (%s)" % constraint.sqltext
+            text += "CONSTRAINT {0!s} ".format( \
+                        self.preparer.format_constraint(constraint))
+        text += "CHECK ({0!s})".format(constraint.sqltext)
         text += self.define_constraint_deferrability(constraint)
         return text
 
@@ -2535,11 +2531,11 @@ class DDLCompiler(Compiled):
             return ''
         text = ""
         if constraint.name is not None:
-            text += "CONSTRAINT %s " % \
-                    self.preparer.format_constraint(constraint)
+            text += "CONSTRAINT {0!s} ".format( \
+                    self.preparer.format_constraint(constraint))
         text += "PRIMARY KEY "
-        text += "(%s)" % ', '.join(self.preparer.quote(c.name)
-                                       for c in constraint)
+        text += "({0!s})".format(', '.join(self.preparer.quote(c.name)
+                                       for c in constraint))
         text += self.define_constraint_deferrability(constraint)
         return text
 
@@ -2547,10 +2543,10 @@ class DDLCompiler(Compiled):
         preparer = self.dialect.identifier_preparer
         text = ""
         if constraint.name is not None:
-            text += "CONSTRAINT %s " % \
-                        preparer.format_constraint(constraint)
+            text += "CONSTRAINT {0!s} ".format( \
+                        preparer.format_constraint(constraint))
         remote_table = list(constraint._elements.values())[0].column.table
-        text += "FOREIGN KEY(%s) REFERENCES %s (%s)" % (
+        text += "FOREIGN KEY({0!s}) REFERENCES {1!s} ({2!s})".format(
             ', '.join(preparer.quote(f.parent.name)
                       for f in constraint._elements.values()),
             self.define_constraint_remote_table(
@@ -2573,20 +2569,20 @@ class DDLCompiler(Compiled):
             return ''
         text = ""
         if constraint.name is not None:
-            text += "CONSTRAINT %s " % \
-                    self.preparer.format_constraint(constraint)
-        text += "UNIQUE (%s)" % (
+            text += "CONSTRAINT {0!s} ".format( \
+                    self.preparer.format_constraint(constraint))
+        text += "UNIQUE ({0!s})".format((
                     ', '.join(self.preparer.quote(c.name)
-                            for c in constraint))
+                            for c in constraint)))
         text += self.define_constraint_deferrability(constraint)
         return text
 
     def define_constraint_cascades(self, constraint):
         text = ""
         if constraint.ondelete is not None:
-            text += " ON DELETE %s" % constraint.ondelete
+            text += " ON DELETE {0!s}".format(constraint.ondelete)
         if constraint.onupdate is not None:
-            text += " ON UPDATE %s" % constraint.onupdate
+            text += " ON UPDATE {0!s}".format(constraint.onupdate)
         return text
 
     def define_constraint_deferrability(self, constraint):
@@ -2597,13 +2593,13 @@ class DDLCompiler(Compiled):
             else:
                 text += " NOT DEFERRABLE"
         if constraint.initially is not None:
-            text += " INITIALLY %s" % constraint.initially
+            text += " INITIALLY {0!s}".format(constraint.initially)
         return text
 
     def define_constraint_match(self, constraint):
         text = ""
         if constraint.match is not None:
-            text += " MATCH %s" % constraint.match
+            text += " MATCH {0!s}".format(constraint.match)
         return text
 
 
@@ -2619,23 +2615,23 @@ class GenericTypeCompiler(TypeCompiler):
         if type_.precision is None:
             return "NUMERIC"
         elif type_.scale is None:
-            return "NUMERIC(%(precision)s)" % \
-                        {'precision': type_.precision}
+            return "NUMERIC({precision!s})".format(** \
+                        {'precision': type_.precision})
         else:
-            return "NUMERIC(%(precision)s, %(scale)s)" % \
+            return "NUMERIC({precision!s}, {scale!s})".format(** \
                         {'precision': type_.precision,
-                        'scale': type_.scale}
+                        'scale': type_.scale})
 
     def visit_DECIMAL(self, type_):
         if type_.precision is None:
             return "DECIMAL"
         elif type_.scale is None:
-            return "DECIMAL(%(precision)s)" % \
-                        {'precision': type_.precision}
+            return "DECIMAL({precision!s})".format(** \
+                        {'precision': type_.precision})
         else:
-            return "DECIMAL(%(precision)s, %(scale)s)" % \
+            return "DECIMAL({precision!s}, {scale!s})".format(** \
                         {'precision': type_.precision,
-                        'scale': type_.scale}
+                        'scale': type_.scale})
 
     def visit_INTEGER(self, type_):
         return "INTEGER"
@@ -2668,9 +2664,9 @@ class GenericTypeCompiler(TypeCompiler):
 
         text = name
         if type_.length:
-            text += "(%d)" % type_.length
+            text += "({0:d})".format(type_.length)
         if type_.collation:
-            text += ' COLLATE "%s"' % type_.collation
+            text += ' COLLATE "{0!s}"'.format(type_.collation)
         return text
 
     def visit_CHAR(self, type_):
@@ -2692,10 +2688,10 @@ class GenericTypeCompiler(TypeCompiler):
         return "BLOB"
 
     def visit_BINARY(self, type_):
-        return "BINARY" + (type_.length and "(%d)" % type_.length or "")
+        return "BINARY" + (type_.length and "({0:d})".format(type_.length) or "")
 
     def visit_VARBINARY(self, type_):
-        return "VARBINARY" + (type_.length and "(%d)" % type_.length or "")
+        return "VARBINARY" + (type_.length and "({0:d})".format(type_.length) or "")
 
     def visit_BOOLEAN(self, type_):
         return "BOOLEAN"

--- a/lib/sqlalchemy/sql/ddl.py
+++ b/lib/sqlalchemy/sql/ddl.py
@@ -373,8 +373,8 @@ class DDL(DDLElement):
 
         if not isinstance(statement, util.string_types):
             raise exc.ArgumentError(
-                "Expected a string or unicode SQL statement, got '%r'" %
-                statement)
+                "Expected a string or unicode SQL statement, got '{0!r}'".format(
+                statement))
 
         self.statement = statement
         self.context = context or {}
@@ -384,10 +384,10 @@ class DDL(DDLElement):
         self._bind = bind
 
     def __repr__(self):
-        return '<%s@%s; %s>' % (
+        return '<{0!s}@{1!s}; {2!s}>'.format(
             type(self).__name__, id(self),
             ', '.join([repr(self.statement)] +
-                      ['%s=%r' % (key, getattr(self, key))
+                      ['{0!s}={1!r}'.format(key, getattr(self, key))
                        for key in ('on', 'context')
                        if getattr(self, key)]))
 

--- a/lib/sqlalchemy/sql/elements.py
+++ b/lib/sqlalchemy/sql/elements.py
@@ -507,7 +507,7 @@ class ClauseElement(Visitable):
         if friendly is None:
             return object.__repr__(self)
         else:
-            return '<%s.%s at 0x%x; %s>' % (
+            return '<{0!s}.{1!s} at 0x{2:x}; {3!s}>'.format(
                 self.__module__, self.__class__.__name__, id(self), friendly)
 
 
@@ -617,7 +617,7 @@ class ColumnElement(ClauseElement, operators.ColumnOperators):
             return getattr(self.comparator, key)
         except AttributeError:
             raise AttributeError(
-                    'Neither %r object nor %r object has an attribute %r' % (
+                    'Neither {0!r} object nor {1!r} object has an attribute {2!r}'.format(
                     type(self).__name__,
                     type(self.comparator).__name__,
                     key)
@@ -755,7 +755,7 @@ class ColumnElement(ClauseElement, operators.ColumnOperators):
         expressions and function calls.
 
         """
-        return _anonymous_label('%%(%d %s)s' % (id(self), getattr(self,
+        return _anonymous_label('%({0:d} {1!s})s'.format(id(self), getattr(self,
                                 'name', 'anon')))
 
 
@@ -990,11 +990,10 @@ class BindParameter(ColumnElement):
             key = quoted_name(key, quote)
 
         if unique:
-            self.key = _anonymous_label('%%(%d %s)s' % (id(self), key
+            self.key = _anonymous_label('%({0:d} {1!s})s'.format(id(self), key
                     or 'param'))
         else:
-            self.key = key or _anonymous_label('%%(%d param)s'
-                    % id(self))
+            self.key = key or _anonymous_label('%({0:d} param)s'.format(id(self)))
 
         # identifying key that won't change across
         # clones, used to identify the bind's logical
@@ -1052,14 +1051,14 @@ class BindParameter(ColumnElement):
     def _clone(self):
         c = ClauseElement._clone(self)
         if self.unique:
-            c.key = _anonymous_label('%%(%d %s)s' % (id(c), c._orig_key
+            c.key = _anonymous_label('%({0:d} {1!s})s'.format(id(c), c._orig_key
                     or 'param'))
         return c
 
     def _convert_to_unique(self):
         if not self.unique:
             self.unique = True
-            self.key = _anonymous_label('%%(%d %s)s' % (id(self),
+            self.key = _anonymous_label('%({0:d} {1!s})s'.format(id(self),
                     self._orig_key or 'param'))
 
     def compare(self, other, **kw):
@@ -1082,7 +1081,7 @@ class BindParameter(ColumnElement):
         return d
 
     def __repr__(self):
-        return 'BindParameter(%r, %r, type_=%r)' % (self.key,
+        return 'BindParameter({0!r}, {1!r}, type_={2!r})'.format(self.key,
                 self.value, self.type)
 
 
@@ -1145,7 +1144,7 @@ class TextClause(Executable, ClauseElement):
 
         def repl(m):
             self._bindparams[m.group(1)] = BindParameter(m.group(1))
-            return ':%s' % m.group(1)
+            return ':{0!s}'.format(m.group(1))
 
         # scan the string and search for bind parameter names, add them
         # to the list of bindparams
@@ -2740,7 +2739,7 @@ class Label(ColumnElement):
         if name:
             self.name = name
         else:
-            self.name = _anonymous_label('%%(%d %s)s' % (id(self),
+            self.name = _anonymous_label('%({0:d} {1!s})s'.format(id(self),
                                 getattr(element, 'name', 'anon')))
         self.key = self._label = self._key_label = self.name
         self._element = element
@@ -3144,7 +3143,7 @@ class quoted_name(util.text_type):
         backslashed = self.encode('ascii', 'backslashreplace')
         if not util.py2k:
             backslashed = backslashed.decode('ascii')
-        return "'%s'" % backslashed
+        return "'{0!s}'".format(backslashed)
 
 class _truncated_label(quoted_name):
     """A unicode subclass used to identify symbolic "
@@ -3216,7 +3215,7 @@ def _string_or_unprintable(element):
         try:
             return str(element)
         except:
-            return "unprintable element %r" % element
+            return "unprintable element {0!r}".format(element)
 
 
 def _expand_cloned(elements):

--- a/lib/sqlalchemy/sql/naming.py
+++ b/lib/sqlalchemy/sql/naming.py
@@ -113,8 +113,8 @@ class ConventionDict(object):
     def __getitem__(self, key):
         if key in self.convention:
             return self.convention[key](self.const, self.table)
-        elif hasattr(self, '_key_%s' % key):
-            return getattr(self, '_key_%s' % key)()
+        elif hasattr(self, '_key_{0!s}'.format(key)):
+            return getattr(self, '_key_{0!s}'.format(key))()
         else:
             col_template = re.match(r".*_?column_(\d+)_.+", key)
             if col_template:

--- a/lib/sqlalchemy/sql/schema.py
+++ b/lib/sqlalchemy/sql/schema.py
@@ -344,7 +344,7 @@ class Table(DialectKWArgs, SchemaItem, TableClause):
         else:
             if mustexist:
                 raise exc.InvalidRequestError(
-                    "Table '%s' not defined" % (key))
+                    "Table '{0!s}' not defined".format((key)))
             table = object.__new__(cls)
             table.dispatch.before_parent_attach(table, metadata)
             metadata._add_table(name, schema, table)
@@ -395,7 +395,7 @@ class Table(DialectKWArgs, SchemaItem, TableClause):
         self.foreign_keys = set()
         self._extra_dependencies = set()
         if self.schema is not None:
-            self.fullname = "%s.%s" % (self.schema, self.name)
+            self.fullname = "{0!s}.{1!s}".format(self.schema, self.name)
         else:
             self.fullname = self.name
 
@@ -522,10 +522,10 @@ class Table(DialectKWArgs, SchemaItem, TableClause):
         return _get_table_key(self.name, self.schema)
 
     def __repr__(self):
-        return "Table(%s)" % ', '.join(
+        return "Table({0!s})".format(', '.join(
             [repr(self.name)] + [repr(self.metadata)] +
             [repr(x) for x in self.columns] +
-            ["%s=%s" % (k, repr(getattr(self, k))) for k in ['schema']])
+            ["{0!s}={1!s}".format(k, repr(getattr(self, k))) for k in ['schema']]))
 
     def __str__(self):
         return _get_table_key(self.description, self.schema)
@@ -1119,13 +1119,13 @@ class Column(SchemaItem, ColumnClause):
             kwarg.append('default')
         if self.server_default:
             kwarg.append('server_default')
-        return "Column(%s)" % ', '.join(
+        return "Column({0!s})".format(', '.join(
             [repr(self.name)] + [repr(self.type)] +
             [repr(x) for x in self.foreign_keys if x is not None] +
             [repr(x) for x in self.constraints] +
-            [(self.table is not None and "table=<%s>" %
-                    self.table.description or "table=None")] +
-            ["%s=%s" % (k, repr(getattr(self, k))) for k in kwarg])
+            [(self.table is not None and "table=<{0!s}>".format(
+                    self.table.description) or "table=None")] +
+            ["{0!s}={1!s}".format(k, repr(getattr(self, k))) for k in kwarg]))
 
     def _set_parent(self, table):
         if not self.name:
@@ -1138,8 +1138,8 @@ class Column(SchemaItem, ColumnClause):
         existing = getattr(self, 'table', None)
         if existing is not None and existing is not table:
             raise exc.ArgumentError(
-                    "Column object already assigned to Table '%s'" %
-                    existing.description)
+                    "Column object already assigned to Table '{0!s}'".format(
+                    existing.description))
 
         if self.key in table._columns:
             col = table._columns.get(self.key)
@@ -1419,7 +1419,7 @@ class ForeignKey(DialectKWArgs, SchemaItem):
         self._unvalidated_dialect_kw = dialect_kw
 
     def __repr__(self):
-        return "ForeignKey(%r)" % self._get_colspec()
+        return "ForeignKey({0!r})".format(self._get_colspec())
 
     def copy(self, schema=None):
         """Produce a copy of this :class:`.ForeignKey` object.
@@ -1462,9 +1462,9 @@ class ForeignKey(DialectKWArgs, SchemaItem):
         """
         if schema:
             _schema, tname, colname = self._column_tokens
-            return "%s.%s.%s" % (schema, tname, colname)
+            return "{0!s}.{1!s}.{2!s}".format(schema, tname, colname)
         elif self._table_column is not None:
-            return "%s.%s" % (
+            return "{0!s}.{1!s}".format(
                     self._table_column.table.fullname, self._table_column.key)
         else:
             return self._colspec
@@ -1512,8 +1512,8 @@ class ForeignKey(DialectKWArgs, SchemaItem):
         m = self._get_colspec().split('.')
         if m is None:
             raise exc.ArgumentError(
-                "Invalid foreign key column specification: %s" %
-                self._colspec)
+                "Invalid foreign key column specification: {0!s}".format(
+                self._colspec))
         if (len(m) == 1):
             tname = m.pop()
             colname = None
@@ -1865,7 +1865,7 @@ class ColumnDefault(DefaultGenerator):
     __visit_name__ = property(_visit_name)
 
     def __repr__(self):
-        return "ColumnDefault(%r)" % self.arg
+        return "ColumnDefault({0!r})".format(self.arg)
 
 
 class Sequence(DefaultGenerator):
@@ -2117,8 +2117,7 @@ class DefaultClause(FetchedValue):
         self.reflected = _reflected
 
     def __repr__(self):
-        return "DefaultClause(%r, for_update=%r)" % \
-                        (self.arg, self.for_update)
+        return "DefaultClause({0!r}, for_update={1!r})".format(self.arg, self.for_update)
 
 
 class PassiveDefault(DefaultClause):
@@ -2643,9 +2642,9 @@ class PrimaryKeyConstraint(ColumnCollectionConstraint):
                     "may become an exception in a future release" %
                     (
                         table.name,
-                        ", ".join("'%s'" % c.name for c in table_pks),
-                        ", ".join("'%s'" % c.name for c in self.columns),
-                        ", ".join("'%s'" % c.name for c in self.columns)
+                        ", ".join("'{0!s}'".format(c.name) for c in table_pks),
+                        ", ".join("'{0!s}'".format(c.name) for c in self.columns),
+                        ", ".join("'{0!s}'".format(c.name) for c in self.columns)
                     )
                 )
             table_pks[:] = []
@@ -2815,8 +2814,7 @@ class Index(DialectKWArgs, ColumnCollectionMixin, SchemaItem):
         for c in self.columns:
             if c.table != self.table:
                 raise exc.ArgumentError(
-                    "Column '%s' is not part of table '%s'." %
-                    (c, self.table.description)
+                    "Column '{0!s}' is not part of table '{1!s}'.".format(c, self.table.description)
                 )
         table.indexes.add(self)
 
@@ -2862,12 +2860,12 @@ class Index(DialectKWArgs, ColumnCollectionMixin, SchemaItem):
         bind._run_visitor(ddl.SchemaDropper, self)
 
     def __repr__(self):
-        return 'Index(%s)' % (
+        return 'Index({0!s})'.format((
                     ", ".join(
                         [repr(self.name)] +
                         [repr(c) for c in self.columns] +
                         (self.unique and ["unique=True"] or [])
-                    ))
+                    )))
 
 
 DEFAULT_NAMING_CONVENTION = util.immutabledict({
@@ -3027,7 +3025,7 @@ class MetaData(SchemaItem):
     """
 
     def __repr__(self):
-        return 'MetaData(bind=%r)' % self.bind
+        return 'MetaData(bind={0!r})'.format(self.bind)
 
     def __contains__(self, table_or_key):
         if not isinstance(table_or_key, util.string_types):
@@ -3220,7 +3218,7 @@ class MetaData(SchemaItem):
                 )
 
             if schema is not None:
-                available_w_schema = util.OrderedSet(["%s.%s" % (schema, name)
+                available_w_schema = util.OrderedSet(["{0!s}.{1!s}".format(schema, name)
                                         for name in available])
             else:
                 available_w_schema = available
@@ -3239,7 +3237,7 @@ class MetaData(SchemaItem):
             else:
                 missing = [name for name in only if name not in available]
                 if missing:
-                    s = schema and (" schema '%s'" % schema) or ''
+                    s = schema and (" schema '{0!s}'".format(schema)) or ''
                     raise exc.InvalidRequestError(
                         'Could not reflect: requested table(s) not available '
                         'in %s%s: (%s)' %

--- a/lib/sqlalchemy/sql/selectable.py
+++ b/lib/sqlalchemy/sql/selectable.py
@@ -599,7 +599,7 @@ class Join(FromClause):
 
     @property
     def description(self):
-        return "Join object on %s(%d) and %s(%d)" % (
+        return "Join object on {0!s}({1:d}) and {2!s}({3:d})".format(
             self.left.description,
             id(self.left),
             self.right.description,
@@ -948,7 +948,7 @@ class Alias(FromClause):
         if name is None:
             if self.original.named_with_column:
                 name = getattr(self.original, 'name', None)
-            name = _anonymous_label('%%(%d %s)s' % (id(self), name
+            name = _anonymous_label('%({0:d} {1!s})s'.format(id(self), name
                     or 'anon'))
         self.name = name
 
@@ -1303,7 +1303,7 @@ class ForUpdateArg(ClauseElement):
         elif arg == 'read_nowait':
             read = nowait = True
         elif arg is not True:
-            raise exc.ArgumentError("Unknown for_update argument: %r" % arg)
+            raise exc.ArgumentError("Unknown for_update argument: {0!r}".format(arg))
 
         return ForUpdateArg(read=read, nowait=nowait)
 
@@ -1987,8 +1987,8 @@ class HasPrefixes(object):
         """
         dialect = kw.pop('dialect', None)
         if kw:
-            raise exc.ArgumentError("Unsupported argument(s): %s" %
-                            ",".join(kw))
+            raise exc.ArgumentError("Unsupported argument(s): {0!s}".format(
+                            ",".join(kw)))
         self._setup_prefixes(expr, dialect)
 
     def _setup_prefixes(self, prefixes, dialect=None):

--- a/lib/sqlalchemy/sql/sqltypes.py
+++ b/lib/sqlalchemy/sql/sqltypes.py
@@ -157,7 +157,7 @@ class String(Concatenable, TypeEngine):
     def literal_processor(self, dialect):
         def process(value):
             value = value.replace("'", "''")
-            return "'%s'" % value
+            return "'{0!s}'".format(value)
         return process
 
     def bind_processor(self, dialect):
@@ -790,7 +790,7 @@ class _Binary(TypeEngine):
     def literal_processor(self, dialect):
         def process(value):
             value = value.decode(dialect.encoding).replace("'", "''")
-            return "'%s'" % value
+            return "'{0!s}'".format(value)
         return process
 
     @property

--- a/lib/sqlalchemy/sql/util.py
+++ b/lib/sqlalchemy/sql/util.py
@@ -226,7 +226,7 @@ def bind_values(clause):
 def _quote_ddl_expr(element):
     if isinstance(element, util.string_types):
         element = element.replace("'", "''")
-        return "'%s'" % element
+        return "'{0!s}'".format(element)
     else:
         return repr(element)
 

--- a/lib/sqlalchemy/sql/visitors.py
+++ b/lib/sqlalchemy/sql/visitors.py
@@ -68,7 +68,7 @@ def _generate_dispatch(cls):
             # There is an optimization opportunity here because the
             # the string name of the class's __visit_name__ is known at
             # this early stage (import time) so it can be pre-constructed.
-            getter = operator.attrgetter("visit_%s" % visit_name)
+            getter = operator.attrgetter("visit_{0!s}".format(visit_name))
 
             def _compiler_dispatch(self, visitor, **kw):
                 try:
@@ -82,7 +82,7 @@ def _generate_dispatch(cls):
             # __visit_name__ is not yet a string. As a result, the visit
             # string has to be recalculated with each compilation.
             def _compiler_dispatch(self, visitor, **kw):
-                visit_attr = 'visit_%s' % self.__visit_name__
+                visit_attr = 'visit_{0!s}'.format(self.__visit_name__)
                 try:
                     meth = getattr(visitor, visit_attr)
                 except AttributeError:
@@ -114,7 +114,7 @@ class ClauseVisitor(object):
 
     def traverse_single(self, obj, **kw):
         for v in self._visitor_iterator:
-            meth = getattr(v, "visit_%s" % obj.__visit_name__, None)
+            meth = getattr(v, "visit_{0!s}".format(obj.__visit_name__), None)
             if meth:
                 return meth(obj, **kw)
 

--- a/lib/sqlalchemy/testing/assertions.py
+++ b/lib/sqlalchemy/testing/assertions.py
@@ -154,8 +154,7 @@ def _assert_no_stray_pool_connections():
         # we'll allow a couple of these at most.
         _STRAY_CONNECTION_FAILURES += 1
 
-        print("Encountered a stray connection in test cleanup: %s"
-                        % str(pool._refs))
+        print("Encountered a stray connection in test cleanup: {0!s}".format(str(pool._refs)))
         # then do a real GC sweep.   We shouldn't even be here
         # so a single sweep should really be doing it, otherwise
         # there's probably a real unreachable cycle somewhere.
@@ -172,32 +171,32 @@ def _assert_no_stray_pool_connections():
         # so the error doesn't at least keep happening.
         pool._refs.clear()
         _STRAY_CONNECTION_FAILURES = 0
-        assert False, "Stray conections in cleanup: %s" % err
+        assert False, "Stray conections in cleanup: {0!s}".format(err)
 
 
 def eq_(a, b, msg=None):
     """Assert a == b, with repr messaging on failure."""
-    assert a == b, msg or "%r != %r" % (a, b)
+    assert a == b, msg or "{0!r} != {1!r}".format(a, b)
 
 
 def ne_(a, b, msg=None):
     """Assert a != b, with repr messaging on failure."""
-    assert a != b, msg or "%r == %r" % (a, b)
+    assert a != b, msg or "{0!r} == {1!r}".format(a, b)
 
 
 def is_(a, b, msg=None):
     """Assert a is b, with repr messaging on failure."""
-    assert a is b, msg or "%r is not %r" % (a, b)
+    assert a is b, msg or "{0!r} is not {1!r}".format(a, b)
 
 
 def is_not_(a, b, msg=None):
     """Assert a is not b, with repr messaging on failure."""
-    assert a is not b, msg or "%r is %r" % (a, b)
+    assert a is not b, msg or "{0!r} is {1!r}".format(a, b)
 
 
 def startswith_(a, fragment, msg=None):
     """Assert a.startswith(fragment), with repr messaging on failure."""
-    assert a.startswith(fragment), msg or "%r does not start with %r" % (
+    assert a.startswith(fragment), msg or "{0!r} does not start with {1!r}".format(
         a, fragment)
 
 
@@ -217,7 +216,7 @@ def assert_raises_message(except_cls, msg, callable_, *args, **kwargs):
         callable_(*args, **kwargs)
         assert False, "Callable did not raise an exception"
     except except_cls as e:
-        assert re.search(msg, util.text_type(e), re.UNICODE), "%r !~ %s" % (msg, e)
+        assert re.search(msg, util.text_type(e), re.UNICODE), "{0!r} !~ {1!s}".format(msg, e)
         print(util.text_type(e).encode('utf-8'))
 
 
@@ -274,7 +273,7 @@ class AssertsCompiledSQL(object):
 
         cc = re.sub(r'[\n\t]', '', util.text_type(c))
 
-        eq_(cc, result, "%r != %r on dialect %r" % (cc, result, dialect))
+        eq_(cc, result, "{0!r} != {1!r} on dialect {2!r}".format(cc, result, dialect))
 
         if checkparams is not None:
             eq_(c.construct_params(params), checkparams)
@@ -317,8 +316,7 @@ class ComparesTables(object):
 
     def assert_types_base(self, c1, c2):
         assert c1.type._compare_type_affinity(c2.type),\
-                "On column %r, type '%s' doesn't correspond to type '%s'" % \
-                (c1.name, c1.type, c2.type)
+                "On column {0!r}, type '{1!s}' doesn't correspond to type '{2!s}'".format(c1.name, c1.type, c2.type)
 
 
 class AssertsExecutionResults(object):
@@ -345,7 +343,7 @@ class AssertsExecutionResults(object):
                     self.assert_row(value[0], getattr(rowobj, key), value[1])
             else:
                 self.assert_(getattr(rowobj, key) == value,
-                             "attribute %s value %s does not match %s" % (
+                             "attribute {0!s} value {1!s} does not match {2!s}".format(
                              key, getattr(rowobj, key), value))
 
     def assert_unordered_result(self, result, cls, *expected):
@@ -363,11 +361,11 @@ class AssertsExecutionResults(object):
         expected = set([immutabledict(e) for e in expected])
 
         for wrong in util.itertools_filterfalse(lambda o: type(o) == cls, found):
-            fail('Unexpected type "%s", expected "%s"' % (
+            fail('Unexpected type "{0!s}", expected "{1!s}"'.format(
                 type(wrong).__name__, cls.__name__))
 
         if len(found) != len(expected):
-            fail('Unexpected object count "%s", expected "%s"' % (
+            fail('Unexpected object count "{0!s}", expected "{1!s}"'.format(
                 len(found), len(expected)))
 
         NOVALUE = object()
@@ -392,7 +390,7 @@ class AssertsExecutionResults(object):
                     break
             else:
                 fail(
-                    "Expected %s instance with attributes %s not found." % (
+                    "Expected {0!s} instance with attributes {1!s} not found.".format(
                     cls.__name__, repr(expected_item)))
         return True
 

--- a/lib/sqlalchemy/testing/assertsql.py
+++ b/lib/sqlalchemy/testing/assertsql.py
@@ -229,8 +229,7 @@ class CountStatements(AssertRule):
 
     def consume_final(self):
         assert self.count == self._statement_count, \
-            'desired statement count %d does not match %d' \
-            % (self.count, self._statement_count)
+            'desired statement count {0:d} does not match {1:d}'.format(self.count, self._statement_count)
         return True
 
 

--- a/lib/sqlalchemy/testing/engines.py
+++ b/lib/sqlalchemy/testing/engines.py
@@ -148,7 +148,7 @@ def all_dialects(exclude=None):
         mod = getattr(d, name, None)
         if not mod:
             mod = getattr(__import__(
-                'sqlalchemy.databases.%s' % name).databases, name)
+                'sqlalchemy.databases.{0!s}'.format(name)).databases, name)
         yield mod.dialect()
 
 

--- a/lib/sqlalchemy/testing/entities.py
+++ b/lib/sqlalchemy/testing/entities.py
@@ -21,9 +21,9 @@ class BasicEntity(object):
             return object.__repr__(self)
         _repr_stack.add(id(self))
         try:
-            return "%s(%s)" % (
+            return "{0!s}({1!s})".format(
                 (self.__class__.__name__),
-                ', '.join(["%s=%r" % (key, getattr(self, key))
+                ', '.join(["{0!s}={1!r}".format(key, getattr(self, key))
                            for key in sorted(self.__dict__.keys())
                            if not key.startswith('_')]))
         finally:

--- a/lib/sqlalchemy/testing/exclusions.py
+++ b/lib/sqlalchemy/testing/exclusions.py
@@ -38,27 +38,26 @@ class skip_if(object):
             yield
         except Exception as ex:
             if self.predicate(config._current):
-                print(("%s failed as expected (%s): %s " % (
+                print(("{0!s} failed as expected ({1!s}): {2!s} ".format(
                     name, self.predicate, str(ex))))
             else:
                 raise
         else:
             if self.predicate(config._current):
                 raise AssertionError(
-                    "Unexpected success for '%s' (%s)" %
-                    (name, self.predicate))
+                    "Unexpected success for '{0!s}' ({1!s})".format(name, self.predicate))
 
     def __call__(self, fn):
         @decorator
         def decorate(fn, *args, **kw):
             if self.predicate(config._current):
                 if self.reason:
-                    msg = "'%s' : %s" % (
+                    msg = "'{0!s}' : {1!s}".format(
                             fn.__name__,
                             self.reason
                         )
                 else:
-                    msg = "'%s': %s" % (
+                    msg = "'{0!s}': {1!s}".format(
                             fn.__name__, self.predicate
                         )
                 raise SkipTest(msg)
@@ -120,13 +119,13 @@ class Predicate(object):
         elif util.callable(predicate):
             return LambdaPredicate(predicate)
         else:
-            assert False, "unknown predicate type: %s" % predicate
+            assert False, "unknown predicate type: {0!s}".format(predicate)
 
 
 class BooleanPredicate(Predicate):
     def __init__(self, value, description=None):
         self.value = value
-        self.description = description or "boolean %s" % value
+        self.description = description or "boolean {0!s}".format(value)
 
     def __call__(self, config):
         return self.value
@@ -187,18 +186,18 @@ class SpecPredicate(Predicate):
             return self.description
         elif self.op is None:
             if negate:
-                return "not %s" % self.db
+                return "not {0!s}".format(self.db)
             else:
-                return "%s" % self.db
+                return "{0!s}".format(self.db)
         else:
             if negate:
-                return "not %s %s %s" % (
+                return "not {0!s} {1!s} {2!s}".format(
                         self.db,
                         self.op,
                         self.spec
                     )
             else:
-                return "%s %s %s" % (
+                return "{0!s} {1!s} {2!s}".format(
                         self.db,
                         self.op,
                         self.spec

--- a/lib/sqlalchemy/testing/fixtures.py
+++ b/lib/sqlalchemy/testing/fixtures.py
@@ -144,7 +144,7 @@ class TablesTest(TestBase):
                     table.delete().execute().close()
                 except sa.exc.DBAPIError as ex:
                     util.print_(
-                        ("Error emptying table %s: %r" % (table, ex)),
+                        ("Error emptying table {0!s}: {1!r}".format(table, ex)),
                         file=sys.stderr)
 
     def setup(self):

--- a/lib/sqlalchemy/testing/pickleable.py
+++ b/lib/sqlalchemy/testing/pickleable.py
@@ -80,7 +80,7 @@ class Bar(object):
             other.y == self.y
 
     def __str__(self):
-        return "Bar(%d, %d)" % (self.x, self.y)
+        return "Bar({0:d}, {1:d})".format(self.x, self.y)
 
 
 class OldSchool:
@@ -109,7 +109,7 @@ class BarWithoutCompare(object):
         self.y = y
 
     def __str__(self):
-        return "Bar(%d, %d)" % (self.x, self.y)
+        return "Bar({0:d}, {1:d})".format(self.x, self.y)
 
 
 class NotComparable(object):

--- a/lib/sqlalchemy/testing/plugin/plugin_base.py
+++ b/lib/sqlalchemy/testing/plugin/plugin_base.py
@@ -135,7 +135,7 @@ def _log(opt_str, value, parser):
 def _list_dbs(*args):
     print("Available --db options (use --dburi to override)")
     for macro in sorted(file_config.options('db')):
-        print("%20s\t%s" % (macro, file_config.get('db', macro)))
+        print("{0:20!s}\t{1!s}".format(macro, file_config.get('db', macro)))
     sys.exit(0)
 
 
@@ -188,8 +188,7 @@ def _engine_uri(options, file_config):
             for db in re.split(r'[,\s]+', db_token):
                 if db not in file_config.options('db'):
                     raise RuntimeError(
-                        "Unknown URI specifier '%s'.  Specify --dbs for known uris."
-                                % db)
+                        "Unknown URI specifier '{0!s}'.  Specify --dbs for known uris.".format(db))
                 else:
                     db_urls.append(file_config.get('db', db))
 
@@ -319,12 +318,12 @@ def want_class(cls):
 def generate_sub_tests(cls, module):
     if getattr(cls, '__backend__', False):
         for cfg in config.Config.all_configs():
-            name = "%s_%s_%s" % (cls.__name__, cfg.db.name, cfg.db.driver)
+            name = "{0!s}_{1!s}_{2!s}".format(cls.__name__, cfg.db.name, cfg.db.driver)
             subcls = type(
                         name,
                         (cls, ),
                         {
-                            "__only_on__": ("%s+%s" % (cfg.db.name, cfg.db.driver)),
+                            "__only_on__": ("{0!s}+{1!s}".format(cfg.db.name, cfg.db.driver)),
                             "__backend__": False}
                         )
             setattr(module, name, subcls)
@@ -357,11 +356,11 @@ def before_test(test, test_module_name, test_class, test_name):
     # "test.aaa_profiling.test_compiler.CompileTest.test_update_whereclause"
     name = test_class.__name__
 
-    suffix = "_%s_%s" % (config.db.name, config.db.driver)
+    suffix = "_{0!s}_{1!s}".format(config.db.name, config.db.driver)
     if name.endswith(suffix):
         name = name[0:-(len(suffix))]
 
-    id_ = "%s.%s.%s" % (test_module_name, name, test_name)
+    id_ = "{0!s}.{1!s}.{2!s}".format(test_module_name, name, test_name)
 
     warnings.resetwarnings()
     profiling._current_test = id_
@@ -414,7 +413,7 @@ def _do_skips(cls):
     if getattr(cls, '__skip_if__', False):
         for c in getattr(cls, '__skip_if__'):
             if c():
-                raise SkipTest("'%s' skipped by %s" % (
+                raise SkipTest("'{0!s}' skipped by {1!s}".format(
                     cls.__name__, c.__name__)
                 )
 
@@ -428,9 +427,9 @@ def _do_skips(cls):
 
     if not all_configs:
         raise SkipTest(
-            "'%s' unsupported on DB implementation %s%s" % (
+            "'{0!s}' unsupported on DB implementation {1!s}{2!s}".format(
                 cls.__name__,
-                ", ".join("'%s' = %s" % (
+                ", ".join("'{0!s}' = {1!s}".format(
                                 config_obj.db.name,
                                 config_obj.db.dialect.server_version_info)
                     for config_obj in config.Config.all_configs()

--- a/lib/sqlalchemy/testing/profiling.py
+++ b/lib/sqlalchemy/testing/profiling.py
@@ -58,14 +58,14 @@ def profiled(target=None, **target_opts):
 
         graphic = target_opts.get('graphic', profile_config['graphic'])
         if graphic:
-            os.system("runsnake %s" % filename)
+            os.system("runsnake {0!s}".format(filename))
         else:
             report = target_opts.get('report', profile_config['report'])
             if report:
                 sort_ = target_opts.get('sort', profile_config['sort'])
                 limit = target_opts.get('limit', profile_config['limit'])
-                print(("Profile report for target '%s'" % (
-                    target, )
+                print(("Profile report for target '{0!s}'".format(
+                    target )
                     ))
 
                 stats = load_stats()
@@ -210,17 +210,17 @@ class ProfileStatsFile(object):
         profile_f.close()
 
     def _write(self):
-        print(("Writing profile file %s" % self.fname))
+        print(("Writing profile file {0!s}".format(self.fname)))
         profile_f = open(self.fname, "w")
         profile_f.write(self._header())
         for test_key in sorted(self.data):
 
             per_fn = self.data[test_key]
-            profile_f.write("\n# TEST: %s\n\n" % test_key)
+            profile_f.write("\n# TEST: {0!s}\n\n".format(test_key))
             for platform_key in sorted(per_fn):
                 per_platform = per_fn[platform_key]
                 c = ",".join(str(count) for count in per_platform['counts'])
-                profile_f.write("%s %s %s\n" % (test_key, platform_key, c))
+                profile_f.write("{0!s} {1!s} {2!s}\n".format(test_key, platform_key, c))
         profile_f.close()
 
 
@@ -265,7 +265,7 @@ def function_call_count(variance=0.05):
             else:
                 line_no, expected_count = expected
 
-            print(("Pstats calls: %d Expected %s" % (
+            print(("Pstats calls: {0:d} Expected {1!s}".format(
                     callcount,
                     expected_count
                 )
@@ -294,7 +294,7 @@ def function_call_count(variance=0.05):
 
 
 def _profile(fn, *args, **kw):
-    filename = "%s.prof" % fn.__name__
+    filename = "{0!s}.prof".format(fn.__name__)
 
     def load_stats():
         st = pstats.Stats(filename)

--- a/lib/sqlalchemy/testing/suite/test_reflection.py
+++ b/lib/sqlalchemy/testing/suite/test_reflection.py
@@ -60,7 +60,7 @@ class ComponentReflectionTest(fixtures.TablesTest):
                 Column('test1', sa.CHAR(5), nullable=False),
                 Column('test2', sa.Float(5), nullable=False),
                 Column('parent_user_id', sa.Integer,
-                            sa.ForeignKey('%susers.user_id' % schema_prefix)),
+                            sa.ForeignKey('{0!s}users.user_id'.format(schema_prefix))),
                 schema=schema,
                 test_needs_fk=True,
             )
@@ -76,8 +76,8 @@ class ComponentReflectionTest(fixtures.TablesTest):
         Table("dingalings", metadata,
                   Column('dingaling_id', sa.Integer, primary_key=True),
                   Column('address_id', sa.Integer,
-                    sa.ForeignKey('%semail_addresses.address_id' %
-                                    schema_prefix)),
+                    sa.ForeignKey('{0!s}email_addresses.address_id'.format(
+                                    schema_prefix))),
                   Column('data', sa.String(30)),
                   schema=schema,
                   test_needs_fk=True,
@@ -107,9 +107,9 @@ class ComponentReflectionTest(fixtures.TablesTest):
         for table_name in ('users', 'email_addresses'):
             fullname = table_name
             if schema:
-                fullname = "%s.%s" % (schema, table_name)
+                fullname = "{0!s}.{1!s}".format(schema, table_name)
             view_name = fullname + '_v'
-            query = "CREATE VIEW %s AS SELECT * FROM %s" % (
+            query = "CREATE VIEW {0!s} AS SELECT * FROM {1!s}".format(
                                 view_name, fullname)
 
             event.listen(
@@ -120,7 +120,7 @@ class ComponentReflectionTest(fixtures.TablesTest):
             event.listen(
                 metadata,
                 "before_drop",
-                DDL("DROP VIEW %s" % view_name)
+                DDL("DROP VIEW {0!s}".format(view_name))
             )
 
     @testing.requires.schema_reflection
@@ -233,7 +233,7 @@ class ComponentReflectionTest(fixtures.TablesTest):
                     sql_types.Time,
                     sql_types.String,
                     sql_types._Binary,
-                    ])) > 0, '%s(%s), %s(%s)' % (col.name,
+                    ])) > 0, '{0!s}({1!s}), {2!s}({3!s})'.format(col.name,
                             col.type, cols[i]['name'], ctype))
 
                 if not col.primary_key:
@@ -247,7 +247,7 @@ class ComponentReflectionTest(fixtures.TablesTest):
     def _type_round_trip(self, *types):
         t = Table('t', self.metadata,
                     *[
-                        Column('t%d' % i, type_)
+                        Column('t{0:d}'.format(i), type_)
                         for i, type_ in enumerate(types)
                     ]
                 )

--- a/lib/sqlalchemy/util/_collections.py
+++ b/lib/sqlalchemy/util/_collections.py
@@ -101,7 +101,7 @@ class KeyedTuple(tuple):
 
 class ImmutableContainer(object):
     def _immutable(self, *arg, **kw):
-        raise TypeError("%s object is immutable" % self.__class__.__name__)
+        raise TypeError("{0!s} object is immutable".format(self.__class__.__name__))
 
     __delitem__ = __setitem__ = __setattr__ = _immutable
 
@@ -131,7 +131,7 @@ class immutabledict(ImmutableContainer, dict):
             return d2
 
     def __repr__(self):
-        return "immutabledict(%s)" % dict.__repr__(self)
+        return "immutabledict({0!s})".format(dict.__repr__(self))
 
 
 class Properties(object):
@@ -379,7 +379,7 @@ class OrderedSet(set):
         return self.union(other)
 
     def __repr__(self):
-        return '%s(%r)' % (self.__class__.__name__, self._list)
+        return '{0!s}({1!r})'.format(self.__class__.__name__, self._list)
 
     __str__ = __repr__
 
@@ -647,7 +647,7 @@ class IdentitySet(object):
         raise TypeError('set objects are unhashable')
 
     def __repr__(self):
-        return '%s(%r)' % (type(self).__name__, list(self._members.values()))
+        return '{0!s}({1!r})'.format(type(self).__name__, list(self._members.values()))
 
 
 class WeakSequence(object):
@@ -673,7 +673,7 @@ class WeakSequence(object):
         try:
             obj = self._storage[index]
         except KeyError:
-            raise IndexError("Index %s out of range" % index)
+            raise IndexError("Index {0!s} out of range".format(index))
         else:
             return obj()
 

--- a/lib/sqlalchemy/util/deprecations.py
+++ b/lib/sqlalchemy/util/deprecations.py
@@ -36,8 +36,7 @@ def deprecated(version, message=None, add_deprecation_to_docstring=True):
     """
 
     if add_deprecation_to_docstring:
-        header = ".. deprecated:: %s %s" % \
-                    (version, (message or ''))
+        header = ".. deprecated:: {0!s} {1!s}".format(version, (message or ''))
     else:
         header = None
 
@@ -70,8 +69,7 @@ def pending_deprecation(version, message=None,
     """
 
     if add_deprecation_to_docstring:
-        header = ".. deprecated:: %s (pending) %s" % \
-                        (version, (message or ''))
+        header = ".. deprecated:: {0!s} (pending) {1!s}".format(version, (message or ''))
     else:
         header = None
 

--- a/lib/stevedore/dispatch.py
+++ b/lib/stevedore/dispatch.py
@@ -67,7 +67,7 @@ class DispatchExtensionManager(EnabledExtensionManager):
         """
         if not self.extensions:
             # FIXME: Use a more specific exception class here.
-            raise NoMatches('No %s extensions found' % self.namespace)
+            raise NoMatches('No {0!s} extensions found'.format(self.namespace))
         response = []
         for e in self.extensions:
             if filter_func(e, *args, **kwds):

--- a/lib/stevedore/driver.py
+++ b/lib/stevedore/driver.py
@@ -94,14 +94,12 @@ class DriverManager(NamedExtensionManager):
 
         if not self.extensions:
             name = self._names[0]
-            raise NoMatches('No %r driver found, looking for %r' %
-                            (self.namespace, name))
+            raise NoMatches('No {0!r} driver found, looking for {1!r}'.format(self.namespace, name))
         if len(self.extensions) > 1:
             discovered_drivers = ','.join(e.entry_point_target
                                           for e in self.extensions)
 
-            raise MultipleMatches('Multiple %r drivers found: %s' %
-                                  (self.namespace, discovered_drivers))
+            raise MultipleMatches('Multiple {0!r} drivers found: {1!s}'.format(self.namespace, discovered_drivers))
 
     def __call__(self, func, *args, **kwds):
         """Invokes func() for the single loaded extension.

--- a/lib/stevedore/extension.py
+++ b/lib/stevedore/extension.py
@@ -42,7 +42,7 @@ class Extension(object):
         :return: A string representation of the target of the entry point in
             'dotted.module:object' format.
         """
-        return '%s:%s' % (self.entry_point.module_name,
+        return '{0!s}:{1!s}'.format(self.entry_point.module_name,
                           self.entry_point.attrs[0])
 
 
@@ -219,7 +219,7 @@ class ExtensionManager(object):
         """
         if not self.extensions:
             # FIXME: Use a more specific exception class here.
-            raise NoMatches('No %s extensions found' % self.namespace)
+            raise NoMatches('No {0!s} extensions found'.format(self.namespace))
         response = []
         for e in self.extensions:
             self._invoke_one_plugin(response.append, func, e, args, kwds)

--- a/lib/stevedore/sphinxext.py
+++ b/lib/stevedore/sphinxext.py
@@ -32,7 +32,7 @@ def _simple_list(mgr):
         ext = mgr[name]
         doc = _get_docstring(ext.plugin) or '\n'
         summary = doc.splitlines()[0].strip()
-        yield('* %s -- %s' % (ext.name, summary),
+        yield('* {0!s} -- {1!s}'.format(ext.name, summary),
               ext.entry_point.module_name)
 
 
@@ -52,8 +52,7 @@ def _detailed_list(mgr, over='', under='-', titlecase=False):
         if doc:
             yield (doc, ext.entry_point.module_name)
         else:
-            yield ('.. warning:: No documentation found in %s'
-                   % ext.entry_point,
+            yield ('.. warning:: No documentation found in {0!s}'.format(ext.entry_point),
                    ext.entry_point.module_name)
         yield ('\n', ext.entry_point.module_name)
 
@@ -76,12 +75,12 @@ class ListPluginsDirective(rst.Directive):
         app = env.app
 
         namespace = ' '.join(self.content).strip()
-        app.info('documenting plugins from %r' % namespace)
+        app.info('documenting plugins from {0!r}'.format(namespace))
         overline_style = self.options.get('overline-style', '')
         underline_style = self.options.get('underline-style', '=')
 
         def report_load_failure(mgr, ep, err):
-            app.warn(u'Failed to load %s: %s' % (ep.module_name, err))
+            app.warn(u'Failed to load {0!s}: {1!s}'.format(ep.module_name, err))
 
         mgr = extension.ExtensionManager(
             namespace,

--- a/lib/stevedore/tests/test_sphinxext.py
+++ b/lib/stevedore/tests/test_sphinxext.py
@@ -28,8 +28,8 @@ def _make_ext(name, docstring):
 
     inner.__doc__ = docstring
     m1 = mock.Mock(spec=pkg_resources.EntryPoint)
-    m1.module_name = '%s_module' % name
-    s = mock.Mock(return_value='ENTRY_POINT(%s)' % name)
+    m1.module_name = '{0!s}_module'.format(name)
+    s = mock.Mock(return_value='ENTRY_POINT({0!s})'.format(name))
     m1.__str__ = s
     return extension.Extension(name, m1, inner, None)
 

--- a/lib/subliminal/cli.py
+++ b/lib/subliminal/cli.py
@@ -161,7 +161,7 @@ class LanguageParamType(click.ParamType):
         try:
             return Language.fromietf(value)
         except BabelfishError:
-            self.fail('%s is not a valid language' % value)
+            self.fail('{0!s} is not a valid language'.format(value))
 
 LANGUAGE = LanguageParamType()
 
@@ -187,7 +187,7 @@ class AgeParamType(click.ParamType):
     def convert(self, value, param, ctx):
         match = re.match(r'^(?:(?P<weeks>\d+?)w)?(?:(?P<days>\d+?)d)?(?:(?P<hours>\d+?)h)?$', value)
         if not match:
-            self.fail('%s is not a valid age' % value)
+            self.fail('{0!s} is not a valid age'.format(value))
 
         return timedelta(**{k: int(v) for k, v in match.groupdict(0).items()})
 
@@ -343,12 +343,12 @@ def download(obj, provider, language, age, directory, encoding, single, force, h
     # output errored paths
     if verbose > 0:
         for p in errored_paths:
-            click.secho('%s errored' % p, fg='red')
+            click.secho('{0!s} errored'.format(p), fg='red')
 
     # output ignored videos
     if verbose > 1:
         for video in ignored_videos:
-            click.secho('%s ignored - subtitles: %s / age: %d day%s' % (
+            click.secho('{0!s} ignored - subtitles: {1!s} / age: {2:d} day{3!s}'.format(
                 os.path.split(video.name)[1],
                 ', '.join(str(s) for s in video.subtitle_languages) or 'none',
                 video.age.days,
@@ -356,13 +356,13 @@ def download(obj, provider, language, age, directory, encoding, single, force, h
             ), fg='yellow')
 
     # report collected videos
-    click.echo('%s video%s collected / %s video%s ignored / %s error%s' % (
+    click.echo('{0!s} video{1!s} collected / {2!s} video{3!s} ignored / {4!s} error{5!s}'.format(
         click.style(str(len(videos)), bold=True, fg='green' if videos else None),
         's' if len(videos) > 1 else '',
         click.style(str(len(ignored_videos)), bold=True, fg='yellow' if ignored_videos else None),
         's' if len(ignored_videos) > 1 else '',
         click.style(str(len(errored_paths)), bold=True, fg='red' if errored_paths else None),
-        's' if len(errored_paths) > 1 else '',
+        's' if len(errored_paths) > 1 else ''
     ))
 
     # exit if no video collected
@@ -389,7 +389,7 @@ def download(obj, provider, language, age, directory, encoding, single, force, h
         total_subtitles += len(saved_subtitles)
 
         if verbose > 0:
-            click.echo('%s subtitle%s downloaded for %s' % (click.style(str(len(saved_subtitles)), bold=True),
+            click.echo('{0!s} subtitle{1!s} downloaded for {2!s}'.format(click.style(str(len(saved_subtitles)), bold=True),
                                                             's' if len(saved_subtitles) > 1 else '',
                                                             os.path.split(v.name)[1]))
 
@@ -425,12 +425,12 @@ def download(obj, provider, language, age, directory, encoding, single, force, h
                 # echo some nice colored output
                 click.echo('  - [{score}] {language} subtitle from {provider_name} (match on {matches})'.format(
                     score=click.style('{:5.1f}'.format(scaled_score), fg=score_color, bold=score >= scores['hash']),
-                    language=s.language.name if s.language.country is None else '%s (%s)' % (s.language.name,
+                    language=s.language.name if s.language.country is None else '{0!s} ({1!s})'.format(s.language.name,
                                                                                              s.language.country.name),
                     provider_name=s.provider_name,
                     matches=', '.join(sorted(matches, key=scores.get, reverse=True))
                 ))
 
     if verbose == 0:
-        click.echo('Downloaded %s subtitle%s' % (click.style(str(total_subtitles), bold=True),
+        click.echo('Downloaded {0!s} subtitle{1!s}'.format(click.style(str(total_subtitles), bold=True),
                                                  's' if total_subtitles > 1 else ''))

--- a/lib/subliminal/converters/legendastv.py
+++ b/lib/subliminal/converters/legendastv.py
@@ -32,10 +32,10 @@ class LegendasTvConverter(LanguageReverseConverter):
         if (alpha3,) in self.to_legendastv:
             return self.to_legendastv[(alpha3,)]
 
-        raise ConfigurationError('Unsupported language code for legendastv: %s, %s, %s' % (alpha3, country, script))
+        raise ConfigurationError('Unsupported language code for legendastv: {0!s}, {1!s}, {2!s}'.format(alpha3, country, script))
 
     def reverse(self, legendastv):
         if legendastv in self.from_legendastv:
             return self.from_legendastv[legendastv]
 
-        raise ConfigurationError('Unsupported language number for legendastv: %s' % legendastv)
+        raise ConfigurationError('Unsupported language number for legendastv: {0!s}'.format(legendastv))

--- a/lib/subliminal/converters/thesubdb.py
+++ b/lib/subliminal/converters/thesubdb.py
@@ -17,10 +17,10 @@ class TheSubDBConverter(LanguageReverseConverter):
         if (alpha3,) in self.to_thesubdb:
             return self.to_thesubdb[(alpha3,)]
 
-        raise ConfigurationError('Unsupported language for thesubdb: %s, %s, %s' % (alpha3, country, script))
+        raise ConfigurationError('Unsupported language for thesubdb: {0!s}, {1!s}, {2!s}'.format(alpha3, country, script))
 
     def reverse(self, thesubdb):
         if thesubdb in self.from_thesubdb:
             return self.from_thesubdb[thesubdb]
 
-        raise ConfigurationError('Unsupported language code for thesubdb: %s' % thesubdb)
+        raise ConfigurationError('Unsupported language code for thesubdb: {0!s}'.format(thesubdb))

--- a/lib/subliminal/core.py
+++ b/lib/subliminal/core.py
@@ -380,7 +380,7 @@ def scan_video(path, subtitles=True, subtitles_dir=None, movie_refiners=('metada
 
     # check video extension
     if not path.endswith(VIDEO_EXTENSIONS):
-        raise ValueError('%s is not a valid video extension' % os.path.splitext(path)[1])
+        raise ValueError('{0!s} is not a valid video extension'.format(os.path.splitext(path)[1]))
 
     dirpath, filename = os.path.split(path)
     logger.info('Scanning video %r in %r', filename, dirpath)

--- a/lib/subliminal/providers/__init__.py
+++ b/lib/subliminal/providers/__init__.py
@@ -158,4 +158,4 @@ class Provider(object):
         raise NotImplementedError
 
     def __repr__(self):
-        return '<%s [%r]>' % (self.__class__.__name__, self.video_types)
+        return '<{0!s} [{1!r}]>'.format(self.__class__.__name__, self.video_types)

--- a/lib/subliminal/providers/addic7ed.py
+++ b/lib/subliminal/providers/addic7ed.py
@@ -91,7 +91,7 @@ class Addic7edProvider(Provider):
 
     def initialize(self):
         self.session = Session()
-        self.session.headers['User-Agent'] = 'Subliminal/%s' % __short_version__
+        self.session.headers['User-Agent'] = 'Subliminal/{0!s}'.format(__short_version__)
 
         # login
         if self.username is not None and self.password is not None:
@@ -153,7 +153,7 @@ class Addic7edProvider(Provider):
         series = series.replace('\'', ' ')
 
         # build the params
-        series_year = '%s %d' % (series, year) if year is not None else series
+        series_year = '{0!s} {1:d}'.format(series, year) if year is not None else series
         params = {'search': series_year, 'Submit': 'Search'}
 
         # make the search
@@ -196,12 +196,12 @@ class Addic7edProvider(Provider):
         # attempt with country
         if not show_id and country_code:
             logger.debug('Getting show id with country')
-            show_id = show_ids.get('%s %s' % (series_sanitized, country_code.lower()))
+            show_id = show_ids.get('{0!s} {1!s}'.format(series_sanitized, country_code.lower()))
 
         # attempt with year
         if not show_id and year:
             logger.debug('Getting show id with year')
-            show_id = show_ids.get('%s %d' % (series_sanitized, year))
+            show_id = show_ids.get('{0!s} {1:d}'.format(series_sanitized, year))
 
         # attempt clean
         if not show_id:
@@ -224,7 +224,7 @@ class Addic7edProvider(Provider):
 
         # get the page of the season of the show
         logger.info('Getting the page of show id %d, season %d', show_id, season)
-        r = self.session.get(self.server_url + 'show/%d' % show_id, params={'season': season}, timeout=10)
+        r = self.session.get(self.server_url + 'show/{0:d}'.format(show_id), params={'season': season}, timeout=10)
         r.raise_for_status()
         if r.status_code == 304:
             raise TooManyRequests()

--- a/lib/subliminal/providers/itasa.py
+++ b/lib/subliminal/providers/itasa.py
@@ -84,7 +84,7 @@ class ItaSAProvider(Provider):
 
     def initialize(self):
         self.session = Session()
-        self.session.headers = {'User-Agent': 'Subliminal/%s' % __version__}
+        self.session.headers = {'User-Agent': 'Subliminal/{0!s}'.format(__version__)}
 
         # login
         if self.username is not None and self.password is not None:
@@ -218,7 +218,7 @@ class ItaSAProvider(Provider):
         # attempt with country
         if not show_id and country_code:
             logger.debug('Getting show id with country')
-            show_id = show_ids.get('%s %s' % (series_sanitized, country_code.lower()))
+            show_id = show_ids.get('{0!s} {1!s}'.format(series_sanitized, country_code.lower()))
 
         # attempt clean
         if not show_id:
@@ -274,7 +274,7 @@ class ItaSAProvider(Provider):
         params = {
             'apikey': self.apikey,
             'show_id': show_id,
-            'q': '%dx%02d' % (season, episode),
+            'q': '{0:d}x{1:02d}'.format(season, episode),
             'version': sub_format
             }
         logger.debug(params)
@@ -288,7 +288,7 @@ class ItaSAProvider(Provider):
 
         # Looking for subtitlles in first page
         for subtitle in root.findall('data/subtitles/subtitle'):
-            if '%dx%02d' % (season, episode) in subtitle.find('name').text.lower():
+            if '{0:d}x{1:02d}'.format(season, episode) in subtitle.find('name').text.lower():
 
                 logger.debug('Found subtitle id %d - %s - %s',
                              int(subtitle.find('id').text),
@@ -317,7 +317,7 @@ class ItaSAProvider(Provider):
 
             # Looking for show in following pages
             for subtitle in root.findall('data/subtitles/subtitle'):
-                if '%dx%02d' % (season, episode) in subtitle.find('name').text.lower():
+                if '{0:d}x{1:02d}'.format(season, episode) in subtitle.find('name').text.lower():
 
                     logger.debug('Found subtitle id %d - %s - %s',
                                  int(subtitle.find('id').text),
@@ -346,7 +346,7 @@ class ItaSAProvider(Provider):
                 if 'limite di download' in content:
                     raise TooManyRequests()
                 else:
-                    raise ConfigurationError('Not a zip file: %r' % content)
+                    raise ConfigurationError('Not a zip file: {0!r}'.format(content))
 
             with ZipFile(io.BytesIO(content)) as zf:
                 if len(zf.namelist()) > 1:

--- a/lib/subliminal/providers/legendastv.py
+++ b/lib/subliminal/providers/legendastv.py
@@ -46,7 +46,7 @@ class LegendasTvSubtitle(Subtitle):
 
     @property
     def id(self):
-        return '%s-%s' % (self.subtitle_id, self.name.lower())
+        return '{0!s}-{1!s}'.format(self.subtitle_id, self.name.lower())
 
     def get_matches(self, video, hearing_impaired=False):
         matches = set()
@@ -82,7 +82,7 @@ class LegendasTvProvider(Provider):
         if self.username is not None and self.password is not None:
             logger.info('Logging in')
             data = {'_method': 'POST', 'data[User][username]': self.username, 'data[User][password]': self.password}
-            r = self.session.post('%s/login' % self.server_url, data, allow_redirects=False, timeout=TIMEOUT)
+            r = self.session.post('{0!s}/login'.format(self.server_url), data, allow_redirects=False, timeout=TIMEOUT)
             r.raise_for_status()
 
             soup = ParserBeautifulSoup(r.content, ['lxml', 'html.parser'])
@@ -98,7 +98,7 @@ class LegendasTvProvider(Provider):
         # logout
         if self.logged_in:
             logger.info('Logging out')
-            r = self.session.get('%s/users/logout' % self.server_url, timeout=TIMEOUT)
+            r = self.session.get('{0!s}/users/logout'.format(self.server_url), timeout=TIMEOUT)
             r.raise_for_status()
             logger.debug('Logged out')
             self.logged_in = False
@@ -173,7 +173,7 @@ class LegendasTvProvider(Provider):
         results = dict()
         for keyword in {sanitize(title), title.lower().replace(':', '')}:
             logger.info('Searching candidates using the keyword %s', keyword)
-            r = self.session.get('%s/legenda/sugestao/%s' % (self.server_url, keyword), timeout=TIMEOUT)
+            r = self.session.get('{0!s}/legenda/sugestao/{1!s}'.format(self.server_url, keyword), timeout=TIMEOUT)
             r.raise_for_status()
             results.update({item['_id']: item for item in json.loads(r.text)})
 
@@ -317,7 +317,7 @@ class LegendasTvProvider(Provider):
         for candidate in candidates:
             # page_url: {server_url}/util/carrega_legendas_busca_filme/{title_id}/{language_code}
             candidate_id = candidate.get('id')
-            page_url = '%s/util/carrega_legendas_busca_filme/%s/%d' % (self.server_url, candidate_id, language_code)
+            page_url = '{0!s}/util/carrega_legendas_busca_filme/{1!s}/{2:d}'.format(self.server_url, candidate_id, language_code)
 
             # loop over paginated results
             while page_url:
@@ -459,7 +459,7 @@ class LegendasTvProvider(Provider):
 
         """
         logger.debug('Downloading subtitle_id %s. Last update on %s', subtitle_id, timestamp)
-        r = self.session.get('%s/downloadarquivo/%s' % (self.server_url, subtitle_id), timeout=TIMEOUT)
+        r = self.session.get('{0!s}/downloadarquivo/{1!s}'.format(self.server_url, subtitle_id), timeout=TIMEOUT)
         r.raise_for_status()
 
         return r.content

--- a/lib/subliminal/providers/napiprojekt.py
+++ b/lib/subliminal/providers/napiprojekt.py
@@ -30,7 +30,7 @@ def get_subhash(hash):
         i = idx[i]
         t = a + int(hash[i], 16)
         v = int(hash[t:t + 2], 16)
-        b.append(('%x' % (v * m))[-1])
+        b.append(('{0:x}'.format((v * m)))[-1])
 
     return ''.join(b)
 
@@ -63,7 +63,7 @@ class NapiProjektProvider(Provider):
 
     def initialize(self):
         self.session = Session()
-        self.session.headers['User-Agent'] = 'Subliminal/%s' % __short_version__
+        self.session.headers['User-Agent'] = 'Subliminal/{0!s}'.format(__short_version__)
 
     def terminate(self):
         self.session.close()

--- a/lib/subliminal/providers/opensubtitles.py
+++ b/lib/subliminal/providers/opensubtitles.py
@@ -128,7 +128,7 @@ class OpenSubtitlesProvider(Provider):
     def initialize(self):
         logger.info('Logging in')
         response = checked(self.server.LogIn(self.username, self.password, 'eng',
-                                             'subliminal v%s' % __short_version__))
+                                             'subliminal v{0!s}'.format(__short_version__)))
         self.token = response['token']
         logger.debug('Logged in with token %r', self.token)
 

--- a/lib/subliminal/providers/podnapisi.py
+++ b/lib/subliminal/providers/podnapisi.py
@@ -84,7 +84,7 @@ class PodnapisiProvider(Provider):
 
     def initialize(self):
         self.session = Session()
-        self.session.headers['User-Agent'] = 'Subliminal/%s' % __short_version__
+        self.session.headers['User-Agent'] = 'Subliminal/{0!s}'.format(__short_version__)
 
     def terminate(self):
         self.session.close()

--- a/lib/subliminal/providers/subscenter.py
+++ b/lib/subliminal/providers/subscenter.py
@@ -83,7 +83,7 @@ class SubsCenterProvider(Provider):
 
     def initialize(self):
         self.session = Session()
-        self.session.headers['User-Agent'] = 'Subliminal/%s' % __short_version__
+        self.session.headers['User-Agent'] = 'Subliminal/{0!s}'.format(__short_version__)
 
         # login
         if self.username is not None and self.password is not None:

--- a/lib/subliminal/providers/thesubdb.py
+++ b/lib/subliminal/providers/thesubdb.py
@@ -41,8 +41,8 @@ class TheSubDBProvider(Provider):
 
     def initialize(self):
         self.session = Session()
-        self.session.headers['User-Agent'] = ('SubDB/1.0 (subliminal/%s; https://github.com/Diaoul/subliminal)' %
-                                              __short_version__)
+        self.session.headers['User-Agent'] = ('SubDB/1.0 (subliminal/{0!s}; https://github.com/Diaoul/subliminal)'.format(
+                                              __short_version__))
 
     def terminate(self):
         self.session.close()

--- a/lib/subliminal/providers/tvsubtitles.py
+++ b/lib/subliminal/providers/tvsubtitles.py
@@ -78,7 +78,7 @@ class TVsubtitlesProvider(Provider):
 
     def initialize(self):
         self.session = Session()
-        self.session.headers['User-Agent'] = 'Subliminal/%s' % __short_version__
+        self.session.headers['User-Agent'] = 'Subliminal/{0!s}'.format(__short_version__)
 
     def terminate(self):
         self.session.close()
@@ -130,7 +130,7 @@ class TVsubtitlesProvider(Provider):
         """
         # get the page of the season of the show
         logger.info('Getting the page of show id %d, season %d', show_id, season)
-        r = self.session.get(self.server_url + 'tvshow-%d-%d.html' % (show_id, season), timeout=10)
+        r = self.session.get(self.server_url + 'tvshow-{0:d}-{1:d}.html'.format(show_id, season), timeout=10)
         soup = ParserBeautifulSoup(r.content, ['lxml', 'html.parser'])
 
         # loop over episode rows
@@ -168,7 +168,7 @@ class TVsubtitlesProvider(Provider):
 
         # get the episode page
         logger.info('Getting the page for episode %d', episode_ids[episode])
-        r = self.session.get(self.server_url + 'episode-%d.html' % episode_ids[episode], timeout=10)
+        r = self.session.get(self.server_url + 'episode-{0:d}.html'.format(episode_ids[episode]), timeout=10)
         soup = ParserBeautifulSoup(r.content, ['lxml', 'html.parser'])
 
         # loop over subtitles rows
@@ -177,7 +177,7 @@ class TVsubtitlesProvider(Provider):
             # read the item
             language = Language.fromtvsubtitles(row.h5.img['src'][13:-4])
             subtitle_id = int(row.parent['href'][10:-5])
-            page_link = self.server_url + 'subtitle-%d.html' % subtitle_id
+            page_link = self.server_url + 'subtitle-{0:d}.html'.format(subtitle_id)
             rip = row.find('p', title='rip').text.strip() or None
             release = row.find('p', title='release').text.strip() or None
 
@@ -194,7 +194,7 @@ class TVsubtitlesProvider(Provider):
     def download_subtitle(self, subtitle):
         # download as a zip
         logger.info('Downloading subtitle %r', subtitle)
-        r = self.session.get(self.server_url + 'download-%d.html' % subtitle.subtitle_id, timeout=10)
+        r = self.session.get(self.server_url + 'download-{0:d}.html'.format(subtitle.subtitle_id), timeout=10)
         r.raise_for_status()
 
         # open the zip

--- a/lib/subliminal/refiners/metadata.py
+++ b/lib/subliminal/refiners/metadata.py
@@ -39,9 +39,9 @@ def refine(video, embedded_subtitles=True, **kwargs):
             # resolution
             if video_track.height in (480, 720, 1080):
                 if video_track.interlaced:
-                    video.resolution = '%di' % video_track.height
+                    video.resolution = '{0:d}i'.format(video_track.height)
                 else:
-                    video.resolution = '%dp' % video_track.height
+                    video.resolution = '{0:d}p'.format(video_track.height)
                 logger.debug('Found resolution %s', video.resolution)
 
             # video codec

--- a/lib/subliminal/refiners/omdb.py
+++ b/lib/subliminal/refiners/omdb.py
@@ -68,7 +68,7 @@ class OMDBClient(object):
         return j
 
 
-omdb_client = OMDBClient(headers={'User-Agent': 'Subliminal/%s' % __short_version__})
+omdb_client = OMDBClient(headers={'User-Agent': 'Subliminal/{0!s}'.format(__short_version__)})
 
 
 @region.cache_on_arguments(expiration_time=REFINER_EXPIRATION_TIME)

--- a/lib/subliminal/refiners/tvdb.py
+++ b/lib/subliminal/refiners/tvdb.py
@@ -187,7 +187,7 @@ class TVDBClient(object):
 
 
 #: Configured instance of :class:`TVDBClient`
-tvdb_client = TVDBClient('5EC930FB90DA1ADA', headers={'User-Agent': 'Subliminal/%s' % __short_version__})
+tvdb_client = TVDBClient('5EC930FB90DA1ADA', headers={'User-Agent': 'Subliminal/{0!s}'.format(__short_version__)})
 
 
 @region.cache_on_arguments(expiration_time=REFINER_EXPIRATION_TIME)

--- a/lib/subliminal/subtitle.py
+++ b/lib/subliminal/subtitle.py
@@ -159,7 +159,7 @@ class Subtitle(object):
         return hash(self.provider_name + '-' + self.id)
 
     def __repr__(self):
-        return '<%s %r [%s]>' % (self.__class__.__name__, self.id, self.language)
+        return '<{0!s} {1!r} [{2!s}]>'.format(self.__class__.__name__, self.id, self.language)
 
 
 def get_subtitle_path(video_path, language=None, extension='.srt'):

--- a/lib/subliminal/utils.py
+++ b/lib/subliminal/utils.py
@@ -31,7 +31,7 @@ def hash_opensubtitles(video_path):
             (l_value,) = struct.unpack(b'<q', filebuffer)
             filehash += l_value
             filehash &= 0xFFFFFFFFFFFFFFFF
-    returnedhash = '%016x' % filehash
+    returnedhash = '{0:016x}'.format(filehash)
 
     return returnedhash
 

--- a/lib/subliminal/video.py
+++ b/lib/subliminal/video.py
@@ -107,7 +107,7 @@ class Video(object):
         return cls.fromguess(name, guessit(name))
 
     def __repr__(self):
-        return '<%s [%r]>' % (self.__class__.__name__, self.name)
+        return '<{0!s} [{1!r}]>'.format(self.__class__.__name__, self.name)
 
     def __hash__(self):
         return hash(self.name)
@@ -176,9 +176,9 @@ class Episode(Video):
 
     def __repr__(self):
         if self.year is None:
-            return '<%s [%r, %dx%d]>' % (self.__class__.__name__, self.series, self.season, self.episode)
+            return '<{0!s} [{1!r}, {2:d}x{3:d}]>'.format(self.__class__.__name__, self.series, self.season, self.episode)
 
-        return '<%s [%r, %d, %dx%d]>' % (self.__class__.__name__, self.series, self.year, self.season, self.episode)
+        return '<{0!s} [{1!r}, {2:d}, {3:d}x{4:d}]>'.format(self.__class__.__name__, self.series, self.year, self.season, self.episode)
 
 
 class Movie(Video):
@@ -216,6 +216,6 @@ class Movie(Video):
 
     def __repr__(self):
         if self.year is None:
-            return '<%s [%r]>' % (self.__class__.__name__, self.title)
+            return '<{0!s} [{1!r}]>'.format(self.__class__.__name__, self.title)
 
-        return '<%s [%r, %d]>' % (self.__class__.__name__, self.title, self.year)
+        return '<{0!s} [{1!r}, {2:d}]>'.format(self.__class__.__name__, self.title, self.year)

--- a/lib/synchronousdeluge/rencode.py
+++ b/lib/synchronousdeluge/rencode.py
@@ -386,7 +386,7 @@ def dumps(x, float_bits=DEFAULT_FLOAT_BITS):
         elif float_bits == 64:
             encode_func[FloatType] = encode_float64
         else:
-            raise ValueError('Float bits (%d) is not 32 or 64' % float_bits)
+            raise ValueError('Float bits ({0:d}) is not 32 or 64'.format(float_bits))
         r = []
         encode_func[type(x)](x, r)
     finally:

--- a/lib/tornado/auth.py
+++ b/lib/tornado/auth.py
@@ -247,8 +247,8 @@ class OpenIdMixin(object):
     def _on_authentication_verified(self, future, response):
         if response.error or b"is_valid:true" not in response.body:
             future.set_exception(AuthError(
-                "Invalid OpenID response: %s" % (response.error or
-                                                 response.body)))
+                "Invalid OpenID response: {0!s}".format((response.error or
+                                                 response.body))))
             return
 
         # Make sure we got back at least an email from attribute exchange
@@ -438,7 +438,7 @@ class OAuthMixin(object):
     def _on_request_token(self, authorize_url, callback_uri, callback,
                           response):
         if response.error:
-            raise Exception("Could not get request token: %s" % response.error)
+            raise Exception("Could not get request token: {0!s}".format(response.error))
         request_token = _oauth_parse_response(response.body)
         data = (base64.b64encode(escape.utf8(request_token["key"])) + b"|" +
                 base64.b64encode(escape.utf8(request_token["secret"])))
@@ -749,7 +749,7 @@ class TwitterMixin(OAuthMixin):
     def _on_twitter_request(self, future, response):
         if response.error:
             future.set_exception(AuthError(
-                "Error response %s fetching %s" % (response.error,
+                "Error response {0!s} fetching {1!s}".format(response.error,
                                                    response.request.url)))
             return
         future.set_result(escape.json_decode(response.body))
@@ -839,7 +839,7 @@ class GoogleOAuth2Mixin(OAuth2Mixin):
     def _on_access_token(self, future, response):
         """Callback function for the exchange to the access token."""
         if response.error:
-            future.set_exception(AuthError('Google auth error: %s' % str(response)))
+            future.set_exception(AuthError('Google auth error: {0!s}'.format(str(response))))
             return
 
         args = escape.json_decode(response.body)
@@ -911,7 +911,7 @@ class FacebookGraphMixin(OAuth2Mixin):
     def _on_access_token(self, redirect_uri, client_id, client_secret,
                          future, fields, response):
         if response.error:
-            future.set_exception(AuthError('Facebook auth error: %s' % str(response)))
+            future.set_exception(AuthError('Facebook auth error: {0!s}'.format(str(response))))
             return
 
         args = escape.parse_qs_bytes(escape.native_str(response.body))
@@ -1004,8 +1004,7 @@ class FacebookGraphMixin(OAuth2Mixin):
 
     def _on_facebook_request(self, future, response):
         if response.error:
-            future.set_exception(AuthError("Error response %s fetching %s" %
-                                           (response.error, response.request.url)))
+            future.set_exception(AuthError("Error response {0!s} fetching {1!s}".format(response.error, response.request.url)))
             return
 
         future.set_result(escape.json_decode(response.body))
@@ -1031,7 +1030,7 @@ def _oauth_signature(consumer_token, method, url, parameters={}, token=None):
     base_elems = []
     base_elems.append(method.upper())
     base_elems.append(normalized_url)
-    base_elems.append("&".join("%s=%s" % (k, _oauth_escape(str(v)))
+    base_elems.append("&".join("{0!s}={1!s}".format(k, _oauth_escape(str(v)))
                                for k, v in sorted(parameters.items())))
     base_string = "&".join(_oauth_escape(e) for e in base_elems)
 
@@ -1055,7 +1054,7 @@ def _oauth10a_signature(consumer_token, method, url, parameters={}, token=None):
     base_elems = []
     base_elems.append(method.upper())
     base_elems.append(normalized_url)
-    base_elems.append("&".join("%s=%s" % (k, _oauth_escape(str(v)))
+    base_elems.append("&".join("{0!s}={1!s}".format(k, _oauth_escape(str(v)))
                                for k, v in sorted(parameters.items())))
 
     base_string = "&".join(_oauth_escape(e) for e in base_elems)

--- a/lib/tornado/curl_httpclient.py
+++ b/lib/tornado/curl_httpclient.py
@@ -298,7 +298,7 @@ class CurlAsyncHTTPClient(AsyncHTTPClient):
             request.headers["Pragma"] = ""
 
         curl.setopt(pycurl.HTTPHEADER,
-                    ["%s: %s" % (native_str(k), native_str(v))
+                    ["{0!s}: {1!s}".format(native_str(k), native_str(v))
                      for k, v in request.headers.get_all()])
 
         curl.setopt(pycurl.HEADERFUNCTION,
@@ -338,7 +338,7 @@ class CurlAsyncHTTPClient(AsyncHTTPClient):
             curl.setopt(pycurl.PROXY, request.proxy_host)
             curl.setopt(pycurl.PROXYPORT, request.proxy_port)
             if request.proxy_username:
-                credentials = '%s:%s' % (request.proxy_username,
+                credentials = '{0!s}:{1!s}'.format(request.proxy_username,
                                          request.proxy_password)
                 curl.setopt(pycurl.PROXYUSERPWD, credentials)
         else:
@@ -394,8 +394,7 @@ class CurlAsyncHTTPClient(AsyncHTTPClient):
         elif request.method in ("POST", "PUT") or request.body:
             if request.body is None:
                 raise ValueError(
-                    'Body must not be None for "%s" request'
-                    % request.method)
+                    'Body must not be None for "{0!s}" request'.format(request.method))
 
             request_buffer = BytesIO(utf8(request.body))
 
@@ -411,14 +410,14 @@ class CurlAsyncHTTPClient(AsyncHTTPClient):
                 curl.setopt(pycurl.INFILESIZE, len(request.body))
 
         if request.auth_username is not None:
-            userpwd = "%s:%s" % (request.auth_username, request.auth_password or '')
+            userpwd = "{0!s}:{1!s}".format(request.auth_username, request.auth_password or '')
 
             if request.auth_mode is None or request.auth_mode == "basic":
                 curl.setopt(pycurl.HTTPAUTH, pycurl.HTTPAUTH_BASIC)
             elif request.auth_mode == "digest":
                 curl.setopt(pycurl.HTTPAUTH, pycurl.HTTPAUTH_DIGEST)
             else:
-                raise ValueError("Unsupported auth_mode %s" % request.auth_mode)
+                raise ValueError("Unsupported auth_mode {0!s}".format(request.auth_mode))
 
             curl.setopt(pycurl.USERPWD, native_str(userpwd))
             curl_log.debug("%s %s (username: %r)", request.method, request.url,
@@ -459,7 +458,7 @@ class CurlAsyncHTTPClient(AsyncHTTPClient):
             headers.clear()
             try:
                 (__, __, reason) = httputil.parse_response_start_line(header_line)
-                header_line = "X-Http-Reason: %s" % reason
+                header_line = "X-Http-Reason: {0!s}".format(reason)
             except httputil.HTTPInputError:
                 return
         if not header_line:

--- a/lib/tornado/escape.py
+++ b/lib/tornado/escape.py
@@ -200,7 +200,7 @@ def utf8(value):
         return value
     if not isinstance(value, unicode_type):
         raise TypeError(
-            "Expected bytes, unicode, or None; got %r" % type(value)
+            "Expected bytes, unicode, or None; got {0!r}".format(type(value))
         )
     return value.encode("utf-8")
 
@@ -217,7 +217,7 @@ def to_unicode(value):
         return value
     if not isinstance(value, bytes):
         raise TypeError(
-            "Expected bytes, unicode, or None; got %r" % type(value)
+            "Expected bytes, unicode, or None; got {0!r}".format(type(value))
         )
     return value.decode("utf-8")
 
@@ -248,7 +248,7 @@ def to_basestring(value):
         return value
     if not isinstance(value, bytes):
         raise TypeError(
-            "Expected bytes, unicode, or None; got %r" % type(value)
+            "Expected bytes, unicode, or None; got {0!r}".format(type(value))
         )
     return value.decode("utf-8")
 
@@ -364,7 +364,7 @@ def linkify(text, shorten=False, extra_params="",
                 else:
                     # full url is visible on mouse-over (for those who don't
                     # have a status bar, such as Safari by default)
-                    params += ' title="%s"' % href
+                    params += ' title="{0!s}"'.format(href)
 
         return u('<a href="%s"%s>%s</a>') % (href, params, url)
 
@@ -383,11 +383,11 @@ def _convert_entity(m):
             else:
                 return unichr(int(m.group(2)))
         except ValueError:
-            return "&#%s;" % m.group(2)
+            return "&#{0!s};".format(m.group(2))
     try:
         return _HTML_UNICODE_MAP[m.group(2)]
     except KeyError:
-        return "&%s;" % m.group(2)
+        return "&{0!s};".format(m.group(2))
 
 
 def _build_unicode_map():

--- a/lib/tornado/gen.py
+++ b/lib/tornado/gen.py
@@ -148,8 +148,7 @@ def engine(func):
         def final_callback(future):
             if future.result() is not None:
                 raise ReturnValueIgnoredError(
-                    "@gen.engine functions cannot return values: %r" %
-                    (future.result(),))
+                    "@gen.engine functions cannot return values: {0!r}".format(future.result()))
         # The engine interface doesn't give us any way to return
         # errors but to raise them into the stack context.
         # Save the stack context here to use when the Future has resolved.
@@ -824,13 +823,13 @@ class Runner(object):
             self.pending_callbacks = set()
             self.results = {}
         if key in self.pending_callbacks:
-            raise KeyReuseError("key %r is already pending" % (key,))
+            raise KeyReuseError("key {0!r} is already pending".format(key))
         self.pending_callbacks.add(key)
 
     def is_ready(self, key):
         """Returns true if a result is available for ``key``."""
         if self.pending_callbacks is None or key not in self.pending_callbacks:
-            raise UnknownKeyError("key %r is not pending" % (key,))
+            raise UnknownKeyError("key {0!r} is not pending".format(key))
         return key in self.results
 
     def set_result(self, key, result):
@@ -892,8 +891,8 @@ class Runner(object):
                         # had an exception then some callbacks may have been
                         # orphaned, so skip the check in that case.
                         raise LeakedCallbackError(
-                            "finished without waiting for callbacks %r" %
-                            self.pending_callbacks)
+                            "finished without waiting for callbacks {0!r}".format(
+                            self.pending_callbacks))
                     self.result_future.set_result(getattr(e, 'value', None))
                     self.result_future = None
                     self._deactivate_stack_context()
@@ -1023,7 +1022,7 @@ def convert_yielded(yielded):
     elif is_future(yielded):
         return yielded
     else:
-        raise BadYieldError("yielded unknown object %r" % (yielded,))
+        raise BadYieldError("yielded unknown object {0!r}".format(yielded))
 
 if singledispatch is not None:
     convert_yielded = singledispatch(convert_yielded)

--- a/lib/tornado/http1connection.py
+++ b/lib/tornado/http1connection.py
@@ -206,7 +206,7 @@ class HTTP1Connection(httputil.HTTPConnection):
                     if ('Content-Length' in headers or
                             'Transfer-Encoding' in headers):
                         raise httputil.HTTPInputError(
-                            "Response code %d cannot have body" % code)
+                            "Response code {0:d} cannot have body".format(code))
                     # TODO: client delegates will get headers_received twice
                     # in the case of a 100-continue.  Document or change?
                     yield self._read_message(delegate)
@@ -333,7 +333,7 @@ class HTTP1Connection(httputil.HTTPConnection):
         lines = []
         if self.is_client:
             self._request_start_line = start_line
-            lines.append(utf8('%s %s HTTP/1.1' % (start_line[0], start_line[1])))
+            lines.append(utf8('{0!s} {1!s} HTTP/1.1'.format(start_line[0], start_line[1])))
             # Client requests with a non-empty body must have either a
             # Content-Length or a Transfer-Encoding.
             self._chunking_output = (
@@ -342,7 +342,7 @@ class HTTP1Connection(httputil.HTTPConnection):
                 'Transfer-Encoding' not in headers)
         else:
             self._response_start_line = start_line
-            lines.append(utf8('HTTP/1.1 %s %s' % (start_line[1], start_line[2])))
+            lines.append(utf8('HTTP/1.1 {0!s} {1!s}'.format(start_line[1], start_line[2])))
             self._chunking_output = (
                 # TODO: should this use
                 # self._request_start_line.version or
@@ -404,7 +404,7 @@ class HTTP1Connection(httputil.HTTPConnection):
         if self._chunking_output and chunk:
             # Don't write out empty chunks because that means END-OF-STREAM
             # with chunked encoding
-            return utf8("%x" % len(chunk)) + b"\r\n" + chunk + b"\r\n"
+            return utf8("{0:x}".format(len(chunk))) + b"\r\n" + chunk + b"\r\n"
         else:
             return chunk
 
@@ -436,8 +436,8 @@ class HTTP1Connection(httputil.HTTPConnection):
                 not self.stream.closed()):
             self.stream.close()
             raise httputil.HTTPOutputError(
-                "Tried to write %d bytes less than Content-Length" %
-                self._expected_content_remaining)
+                "Tried to write {0:d} bytes less than Content-Length".format(
+                self._expected_content_remaining))
         if self._chunking_output:
             if not self.stream.closed():
                 self._pending_write = self.stream.write(b"0\r\n\r\n")
@@ -509,8 +509,8 @@ class HTTP1Connection(httputil.HTTPConnection):
             headers = httputil.HTTPHeaders.parse(data[eol:])
         except ValueError:
             # probably form split() if there was no ':' in the line
-            raise httputil.HTTPInputError("Malformed HTTP headers: %r" %
-                                          data[eol:100])
+            raise httputil.HTTPInputError("Malformed HTTP headers: {0!r}".format(
+                                          data[eol:100]))
         return start_line, headers
 
     def _read_body(self, code, headers, delegate):
@@ -522,8 +522,8 @@ class HTTP1Connection(httputil.HTTPConnection):
                 pieces = re.split(r',\s*', headers["Content-Length"])
                 if any(i != pieces[0] for i in pieces):
                     raise httputil.HTTPInputError(
-                        "Multiple unequal Content-Lengths: %r" %
-                        headers["Content-Length"])
+                        "Multiple unequal Content-Lengths: {0!r}".format(
+                        headers["Content-Length"]))
                 headers["Content-Length"] = pieces[0]
             content_length = int(headers["Content-Length"])
 
@@ -539,7 +539,7 @@ class HTTP1Connection(httputil.HTTPConnection):
             if ("Transfer-Encoding" in headers or
                     content_length not in (None, 0)):
                 raise httputil.HTTPInputError(
-                    "Response with code %d should not have body" % code)
+                    "Response with code {0:d} should not have body".format(code))
             content_length = 0
 
         if content_length is not None:

--- a/lib/tornado/httpclient.py
+++ b/lib/tornado/httpclient.py
@@ -583,8 +583,8 @@ class HTTPResponse(object):
             raise self.error
 
     def __repr__(self):
-        args = ",".join("%s=%r" % i for i in sorted(self.__dict__.items()))
-        return "%s(%s)" % (self.__class__.__name__, args)
+        args = ",".join("{0!s}={1!r}".format(*i) for i in sorted(self.__dict__.items()))
+        return "{0!s}({1!s})".format(self.__class__.__name__, args)
 
 
 class HTTPError(Exception):
@@ -605,7 +605,7 @@ class HTTPError(Exception):
         self.code = code
         message = message or httputil.responses.get(code, "Unknown")
         self.response = response
-        Exception.__init__(self, "HTTP %d: %s" % (self.code, message))
+        Exception.__init__(self, "HTTP {0:d}: {1!s}".format(self.code, message))
 
 
 class _RequestProxy(object):

--- a/lib/tornado/httputil.py
+++ b/lib/tornado/httputil.py
@@ -454,8 +454,8 @@ class HTTPServerRequest(object):
 
     def __repr__(self):
         attrs = ("protocol", "host", "method", "uri", "version", "remote_ip")
-        args = ", ".join(["%s=%r" % (n, getattr(self, n)) for n in attrs])
-        return "%s(%s, headers=%s)" % (
+        args = ", ".join(["{0!s}={1!r}".format(n, getattr(self, n)) for n in attrs])
+        return "{0!s}({1!s}, headers={2!s})".format(
             self.__class__.__name__, args, dict(self.headers))
 
 
@@ -672,7 +672,7 @@ def _get_content_range(start, end, total):
     """
     start = start or 0
     end = (end or total) - 1
-    return "bytes %s-%s/%s" % (start, end, total)
+    return "bytes {0!s}-{1!s}/{2!s}".format(start, end, total)
 
 
 def _int_or_none(val):
@@ -781,7 +781,7 @@ def format_timestamp(ts):
     elif isinstance(ts, datetime.datetime):
         ts = calendar.timegm(ts.utctimetuple())
     else:
-        raise TypeError("unknown timestamp type: %r" % ts)
+        raise TypeError("unknown timestamp type: {0!r}".format(ts))
     return email.utils.formatdate(ts, usegmt=True)
 
 
@@ -803,7 +803,7 @@ def parse_request_start_line(line):
         raise HTTPInputError("Malformed HTTP request line")
     if not re.match(r"^HTTP/1\.[0-9]$", version):
         raise HTTPInputError(
-            "Malformed HTTP version in HTTP Request-Line: %r" % version)
+            "Malformed HTTP version in HTTP Request-Line: {0!r}".format(version))
     return RequestStartLine(method, path, version)
 
 
@@ -885,7 +885,7 @@ def _encode_header(key, pdict):
             out.append(k)
         else:
             # TODO: quote if necessary.
-            out.append('%s=%s' % (k, v))
+            out.append('{0!s}={1!s}'.format(k, v))
     return '; '.join(out)
 
 

--- a/lib/tornado/ioloop.py
+++ b/lib/tornado/ioloop.py
@@ -441,7 +441,7 @@ class IOLoop(Configurable):
         if timeout is not None:
             self.remove_timeout(timeout_handle)
         if not future_cell[0].done():
-            raise TimeoutError('Operation timed out after %s seconds' % timeout)
+            raise TimeoutError('Operation timed out after {0!s} seconds'.format(timeout))
         return future_cell[0].result()
 
     def time(self):
@@ -491,7 +491,7 @@ class IOLoop(Configurable):
             return self.call_at(self.time() + timedelta_to_seconds(deadline),
                                 callback, *args, **kwargs)
         else:
-            raise TypeError("Unsupported deadline %r" % deadline)
+            raise TypeError("Unsupported deadline {0!r}".format(deadline))
 
     def call_later(self, delay, callback, *args, **kwargs):
         """Runs the ``callback`` after ``delay`` seconds have passed.
@@ -951,7 +951,7 @@ class _Timeout(object):
 
     def __init__(self, deadline, callback, io_loop):
         if not isinstance(deadline, numbers.Real):
-            raise TypeError("Unsupported deadline %r" % deadline)
+            raise TypeError("Unsupported deadline {0!r}".format(deadline))
         self.deadline = deadline
         self.callback = callback
         self.tiebreaker = next(io_loop._timeout_counter)

--- a/lib/tornado/iostream.py
+++ b/lib/tornado/iostream.py
@@ -241,7 +241,7 @@ class BaseIOStream(object):
             self._try_inline_read()
         except UnsatisfiableReadError as e:
             # Handle this the same way as in _handle_events.
-            gen_log.info("Unsatisfiable read, closing connection: %s" % e)
+            gen_log.info("Unsatisfiable read, closing connection: {0!s}".format(e))
             self.close(exc_info=True)
             return future
         except:
@@ -274,7 +274,7 @@ class BaseIOStream(object):
             self._try_inline_read()
         except UnsatisfiableReadError as e:
             # Handle this the same way as in _handle_events.
-            gen_log.info("Unsatisfiable read, closing connection: %s" % e)
+            gen_log.info("Unsatisfiable read, closing connection: {0!s}".format(e))
             self.close(exc_info=True)
             return future
         except:
@@ -536,7 +536,7 @@ class BaseIOStream(object):
                 self._state = state
                 self.io_loop.update_handler(self.fileno(), self._state)
         except UnsatisfiableReadError as e:
-            gen_log.info("Unsatisfiable read, closing connection: %s" % e)
+            gen_log.info("Unsatisfiable read, closing connection: {0!s}".format(e))
             self.close(exc_info=True)
         except Exception:
             gen_log.error("Uncaught exception, closing connection.",
@@ -814,7 +814,7 @@ class BaseIOStream(object):
         if (self._read_max_bytes is not None and
                 size > self._read_max_bytes):
             raise UnsatisfiableReadError(
-                "delimiter %r not found within %d bytes" % (
+                "delimiter {0!r} not found within {1:d} bytes".format(
                     delimiter, self._read_max_bytes))
 
     def _handle_write(self):

--- a/lib/tornado/locale.py
+++ b/lib/tornado/locale.py
@@ -345,13 +345,13 @@ class Locale(object):
 
         tfhour_clock = self.code not in ("en", "en_US", "zh_CN")
         if tfhour_clock:
-            str_time = "%d:%02d" % (local_date.hour, local_date.minute)
+            str_time = "{0:d}:{1:02d}".format(local_date.hour, local_date.minute)
         elif self.code == "zh_CN":
-            str_time = "%s%d:%02d" % (
+            str_time = "{0!s}{1:d}:{2:02d}".format(
                 (u('\u4e0a\u5348'), u('\u4e0b\u5348'))[local_date.hour >= 12],
                 local_date.hour % 12 or 12, local_date.minute)
         else:
-            str_time = "%d:%02d %s" % (
+            str_time = "{0:d}:{1:02d} {2!s}".format(
                 local_date.hour % 12 or 12, local_date.minute,
                 ("am", "pm")[local_date.hour >= 12])
 
@@ -476,8 +476,8 @@ class GettextLocale(Locale):
         """
         if plural_message is not None:
             assert count is not None
-            msgs_with_ctxt = ("%s%s%s" % (context, CONTEXT_SEPARATOR, message),
-                          "%s%s%s" % (context, CONTEXT_SEPARATOR, plural_message),
+            msgs_with_ctxt = ("{0!s}{1!s}{2!s}".format(context, CONTEXT_SEPARATOR, message),
+                          "{0!s}{1!s}{2!s}".format(context, CONTEXT_SEPARATOR, plural_message),
                           count)
             result = self.ngettext(*msgs_with_ctxt)
             if CONTEXT_SEPARATOR in result:
@@ -485,7 +485,7 @@ class GettextLocale(Locale):
                 result = self.ngettext(message, plural_message, count)
             return result
         else:
-            msg_with_ctxt = "%s%s%s" % (context, CONTEXT_SEPARATOR, message)
+            msg_with_ctxt = "{0!s}{1!s}{2!s}".format(context, CONTEXT_SEPARATOR, message)
             result = self.gettext(msg_with_ctxt)
             if CONTEXT_SEPARATOR in result:
                 # Translation not found

--- a/lib/tornado/locks.py
+++ b/lib/tornado/locks.py
@@ -111,9 +111,9 @@ class Condition(_TimeoutGarbageCollector):
         self.io_loop = ioloop.IOLoop.current()
 
     def __repr__(self):
-        result = '<%s' % (self.__class__.__name__, )
+        result = '<{0!s}'.format(self.__class__.__name__ )
         if self._waiters:
-            result += ' waiters[%s]' % len(self._waiters)
+            result += ' waiters[{0!s}]'.format(len(self._waiters))
         return result + '>'
 
     def wait(self, timeout=None):
@@ -193,7 +193,7 @@ class Event(object):
         self._future = Future()
 
     def __repr__(self):
-        return '<%s %s>' % (
+        return '<{0!s} {1!s}>'.format(
             self.__class__.__name__, 'set' if self.is_set() else 'clear')
 
     def is_set(self):
@@ -429,7 +429,7 @@ class Lock(object):
         self._block = BoundedSemaphore(value=1)
 
     def __repr__(self):
-        return "<%s _block=%s>" % (
+        return "<{0!s} _block={1!s}>".format(
             self.__class__.__name__,
             self._block)
 

--- a/lib/tornado/log.py
+++ b/lib/tornado/log.py
@@ -151,7 +151,7 @@ class LogFormatter(logging.Formatter):
             # byte strings whereever possible).
             record.message = _safe_unicode(message)
         except Exception as e:
-            record.message = "Bad message (%r): %r" % (e, record.__dict__)
+            record.message = "Bad message ({0!r}): {1!r}".format(e, record.__dict__)
 
         record.asctime = self.formatTime(record, self.datefmt)
 

--- a/lib/tornado/options.py
+++ b/lib/tornado/options.py
@@ -106,12 +106,12 @@ class OptionParser(object):
     def __getattr__(self, name):
         if isinstance(self._options.get(name), _Option):
             return self._options[name].value()
-        raise AttributeError("Unrecognized option %r" % name)
+        raise AttributeError("Unrecognized option {0!r}".format(name))
 
     def __setattr__(self, name, value):
         if isinstance(self._options.get(name), _Option):
             return self._options[name].set(value)
-        raise AttributeError("Unrecognized option %r" % name)
+        raise AttributeError("Unrecognized option {0!r}".format(name))
 
     def __iter__(self):
         return iter(self._options)
@@ -200,8 +200,7 @@ class OptionParser(object):
         by later flags.
         """
         if name in self._options:
-            raise Error("Option %r already defined in %s" %
-                        (name, self._options[name].file_name))
+            raise Error("Option {0!r} already defined in {1!s}".format(name, self._options[name].file_name))
         frame = sys._getframe(0)
         options_file = frame.f_code.co_filename
 
@@ -258,13 +257,13 @@ class OptionParser(object):
             name = name.replace('-', '_')
             if name not in self._options:
                 self.print_help()
-                raise Error('Unrecognized command line option: %r' % name)
+                raise Error('Unrecognized command line option: {0!r}'.format(name))
             option = self._options[name]
             if not equals:
                 if option.type == bool:
                     value = "true"
                 else:
-                    raise Error('Option %r requires a value' % name)
+                    raise Error('Option {0!r} requires a value'.format(name))
             option.parse(value)
 
         if final:
@@ -297,7 +296,7 @@ class OptionParser(object):
         """Prints all the command line options to stderr (or another file)."""
         if file is None:
             file = sys.stderr
-        print("Usage: %s [OPTIONS]" % sys.argv[0], file=file)
+        print("Usage: {0!s} [OPTIONS]".format(sys.argv[0]), file=file)
         print("\nOptions:\n", file=file)
         by_group = {}
         for option in self._options.values():
@@ -305,7 +304,7 @@ class OptionParser(object):
 
         for filename, o in sorted(by_group.items()):
             if filename:
-                print("\n%s options:\n" % os.path.normpath(filename), file=file)
+                print("\n{0!s} options:\n".format(os.path.normpath(filename)), file=file)
             o.sort(key=lambda option: option.name)
             for option in o:
                 prefix = option.name
@@ -313,13 +312,13 @@ class OptionParser(object):
                     prefix += "=" + option.metavar
                 description = option.help or ""
                 if option.default is not None and option.default != '':
-                    description += " (default %s)" % option.default
+                    description += " (default {0!s})".format(option.default)
                 lines = textwrap.wrap(description, 79 - 35)
                 if len(prefix) > 30 or len(lines) == 0:
                     lines.insert(0, '')
-                print("  --%-30s %s" % (prefix, lines[0]), file=file)
+                print("  --{0:<30!s} {1!s}".format(prefix, lines[0]), file=file)
                 for line in lines[1:]:
-                    print("%-34s %s" % (' ', line), file=file)
+                    print("{0:<34!s} {1!s}".format(' ', line), file=file)
         print(file=file)
 
     def _help_callback(self, value):
@@ -431,16 +430,13 @@ class _Option(object):
     def set(self, value):
         if self.multiple:
             if not isinstance(value, list):
-                raise Error("Option %r is required to be a list of %s" %
-                            (self.name, self.type.__name__))
+                raise Error("Option {0!r} is required to be a list of {1!s}".format(self.name, self.type.__name__))
             for item in value:
                 if item is not None and not isinstance(item, self.type):
-                    raise Error("Option %r is required to be a list of %s" %
-                                (self.name, self.type.__name__))
+                    raise Error("Option {0!r} is required to be a list of {1!s}".format(self.name, self.type.__name__))
         else:
             if value is not None and not isinstance(value, self.type):
-                raise Error("Option %r is required to be a %s (%s given)" %
-                            (self.name, self.type.__name__, type(value)))
+                raise Error("Option {0!r} is required to be a {1!s} ({2!s} given)".format(self.name, self.type.__name__, type(value)))
         self._value = value
         if self.callback is not None:
             self.callback(self._value)
@@ -465,7 +461,7 @@ class _Option(object):
                 return datetime.datetime.strptime(value, format)
             except ValueError:
                 pass
-        raise Error('Unrecognized date/time format: %r' % value)
+        raise Error('Unrecognized date/time format: {0!r}'.format(value))
 
     _TIMEDELTA_ABBREVS = [
         ('hours', ['h']),
@@ -484,7 +480,7 @@ class _Option(object):
     _FLOAT_PATTERN = r'[-+]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][-+]?\d+)?'
 
     _TIMEDELTA_PATTERN = re.compile(
-        r'\s*(%s)\s*(\w*)\s*' % _FLOAT_PATTERN, re.IGNORECASE)
+        r'\s*({0!s})\s*(\w*)\s*'.format(_FLOAT_PATTERN), re.IGNORECASE)
 
     def _parse_timedelta(self, value):
         try:

--- a/lib/tornado/platform/asyncio.py
+++ b/lib/tornado/platform/asyncio.py
@@ -56,7 +56,7 @@ class BaseAsyncIOLoop(IOLoop):
     def add_handler(self, fd, handler, events):
         fd, fileobj = self.split_fd(fd)
         if fd in self.handlers:
-            raise ValueError("fd %s added twice" % fd)
+            raise ValueError("fd {0!s} added twice".format(fd))
         self.handlers[fd] = (fileobj, stack_context.wrap(handler))
         if events & IOLoop.READ:
             self.asyncio_loop.add_reader(

--- a/lib/tornado/platform/caresresolver.py
+++ b/lib/tornado/platform/caresresolver.py
@@ -61,8 +61,7 @@ class CaresResolver(Resolver):
             assert not callback_args.kwargs
             result, error = callback_args.args
             if error:
-                raise Exception('C-Ares returned error %s: %s while resolving %s' %
-                                (error, pycares.errno.strerror(error), host))
+                raise Exception('C-Ares returned error {0!s}: {1!s} while resolving {2!s}'.format(error, pycares.errno.strerror(error), host))
             addresses = result.addresses
         addrinfo = []
         for address in addresses:
@@ -73,7 +72,6 @@ class CaresResolver(Resolver):
             else:
                 address_family = socket.AF_UNSPEC
             if family != socket.AF_UNSPEC and family != address_family:
-                raise Exception('Requested socket family %d but got %d' %
-                                (family, address_family))
+                raise Exception('Requested socket family {0:d} but got {1:d}'.format(family, address_family))
             addrinfo.append((address_family, (address, port)))
         raise gen.Return(addrinfo)

--- a/lib/tornado/platform/kqueue.py
+++ b/lib/tornado/platform/kqueue.py
@@ -37,7 +37,7 @@ class _KQueue(object):
 
     def register(self, fd, events):
         if fd in self._active:
-            raise IOError("fd %s already registered" % fd)
+            raise IOError("fd {0!s} already registered".format(fd))
         self._control(fd, events, select.KQ_EV_ADD)
         self._active[fd] = events
 

--- a/lib/tornado/platform/select.py
+++ b/lib/tornado/platform/select.py
@@ -37,7 +37,7 @@ class _Select(object):
 
     def register(self, fd, events):
         if fd in self.read_fds or fd in self.write_fds or fd in self.error_fds:
-            raise IOError("fd %s already registered" % fd)
+            raise IOError("fd {0!s} already registered".format(fd))
         if events & IOLoop.READ:
             self.read_fds.add(fd)
         if events & IOLoop.WRITE:

--- a/lib/tornado/platform/twisted.py
+++ b/lib/tornado/platform/twisted.py
@@ -192,7 +192,7 @@ class TornadoReactor(PosixReactorBase):
     # IReactorThreads
     def callFromThread(self, f, *args, **kw):
         """See `twisted.internet.interfaces.IReactorThreads.callFromThread`"""
-        assert callable(f), "%s is not callable" % f
+        assert callable(f), "{0!s} is not callable".format(f)
         with NullContext():
             # This NullContext is mainly for an edge case when running
             # TwistedIOLoop on top of a TornadoReactor.
@@ -436,7 +436,7 @@ class TwistedIOLoop(tornado.ioloop.IOLoop):
 
     def add_handler(self, fd, handler, events):
         if fd in self.fds:
-            raise ValueError('fd %s added twice' % fd)
+            raise ValueError('fd {0!s} added twice'.format(fd))
         fd, fileobj = self.split_fd(fd)
         self.fds[fd] = _FD(fd, fileobj, wrap(handler))
         if events & tornado.ioloop.IOLoop.READ:
@@ -562,8 +562,7 @@ class TwistedResolver(Resolver):
             else:
                 resolved_family = socket.AF_UNSPEC
         if family != socket.AF_UNSPEC and family != resolved_family:
-            raise Exception('Requested socket family %d but got %d' %
-                            (family, resolved_family))
+            raise Exception('Requested socket family {0:d} but got {1:d}'.format(family, resolved_family))
         result = [
             (resolved_family, (resolved, port)),
         ]

--- a/lib/tornado/queues.py
+++ b/lib/tornado/queues.py
@@ -240,22 +240,22 @@ class Queue(object):
             self._getters.popleft()
 
     def __repr__(self):
-        return '<%s at %s %s>' % (
+        return '<{0!s} at {1!s} {2!s}>'.format(
             type(self).__name__, hex(id(self)), self._format())
 
     def __str__(self):
-        return '<%s %s>' % (type(self).__name__, self._format())
+        return '<{0!s} {1!s}>'.format(type(self).__name__, self._format())
 
     def _format(self):
-        result = 'maxsize=%r' % (self.maxsize, )
+        result = 'maxsize={0!r}'.format(self.maxsize )
         if getattr(self, '_queue', None):
-            result += ' queue=%r' % self._queue
+            result += ' queue={0!r}'.format(self._queue)
         if self._getters:
-            result += ' getters[%s]' % len(self._getters)
+            result += ' getters[{0!s}]'.format(len(self._getters))
         if self._putters:
-            result += ' putters[%s]' % len(self._putters)
+            result += ' putters[{0!s}]'.format(len(self._putters))
         if self._unfinished_tasks:
-            result += ' tasks=%s' % self._unfinished_tasks
+            result += ' tasks={0!s}'.format(self._unfinished_tasks)
         return result
 
 

--- a/lib/tornado/simple_httpclient.py
+++ b/lib/tornado/simple_httpclient.py
@@ -203,8 +203,8 @@ class _HTTPConnection(httputil.HTTPMessageDelegate):
         with stack_context.ExceptionStackContext(self._handle_exception):
             self.parsed = urlparse.urlsplit(_unicode(self.request.url))
             if self.parsed.scheme not in ("http", "https"):
-                raise ValueError("Unsupported url scheme: %s" %
-                                 self.request.url)
+                raise ValueError("Unsupported url scheme: {0!s}".format(
+                                 self.request.url))
             # urlsplit results have hostname and port results, but they
             # didn't support ipv6 literals until python 2.7.
             netloc = self.parsed.netloc
@@ -310,12 +310,12 @@ class _HTTPConnection(httputil.HTTPMessageDelegate):
                 stack_context.wrap(self._on_timeout))
         if (self.request.method not in self._SUPPORTED_METHODS and
                 not self.request.allow_nonstandard_methods):
-            raise KeyError("unknown method %s" % self.request.method)
+            raise KeyError("unknown method {0!s}".format(self.request.method))
         for key in ('network_interface',
                     'proxy_host', 'proxy_port',
                     'proxy_username', 'proxy_password'):
             if getattr(self.request, key, None):
-                raise NotImplementedError('%s not supported' % key)
+                raise NotImplementedError('{0!s} not supported'.format(key))
         if "Connection" not in self.request.headers:
             self.request.headers["Connection"] = "close"
         if "Host" not in self.request.headers:
@@ -465,9 +465,9 @@ class _HTTPConnection(httputil.HTTPMessageDelegate):
 
         if self.request.header_callback is not None:
             # Reassemble the start line.
-            self.request.header_callback('%s %s %s\r\n' % first_line)
+            self.request.header_callback('{0!s} {1!s} {2!s}\r\n'.format(*first_line))
             for k, v in self.headers.get_all():
-                self.request.header_callback("%s: %s\r\n" % (k, v))
+                self.request.header_callback("{0!s}: {1!s}\r\n".format(k, v))
             self.request.header_callback('\r\n')
 
     def finish(self):

--- a/lib/tornado/tcpserver.py
+++ b/lib/tornado/tcpserver.py
@@ -108,12 +108,12 @@ class TCPServer(object):
                 raise KeyError('missing key "certfile" in ssl_options')
 
             if not os.path.exists(self.ssl_options['certfile']):
-                raise ValueError('certfile "%s" does not exist' %
-                                 self.ssl_options['certfile'])
+                raise ValueError('certfile "{0!s}" does not exist'.format(
+                                 self.ssl_options['certfile']))
             if ('keyfile' in self.ssl_options and
                     not os.path.exists(self.ssl_options['keyfile'])):
-                raise ValueError('keyfile "%s" does not exist' %
-                                 self.ssl_options['keyfile'])
+                raise ValueError('keyfile "{0!s}" does not exist'.format(
+                                 self.ssl_options['keyfile']))
 
     def listen(self, port, address=""):
         """Starts accepting connections on the given port.

--- a/lib/tornado/test/auth_test.py
+++ b/lib/tornado/test/auth_test.py
@@ -70,7 +70,7 @@ class OAuth1ClientLoginHandler(RequestHandler, OAuthMixin):
         if self.get_argument('fail_in_get_user', None):
             raise Exception("failing in get_user")
         if access_token != dict(key='uiop', secret='5678'):
-            raise Exception("incorrect access token %r" % access_token)
+            raise Exception("incorrect access token {0!r}".format(access_token))
         callback(dict(email='foo@example.com'))
 
 
@@ -85,7 +85,7 @@ class OAuth1ClientLoginCoroutineHandler(OAuth1ClientLoginHandler):
                 yield self.get_authenticated_user()
             except Exception as e:
                 self.set_status(503)
-                self.write("got exception: %s" % e)
+                self.write("got exception: {0!s}".format(e))
         else:
             yield self.authorize_redirect()
 
@@ -182,7 +182,7 @@ class TwitterClientShowUserHandler(TwitterClientHandler):
         # TODO: would be nice to go through the login flow instead of
         # cheating with a hard-coded access token.
         response = yield gen.Task(self.twitter_request,
-                                  '/users/show/%s' % self.get_argument('name'),
+                                  '/users/show/{0!s}'.format(self.get_argument('name')),
                                   access_token=dict(key='hjkl', secret='vbnm'))
         if response is None:
             self.set_status(500)
@@ -197,7 +197,7 @@ class TwitterClientShowUserFutureHandler(TwitterClientHandler):
     def get(self):
         try:
             response = yield self.twitter_request(
-                '/users/show/%s' % self.get_argument('name'),
+                '/users/show/{0!s}'.format(self.get_argument('name')),
                 access_token=dict(key='hjkl', secret='vbnm'))
         except AuthError as e:
             self.set_status(500)

--- a/lib/tornado/test/concurrent_test.py
+++ b/lib/tornado/test/concurrent_test.py
@@ -188,7 +188,7 @@ class CapServer(TCPServer):
             self.stream.write(b"error\talready capitalized\n")
         else:
             # data already has \n
-            self.stream.write(utf8("ok\t%s" % data.upper()))
+            self.stream.write(utf8("ok\t{0!s}".format(data.upper())))
         self.stream.close()
 
 

--- a/lib/tornado/test/curl_httpclient_test.py
+++ b/lib/tornado/test/curl_httpclient_test.py
@@ -54,10 +54,10 @@ class DigestAuthHandler(RequestHandler):
             assert param_dict['nonce'] == nonce
             assert param_dict['username'] == username
             assert param_dict['uri'] == self.request.path
-            h1 = md5(utf8('%s:%s:%s' % (username, realm, password))).hexdigest()
-            h2 = md5(utf8('%s:%s' % (self.request.method,
+            h1 = md5(utf8('{0!s}:{1!s}:{2!s}'.format(username, realm, password))).hexdigest()
+            h2 = md5(utf8('{0!s}:{1!s}'.format(self.request.method,
                                      self.request.path))).hexdigest()
-            digest = md5(utf8('%s:%s:%s' % (h1, nonce, h2))).hexdigest()
+            digest = md5(utf8('{0!s}:{1!s}:{2!s}'.format(h1, nonce, h2))).hexdigest()
             if digest == param_dict['response']:
                 self.write('ok')
             else:
@@ -65,8 +65,7 @@ class DigestAuthHandler(RequestHandler):
         else:
             self.set_status(401)
             self.set_header('WWW-Authenticate',
-                            'Digest realm="%s", nonce="%s", opaque="%s"' %
-                            (realm, nonce, opaque))
+                            'Digest realm="{0!s}", nonce="{1!s}", opaque="{2!s}"'.format(realm, nonce, opaque))
 
 
 class CustomReasonHandler(RequestHandler):

--- a/lib/tornado/test/gen_test.py
+++ b/lib/tornado/test/gen_test.py
@@ -1069,7 +1069,7 @@ class GenWebTest(AsyncHTTPTestCase):
         self.assertEqual(response.body, b"123")
 
     def test_task_handler(self):
-        response = self.fetch('/task?url=%s' % url_escape(self.get_url('/sequence')))
+        response = self.fetch('/task?url={0!s}'.format(url_escape(self.get_url('/sequence'))))
         self.assertEqual(response.body, b"got response: 123")
 
     def test_exception_handler(self):

--- a/lib/tornado/test/httpclient_test.py
+++ b/lib/tornado/test/httpclient_test.py
@@ -31,12 +31,12 @@ class HelloWorldHandler(RequestHandler):
     def get(self):
         name = self.get_argument("name", "world")
         self.set_header("Content-Type", "text/plain")
-        self.finish("Hello %s!" % name)
+        self.finish("Hello {0!s}!".format(name))
 
 
 class PostHandler(RequestHandler):
     def post(self):
-        self.finish("Post arg1: %s, arg2: %s" % (
+        self.finish("Post arg1: {0!s}, arg2: {1!s}".format(
             self.get_argument("arg1"), self.get_argument("arg2")))
 
 
@@ -203,7 +203,7 @@ Transfer-Encoding: chunked
                 stream.read_until(b"\r\n\r\n",
                                   functools.partial(write_response, stream))
             netutil.add_accept_handler(sock, accept_callback, self.io_loop)
-            self.http_client.fetch("http://127.0.0.1:%d/" % port, self.stop)
+            self.http_client.fetch("http://127.0.0.1:{0:d}/".format(port), self.stop)
             resp = self.wait()
             resp.rethrow()
             self.assertEqual(resp.body, b"12")
@@ -368,8 +368,7 @@ Transfer-Encoding: chunked
                 resp = self.fetch('/user_agent', headers=headers)
                 self.assertEqual(
                     resp.body, b"MyUserAgent",
-                    "response=%r, value=%r, container=%r" %
-                    (resp.body, value, container))
+                    "response={0!r}, value={1!r}, container={2!r}".format(resp.body, value, container))
 
     def test_304_with_content_length(self):
         # According to the spec 304 responses SHOULD NOT include
@@ -562,7 +561,7 @@ class SyncHTTPClientTest(unittest.TestCase):
         self.server_ioloop.close(all_fds=True)
 
     def get_url(self, path):
-        return 'http://127.0.0.1:%d%s' % (self.port, path)
+        return 'http://127.0.0.1:{0:d}{1!s}'.format(self.port, path)
 
     def test_sync_client(self):
         response = self.http_client.fetch(self.get_url('/'))

--- a/lib/tornado/test/httpserver_test.py
+++ b/lib/tornado/test/httpserver_test.py
@@ -66,7 +66,7 @@ class HelloWorldRequestHandler(RequestHandler):
         self.finish("Hello world")
 
     def post(self):
-        self.finish("Got %d bytes in POST" % len(self.request.body))
+        self.finish("Got {0:d} bytes in POST".format(len(self.request.body)))
 
 
 # In pre-1.0 versions of openssl, SSLv23 clients always send SSLv2
@@ -205,7 +205,7 @@ class HTTPConnectionTest(AsyncHTTPTestCase):
             self.wait()
             stream.write(
                 newline.join(headers +
-                             [utf8("Content-Length: %d" % len(body))]) +
+                             [utf8("Content-Length: {0:d}".format(len(body)))]) +
                 newline + newline + body)
             read_stream_body(stream, self.stop)
             headers, body = self.wait()
@@ -316,7 +316,7 @@ class TypeCheckHandler(RequestHandler):
     def check_type(self, name, obj, expected_type):
         actual_type = type(obj)
         if expected_type != actual_type:
-            self.errors[name] = "expected %s, got %s" % (expected_type,
+            self.errors[name] = "expected {0!s}, got {1!s}".format(expected_type,
                                                          actual_type)
 
 

--- a/lib/tornado/test/httputil_test.py
+++ b/lib/tornado/test/httputil_test.py
@@ -110,10 +110,10 @@ Foo
             logging.debug("trying filename %r", filename)
             data = """\
 --1234
-Content-Disposition: form-data; name="files"; filename="%s"
+Content-Disposition: form-data; name="files"; filename="{0!s}"
 
 Foo
---1234--""" % filename.replace('\\', '\\\\').replace('"', '\\"')
+--1234--""".format(filename.replace('\\', '\\\\').replace('"', '\\"'))
             data = utf8(data.replace("\n", "\r\n"))
             args = {}
             files = {}

--- a/lib/tornado/test/locale_test.py
+++ b/lib/tornado/test/locale_test.py
@@ -81,11 +81,11 @@ class EnglishTest(unittest.TestCase):
 
         date = now - datetime.timedelta(days=300)
         self.assertEqual(locale.format_date(date, full_format=False, shorter=True),
-                         '%s %d' % (locale._months[date.month - 1], date.day))
+                         '{0!s} {1:d}'.format(locale._months[date.month - 1], date.day))
 
         date = now - datetime.timedelta(days=500)
         self.assertEqual(locale.format_date(date, full_format=False, shorter=True),
-                         '%s %d, %d' % (locale._months[date.month - 1], date.day, date.year))
+                         '{0!s} {1:d}, {2:d}'.format(locale._months[date.month - 1], date.day, date.year))
 
     def test_friendly_number(self):
         locale = tornado.locale.get('en_US')

--- a/lib/tornado/test/locks_test.py
+++ b/lib/tornado/test/locks_test.py
@@ -365,15 +365,15 @@ class SemaphoreContextManagerTest(AsyncTestCase):
         @gen.coroutine
         def f(index):
             with (yield sem.acquire()):
-                history.append('acquired %d' % index)
+                history.append('acquired {0:d}'.format(index))
                 yield gen.sleep(0.01)
-                history.append('release %d' % index)
+                history.append('release {0:d}'.format(index))
 
         yield [f(i) for i in range(2)]
 
         expected_history = []
         for i in range(2):
-            expected_history.extend(['acquired %d' % i, 'release %d' % i])
+            expected_history.extend(['acquired {0:d}'.format(i), 'release {0:d}'.format(i)])
 
         self.assertEqual(expected_history, history)
 

--- a/lib/tornado/test/log_test.py
+++ b/lib/tornado/test/log_test.py
@@ -82,7 +82,7 @@ class LogFormatterTest(unittest.TestCase):
             if m:
                 return m.group(1)
             else:
-                raise Exception("output didn't match regex: %r" % line)
+                raise Exception("output didn't match regex: {0!r}".format(line))
 
     def test_basic_logging(self):
         self.logger.error("foo")
@@ -176,7 +176,7 @@ class LoggingOptionTest(unittest.TestCase):
             [sys.executable, '-c', program] + (args or []),
             stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
         stdout, stderr = proc.communicate()
-        self.assertEqual(proc.returncode, 0, 'process failed: %r' % stdout)
+        self.assertEqual(proc.returncode, 0, 'process failed: {0!r}'.format(stdout))
         return b'hello' in stdout
 
     def test_default(self):

--- a/lib/tornado/test/process_test.py
+++ b/lib/tornado/test/process_test.py
@@ -66,7 +66,7 @@ class ProcessTest(unittest.TestCase):
             sock, port = bind_unused_port()
 
             def get_url(path):
-                return "http://127.0.0.1:%d%s" % (port, path)
+                return "http://127.0.0.1:{0:d}{1!s}".format(port, path)
             # ensure that none of these processes live too long
             signal.alarm(5)  # master process
             try:

--- a/lib/tornado/test/runtests.py
+++ b/lib/tornado/test/runtests.py
@@ -66,8 +66,8 @@ class TornadoTextTestRunner(unittest.TextTestRunner):
         if result.skipped:
             skip_reasons = set(reason for (test, reason) in result.skipped)
             self.stream.write(textwrap.fill(
-                "Some tests were skipped because: %s" %
-                ", ".join(sorted(skip_reasons))))
+                "Some tests were skipped because: {0!s}".format(
+                ", ".join(sorted(skip_reasons)))))
             self.stream.write("\n")
         return result
 

--- a/lib/tornado/test/simple_httpclient_test.py
+++ b/lib/tornado/test/simple_httpclient_test.py
@@ -80,7 +80,7 @@ class NoContentHandler(RequestHandler):
 class SeeOtherPostHandler(RequestHandler):
     def post(self):
         redirect_code = int(self.request.body)
-        assert redirect_code in (302, 303), "unexpected body %r" % self.request.body
+        assert redirect_code in (302, 303), "unexpected body {0!r}".format(self.request.body)
         self.set_header("Location", "/see_other_get")
         self.set_status(redirect_code)
 
@@ -88,7 +88,7 @@ class SeeOtherPostHandler(RequestHandler):
 class SeeOtherGetHandler(RequestHandler):
     def get(self):
         if self.request.body:
-            raise Exception("unexpected body %r" % self.request.body)
+            raise Exception("unexpected body {0!r}".format(self.request.body))
         self.write("ok")
 
 
@@ -227,7 +227,7 @@ class SimpleHTTPClientTestMixin(object):
 
     def test_see_other_redirect(self):
         for code in (302, 303):
-            response = self.fetch("/see_other_post", method="POST", body="%d" % code)
+            response = self.fetch("/see_other_post", method="POST", body="{0:d}".format(code))
             self.assertEqual(200, response.code)
             self.assertTrue(response.request.url.endswith("/see_other_post"))
             self.assertTrue(response.effective_url.endswith("/see_other_get"))
@@ -262,7 +262,7 @@ class SimpleHTTPClientTestMixin(object):
                 # interface, so skip this test.
                 return
             raise
-        url = '%s://[::1]:%d/hello' % (self.get_protocol(), port)
+        url = '{0!s}://[::1]:{1:d}/hello'.format(self.get_protocol(), port)
 
         # ipv6 is currently enabled by default but can be disabled
         self.http_client.fetch(url, self.stop, allow_ipv6=False)
@@ -326,7 +326,7 @@ class SimpleHTTPClientTestMixin(object):
         cleanup_func, port = refusing_port()
         self.addCleanup(cleanup_func)
         with ExpectLog(gen_log, ".*", required=False):
-            self.http_client.fetch("http://127.0.0.1:%d/" % port, self.stop)
+            self.http_client.fetch("http://127.0.0.1:{0:d}/".format(port), self.stop)
             response = self.wait()
         self.assertEqual(599, response.code)
 
@@ -572,7 +572,7 @@ class HostnameMappingTestCase(AsyncHTTPTestCase):
 
     def test_hostname_mapping(self):
         self.http_client.fetch(
-            'http://www.example.com:%d/hello' % self.get_http_port(), self.stop)
+            'http://www.example.com:{0:d}/hello'.format(self.get_http_port()), self.stop)
         response = self.wait()
         response.rethrow()
         self.assertEqual(response.body, b'Hello world!')

--- a/lib/tornado/test/twisted_test.py
+++ b/lib/tornado/test/twisted_test.py
@@ -474,32 +474,32 @@ class CompatibilityTests(unittest.TestCase):
     def testTwistedServerTornadoClientIOLoop(self):
         self.start_twisted_server()
         response = self.tornado_fetch(
-            'http://127.0.0.1:%d' % self.twisted_port, self.run_ioloop)
+            'http://127.0.0.1:{0:d}'.format(self.twisted_port), self.run_ioloop)
         self.assertEqual(response.body, 'Hello from twisted!')
 
     def testTwistedServerTornadoClientReactor(self):
         self.start_twisted_server()
         response = self.tornado_fetch(
-            'http://127.0.0.1:%d' % self.twisted_port, self.run_reactor)
+            'http://127.0.0.1:{0:d}'.format(self.twisted_port), self.run_reactor)
         self.assertEqual(response.body, 'Hello from twisted!')
 
     def testTornadoServerTwistedClientIOLoop(self):
         self.start_tornado_server()
         response = self.twisted_fetch(
-            'http://127.0.0.1:%d' % self.tornado_port, self.run_ioloop)
+            'http://127.0.0.1:{0:d}'.format(self.tornado_port), self.run_ioloop)
         self.assertEqual(response, 'Hello from tornado!')
 
     def testTornadoServerTwistedClientReactor(self):
         self.start_tornado_server()
         response = self.twisted_fetch(
-            'http://127.0.0.1:%d' % self.tornado_port, self.run_reactor)
+            'http://127.0.0.1:{0:d}'.format(self.tornado_port), self.run_reactor)
         self.assertEqual(response, 'Hello from tornado!')
 
     @skipIfNoSingleDispatch
     def testTornadoServerTwistedCoroutineClientIOLoop(self):
         self.start_tornado_server()
         response = self.twisted_coroutine_fetch(
-            'http://127.0.0.1:%d' % self.tornado_port, self.run_ioloop)
+            'http://127.0.0.1:{0:d}'.format(self.tornado_port), self.run_ioloop)
         self.assertEqual(response, 'Hello from tornado!')
 
 

--- a/lib/tornado/test/websocket_test.py
+++ b/lib/tornado/test/websocket_test.py
@@ -92,7 +92,7 @@ class WebSocketBaseTestCase(AsyncHTTPTestCase):
     @gen.coroutine
     def ws_connect(self, path, compression_options=None):
         ws = yield websocket_connect(
-            'ws://127.0.0.1:%d%s' % (self.get_http_port(), path),
+            'ws://127.0.0.1:{0:d}{1!s}'.format(self.get_http_port(), path),
             compression_options=compression_options)
         raise gen.Return(ws)
 
@@ -137,7 +137,7 @@ class WebSocketTest(WebSocketBaseTestCase):
 
     def test_websocket_callbacks(self):
         websocket_connect(
-            'ws://127.0.0.1:%d/echo' % self.get_http_port(),
+            'ws://127.0.0.1:{0:d}/echo'.format(self.get_http_port()),
             io_loop=self.io_loop, callback=self.stop)
         ws = self.wait().result()
         ws.write_message('hello')
@@ -191,14 +191,14 @@ class WebSocketTest(WebSocketBaseTestCase):
         with self.assertRaises(IOError):
             with ExpectLog(gen_log, ".*"):
                 yield websocket_connect(
-                    'ws://127.0.0.1:%d/' % port,
+                    'ws://127.0.0.1:{0:d}/'.format(port),
                     io_loop=self.io_loop,
                     connect_timeout=3600)
 
     @gen_test
     def test_websocket_close_buffered_data(self):
         ws = yield websocket_connect(
-            'ws://127.0.0.1:%d/echo' % self.get_http_port())
+            'ws://127.0.0.1:{0:d}/echo'.format(self.get_http_port()))
         ws.write_message('hello')
         ws.write_message('world')
         # Close the underlying stream.
@@ -209,7 +209,7 @@ class WebSocketTest(WebSocketBaseTestCase):
     def test_websocket_headers(self):
         # Ensure that arbitrary headers can be passed through websocket_connect.
         ws = yield websocket_connect(
-            HTTPRequest('ws://127.0.0.1:%d/header' % self.get_http_port(),
+            HTTPRequest('ws://127.0.0.1:{0:d}/header'.format(self.get_http_port()),
                         headers={'X-Test': 'hello'}))
         response = yield ws.read_message()
         self.assertEqual(response, 'hello')
@@ -251,8 +251,8 @@ class WebSocketTest(WebSocketBaseTestCase):
     def test_check_origin_valid_no_path(self):
         port = self.get_http_port()
 
-        url = 'ws://127.0.0.1:%d/echo' % port
-        headers = {'Origin': 'http://127.0.0.1:%d' % port}
+        url = 'ws://127.0.0.1:{0:d}/echo'.format(port)
+        headers = {'Origin': 'http://127.0.0.1:{0:d}'.format(port)}
 
         ws = yield websocket_connect(HTTPRequest(url, headers=headers),
                                      io_loop=self.io_loop)
@@ -265,8 +265,8 @@ class WebSocketTest(WebSocketBaseTestCase):
     def test_check_origin_valid_with_path(self):
         port = self.get_http_port()
 
-        url = 'ws://127.0.0.1:%d/echo' % port
-        headers = {'Origin': 'http://127.0.0.1:%d/something' % port}
+        url = 'ws://127.0.0.1:{0:d}/echo'.format(port)
+        headers = {'Origin': 'http://127.0.0.1:{0:d}/something'.format(port)}
 
         ws = yield websocket_connect(HTTPRequest(url, headers=headers),
                                      io_loop=self.io_loop)
@@ -279,8 +279,8 @@ class WebSocketTest(WebSocketBaseTestCase):
     def test_check_origin_invalid_partial_url(self):
         port = self.get_http_port()
 
-        url = 'ws://127.0.0.1:%d/echo' % port
-        headers = {'Origin': '127.0.0.1:%d' % port}
+        url = 'ws://127.0.0.1:{0:d}/echo'.format(port)
+        headers = {'Origin': '127.0.0.1:{0:d}'.format(port)}
 
         with self.assertRaises(HTTPError) as cm:
             yield websocket_connect(HTTPRequest(url, headers=headers),
@@ -291,7 +291,7 @@ class WebSocketTest(WebSocketBaseTestCase):
     def test_check_origin_invalid(self):
         port = self.get_http_port()
 
-        url = 'ws://127.0.0.1:%d/echo' % port
+        url = 'ws://127.0.0.1:{0:d}/echo'.format(port)
         # Host is 127.0.0.1, which should not be accessible from some other
         # domain
         headers = {'Origin': 'http://somewhereelse.com'}
@@ -306,7 +306,7 @@ class WebSocketTest(WebSocketBaseTestCase):
     def test_check_origin_invalid_subdomains(self):
         port = self.get_http_port()
 
-        url = 'ws://localhost:%d/echo' % port
+        url = 'ws://localhost:{0:d}/echo'.format(port)
         # Subdomains should be disallowed by default.  If we could pass a
         # resolver to websocket_connect we could test sibling domains as well.
         headers = {'Origin': 'http://subtenant.localhost'}

--- a/lib/tornado/testing.py
+++ b/lib/tornado/testing.py
@@ -122,8 +122,8 @@ class _TestMethodWrapper(object):
             raise TypeError("Generator test methods should be decorated with "
                             "tornado.testing.gen_test")
         elif result is not None:
-            raise ValueError("Return value from test method ignored: %r" %
-                             result)
+            raise ValueError("Return value from test method ignored: {0!r}".format(
+                             result))
 
     def __getattr__(self, name):
         """Proxy all unknown attributes to the original method.
@@ -300,8 +300,8 @@ class AsyncTestCase(unittest.TestCase):
                 def timeout_func():
                     try:
                         raise self.failureException(
-                            'Async operation timed out after %s seconds' %
-                            timeout)
+                            'Async operation timed out after {0!s} seconds'.format(
+                            timeout))
                     except Exception:
                         self.__failure = sys.exc_info()
                     self.stop()
@@ -398,7 +398,7 @@ class AsyncHTTPTestCase(AsyncTestCase):
 
     def get_url(self, path):
         """Returns an absolute url for the given path on the test server."""
-        return '%s://localhost:%s%s' % (self.get_protocol(),
+        return '{0!s}://localhost:{1!s}{2!s}'.format(self.get_protocol(),
                                         self.get_http_port(), path)
 
     def tearDown(self):

--- a/lib/tornado/util.py
+++ b/lib/tornado/util.py
@@ -126,7 +126,7 @@ def import_object(name):
     try:
         return getattr(obj, parts[-1])
     except AttributeError:
-        raise ImportError("No module named %s" % parts[-1])
+        raise ImportError("No module named {0!s}".format(parts[-1]))
 
 
 # Deprecated alias that was used before we dropped py25 support.
@@ -250,7 +250,7 @@ class Configurable(object):
         if isinstance(impl, (unicode_type, bytes)):
             impl = import_object(impl)
         if impl is not None and not issubclass(impl, cls):
-            raise ValueError("Invalid subclass of %s" % cls)
+            raise ValueError("Invalid subclass of {0!s}".format(cls))
         base.__impl_class = impl
         base.__impl_kwargs = kwargs
 

--- a/lib/tornado/web.py
+++ b/lib/tornado/web.py
@@ -280,7 +280,7 @@ class RequestHandler(object):
     def clear(self):
         """Resets all headers and content for this response."""
         self._headers = httputil.HTTPHeaders({
-            "Server": "TornadoServer/%s" % tornado.version,
+            "Server": "TornadoServer/{0!s}".format(tornado.version),
             "Content-Type": "text/html; charset=UTF-8",
             "Date": httputil.format_timestamp(time.time()),
         })
@@ -360,7 +360,7 @@ class RequestHandler(object):
         elif isinstance(value, datetime.datetime):
             return httputil.format_timestamp(value)
         else:
-            raise TypeError("Unsupported header value %r" % value)
+            raise TypeError("Unsupported header value {0!r}".format(value))
         # If \n is allowed into the header, it is possible to inject
         # additional headers or split the request. Also cap length to
         # prevent obviously erroneous values.
@@ -492,8 +492,7 @@ class RequestHandler(object):
         try:
             return _unicode(value)
         except UnicodeDecodeError:
-            raise HTTPError(400, "Invalid unicode in %s: %r" %
-                            (name or "url", value[:40]))
+            raise HTTPError(400, "Invalid unicode in {0!s}: {1!r}".format(name or "url", value[:40]))
 
     @property
     def cookies(self):
@@ -521,7 +520,7 @@ class RequestHandler(object):
         value = escape.native_str(value)
         if re.search(r"[\x00-\x20]", name + value):
             # Don't let us accidentally inject bad stuff
-            raise ValueError("Invalid cookie %r: %r" % (name, value))
+            raise ValueError("Invalid cookie {0!r}: {1!r}".format(name, value))
         if not hasattr(self, "_new_cookie"):
             self._new_cookie = Cookie.SimpleCookie()
         if name in self._new_cookie:
@@ -1308,7 +1307,7 @@ class RequestHandler(object):
         hasher = hashlib.sha1()
         for part in self._write_buffer:
             hasher.update(part)
-        return '"%s"' % hasher.hexdigest()
+        return '"{0!s}"'.format(hasher.hexdigest())
 
     def set_etag_header(self):
         """Sets the response's Etag header using ``self.compute_etag()``.
@@ -1391,7 +1390,7 @@ class RequestHandler(object):
             if is_future(result):
                 result = yield result
             if result is not None:
-                raise TypeError("Expected None, got %r" % result)
+                raise TypeError("Expected None, got {0!r}".format(result))
             if self._prepared_future is not None:
                 # Tell the Application we've finished with prepare()
                 # and are ready for the body to arrive.
@@ -1414,7 +1413,7 @@ class RequestHandler(object):
             if is_future(result):
                 result = yield result
             if result is not None:
-                raise TypeError("Expected None, got %r" % result)
+                raise TypeError("Expected None, got {0!r}".format(result))
             if self._auto_finish and not self._finished:
                 self.finish()
         except Exception as e:
@@ -1446,7 +1445,7 @@ class RequestHandler(object):
         self.application.log_request(self)
 
     def _request_summary(self):
-        return "%s %s (%s)" % (self.request.method, self.request.uri,
+        return "{0!s} {1!s} ({2!s})".format(self.request.method, self.request.uri,
                                self.request.remote_ip)
 
     def _handle_request_exception(self, e):
@@ -1884,7 +1883,7 @@ class Application(httputil.HTTPServerConnectionDelegate):
         """
         if name in self.named_handlers:
             return self.named_handlers[name].reverse(*args)
-        raise KeyError("%s not found in named urls" % name)
+        raise KeyError("{0!s} not found in named urls".format(name))
 
     def log_request(self, handler):
         """Writes a completed HTTP request to the logs.
@@ -1939,8 +1938,7 @@ class _RequestDispatcher(httputil.HTTPMessageDelegate):
         handlers = app._get_host_handlers(self.request)
         if not handlers:
             self.handler_class = RedirectHandler
-            self.handler_kwargs = dict(url="%s://%s/"
-                                       % (self.request.protocol,
+            self.handler_kwargs = dict(url="{0!s}://{1!s}/".format(self.request.protocol,
                                           app.default_host))
             return
         for spec in handlers:
@@ -2052,7 +2050,7 @@ class HTTPError(Exception):
             self.log_message = log_message.replace('%', '%%')
 
     def __str__(self):
-        message = "HTTP %d: %s" % (
+        message = "HTTP {0:d}: {1!s}".format(
             self.status_code,
             self.reason or httputil.responses.get(self.status_code, 'Unknown'))
         if self.log_message:
@@ -2090,7 +2088,7 @@ class MissingArgumentError(HTTPError):
     """
     def __init__(self, arg_name):
         super(MissingArgumentError, self).__init__(
-            400, 'Missing argument %s' % arg_name)
+            400, 'Missing argument {0!s}'.format(arg_name))
         self.arg_name = arg_name
 
 
@@ -2239,7 +2237,7 @@ class StaticFileHandler(RequestHandler):
                 # content, or when a suffix with length 0 is specified
                 self.set_status(416)  # Range Not Satisfiable
                 self.set_header("Content-Type", "text/plain")
-                self.set_header("Content-Range", "bytes */%s" % (size, ))
+                self.set_header("Content-Range", "bytes */{0!s}".format(size ))
                 return
             if start is not None and start < 0:
                 start += size
@@ -2293,7 +2291,7 @@ class StaticFileHandler(RequestHandler):
         version_hash = self._get_cached_version(self.absolute_path)
         if not version_hash:
             return None
-        return '"%s"' % (version_hash, )
+        return '"{0!s}"'.format(version_hash )
 
     def set_headers(self):
         """Sets the content and caching headers on the response.
@@ -2541,7 +2539,7 @@ class StaticFileHandler(RequestHandler):
         if not version_hash:
             return url
 
-        return '%s?v=%s' % (url, version_hash)
+        return '{0!s}?v={1!s}'.format(url, version_hash)
 
     def parse_url_path(self, url_path):
         """Converts a static URL path into a filesystem path.
@@ -2917,8 +2915,7 @@ class URLSpec(object):
         self._path, self._group_count = self._find_groups()
 
     def __repr__(self):
-        return '%s(%r, %s, kwargs=%r, name=%r)' % \
-            (self.__class__.__name__, self.regex.pattern,
+        return '{0!s}({1!r}, {2!s}, kwargs={3!r}, name={4!r})'.format(self.__class__.__name__, self.regex.pattern,
              self.handler_class, self.kwargs, self.name)
 
     def _find_groups(self):
@@ -3011,7 +3008,7 @@ def create_signed_value(secret, name, value, version=None, clock=None,
         # - value (base64-encoded)
         # - signature (hex-encoded; no length prefix)
         def format_field(s):
-            return utf8("%d:" % len(s)) + utf8(s)
+            return utf8("{0:d}:".format(len(s))) + utf8(s)
         to_sign = b"|".join([
             b"2",
             format_field(str(key_version or 0)),
@@ -3028,7 +3025,7 @@ def create_signed_value(secret, name, value, version=None, clock=None,
         signature = _create_signature_v2(secret, to_sign)
         return to_sign + signature
     else:
-        raise ValueError("Unsupported version %d" % version)
+        raise ValueError("Unsupported version {0:d}".format(version))
 
 # A leading version number in decimal
 # with no leading zeros, followed by a pipe.
@@ -3065,7 +3062,7 @@ def decode_signed_value(secret, name, value, max_age_days=31,
     if min_version is None:
         min_version = DEFAULT_SIGNED_VALUE_MIN_VERSION
     if min_version > 2:
-        raise ValueError("Unsupported min_version %d" % min_version)
+        raise ValueError("Unsupported min_version {0:d}".format(min_version))
     if not value:
         return None
 

--- a/lib/tornado/websocket.py
+++ b/lib/tornado/websocket.py
@@ -557,8 +557,7 @@ class WebSocketProtocol13(WebSocketProtocol):
             selected = self.handler.select_subprotocol(subprotocols)
             if selected:
                 assert selected in subprotocols
-                subprotocol_header = ("Sec-WebSocket-Protocol: %s\r\n"
-                                      % selected)
+                subprotocol_header = ("Sec-WebSocket-Protocol: {0!s}\r\n".format(selected))
 
         extension_header = ''
         extensions = self._parse_extensions_header(self.request.headers)
@@ -573,9 +572,9 @@ class WebSocketProtocol13(WebSocketProtocol):
                     # Don't echo an offered client_max_window_bits
                     # parameter with no value.
                     del ext[1]['client_max_window_bits']
-                extension_header = ('Sec-WebSocket-Extensions: %s\r\n' %
+                extension_header = ('Sec-WebSocket-Extensions: {0!s}\r\n'.format(
                                     httputil._encode_header(
-                                        'permessage-deflate', ext[1]))
+                                        'permessage-deflate', ext[1])))
                 break
 
         if self.stream.closed():
@@ -640,7 +639,7 @@ class WebSocketProtocol13(WebSocketProtocol):
                             'client_max_window_bits'])
         for key in agreed_parameters:
             if key not in allowed_keys:
-                raise ValueError("unsupported compression parameter %r" % key)
+                raise ValueError("unsupported compression parameter {0!r}".format(key))
         other_side = 'client' if (side == 'server') else 'server'
         self._compressor = _PerMessageDeflateCompressor(
             **self._get_compressor_options(side, agreed_parameters))

--- a/lib/tornado/wsgi.py
+++ b/lib/tornado/wsgi.py
@@ -111,7 +111,7 @@ class _WSGIConnection(httputil.HTTPConnection):
         else:
             self._expected_content_remaining = None
         self.start_response(
-            '%s %s' % (start_line.code, start_line.reason),
+            '{0!s} {1!s}'.format(start_line.code, start_line.reason),
             [(native_str(k), native_str(v)) for (k, v) in headers.get_all()])
         if chunk is not None:
             self.write(chunk, callback)
@@ -135,8 +135,8 @@ class _WSGIConnection(httputil.HTTPConnection):
         if (self._expected_content_remaining is not None and
                 self._expected_content_remaining != 0):
             self._error = httputil.HTTPOutputError(
-                "Tried to write %d bytes less than Content-Length" %
-                self._expected_content_remaining)
+                "Tried to write {0:d} bytes less than Content-Length".format(
+                self._expected_content_remaining))
             raise self._error
         self._finished = True
 
@@ -295,7 +295,7 @@ class WSGIContainer(object):
             if "content-type" not in header_set:
                 headers.append(("Content-Type", "text/html; charset=UTF-8"))
         if "server" not in header_set:
-            headers.append(("Server", "TornadoServer/%s" % tornado.version))
+            headers.append(("Server", "TornadoServer/{0!s}".format(tornado.version)))
 
         start_line = httputil.ResponseStartLine("HTTP/1.1", status_code, reason)
         header_obj = httputil.HTTPHeaders()

--- a/lib/tvdb_api/tvdb_api.py
+++ b/lib/tvdb_api/tvdb_api.py
@@ -76,7 +76,7 @@ def retry(ExceptionToCheck, tries=4, delay=3, backoff=2, logger=None):
                 try:
                     return f(*args, **kwargs)
                 except ExceptionToCheck, e:
-                    msg = "%s, Retrying in %d seconds..." % (str(e), mdelay)
+                    msg = "{0!s}, Retrying in {1:d} seconds...".format(str(e), mdelay)
                     if logger:
                         logger.warning(msg)
                     else:
@@ -123,7 +123,7 @@ class Show(dict):
         self.data = {}
 
     def __repr__(self):
-        return "<Show %s (containing %s seasons)>" % (
+        return "<Show {0!s} (containing {1!s} seasons)>".format(
             self.data.get(u'seriesname', 'instance'),
             len(self)
         )
@@ -151,16 +151,16 @@ class Show(dict):
         # Data wasn't found, raise appropriate error
         if isinstance(key, int) or key.isdigit():
             # Episode number x was not found
-            raise tvdb_seasonnotfound("Could not find season %s" % (repr(key)))
+            raise tvdb_seasonnotfound("Could not find season {0!s}".format((repr(key))))
         else:
             # If it's not numeric, it must be an attribute name, which
             # doesn't exist, so attribute error.
-            raise tvdb_attributenotfound("Cannot find attribute %s" % (repr(key)))
+            raise tvdb_attributenotfound("Cannot find attribute {0!s}".format((repr(key))))
 
     def airedOn(self, date):
         ret = self.search(str(date), 'firstaired')
         if len(ret) == 0:
-            raise tvdb_episodenotfound("Could not find any episodes that aired on %s" % date)
+            raise tvdb_episodenotfound("Could not find any episodes that aired on {0!s}".format(date))
         return ret
 
     def search(self, term=None, key=None):
@@ -230,9 +230,9 @@ class Season(dict):
         self.show = show
 
     def __repr__(self):
-        return "<Season instance (containing %s episodes)>" % (
+        return "<Season instance (containing {0!s} episodes)>".format((
             len(self.keys())
-        )
+        ))
 
     def __getattr__(self, episode_number):
         if episode_number in self:
@@ -241,7 +241,7 @@ class Season(dict):
 
     def __getitem__(self, episode_number):
         if episode_number not in self:
-            raise tvdb_episodenotfound("Could not find episode %s" % (repr(episode_number)))
+            raise tvdb_episodenotfound("Could not find episode {0!s}".format((repr(episode_number))))
         else:
             return dict.__getitem__(self, episode_number)
 
@@ -277,9 +277,9 @@ class Episode(dict):
         epno = int(self.get(u'episodenumber', 0))
         epname = self.get(u'episodename')
         if epname is not None:
-            return "<Episode %02dx%02d - %s>" % (seasno, epno, epname)
+            return "<Episode {0:02d}x{1:02d} - {2!s}>".format(seasno, epno, epname)
         else:
-            return "<Episode %02dx%02d>" % (seasno, epno)
+            return "<Episode {0:02d}x{1:02d}>".format(seasno, epno)
 
     def __getattr__(self, key):
         if key in self:
@@ -290,7 +290,7 @@ class Episode(dict):
         try:
             return dict.__getitem__(self, key)
         except KeyError:
-            raise tvdb_attributenotfound("Cannot find attribute %s" % (repr(key)))
+            raise tvdb_attributenotfound("Cannot find attribute {0!s}".format((repr(key))))
 
     def search(self, term=None, key=None):
         """Search episode data for term, if it matches, return the Episode (self).
@@ -344,7 +344,7 @@ class Actor(dict):
     """
 
     def __repr__(self):
-        return "<Actor \"%s\">" % (self.get("name"))
+        return "<Actor \"{0!s}\">".format((self.get("name")))
 
 
 class Tvdb:
@@ -477,7 +477,7 @@ class Tvdb:
             self.config['cache_enabled'] = True
             self.config['cache_location'] = cache
         else:
-            raise ValueError("Invalid value for Cache %r (type was %s)" % (cache, type(cache)))
+            raise ValueError("Invalid value for Cache {0!r} (type was {1!s})".format(cache, type(cache)))
 
         self.config['session'] = requests.Session()
 
@@ -512,7 +512,7 @@ class Tvdb:
             self.config['language'] = 'en'
         else:
             if language not in self.config['valid_languages']:
-                raise ValueError("Invalid language %s, options are: %s" % (
+                raise ValueError("Invalid language {0!s}, options are: {1!s}".format(
                     language, self.config['valid_languages']
                 ))
             else:
@@ -523,32 +523,32 @@ class Tvdb:
         self.config['base_url'] = "http://thetvdb.com"
 
         if self.config['search_all_languages']:
-            self.config['url_getSeries'] = u"%(base_url)s/api/GetSeries.php" % self.config
+            self.config['url_getSeries'] = u"{base_url!s}/api/GetSeries.php".format(**self.config)
             self.config['params_getSeries'] = {"seriesname": "", "language": "all"}
         else:
-            self.config['url_getSeries'] = u"%(base_url)s/api/GetSeries.php" % self.config
+            self.config['url_getSeries'] = u"{base_url!s}/api/GetSeries.php".format(**self.config)
             self.config['params_getSeries'] = {"seriesname": "", "language": self.config['language']}
 
-        self.config['url_epInfo'] = u"%(base_url)s/api/%(apikey)s/series/%%s/all/%%s.xml" % self.config
-        self.config['url_epInfo_zip'] = u"%(base_url)s/api/%(apikey)s/series/%%s/all/%%s.zip" % self.config
+        self.config['url_epInfo'] = u"{base_url!s}/api/{apikey!s}/series/%s/all/%s.xml".format(**self.config)
+        self.config['url_epInfo_zip'] = u"{base_url!s}/api/{apikey!s}/series/%s/all/%s.zip".format(**self.config)
 
-        self.config['url_seriesInfo'] = u"%(base_url)s/api/%(apikey)s/series/%%s/%%s.xml" % self.config
-        self.config['url_actorsInfo'] = u"%(base_url)s/api/%(apikey)s/series/%%s/actors.xml" % self.config
+        self.config['url_seriesInfo'] = u"{base_url!s}/api/{apikey!s}/series/%s/%s.xml".format(**self.config)
+        self.config['url_actorsInfo'] = u"{base_url!s}/api/{apikey!s}/series/%s/actors.xml".format(**self.config)
 
-        self.config['url_seriesBanner'] = u"%(base_url)s/api/%(apikey)s/series/%%s/banners.xml" % self.config
-        self.config['url_artworkPrefix'] = u"%(base_url)s/banners/%%s" % self.config
+        self.config['url_seriesBanner'] = u"{base_url!s}/api/{apikey!s}/series/%s/banners.xml".format(**self.config)
+        self.config['url_artworkPrefix'] = u"{base_url!s}/banners/%s".format(**self.config)
 
-        self.config['url_updates_all'] = u"%(base_url)s/api/%(apikey)s/updates_all.zip" % self.config
-        self.config['url_updates_month'] = u"%(base_url)s/api/%(apikey)s/updates_month.zip" % self.config
-        self.config['url_updates_week'] = u"%(base_url)s/api/%(apikey)s/updates_week.zip" % self.config
-        self.config['url_updates_day'] = u"%(base_url)s/api/%(apikey)s/updates_day.zip" % self.config
+        self.config['url_updates_all'] = u"{base_url!s}/api/{apikey!s}/updates_all.zip".format(**self.config)
+        self.config['url_updates_month'] = u"{base_url!s}/api/{apikey!s}/updates_month.zip".format(**self.config)
+        self.config['url_updates_week'] = u"{base_url!s}/api/{apikey!s}/updates_week.zip".format(**self.config)
+        self.config['url_updates_day'] = u"{base_url!s}/api/{apikey!s}/updates_day.zip".format(**self.config)
 
     def _getTempDir(self):
         """Returns the [system temp dir]/tvdb_api-u501 (or
         tvdb_api-myuser)
         """
         if hasattr(os, 'getuid'):
-            uid = "u%d" % (os.getuid())
+            uid = "u{0:d}".format((os.getuid()))
         else:
             # For Windows
             try:
@@ -556,12 +556,12 @@ class Tvdb:
             except ImportError:
                 return os.path.join(tempfile.gettempdir(), "tvdb_api")
 
-        return os.path.join(tempfile.gettempdir(), "tvdb_api-%s" % (uid))
+        return os.path.join(tempfile.gettempdir(), "tvdb_api-{0!s}".format((uid)))
 
     @retry(tvdb_error)
     def _loadUrl(self, url, params=None, language=None):
         try:
-            log().debug("Retrieving URL %s" % url)
+            log().debug("Retrieving URL {0!s}".format(url))
 
             # get response from TVDB
             if self.config['cache_enabled']:
@@ -569,7 +569,7 @@ class Tvdb:
                 # session = CacheControl(sess=self.config['session'], cache=caches.FileCache(self.config['cache_location'], use_dir_lock=True), cache_etags=False)
                 session = self.config['session']
                 if self.config['proxy']:
-                    log().debug("Using proxy for URL: %s" % url)
+                    log().debug("Using proxy for URL: {0!s}".format(url))
                     session.proxies = {
                         "http": self.config['proxy'],
                         "https": self.config['proxy'],
@@ -618,7 +618,7 @@ class Tvdb:
                 zipdata = StringIO.StringIO()
                 zipdata.write(resp.content)
                 myzipfile = zipfile.ZipFile(zipdata)
-                return xmltodict.parse(myzipfile.read('%s.xml' % language), postprocessor=process)
+                return xmltodict.parse(myzipfile.read('{0!s}.xml'.format(language)), postprocessor=process)
             except zipfile.BadZipfile:
                 raise tvdb_error("Bad zip file received from thetvdb.com, could not read it")
         else:
@@ -682,7 +682,7 @@ class Tvdb:
         and returns the result list
         """
         series = series.encode("utf-8")
-        log().debug("Searching for show %s" % series)
+        log().debug("Searching for show {0!s}".format(series))
         self.config['params_getSeries']['seriesname'] = series
 
         results = self._getetsrc(self.config['url_getSeries'], self.config['params_getSeries'])
@@ -706,7 +706,7 @@ class Tvdb:
             allSeries = [allSeries]
 
         if self.config['custom_ui'] is not None:
-            log().debug("Using custom UI %s" % (repr(self.config['custom_ui'])))
+            log().debug("Using custom UI {0!s}".format((repr(self.config['custom_ui']))))
             CustomUI = self.config['custom_ui']
             ui = CustomUI(config=self.config)
         else:
@@ -737,7 +737,7 @@ class Tvdb:
 
         This interface will be improved in future versions.
         """
-        log().debug('Getting season banners for %s' % (sid))
+        log().debug('Getting season banners for {0!s}'.format((sid)))
         bannersEt = self._getetsrc(self.config['url_seriesBanner'] % (sid))
 
         if not bannersEt:
@@ -767,8 +767,8 @@ class Tvdb:
 
             for k, v in banners[btype][btype2][bid].items():
                 if k.endswith("path"):
-                    new_key = "_%s" % (k)
-                    log().debug("Transforming %s to %s" % (k, new_key))
+                    new_key = "_{0!s}".format((k))
+                    log().debug("Transforming {0!s} to {1!s}".format(k, new_key))
                     new_url = self.config['url_artworkPrefix'] % (v)
                     banners[btype][btype2][bid][new_key] = new_url
 
@@ -798,7 +798,7 @@ class Tvdb:
         Any key starting with an underscore has been processed (not the raw
         data from the XML)
         """
-        log().debug("Getting actors for %s" % (sid))
+        log().debug("Getting actors for {0!s}".format((sid)))
         actorsEt = self._getetsrc(self.config['url_actorsInfo'] % (sid))
 
         if not actorsEt:
@@ -835,7 +835,7 @@ class Tvdb:
             getShowInLanguage = language
         else:
             log().debug(
-                'Configured language %s override show language of %s' % (
+                'Configured language {0!s} override show language of {1!s}'.format(
                     self.config['language'],
                     language
                 )
@@ -843,7 +843,7 @@ class Tvdb:
             getShowInLanguage = self.config['language']
 
         # Parse show information
-        log().debug('Getting all series data for %s' % (sid))
+        log().debug('Getting all series data for {0!s}'.format((sid)))
         seriesInfoEt = self._getetsrc(
             self.config['url_seriesInfo'] % (sid, getShowInLanguage)
         )
@@ -873,7 +873,7 @@ class Tvdb:
                 self._parseActors(sid)
 
             # Parse episode data
-            log().debug('Getting all episodes of %s' % (sid))
+            log().debug('Getting all episodes of {0!s}'.format((sid)))
             if self.config['useZip']:
                 url = self.config['url_epInfo_zip'] % (sid, language)
             else:
@@ -904,7 +904,7 @@ class Tvdb:
                     seasnum, epno = cur_ep['seasonnumber'], cur_ep['episodenumber']
 
                 if seasnum is None or epno is None:
-                    log().warning("An episode has incomplete season/episode number (season: %r, episode: %r)" % (
+                    log().warning("An episode has incomplete season/episode number (season: {0!r}, episode: {1!r})".format(
                         seasnum, epno))
                     continue  # Skip to next episode
 
@@ -931,10 +931,10 @@ class Tvdb:
         the correct SID.
         """
         if name in self.corrections:
-            log().debug('Correcting %s to %s' % (name, self.corrections[name]))
+            log().debug('Correcting {0!s} to {1!s}'.format(name, self.corrections[name]))
             return self.corrections[name]
         else:
-            log().debug('Getting show %s' % (name))
+            log().debug('Getting show {0!s}'.format((name)))
             selected_series = self._getSeries(name)
             if isinstance(selected_series, dict):
                 selected_series = [selected_series]

--- a/lib/tvdb_api/tvdb_cache.py
+++ b/lib/tvdb_api/tvdb_cache.py
@@ -187,7 +187,7 @@ class CachedResponse(StringIO.StringIO):
         self.msg     = "OK"
         headerbuf = file(hpath, "rb").read()
         if set_cache_header:
-            headerbuf += "x-local-cache: %s\r\n" % (bpath)
+            headerbuf += "x-local-cache: {0!s}\r\n".format((bpath))
         self.headers = httplib.HTTPMessage(StringIO.StringIO(headerbuf))
 
     def info(self):

--- a/lib/tvdb_api/tvdb_ui.py
+++ b/lib/tvdb_api/tvdb_ui.py
@@ -83,13 +83,13 @@ class ConsoleUI(BaseUI):
         print "TVDB Search Results:"
         for i, cshow in enumerate(toshow):
             i_show = i + 1 # Start at more human readable number 1 (not 0)
-            log().debug('Showing allSeries[%s], series %s)' % (i_show, allSeries[i]['seriesname']))
+            log().debug('Showing allSeries[{0!s}], series {1!s})'.format(i_show, allSeries[i]['seriesname']))
             if i == 0:
                 extra = " (default)"
             else:
                 extra = ""
 
-            print "%s -> %s [%s] # http://thetvdb.com/?tab=series&id=%s&lid=%s%s" % (
+            print "{0!s} -> {1!s} [{2!s}] # http://thetvdb.com/?tab=series&id={3!s}&lid={4!s}{5!s}".format(
                 i_show,
                 cshow['seriesname'].encode("UTF-8", "ignore"),
                 cshow['language'].encode("UTF-8", "ignore"),
@@ -119,7 +119,7 @@ class ConsoleUI(BaseUI):
             except EOFError:
                 raise tvdb_userabort("User aborted (EOF received)")
 
-            log().debug('Got choice of: %s' % (ans))
+            log().debug('Got choice of: {0!s}'.format((ans)))
             try:
                 selected_id = int(ans) - 1 # The human entered 1 as first result, not zero
             except ValueError: # Input was not number
@@ -141,9 +141,9 @@ class ConsoleUI(BaseUI):
                 elif ans.lower() in ["a", "all"]:
                     self._displaySeries(allSeries, limit = None)
                 else:
-                    log().debug('Unknown keypress %s' % (ans))
+                    log().debug('Unknown keypress {0!s}'.format((ans)))
             else:
-                log().debug('Trying to return ID: %d' % (selected_id))
+                log().debug('Trying to return ID: {0:d}'.format((selected_id)))
                 try:
                     return allSeries[selected_id]
                 except IndexError:

--- a/lib/unidecode/__init__.py
+++ b/lib/unidecode/__init__.py
@@ -50,7 +50,7 @@ def unidecode(string):
             table = Cache[section]
         except KeyError:
             try:
-                mod = __import__('unidecode.x%03x'%(section), [], [], ['data'])
+                mod = __import__('unidecode.x{0:03x}'.format((section)), [], [], ['data'])
             except ImportError:
                 Cache[section] = None
                 continue   # No match: ignore this character and carry on.

--- a/lib/unrar2/__init__.py
+++ b/lib/unrar2/__init__.py
@@ -80,7 +80,7 @@ class RarInfo(object):
             arcName = self.rarfile.archiveName
         except ReferenceError:
             arcName = "[ARCHIVE_NO_LONGER_LOADED]"
-        return '<RarInfo "%s" in "%s">' % (self.filename, arcName)
+        return '<RarInfo "{0!s}" in "{1!s}">'.format(self.filename, arcName)
 
 class RarFile(RarFileImplementation):
 


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:SickRage:SickRage?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:SickRage:SickRage?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
