### PR TITLE
Make "Available Groups" sort by alphabetical order

### DIFF
--- a/lib/adba/aniDBAbstracter.py
+++ b/lib/adba/aniDBAbstracter.py
@@ -175,7 +175,7 @@ class Anime(aniDBabstractObject):
                                         "rating": line["rating"],
                                         "range": line["episode_range"]
             })
-        return self.release_groups
+        return sorted(self.release_groups)
 
     # TODO: refactor and use the new functions in anidbFileinfo
     def _get_aid_from_xml(self, name):


### PR DESCRIPTION
Feature #

Proposed changes in this pull request:
- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read [contribution guide](https://github.com/SickRage/SickRage/blob/master/.github/CONTRIBUTING.md)

I was annoyed that the anime groups list was not in order. A single function did the job.
It now sorts the groups list in order if it is an anime.
