### PR TITLE
Update network_timezones.txt - Bravo (NZ) added

### DIFF
--- a/lib/network_timezones/network_timezones.txt
+++ b/lib/network_timezones/network_timezones.txt
@@ -288,6 +288,7 @@ BR-alpha:Europe/Berlin
 Bravo (CA):Canada/Eastern
 Bravo (UK):Europe/London
 Bravo (US):US/Eastern
+Bravo (NZ):Pacific/Auckland
 Bravo!:Canada/Eastern
 Bravo:US/Eastern
 bravotv.com (US):US/Eastern


### PR DESCRIPTION
Fixes #

Proposed changes in this pull request:
## \- missing timezone for Bravo (NZ) added
## 
- [ ] PR is based on the DEVELOP branch
- [ ] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [ ] Read [contribution guide](https://github.com/SickRage/SickRage/blob/master/.github/CONTRIBUTING.md)

added missing timezone Bravo (NZ)
