### PR TITLE
Fixed provider config list duplication

### DIFF
--- a/gui/slick/js/configProviders.js
+++ b/gui/slick/js/configProviders.js
@@ -315,7 +315,7 @@ $(document).ready(function(){
     };
 
     $.fn.refreshEditAProvider = function() {
-        $('#provider-list').empty();
+        $('#editAProvider').empty();
 
         var idArr = $("#provider_order_list").sortable('toArray');
         var finalArr = [];


### PR DESCRIPTION
Fixes #1844

Proposed changes in this pull request:
- This makes it so the list of providers doesn't get duplicated when checking a new provide then going to the provider config/properties tab
