### PR TITLE
Fix anime episode search

### DIFF
--- a/sickrage/providers/GenericProvider.py
+++ b/sickrage/providers/GenericProvider.py
@@ -397,7 +397,7 @@ class GenericProvider(object):  # pylint: disable=too-many-instance-attributes
                 episode_string += ('|', ' ')[len(self.proper_strings) > 1]
                 episode_string += episode.airdate.strftime('%b')
             elif episode.show.anime:
-                episode_string += '{0:03d}'.format(int(episode.scene_absolute_number))
+                episode_string += '{0:02d}'.format(int(episode.scene_absolute_number))
             else:
                 episode_string += sickbeard.config.naming_ep_type[2] % {
                     'seasonnumber': episode.scene_season,


### PR DESCRIPTION
Searching for anime series with 001 does not always seem to work.
Instead searching with 01 does work.
Example failing:
https://www.nyaa.se/?sort=2&term=All+Out%21%21+001&cats=1_0&page=rss&order=1

Example working:
https://www.nyaa.se/?sort=2&term=All+Out%21%21+01&cats=1_0&page=rss&order=1

This will still list the series which are labeled as 001 since 01 is a subset of the search query.


- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read [contribution guide](https://github.com/SickRage/SickRage/blob/master/.github/CONTRIBUTING.md)
