### PR TITLE
Initialize curShowName and curShowid before looping over results

### DIFF
--- a/sickbeard/tv.py
+++ b/sickbeard/tv.py
@@ -486,6 +486,9 @@ class TVShow(object):  # pylint: disable=too-many-instance-attributes, too-many-
         cachedShow = t[self.indexerid]
         cachedSeasons = {}
 
+        curShowid = None
+        curShowName = None
+
         for curResult in sql_results:
 
             curSeason = int(curResult[b"season"])
@@ -530,8 +533,9 @@ class TVShow(object):  # pylint: disable=too-many-instance-attributes, too-many-
                            logger.DEBUG)
                 continue
 
-        logger.log("{id}: Finished loading all episodes for {show} from the DB".format
-                   (show=curShowName, id=curShowid), logger.DEBUG)
+        if curShowName and curShowid:
+            logger.log("{id}: Finished loading all episodes for {show} from the DB".format
+                       (show=curShowName, id=curShowid), logger.DEBUG)
 
         return scannedEps
 


### PR DESCRIPTION
Fixes #2356 

Proposed changes in this pull request:
- Initialize the curShowid and curShowName variables outside of the loop so later logging does not throw exceptions.
- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read [contribution guide](https://github.com/SickRage/SickRage/blob/master/.github/CONTRIBUTING.md)
