### PR TITLE
Support reversed symlink => the original file doesn't move

### DIFF
--- a/gui/slick/views/home_postprocess.mako
+++ b/gui/slick/views/home_postprocess.mako
@@ -26,7 +26,7 @@
                     </div>
                     <div class="col-lg-6 col-md-6 col-sm-6 col-xs-12">
                         <select name="process_method" id="process_method" class="form-control form-control-inline input-sm" title="process method">
-                            <% process_method_text = {'copy': _('Copy'), 'move': _('Move'), 'hardlink': _('Hard Link'), 'symlink' : _('Symbolic Link')} %>
+                            <% process_method_text = {'copy': _('Copy'), 'move': _('Move'), 'hardlink': _('Hard Link'), 'symlink' : _('Symbolic Link'), 'symlink_reversed' : _('Symbolic Link Reversed')} %>
                             % for curAction in process_method_text:
                                 <option value="${curAction}" ${('', 'selected="selected"')[sickbeard.PROCESS_METHOD == curAction]}>${process_method_text[curAction]}</option>
                             % endfor

--- a/sickbeard/postProcessor.py
+++ b/sickbeard/postProcessor.py
@@ -449,6 +449,30 @@ class PostProcessor(object):  # pylint: disable=too-many-instance-attributes
         self._combined_file_operation(file_path, new_path, new_base_name, associated_files,
                                       action=_int_move_and_sym_link, subtitles=subtitles)
 
+    def _symlink(self, file_path, new_path, new_base_name, associated_files=False, subtitles=False):  # pylint: disable=too-many-arguments
+        """
+        symlink destination to source location, and set proper permissions
+
+        :param file_path: The full path of the media file to move
+        :param new_path: Destination path where we want to move the file to create a symbolic link to
+        :param new_base_name: The base filename (no extension) to use during the link. Use None to keep the same name.
+        :param associated_files: Boolean, whether we should move similarly-named files too
+        """
+
+        def _int_sym_link(cur_file_path, new_file_path):
+
+            self._log(u"Creating then symbolic linking file from " + new_file_path + " to " + cur_file_path, logger.DEBUG)
+            try:
+                helpers.symlink(cur_file_path, new_file_path)
+                helpers.chmodAsParent(cur_file_path)
+            except (IOError, OSError) as e:
+                self._log("Unable to link file " + cur_file_path + " to " + new_file_path + ": " + ex(e), logger.ERROR)
+                raise
+
+        self._combined_file_operation(file_path, new_path, new_base_name, associated_files,
+                                      action=_int_sym_link, subtitles=subtitles)
+
+        
     def _history_lookup(self):
         """
         Look up the NZB name in the history and see if it contains a record for self.nzb_name
@@ -1151,6 +1175,9 @@ class PostProcessor(object):  # pylint: disable=too-many-instance-attributes
                 if helpers.isFileLocked(self.file_path, True):
                     raise EpisodePostProcessingFailedException("File is locked for reading/writing")
                 self._moveAndSymlink(self.file_path, dest_path, new_base_name, sickbeard.MOVE_ASSOCIATED_FILES,
+                                     sickbeard.USE_SUBTITLES and ep_obj.show.subtitles)
+            elif self.process_method == "symlink_reversed":
+                self._symlink(self.file_path, dest_path, new_base_name, sickbeard.MOVE_ASSOCIATED_FILES,
                                      sickbeard.USE_SUBTITLES and ep_obj.show.subtitles)
             else:
                 logger.log(u"Unknown process method: " + str(self.process_method), logger.ERROR)


### PR DESCRIPTION
Proposed changes in this pull request:
- This commit permits users to Symlink files without moving. In the "sickrage directory" there is only symlink.
- The aim ? Personally I manage my files with Transmission, when I delete a file from Transmission I want it deleted on my HDD, a script can easily delete orphan symlink (can be added to SickRage if necessary)
