### PR TITLE
Typo in apibuilder causes double parameter

### DIFF
--- a/sickbeard/webapi.py
+++ b/sickbeard/webapi.py
@@ -1541,7 +1541,7 @@ class CMD_SickBeardPauseBacklog(ApiCall):
     _help = {
         "desc": "Pause or un-pause the backlog search",
         "optionalParameters": {
-            "pause ": {"desc": "True to pause the backlog search, False to un-pause it"}
+            "pause": {"desc": "True to pause the backlog search, False to un-pause it"}
         }
     }
 


### PR DESCRIPTION
Fixes #2495

Proposed change in this pull request:
- Replace "pause " with "pause" to prevent double parameter description.
