### PR TITLE
Added optional episode separator to name_parser 'bare' regex

### DIFF
--- a/sickbeard/name_parser/regexes.py
+++ b/sickbeard/name_parser/regexes.py
@@ -175,6 +175,7 @@ normal_regexes = [
      r'''
      ^(?P<series_name>.+?)[. _-]+                # Show_Name and separator
      (?P<season_num>\d{1,2})                     # 1
+     (e?)                                        # Optional episode separator
      (?P<ep_num>\d{2})                           # 02 and separator
      ([. _-]+(?P<extra_info>(?!\d{3}[. _-]+)[^-]+) # Source_Quality_Etc-
      (-(?P<release_group>[^ -]+([. _-]\[.*\])?))?)?$                # Group

--- a/tests/name_parser_tests.py
+++ b/tests/name_parser_tests.py
@@ -74,6 +74,7 @@ SIMPLE_TEST_CASES = {
         'show.name.2010.123.source.quality.etc-group': parser.ParseResult(None, 'show name 2010', 1, [23], 'source.quality.etc', 'group'),
         'show.name.2010.222.123.source.quality.etc-group': parser.ParseResult(None, 'show name 2010.222', 1, [23], 'source.quality.etc', 'group'),
         'Show.Name.102': parser.ParseResult(None, 'Show Name', 1, [2]),
+        'Show.Name.01e02': parser.ParseResult(None, 'Show Name', 1, [2]),
         'the.event.401.hdtv-group': parser.ParseResult(None, 'the event', 4, [1], 'hdtv', 'group'),
         'show.name.2010.special.hdtv-blah': None,
         'show.ex-name.102.hdtv-group': parser.ParseResult(None, 'show ex-name', 1, [2], 'hdtv', 'group'),


### PR DESCRIPTION
Checklist:
- [x] PR description
- [x] Based on develop branch (latest version)
- [x] Single change per PR

I noticed the post-processor was failing to rename episodes with the format:

show.name.01e05.blah.avi

I extended the name_parser 'bare' regex to add support for an optional episode separator, and also added a name_parser test case to verify the change has not broken any existing tests and also passes a new test for this case.

This is my first contribution ever on GitHub so apologies if I've done something dumb. :)
