### PR TITLE
Fix web_root prepend for redirects.

### DIFF
--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -234,7 +234,7 @@ class BaseHandler(RequestHandler):
         """
         from tornado.escape import utf8
         if not url.startswith(sickbeard.WEB_ROOT):
-            url = urljoin(sickbeard.WEB_ROOT, url)
+            url = sickbeard.WEB_ROOT + url
 
         if self._headers_written:
             raise Exception("Cannot redirect after headers have been written")


### PR DESCRIPTION
Proposed changes in this pull request:
- urljoin does not work with relative urls, revert back to using WEB_ROOT + url.

```
Python 2.7.10 (default, Nov  9 2015, 03:16:38) 
[GCC 4.8.4] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import urlparse
>>> print urlparse.urljoin("/sickrage", "/manage/manageSearches/")
/manage/manageSearches/
>>> print urlparse.urljoin("/sickrage/", "/manage/manageSearches/")
/manage/manageSearches/
```
