### PR TITLE
Fixed typo which loaded the cookies setting into api_key variable.

### DIFF
--- a/sickbeard/__init__.py
+++ b/sickbeard/__init__.py
@@ -1386,7 +1386,7 @@ def initialize(consoleLogging=True):  # pylint: disable=too-many-locals, too-man
                 curTorrentProvider.subtitle = bool(check_setting_int(CFG, curTorrentProvider.get_id().upper(),
                                                                      curTorrentProvider.get_id() + '_subtitle', 0))
             if hasattr(curTorrentProvider, 'cookies'):
-                curTorrentProvider.api_key = check_setting_str(CFG, curTorrentProvider.get_id().upper(),
+                curTorrentProvider.cookies = check_setting_str(CFG, curTorrentProvider.get_id().upper(),
                                                                curTorrentProvider.get_id() + '_cookies', '', censor_log=True)
 
         for curNzbProvider in [curProvider for curProvider in providers.sortedProviderList() if


### PR DESCRIPTION
Fixes #1892 

Proposed changes in this pull request:
- Fixed an issue when restarting SR, the cookies setting was loaded into api var.
- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read [contribution guide](https://github.com/SickRage/SickRage/blob/master/.github/CONTRIBUTING.md)
