### PR TITLE
Add more clarity to log message when connection fails while downloading file

### DIFF
--- a/sickbeard/helpers.py
+++ b/sickbeard/helpers.py
@@ -1426,8 +1426,8 @@ def download_file(url, filename, session=None, headers=None, **kwargs):  # pylin
                             fp.flush()
 
                 chmodAsParent(filename)
-            except Exception:
-                logger.log("Problem setting permissions or writing file to: {0}".format(filename), logger.WARNING)
+            except Exception as error:
+                logger.log("Problem downloading file, setting permissions or writing file to \"{0}\" - ERROR: {1}".format(filename, error), logger.WARNING)
 
     except Exception as error:
         handle_requests_exception(error)


### PR DESCRIPTION
### Proposed changes in this pull request:
- Change the log message to include a better description of the actual error when trying to download a file
- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read [contribution guide](https://github.com/SickRage/SickRage/blob/master/.github/CONTRIBUTING.md)
### Explanation

My SickRage setup had been working without an issue for a few months but all of a sudden all torrents failed to download with a log message like this:

```
Problem setting permissions or writing file to C:\Users\xxx\sickrage\foo.torrent
```

I tried changing the permissions of the folder but nothing helped. Then I modified the code so I could read the actual error message and this is what I got:

```
('Connection broken: IncompleteRead(29 bytes read)', IncompleteRead(29 bytes read))
```

Basically, it was failing to _download_ the file, not _write_ it. I still haven't been able to figure out why it's failing to download (all other scripts that are running on my computer are able to download files just fine), but in the meantime I'm submitting this PR to fix the log message.
