### PR TITLE
Remove nzbToMedia from source control. It auto updates and breaks git…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,7 @@ lib/unrar2/UnRAR.exe
 .tox/
 .coverage
 htmlcov
+
+# nzbToMedia #
+######################
+contrib/nzbToMedia

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "contrib/nzbToMedia"]
-	path = contrib/nzbToMedia
-	url = https://github.com/clinton-hall/nzbToMedia


### PR DESCRIPTION
... pull

@SickRage/collaborators @SickRage/moderators 

This will leave the nzbToMedia repo in contrib/ intact, but no longer track it in our repository.

Since nzbToMedia updates itself, it creates "local changes" to the repository, and this breaks the updater in sickrage

Everyone ok with this?
