### PR TITLE
Fix 'Error: [Errno 1] Operation not permitted:' when using SymLink

### DIFF
--- a/sickbeard/helpers.py
+++ b/sickbeard/helpers.py
@@ -446,9 +446,8 @@ def moveAndSymlinkFile(srcFile, destFile):
     """
 
     try:
-        ek(shutil.move, srcFile, destFile)
-        fixSetGroupID(destFile)
-        ek(symlink, destFile, srcFile)
+        moveFile(srcFile, destFile)
+        symlink(destFile, srcFile)
     except Exception as error:
         logger.log("Failed to create symlink of {0} at {1}. Error: {2}. Copying instead".format
                    (srcFile, destFile, error), logger.WARNING)


### PR DESCRIPTION
Fixes #2228   

Proposed changes in this pull request:
-Make use of other functions to handle the task
-Remove redundant ek calls as those functions called already perform them
-Allows python to properly handle moving files across different mount points before symlink
-Allows for additional exception handling; ie. if the move function failed it will throw an exception first.
- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read [contribution guide](https://github.com/SickRage/SickRage/blob/master/.github/CONTRIBUTING.md)
