### PR TITLE
qualityFromFileMeta was getting double and triple called...

### DIFF
--- a/sickbeard/common.py
+++ b/sickbeard/common.py
@@ -281,11 +281,14 @@ class Quality(object):
         if quality != Quality.UNKNOWN:
             return quality
 
-        quality = Quality.assumeQuality(name)
+        quality = Quality.qualityFromFileMeta(name)
         if quality != Quality.UNKNOWN:
             return quality
 
-        return Quality.UNKNOWN
+        if name.lower().endswith(".ts"):
+            return Quality.RAWHDTV
+        else:
+            return Quality.UNKNOWN
 
     @staticmethod
     def scene_quality(name, anime=False):  # pylint: disable=too-many-branches, too-many-statements
@@ -372,23 +375,6 @@ class Quality(object):
                 result = Quality.SDTV
 
         return Quality.UNKNOWN if result is None else result
-
-    @staticmethod
-    def assumeQuality(name):
-        """
-        Assume a quality from file extension if we cannot resolve it otherwise
-
-        :param name: File name of episode to analyse
-        :return: Quality prefix
-        """
-        quality = Quality.qualityFromFileMeta(name)
-        if quality != Quality.UNKNOWN:
-            return quality
-
-        if name.lower().endswith(".ts"):
-            return Quality.RAWHDTV
-        else:
-            return Quality.UNKNOWN
 
     @staticmethod
     def qualityFromFileMeta(filename):  # pylint: disable=too-many-branches
@@ -541,19 +527,15 @@ class Quality(object):
             return ""
 
     @staticmethod
-    def statusFromName(name, assume=True, anime=False):
+    def statusFromName(name, anime=False):
         """
         Get a status object from filename
 
         :param name: Filename to check
-        :param assume: boolean to assume quality by extension if we can't figure it out
         :param anime: boolean to enable anime parsing
         :return: Composite status/quality object
         """
-        quality = Quality.nameQuality(name, anime)
-        if assume and quality == Quality.UNKNOWN:
-            quality = Quality.assumeQuality(name)
-        return Quality.compositeStatus(DOWNLOADED, quality)
+        return Quality.compositeStatus(DOWNLOADED, Quality.nameQuality(name, anime))
 
     DOWNLOADED = None
     SNATCHED = None

--- a/sickbeard/databases/mainDB.py
+++ b/sickbeard/databases/mainDB.py
@@ -65,7 +65,7 @@ class MainSanityCheck(db.DBSanityCheck):
             fixedStatus = common.Quality.compositeStatus(common.ARCHIVED, common.Quality.UNKNOWN)
             existing = archivedEp['location'] and ek(os.path.exists, archivedEp['location'])
             if existing:
-                quality = common.Quality.assumeQuality(archivedEp['location'])
+                quality = common.Quality.nameQuality(archivedEp['location'])
                 fixedStatus = common.Quality.compositeStatus(common.ARCHIVED, quality)
 
             logger.log(u'Changing status from {old_status} to {new_status} for {id}: {ep} at {location} (File {result})'.format

--- a/sickbeard/postProcessor.py
+++ b/sickbeard/postProcessor.py
@@ -824,7 +824,7 @@ class PostProcessor(object):  # pylint: disable=too-many-instance-attributes
                 return ep_quality
 
         # Try guessing quality from the file name
-        ep_quality = common.Quality.assumeQuality(self.file_path)
+        ep_quality = common.Quality.nameQuality(self.file_path)
         self._log(
             u"Guessing quality for name " + self.file_name + u", got " + common.Quality.qualityStrings[ep_quality],
             logger.DEBUG)

--- a/sickbeard/tv.py
+++ b/sickbeard/tv.py
@@ -670,7 +670,7 @@ class TVShow(object):  # pylint: disable=too-many-instance-attributes, too-many-
 
             else:
                 # if there is a new file associated with this ep then re-check the quality
-                if not curEp.location or ek(os.path.normpath, curEp.location) != ek(os.path.normpath, filepath):
+                if curEp.location and ek(os.path.normpath, curEp.location) != ek(os.path.normpath, filepath):
                     logger.log(
                         "{0}: The old episode had a different file associated with it, re-checking the quality using the new filename {1}".format
                         (self.indexerid, filepath), logger.DEBUG)
@@ -700,9 +700,9 @@ class TVShow(object):  # pylint: disable=too-many-instance-attributes, too-many-
                 newQuality = Quality.nameQuality(filepath, self.is_anime)
                 logger.log("{0}: Since this file has been renamed, I checked {1} and found quality {2}".format
                            (self.indexerid, filepath, Quality.qualityStrings[newQuality]), logger.DEBUG)
-                if newQuality != Quality.UNKNOWN:
-                    with curEp.lock:
-                        curEp.status = Quality.compositeStatus(DOWNLOADED, newQuality)
+
+                with curEp.lock:
+                    curEp.status = Quality.compositeStatus(DOWNLOADED, newQuality)
 
             # check for status/quality changes as long as it's a new file
             elif not same_file and sickbeard.helpers.isMediaFile(filepath) and curEp.status not in Quality.DOWNLOADED + Quality.ARCHIVED + [IGNORED]:

--- a/sickbeard/tv.py
+++ b/sickbeard/tv.py
@@ -708,8 +708,6 @@ class TVShow(object):  # pylint: disable=too-many-instance-attributes, too-many-
             elif not same_file and sickbeard.helpers.isMediaFile(filepath) and curEp.status not in Quality.DOWNLOADED + Quality.ARCHIVED + [IGNORED]:
                 oldStatus, oldQuality = Quality.splitCompositeStatus(curEp.status)
                 newQuality = Quality.nameQuality(filepath, self.is_anime)
-                if newQuality == Quality.UNKNOWN:
-                    newQuality = Quality.assumeQuality(filepath)
 
                 newStatus = None
 

--- a/tests/common_tests.py
+++ b/tests/common_tests.py
@@ -10,7 +10,6 @@ Classes:
         splitQuality
         nameQuality
         scene_quality
-        assumeQuality
         qualityFromFileMeta
         compositeStatus
         qualityDownloaded
@@ -357,13 +356,6 @@ class QualityTests(unittest.TestCase):
     def test_scene_quality(self):
         """
         Test scene_quality
-        """
-        pass
-
-    @unittest.skip('Not yet implemented')
-    def test_assume_quality(self):
-        """
-        Test assumeQuality
         """
         pass
 


### PR DESCRIPTION
Ugly bug that made qualityFromFileMeta be called more than once, which causes hella stalling on AVI/WMV since hachoir is very slow on them.

Also fix some errors when rescanning and the file has changed or quality cannot be determined that would leave the episode set to whatever status it previously was set to.
