### PR TITLE
Don't require free space when moving files

### DIFF
--- a/sickbeard/helpers.py
+++ b/sickbeard/helpers.py
@@ -1552,7 +1552,7 @@ def disk_usage(path):
         raise Exception("Unable to determine free space on your OS")
 
 
-def verify_freespace(src, dest, oldfile=None):
+def verify_freespace(src, dest, oldfile=None, method="copy"):
     """
     Checks if the target system has enough free space to copy or move a file.
 
@@ -1566,6 +1566,11 @@ def verify_freespace(src, dest, oldfile=None):
         oldfile = [oldfile]
 
     logger.log("Trying to determine free space on destination drive", logger.DEBUG)
+
+    # shortcut: if we are moving the file and the destination == src dir,
+    # then by definition there is enough space
+    if method == "move" and os.stat(src).st_dev == os.stat(dest).st_dev:
+        return True
 
     if not ek(os.path.isfile, src):
         logger.log("A path to a file is required for the source. {0} is not a file.".format(src), logger.WARNING)

--- a/sickbeard/postProcessor.py
+++ b/sickbeard/postProcessor.py
@@ -1024,7 +1024,7 @@ class PostProcessor(object):  # pylint: disable=too-many-instance-attributes
 
         # try to find out if we have enough space to perform the copy or move action.
         if not helpers.isFileLocked(self.file_path, False):
-            if not verify_freespace(self.file_path, ep_obj.show._location, [ep_obj] + ep_obj.relatedEps):  # pylint: disable=protected-access
+            if not verify_freespace(self.file_path, ep_obj.show._location, [ep_obj] + ep_obj.relatedEps, method=self.process_method):  # pylint: disable=protected-access
                 self._log("Not enough space to continue PP, exiting", logger.WARNING)
                 return False
         else:


### PR DESCRIPTION
Fixes #1040 (https://github.com/SickRage/sickrage-issues/issues/1040)

Proposed changes in this pull request:
- only require additional space during post-processing if the operation is not a move
- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read [contribution guide](https://github.com/SickRage/SickRage/blob/master/.github/CONTRIBUTING.md)

When post-processing is set to move (not copy) a file and the source
and target filesystem are the same, there is no additional space
requirement, so space checking should not require additional space.
