### PR TITLE
Enable cookies field for all TorrentProviders, if they have the provi…

### DIFF
--- a/gui/slick/views/config_providers.mako
+++ b/gui/slick/views/config_providers.mako
@@ -275,7 +275,6 @@
                                     </div>
                                 % endif
 
-
                                 % if hasattr(curNzbProvider, 'enable_daily'):
                                     <div class="field-pair row">
                                         <div class="col-lg-3 col-md-4 col-sm-5 col-xs-12">
@@ -446,6 +445,20 @@
                                                    id="${curTorrentProvider.get_id()}_passkey"
                                                    value="${curTorrentProvider.passkey}" class="form-control input-sm input350"
                                                    autocapitalize="off"/>
+                                        </div>
+                                    </div>
+                                % endif
+
+                                % if curTorrentProvider.enable_cookies:
+                                    <div class="field-pair row">
+                                        <div class="col-lg-3 col-md-4 col-sm-5 col-xs-12">
+                                            <label class="component-title">${_('Cookies')}</label>
+                                        </div>
+                                        <div class="col-lg-9 col-md-8 col-sm-7 col-xs-12 component-desc">
+                                            <input type="text" name="${curTorrentProvider.get_id()}_cookies"
+                                                   id="${curTorrentProvider.get_id()}_cookies"
+                                                   value="${curTorrentProvider.cookies}" class="form-control input-sm input350"
+                                                   autocapitalize="off" autocomplete="no"/>
                                         </div>
                                     </div>
                                 % endif

--- a/sickbeard/__init__.py
+++ b/sickbeard/__init__.py
@@ -1385,6 +1385,9 @@ def initialize(consoleLogging=True):  # pylint: disable=too-many-locals, too-man
             if hasattr(curTorrentProvider, 'subtitle'):
                 curTorrentProvider.subtitle = bool(check_setting_int(CFG, curTorrentProvider.get_id().upper(),
                                                                      curTorrentProvider.get_id() + '_subtitle', 0))
+            if hasattr(curTorrentProvider, 'cookies'):
+                curTorrentProvider.api_key = check_setting_str(CFG, curTorrentProvider.get_id().upper(),
+                                                               curTorrentProvider.get_id() + '_cookies', '', censor_log=True)
 
         for curNzbProvider in [curProvider for curProvider in providers.sortedProviderList() if
                                curProvider.provider_type == GenericProvider.NZB]:
@@ -1734,6 +1737,9 @@ def save_config():  # pylint: disable=too-many-statements, too-many-branches
         if hasattr(curTorrentProvider, 'subtitle'):
             new_config[curTorrentProvider.get_id().upper()][curTorrentProvider.get_id() + '_subtitle'] = int(
                 curTorrentProvider.subtitle)
+        if hasattr(curTorrentProvider, 'cookies'):
+            new_config[curTorrentProvider.get_id().upper()][
+                curTorrentProvider.get_id() + '_cookies'] = curTorrentProvider.cookies
 
     for curNzbProvider in [curProvider for curProvider in providers.sortedProviderList() if
                            curProvider.provider_type == GenericProvider.NZB]:

--- a/sickbeard/providers/rsstorrent.py
+++ b/sickbeard/providers/rsstorrent.py
@@ -51,6 +51,7 @@ class TorrentRssProvider(TorrentProvider):  # pylint: disable=too-many-instance-
         self.search_fallback = search_fallback
         self.enable_daily = enable_daily
         self.enable_backlog = enable_backlog
+        self.enable_cookies = True
         self.cookies = cookies
         self.titleTAG = titleTAG
 

--- a/sickbeard/providers/torrentday.py
+++ b/sickbeard/providers/torrentday.py
@@ -60,34 +60,40 @@ class TorrentDayProvider(TorrentProvider):  # pylint: disable=too-many-instance-
             'RSS': {'c2': 1, 'c26': 1, 'c7': 1, 'c24': 1, 'c14': 1}
         }
 
+        self.enable_cookies = True
+
         # Cache
         self.cache = tvcache.TVCache(self, min_time=10)  # Only poll IPTorrents every 10 minutes max
 
     def login(self):
-        if any(dict_from_cookiejar(self.session.cookies).values()):
+        if dict_from_cookiejar(self.session.cookies).get('uid') and dict_from_cookiejar(self.session.cookies).get('pass'):
             return True
 
-        login_params = {
-            'username': self.username,
-            'password': self.password,
-            'submit.x': 0,
-            'submit.y': 0
-        }
+        if self.cookies:
+            if 'uid' in self.cookies and 'pass' in self.cookies:
+                self.add_cookies_from_ui()
 
-        response = self.get_url(self.urls['login'], post_data=login_params, returns='text')
-        if not response:
-            logger.log('Unable to connect to provider', logger.WARNING)
-            return False
+            login_params = {
+                'username': self.username,
+                'password': self.password,
+                'submit.x': 0,
+                'submit.y': 0,
+            }
 
-        if re.search('Password not correct', response):
-            logger.log('Your login is incorrect', logger.WARNING)
-            return False
+            response = self.get_url(self.urls['login'], post_data=login_params, returns='response')
+            if response.status_code not in [200]:
+                logger.log('Unable to connect to provider', logger.WARNING)
+                return False
 
-        if re.search('You tried too often', response):
-            logger.log('Too many login access attempts', logger.WARNING)
-            return False
+            if re.search('You tried too often', response.text):
+                logger.log('Too many login access attempts', logger.WARNING)
+                return False
 
-        return True
+            if dict_from_cookiejar(self.session.cookies).get('uid') in response.text:
+                return True
+            else:
+                logger.log('Failed to login, check your cookies', logger.WARNING)
+                return False
 
     def search(self, search_params, age=0, ep_obj=None):  # pylint: disable=too-many-locals
         results = []
@@ -112,6 +118,7 @@ class TorrentDayProvider(TorrentProvider):  # pylint: disable=too-many-instance-
                 parsedJSON = self.get_url(self.urls['search'], post_data=post_data, returns='json')
                 if not parsedJSON:
                     logger.log('No data returned from provider', logger.DEBUG)
+                    self.session.cookies.clear()
                     continue
 
                 try:

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -4801,6 +4801,12 @@ class ConfigProviders(Config):
                 except Exception:
                     curTorrentProvider.subtitle = 0
 
+            if curTorrentProvider.enable_cookies:
+                try:
+                    curTorrentProvider.cookies = str(kwargs['{id}_cookies'.format(id=curTorrentProvider.get_id())]).strip()
+                except Exception:
+                    pass  # I don't want to configure a default value here, as it can also be configured intially as a custom rss torrent provider
+
         for curNzbProvider in [prov for prov in sickbeard.providers.sortedProviderList() if
                                prov.provider_type == GenericProvider.NZB]:
 

--- a/sickrage/providers/GenericProvider.py
+++ b/sickrage/providers/GenericProvider.py
@@ -36,6 +36,7 @@ from sickbeard.show_name_helpers import allPossibleShowNames
 from sickbeard.tvcache import TVCache
 from sickrage.helper.common import replace_extension, sanitize_filename
 from sickrage.helper.encoding import ek
+from requests.utils import add_dict_to_cookiejar
 
 
 class GenericProvider(object):  # pylint: disable=too-many-instance-attributes
@@ -69,6 +70,11 @@ class GenericProvider(object):  # pylint: disable=too-many-instance-attributes
         self.supports_backlog = True
         self.url = ''
         self.urls = {}
+
+        # Use and configure the attribute enable_cookies to show or hide the cookies input field per provider
+        self.enable_cookies = False
+        self.cookies = ''
+        self.rss_cookies = ''
 
         shuffle(self.bt_cache_urls)
 
@@ -486,3 +492,19 @@ class GenericProvider(object):  # pylint: disable=too-many-instance-attributes
 
     def _verify_download(self, file_name=None):  # pylint: disable=unused-argument,no-self-use
         return True
+
+    def add_cookies_from_ui(self):
+        """
+        Adds the cookies configured from UI to the providers requests session
+        :return: A tuple with the the (success result, and a descriptive message in str)
+        """
+
+        # This is the generic attribute used to manually add cookies for provider authentication
+        if self.enable_cookies and self.cookies:
+            cookie_validator = re.compile(r'^(\w+=\w+)(;\w+=\w+)*$')
+            if not cookie_validator.match(self.cookies):
+                return False, 'Cookie is not correctly formatted: {0}'.format(self.cookies)
+            add_dict_to_cookiejar(self.session.cookies, dict(x.rsplit('=', 1) for x in self.cookies.split(';')))
+            return True, 'torrent cookie'
+
+        return False, 'No Cookies added from ui for provider: {0}'.format(self.name)


### PR DESCRIPTION
Fixes #1892 

Proposed changes in this pull request:
## \- Added field for manually adding cookies
## 
- [ ] PR is based on the DEVELOP branch
- [ ] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [ ] Read [contribution guide](https://github.com/SickRage/SickRage/blob/master/.github/CONTRIBUTING.md)

Enable cookies field for all TorrentProviders, if they have the provider.enable_cookies attribute set.
- Can be used to set the uid and pass cookies for TorrentDay.
