### PR TITLE
Added Subtile Provider Cache

### DIFF
--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -5145,6 +5145,8 @@ class ConfigSubtitles(Config):
         sickbeard.OPENSUBTITLES_PASS = opensubtitles_pass or ''
 
         sickbeard.save_config()
+        # Reset provider pool so next time we use the newest settings
+        subtitles.SubtitleProviderPool().reset()
 
         if len(results) > 0:
             for x in results:


### PR DESCRIPTION
I've added a little cache to the subtitle download functions, so the provider won't be reinitialized too many times, which can cause a temporary ban from some provider caused by too many logins.
The cache will discard the pool and reinitialize after 15 minutes, or when the subtitles settings are changed.
- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read [contribution guide](https://github.com/SickRage/SickRage/blob/master/.github/CONTRIBUTING.md)
