### PR TITLE
First crack at fixing weird log censoring bug

### DIFF
--- a/sickbeard/providers/freshontv.py
+++ b/sickbeard/providers/freshontv.py
@@ -85,9 +85,9 @@ class FreshOnTVProvider(TorrentProvider):  # pylint: disable=too-many-instance-a
                     if dict_from_cookiejar(self.session.cookies)['uid'] and dict_from_cookiejar(self.session.cookies)['pass']:
                         self._uid = dict_from_cookiejar(self.session.cookies)['uid']
                         self._hash = dict_from_cookiejar(self.session.cookies)['pass']
-
-                        self.cookies = {'uid': self._uid,
+                        cookie_dict = {'uid': self._uid,
                                         'pass': self._hash}
+                        add_dict_to_cookiejar(self.cookies, cookie_dict)
                         return True
                 except Exception:
                     logger.log(u"Unable to login to provider (cookie)", logger.WARNING)


### PR DESCRIPTION
Seems like cookie formatting into non cookiejar format is causing logger issues. Cookie should not be stored as key-value pair but in cookie-jar format I believe.

Fixes #

Proposed changes in this pull request:
-
-
-

- [ ] PR is based on the DEVELOP branch
- [ ] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [ ] Read [contribution guide](https://github.com/SickRage/SickRage/blob/master/.github/CONTRIBUTING.md)
