### PR TITLE
fixed up test connection error for transmission because of a 409 HTTP…

### DIFF
--- a/sickbeard/clients/transmission_client.py
+++ b/sickbeard/clients/transmission_client.py
@@ -21,7 +21,9 @@
 import os
 import re
 import json
+
 from base64 import b64encode
+from requests.models import HTTPError
 
 import sickbeard
 from sickbeard.clients.generic import GenericClient
@@ -162,6 +164,28 @@ class TransmissionAPI(GenericClient):
         self._request(method='post', data=post_data)
 
         return self.response.json()['result'] == "success"
+
+    def testAuthentication(self):                                                                                                                             
+        """                                                                                                                                                   
+        Tests the parameters the user has provided in the ui to see if they are correct                                                                       
+        """                                                                                                                                                   
+        try:                                                                                                                                                  
+            self.response = self.session.get(self.url, timeout=120, verify=False)                                                                             
+                                                                                                                                                              
+            if self.response.status_code != 409:                                                                                                              
+                self.response.raise_for_status()                                                                                                              
+        except HTTPError as error:                                                                                                                            
+            helpers.handle_requests_exception(error)                                                                                                          
+            return False, '{0}'.format(error)                                                                                                                 
+                                                                                                                                                              
+        try:                                                                                                                                                  
+            self._get_auth()                                                                                                                                  
+            self.response.raise_for_status()                                                                                                                  
+            return True, 'Success: Connected and Authenticated'                                                                                               
+        except Exception:                                                                                                                                     
+            helpers.handle_requests_exception(error)                                                                                                          
+            return False, '{0}'.format(error) 
+
 
 
 api = TransmissionAPI()


### PR DESCRIPTION
Fixes #
Transmission v2.84 (at least) sends a 409 HTTP status code when it requests a x-transmission-session-id, this cause a bug that would fail the transmission connection test.

Proposed changes in this pull request:
- check for a 409 error and do not throw exception continue with authentication
- changed exception catch to the specific HTTPError exception to be more explicit instead of just catching any error and failing
- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read [contribution guide](https://github.com/SickRage/SickRage/blob/master/.github/CONTRIBUTING.md)

…Error
