### PR TITLE
Updates qbittorrent api calls to reflect changes made in qbittorrent …

### DIFF
--- a/sickbeard/clients/qbittorrent_client.py
+++ b/sickbeard/clients/qbittorrent_client.py
@@ -81,10 +81,16 @@ class qbittorrentAPI(GenericClient):
         if result.show.is_anime:
             label = sickbeard.TORRENT_LABEL_ANIME
 
-        if self.api > 6 and label:
+        if self.api > 6 and self.api <  10 and label:
             self.url = self.host + 'command/setLabel'
             data = {'hashes': result.hash.lower(), 'label': label.replace(' ', '_')}
             return self._request(method='post', data=data, cookies=self.session.cookies)
+
+        elif self.api >= 10 and label:
+            self.url = self.host + 'command/setCategory'
+            data = {'hashes': result.hash.lower(), 'category': label.replace(' ', '_')}
+            return self._request(method='post', data=data, cookies=self.session.cookies)
+
         return True
 
     def _set_torrent_priority(self, result):


### PR DESCRIPTION
Fixes #1990 (Sorry did not see the 'topic' branch name convention till too late)

Proposed changes in this pull request:
## \- changes API command from setLabel to setCategory (change in WEBAPI in qbt). Also handles backward compatibility with older versions of qbt.
## 
- [x ] PR is based on the DEVELOP branch
- [x ] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x ] Read [contribution guide](https://github.com/SickRage/SickRage/blob/master/.github/CONTRIBUTING.md)

…with version 3.3.5. Ensure backward compatibility with older versions of qbt.
