### PR TITLE
Fixes #1976 - encoding userid/password before logging in to SMTP server

### DIFF
--- a/sickbeard/notifiers/emailnotify.py
+++ b/sickbeard/notifiers/emailnotify.py
@@ -320,7 +320,7 @@ class Notifier(object):
                 srv.ehlo()
             if user and pwd:
                 logger.log('Sending LOGIN command!', logger.DEBUG)
-                srv.login(user, pwd)
+                srv.login(user.encode('utf-8'), pwd.encode('utf-8'))
 
             srv.sendmail(smtp_from, to, msg.as_string())
             srv.quit()


### PR DESCRIPTION
Fixes #
## Proposed changes in this pull request:
## 
## 
- [ ] PR is based on the DEVELOP branch
- [ ] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [ ] Read [contribution guide](https://github.com/SickRage/SickRage/blob/master/.github/CONTRIBUTING.md)
