### PR TITLE
Subtitle: Fix guessit on empty release name

### DIFF
--- a/sickbeard/subtitles.py
+++ b/sickbeard/subtitles.py
@@ -539,10 +539,11 @@ def run_subs_extra_scripts(episode, subtitle, video, single=False):
 
 def refine_video(video, episode):
     # try to enrich video object using information in original filename
-    guess_ep = Episode.fromguess(None, guessit(episode.release_name))
-    for name in vars(guess_ep):
-        if getattr(guess_ep, name) and not getattr(video, name):
-            setattr(video, name, getattr(guess_ep, name))
+    if episode.release_name:
+        guess_ep = Episode.fromguess(None, guessit(episode.release_name))
+        for name in vars(guess_ep):
+            if getattr(guess_ep, name) and not getattr(video, name):
+                setattr(video, name, getattr(guess_ep, name))
 
     # Use sickbeard metadata
     metadata_mapping = {


### PR DESCRIPTION
Fixes subtitles cannot be downloaded when release (stored in SR DB is empty)
- [x] PR is based on the DEVELOP branch
