### PR TITLE
release group sort is now case insensitive

### DIFF
--- a/lib/adba/aniDBAbstracter.py
+++ b/lib/adba/aniDBAbstracter.py
@@ -175,7 +175,7 @@ class Anime(aniDBabstractObject):
                                         "rating": line["rating"],
                                         "range": line["episode_range"]
             })
-        return sorted(self.release_groups)
+        return sorted(self.release_groups, key=lambda x: x['name'].lower())
 
     # TODO: refactor and use the new functions in anidbFileinfo
     def _get_aid_from_xml(self, name):


### PR DESCRIPTION
Proposed changes in this pull request:
- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read [contribution guide](https://github.com/SickRage/SickRage/blob/master/.github/CONTRIBUTING.md)

I found that my initial commit had a bug with release group that start with a lower case.
I now have made it to sort using case insensitive.
