### PR TITLE
Add x265 categories to Torrentday provider

### DIFF
--- a/sickbeard/providers/torrentday.py
+++ b/sickbeard/providers/torrentday.py
@@ -56,8 +56,8 @@ class TorrentDayProvider(TorrentProvider):  # pylint: disable=too-many-instance-
 
         self.categories = {
             'Season': {'c14': 1},
-            'Episode': {'c2': 1, 'c26': 1, 'c7': 1, 'c24': 1},
-            'RSS': {'c2': 1, 'c26': 1, 'c7': 1, 'c24': 1, 'c14': 1}
+            'Episode': {'c2': 1, 'c26': 1, 'c7': 1, 'c24': 1, 'c34': 1},
+            'RSS': {'c2': 1, 'c26': 1, 'c7': 1, 'c24': 1, 'c34': 1, 'c14': 1}
         }
 
         self.enable_cookies = True


### PR DESCRIPTION
Proposed changes in this pull request:
- Adds the TV/x265 category on Torrentday when searching for torrents. Currently such files are not found.
- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read [contribution guide](https://github.com/SickRage/SickRage/blob/master/.github/CONTRIBUTING.md)
