### PR TITLE
Backport glob.escape from python 3.4

### DIFF
--- a/sickbeard/helpers.py
+++ b/sickbeard/helpers.py
@@ -70,11 +70,6 @@ shutil.copyfile = shutil_custom.copyfile_custom
 urllib._urlopener = classes.SickBeardURLopener()
 
 
-def fixGlob(path):
-    path = re.sub(r'\[', '[[]', path)
-    return re.sub(r'(?<!\[)\]', '[]]', path)
-
-
 def indentXML(elem, level=0):
     """
     Does our pretty printing, makes Matt very happy

--- a/sickbeard/tv.py
+++ b/sickbeard/tv.py
@@ -24,7 +24,6 @@ import os.path
 import datetime
 import threading
 import re
-import glob
 import stat
 import traceback
 
@@ -51,6 +50,8 @@ from sickbeard.blackandwhitelist import BlackAndWhiteList
 from sickbeard import network_timezones
 from sickbeard.indexers.indexer_config import INDEXER_TVRAGE
 from sickbeard.name_parser.parser import NameParser, InvalidNameException, InvalidShowException
+
+from sickrage.helper import glob
 from sickrage.helper.common import dateTimeFormat, remove_extension, replace_extension, sanitize_filename, try_int, episode_num
 from sickrage.helper.encoding import ek
 from sickrage.helper.exceptions import EpisodeDeletedException, EpisodeNotFoundException, ex
@@ -986,7 +987,7 @@ class TVShow(object):  # pylint: disable=too-many-instance-attributes, too-many-
 
         # clear the cache
         image_cache_dir = ek(os.path.join, sickbeard.CACHE_DIR, 'images')
-        for cache_file in ek(glob.glob, ek(os.path.join, image_cache_dir, str(self.indexerid) + '.*')):
+        for cache_file in ek(glob.glob, ek(os.path.join, glob.escape(image_cache_dir), str(self.indexerid) + '.*')):
             logger.log('Attempt to {0} cache file {1}'.format(action, cache_file))
             try:
                 if sickbeard.TRASH_REMOVE_SHOW:

--- a/sickbeard/versionChecker.py
+++ b/sickbeard/versionChecker.py
@@ -114,8 +114,8 @@ class CheckVersion(object):
         if not backupDir:
             return False
 
-        import glob
-        files = glob.glob(ek(os.path.join, backupDir, '*.zip'))
+        from sickrage.helper import glob
+        files = glob.glob(ek(os.path.join, glob.escape(backupDir), '*.zip'))
         if not files:
             return True
 

--- a/sickrage/helper/__init__.py
+++ b/sickrage/helper/__init__.py
@@ -1,1 +1,2 @@
 # coding=utf-8
+from common import custom_glob as glob

--- a/sickrage/helper/common.py
+++ b/sickrage/helper/common.py
@@ -20,7 +20,9 @@
 from __future__ import unicode_literals
 
 import io
+import os
 import re
+import glob
 import binascii
 from enzyme import MKV
 from fnmatch import fnmatch
@@ -366,3 +368,25 @@ def mkv_screen_size(filename):
         return mkv.video_tracks[0].width, mkv.video_tracks[0].height
     except Exception:
         return None, None
+
+# Backport glob.escape from python 3.4
+# https://hg.python.org/cpython/file/3.4/Lib/glob.py#l87
+magic_check = re.compile('([*?[])')
+magic_check_bytes = re.compile(b'([*?[])')
+
+
+# https://hg.python.org/cpython/file/3.4/Lib/glob.py#l100
+def glob_escape(pathname):
+    """Escape all special characters.
+    """
+    # Escaping is done by wrapping any of "*?[" between square brackets.
+    # Metacharacters do not work in the drive part and shouldn't be escaped.
+    drive, pathname = os.path.splitdrive(pathname)
+    if isinstance(pathname, bytes):
+        pathname = magic_check_bytes.sub(br'[\1]', pathname)
+    else:
+        pathname = magic_check.sub(r'[\1]', pathname)
+    return drive + pathname
+
+custom_glob = glob
+custom_glob.escape = glob_escape

--- a/tests/helpers_tests.py
+++ b/tests/helpers_tests.py
@@ -22,7 +22,6 @@
 Test sickbeard.helpers
 
 Public Methods:
-    fixGlob
     indentXML
     remove_non_release_groups
     isMediaFile
@@ -598,13 +597,6 @@ class HelpersMiscTests(unittest.TestCase):
     """
     Test misc helper methods
     """
-    @unittest.skip('Not yet implemented')
-    def test_fix_glob(self):
-        """
-        Test fixGlob
-        """
-        pass
-
     @unittest.skip('Not yet implemented')
     def test_indent_xml(self):
         """

--- a/tests/pp_tests.py
+++ b/tests/pp_tests.py
@@ -24,14 +24,17 @@ Test post processing
 import os.path
 import sys
 import unittest
+import shutil
 
 sys.path.insert(1, os.path.abspath(os.path.join(os.path.dirname(__file__), '../lib')))
 sys.path.insert(1, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
+import sickbeard
+from sickbeard.helpers import make_dirs
 from sickbeard.name_cache import addNameToCache
 from sickbeard.postProcessor import PostProcessor
 from sickbeard.tv import TVEpisode, TVShow
-import sickbeard
+
 import tests.test_lib as test
 
 
@@ -83,6 +86,66 @@ class PPBasicTests(test.SickbeardTestDBCase):
         self.assertTrue(post_processor.process())
 
 
+class ListAssociatedFiles(unittest.TestCase):
+    def __init__(self, test_case):
+        super(ListAssociatedFiles, self).__init__(test_case)
+        self.test_tree = os.path.join(u'Show Name', u'associated_files', u'random', u'recursive', u'subdir')
+
+        file_names = [
+            u'Show Name [SickRage].avi',
+            u'Show Name [SickRage].srt',
+            u'Show Name [SickRage].nfo',
+            u'Show Name [SickRage].en.srt'
+        ]
+        self.file_list = [os.path.join(u'Show Name', f) for f in file_names] + [os.path.join(self.test_tree, f) for f in file_names]
+        self.maxDiff = None
+
+    def setUp(self):
+        make_dirs(self.test_tree)
+        for test_file in self.file_list:
+            open(test_file, 'a').close()
+
+    def tearDown(self):
+        shutil.rmtree(u'Show Name')
+
+    # list_associated_files(self, file_path, base_name_only=False, subtitles_only=False, subfolders=False)
+    def test_subfolders(self):
+        post_processor = PostProcessor(self.file_list[0])
+        associated_files = post_processor.list_associated_files(self.file_list[0], subfolders=True)
+
+        associated_files = sorted(file_name.lstrip('./') for file_name in associated_files)
+        out_list = sorted(self.file_list[1:])
+
+        self.assertEqual(out_list, associated_files)
+
+    def test_no_subfolders(self):
+        post_processor = PostProcessor(self.file_list[0])
+        associated_files = post_processor.list_associated_files(self.file_list[0], subfolders=False)
+
+        associated_files = sorted(file_name.lstrip('./') for file_name in associated_files)
+        out_list = sorted(file_name for file_name in self.file_list[1:] if 'associated_files' not in file_name)
+
+        self.assertEqual(out_list, associated_files)
+
+    def test_subtitles_only(self):
+        post_processor = PostProcessor(self.file_list[0])
+        associated_files = post_processor.list_associated_files(self.file_list[0], subtitles_only=True, subfolders=True)
+
+        associated_files = sorted(file_name.lstrip('./') for file_name in associated_files)
+        out_list = sorted(file_name for file_name in self.file_list if file_name.endswith('.srt'))
+
+        self.assertEqual(out_list, associated_files)
+
+    def test_subtitles_only_no_subfolders(self):
+        post_processor = PostProcessor(self.file_list[0])
+        associated_files = post_processor.list_associated_files(self.file_list[0], subtitles_only=True, subfolders=False)
+
+        associated_files = sorted(file_name.lstrip('./') for file_name in associated_files)
+        out_list = sorted(file_name for file_name in self.file_list if file_name.endswith('.srt') and 'associated_files' not in file_name)
+
+        self.assertEqual(out_list, associated_files)
+
+
 if __name__ == '__main__':
     print "=================="
     print "STARTING - PostProcessor TESTS"
@@ -95,4 +158,9 @@ if __name__ == '__main__':
     print "######################################################################"
 
     SUITE = unittest.TestLoader().loadTestsFromTestCase(PPBasicTests)
+    unittest.TextTestRunner(verbosity=2).run(SUITE)
+
+    print "######################################################################"
+
+    SUITE = unittest.TestLoader().loadTestsFromTestCase(ListAssociatedFiles)
     unittest.TextTestRunner(verbosity=2).run(SUITE)

--- a/tests/sickrage_tests/helper/common_tests.py
+++ b/tests/sickrage_tests/helper/common_tests.py
@@ -33,6 +33,7 @@ sys.path.insert(1, os.path.abspath(os.path.join(os.path.dirname(__file__), '../.
 sys.path.insert(1, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../..')))
 
 import sickbeard
+from sickrage.helper import glob
 from sickrage.helper.common import http_code_description, is_sync_file, is_torrent_or_nzb_file, pretty_file_size
 from sickrage.helper.common import remove_extension, replace_extension, sanitize_filename, try_int, convert_size, episode_num
 
@@ -468,6 +469,12 @@ class CommonTests(unittest.TestCase):
 
         # Absolute numbering can't have both season and episode
         self.assertEqual(episode_num(1, 1, numbering='absolute'), None)
+
+    def test_glob_escape(self):
+        self.assertEqual(glob.escape('S01E01 - Show Name [SickRage].avi'), 'S01E01 - Show Name [[]SickRage].avi')
+        self.assertEqual(glob.escape(u'S01E01 - Show Name [SickRage].avi'), u'S01E01 - Show Name [[]SickRage].avi')
+        self.assertEqual(glob.escape(u'S01E01 - Show Name [SickRage].avi'), 'S01E01 - Show Name [[]SickRage].avi')
+        self.assertEqual(glob.escape('S01E01 - Show Name [SickRage].avi'), u'S01E01 - Show Name [[]SickRage].avi')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fix list_associated_files for post processing, renamer, and deleting
Fixes #1332

Add test for custom glob.escape

Add pp tests for list_associated files

Fixes PP processing each video twice because the video was also in the associated files list

Fix a hellishly broken list_associated files
Now moves subtitle files without language extension
Now detects nfo files
Now honors all params
