### PR TITLE
fix upstart to use default folder

### DIFF
--- a/runscripts/init.upstart
+++ b/runscripts/init.upstart
@@ -30,7 +30,5 @@ script
         echo "/etc/default/sickrage not found using default settings.";
     fi
 
-    [ -z $SR_HOME ] && echo "I can't start SickRage if I don't know where it is"
-
-    exec ${SR_HOME}/SickBeard.py -q --nolaunch --datadir=${SR_DATA-SR_HOME} ${SR_OPTS-}
+    exec ${SR_HOME-/opt/sickrage}/SickBeard.py -q --nolaunch --datadir=${SR_DATA-/opt/sickrage} ${SR_OPTS-}
 end script


### PR DESCRIPTION
# Fixes
## Proposed changes in this pull request:
## 
## 
- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read [contribution guide](https://github.com/SickRage/SickRage/blob/master/.github/CONTRIBUTING.md)

fix upstart to use default app folder if variable not found
