### PR TITLE
providers/scenetime: Fix broken search after site changes

### DIFF
--- a/sickbeard/providers/scenetime.py
+++ b/sickbeard/providers/scenetime.py
@@ -45,12 +45,12 @@ class SceneTimeProvider(TorrentProvider):  # pylint: disable=too-many-instance-a
         self.urls = {'base_url': 'https://www.scenetime.com',
                      'login': 'https://www.scenetime.com/takelogin.php',
                      'detail': 'https://www.scenetime.com/details.php?id=%s',
-                     'search': 'https://www.scenetime.com/browse.php?search=%s%s',
+                     'apisearch': 'https://www.scenetime.com/browse_API.php',
                      'download': 'https://www.scenetime.com/download.php/%s/%s'}
 
         self.url = self.urls['base_url']
 
-        self.categories = "&c2=1&c43=13&c9=1&c63=1&c77=1&c79=1&c100=1&c101=1"
+        self.categories = [2, 42, 9, 63, 77, 79, 100, 83] 
 
     def login(self):
         if any(dict_from_cookiejar(self.session.cookies).values()):
@@ -84,17 +84,16 @@ class SceneTimeProvider(TorrentProvider):  # pylint: disable=too-many-instance-a
                     logger.log(u"Search string: {0}".format
                                (search_string.decode("utf-8")), logger.DEBUG)
 
-                search_url = self.urls['search'] % (quote(search_string), self.categories)
+                query = { 'sec': 'jax', 'cata': 'yes', 'search': search_string }
+                query.update({"c%s"%i: 1 for i in self.categories})
 
-                data = self.get_url(search_url, returns='text')
+                data = self.get_url(self.urls['apisearch'], returns='text', post_data=query)
+
                 if not data:
                     continue
 
                 with BS4Parser(data, 'html5lib') as html:
-                    torrent_table = html.find('div', id="torrenttable")
-                    torrent_rows = []
-                    if torrent_table:
-                        torrent_rows = torrent_table.select("tr")
+                    torrent_rows = html.findAll('tr')
 
                     # Continue only if one Release is found
                     if len(torrent_rows) < 2:


### PR DESCRIPTION
SceneTime recently started doing all search/browse functionality via the /browse_API.php endpoint  (Which just serves partial html via an xhr as opposed to a real api). This PR applies the necessary fixes to interact with /browse_API instead of /browse.

(Attemt two - I suck at git)
