### PR TITLE
Fix Debian/Ubuntu install script

### DIFF
--- a/contrib/debian-ubuntu-install.sh
+++ b/contrib/debian-ubuntu-install.sh
@@ -101,7 +101,7 @@ elif [[ $distro = debian ]]; then
         systemctl -q enable sickrage && systemctl -q start sickrage
     else
         cp /opt/sickrage/runscripts/init.debian /etc/init.d/sickrage
-        chown root:root /etc/init.d/sickrage && chmod 644 /etc/init.d/sickrage
+        chown root:root /etc/init.d/sickrage && chmod 644 /etc/init.d/sickrage && chmod +x /etc/init.d/sickrage
         update-rc.d sickrage defaults && service sickrage start
     fi
 fi

--- a/contrib/debian-ubuntu-install.sh
+++ b/contrib/debian-ubuntu-install.sh
@@ -101,7 +101,7 @@ elif [[ $distro = debian ]]; then
         systemctl -q enable sickrage && systemctl -q start sickrage
     else
         cp /opt/sickrage/runscripts/init.debian /etc/init.d/sickrage
-        chown root:root /etc/init.d/sickrage && chmod 644 /etc/init.d/sickrage && chmod +x /etc/init.d/sickrage
+        chown root:root /etc/init.d/sickrage && chmod 755 /etc/init.d/sickrage
         update-rc.d sickrage defaults && service sickrage start
     fi
 fi


### PR DESCRIPTION
(partially) Fix Debian/Ubuntu install script by making the init.d file executable before trying to run it.

This probably has to be added to all other if/else statements but I don't know much about those distros and can't test those cases.
