### PR TITLE
Develop: Fix 'Error: [Errno 1] Operation not permitted:' when using SymLink

### DIFF
--- a/gui/slick/css/style.css
+++ b/gui/slick/css/style.css
@@ -3605,3 +3605,7 @@ input.tablesorter-filter.disabled {
 .horizontal-scroll {
     overflow-x: auto;
 }
+
+#episodeDir {
+    width: 100%;
+}

--- a/gui/slick/js/massUpdate.js
+++ b/gui/slick/js/massUpdate.js
@@ -9,7 +9,7 @@ $(document).ready(function(){
         if(editArr.length === 0) { return; }
 
         $(
-            "<form method='post' action='/manage/massEdit'>" +
+            "<form method='post' action='" + srRoot + "/manage/massEdit'>" +
                 "<input type='hidden' name='toEdit' value='" + editArr.join('|') + "'/>" +
             "</form>"
         ).submit();

--- a/gui/slick/views/home_postprocess.mako
+++ b/gui/slick/views/home_postprocess.mako
@@ -17,7 +17,7 @@
                         <b class="pull-lg-right pull-md-right pull-sm-right">${_('Enter the folder containing the episode')}</b>
                     </div>
                     <div class="col-lg-6 col-md-6 col-sm-6 col-xs-12">
-                        <input type="text" name="proc_dir" id="episodeDir" class="form-control form-control-inline input-sm" autocapitalize="off" title="directory"/>
+                        <input type="text" name="proc_dir" id="episodeDir" class="form-control form-control-inline input-sm input250" autocapitalize="off" title="directory"/>
                     </div>
                 </div>
                 <div class="row">
@@ -62,7 +62,7 @@
                 % if sickbeard.USE_FAILED_DOWNLOADS:
                     <div class="row">
                         <div class="col-lg-6 col-md-6 col-sm-6 col-xs-12">
-                            <b>${_('Mark download as failed')}:</b>
+                            <b class="pull-lg-right pull-md-right pull-sm-right">${_('Mark download as failed')}</b>
                         </div>
                         <div class="col-lg-6 col-md-6 col-sm-6 col-xs-12">
                             <input id="failed" name="failed" type="checkbox">

--- a/sickbeard/providers/__init__.py
+++ b/sickbeard/providers/__init__.py
@@ -22,7 +22,7 @@ from os import sys
 from random import shuffle
 
 import sickbeard
-from sickbeard.providers import btn, womble, thepiratebay, torrentleech, iptorrents, torrentz, \
+from sickbeard.providers import btn, womble, thepiratebay, torrentleech, iptorrents, \
     omgwtfnzbs, scc, hdtorrents, torrentday, hdbits, hounddawgs, speedcd, nyaatorrents, bluetigers, xthor, abnormal, torrentbytes, cpasbien,\
     freshontv, morethantv, t411, tokyotoshokan, shazbat, rarbg, alpharatio, tntvillage, binsearch, torrentproject, extratorrent, \
     scenetime, btdigg, transmitthenet, tvchaosuk, bitcannon, pretome, gftracker, hdspace, newpct, elitetorrent, bitsnoop, danishbits, hd4free, limetorrents, \
@@ -35,7 +35,7 @@ __all__ = [
     'morethantv', 't411', 'tokyotoshokan', 'alpharatio',
     'shazbat', 'rarbg', 'tntvillage', 'binsearch', 'bluetigers',
     'xthor', 'abnormal', 'scenetime', 'btdigg', 'transmitthenet', 'tvchaosuk',
-    'torrentproject', 'extratorrent', 'bitcannon', 'torrentz', 'pretome', 'gftracker',
+    'torrentproject', 'extratorrent', 'bitcannon', 'pretome', 'gftracker',
     'hdspace', 'newpct', 'elitetorrent', 'bitsnoop', 'danishbits', 'hd4free', 'limetorrents',
     'norbits', 'ilovetorrents'
 ]

--- a/sickbeard/providers/iptorrents.py
+++ b/sickbeard/providers/iptorrents.py
@@ -119,7 +119,7 @@ class IPTorrentsProvider(TorrentProvider):  # pylint: disable=too-many-instance-
                             logger.log(u"Data returned from provider does not contain any torrents", logger.DEBUG)
                             continue
 
-                        torrent_table = html.find('table', class_='torrents')
+                        torrent_table = html.find('table', id='torrents')
                         torrents = torrent_table('tr') if torrent_table else []
 
                         # Continue only if one Release is found


### PR DESCRIPTION
Fixes #2229 

Proposed changes in this pull request:
-Make use of other functions to handle the task
-Remove redundant ek calls as those functions called already perform them
-Allows python to properly handle moving files across different mount points before symlink
-Allows for additional exception handling; ie. if the move function failed it will throw an exception first.
- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read [contribution guide](https://github.com/SickRage/SickRage/blob/master/.github/CONTRIBUTING.md)
