### PR TITLE
if folder not exist, clone repo

### DIFF
--- a/contrib/debian-ubuntu-install.sh
+++ b/contrib/debian-ubuntu-install.sh
@@ -64,6 +64,7 @@ fi
 # if they do, remove the whole directory and recreate
 if [[ ! -d /opt/sickrage ]]; then
     mkdir /opt/sickrage && chown sickrage:sickrage /opt/sickrage
+    su -c "git clone -q https://github.com/SickRage/SickRage.git /opt/sickrage" -s /bin/bash sickrage
 else
     whiptail --title 'Overwrite?' --yesno "/opt/sickrage already exists, do you want to overwrite it?" 8 40
     choice=$?


### PR DESCRIPTION
Fixes #

Proposed changes in this pull request:
- the script didnt git clone the repo if the folder was created, it will now clone the repo
- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read [contribution guide](https://github.com/SickRage/SickRage/blob/master/.github/CONTRIBUTING.md)

the script forgot to clone the repo if the folder didnt exist
