### PR TITLE
Added network Belgische Radio en Televisie (BRTN)

### DIFF
--- a/lib/network_timezones/network_timezones.txt
+++ b/lib/network_timezones/network_timezones.txt
@@ -2283,3 +2283,4 @@ ZUUS Latino (US):US/Eastern
 ערוץ הילדים‎:Asia/Jerusalem
 קשת:Asia/Jerusalem
 רשת:Asia/Jerusalem
+Belgische Radio en Televisie (BRTN):Europe/Brussels


### PR DESCRIPTION
Fixes #
Missing time zone for network: Belgische Radio en Televisie (BRTN)

Proposed changes in this pull request:
- Added network Belgische Radio en Televisie (BRTN)
- [ ] PR is based on the DEVELOP branch
- [ ] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [ ] Read [contribution guide](https://github.com/SickRage/SickRage/blob/master/.github/CONTRIBUTING.md)
