### PR TITLE
don't log exception for http connection attempt on https server

### DIFF
--- a/lib/tornado/iostream.py
+++ b/lib/tornado/iostream.py
@@ -1258,7 +1258,7 @@ class SSLIOStream(IOStream):
                     peer = '(not connected)'
                 gen_log.warning("SSL Error on %s %s: %s",
                                 self.socket.fileno(), peer, err)
-                return self.close(exc_info=True)
+                return self.close(exc_info=False)
             raise
         except socket.error as err:
             # Some port scans (e.g. nmap in -sT mode) have been known


### PR DESCRIPTION
Fixes #1386

Proposed changes in this pull request:
## -remove exception logging for http client trying to connect to https server in tornado
## 
- [ ] PR is based on the DEVELOP branch
- [ ] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [ ] Read [contribution guide](https://github.com/SickRage/SickRage/blob/master/.github/CONTRIBUTING.md)
