### PR TITLE
Fix anime episode search (part 3)

### DIFF
--- a/sickbeard/providers/btn.py
+++ b/sickbeard/providers/btn.py
@@ -203,7 +203,7 @@ class BTNProvider(TorrentProvider):
             # Search for the year of the air by date show
             current_params['name'] = str(ep_obj.airdate).split('-')[0]
         elif ep_obj.show.is_anime:
-            current_params['name'] = "{0:02d}".format(ep_obj.scene_absolute_number)
+            current_params['name'] = "{0:d}".format(ep_obj.scene_absolute_number)
         else:
             current_params['name'] = 'Season ' + str(ep_obj.scene_season)
 
@@ -237,7 +237,7 @@ class BTNProvider(TorrentProvider):
             # combined with the series identifier should result in just one episode
             search_params['name'] = date_str.replace('-', '.')
         elif ep_obj.show.anime:
-            search_params['name'] = "{0:02d}".format(int(ep_obj.scene_absolute_number))
+            search_params['name'] = "{0:d}".format(int(ep_obj.scene_absolute_number))
         else:
             # Do a general name search for the episode, formatted like SXXEYY
             search_params['name'] = u"{ep}".format(ep=episode_num(ep_obj.scene_season, ep_obj.scene_episode))

--- a/sickbeard/providers/hdbits.py
+++ b/sickbeard/providers/hdbits.py
@@ -147,7 +147,7 @@ class HDBitsProvider(TorrentProvider):
             elif show.anime:
                 post_data['tvdb'] = {
                     'id': show.indexerid,
-                    'episode': "{0:02d}".format(int(episode.scene_absolute_number))
+                    'episode': "{0:d}".format(int(episode.scene_absolute_number))
                 }
             else:
                 post_data['tvdb'] = {
@@ -165,7 +165,7 @@ class HDBitsProvider(TorrentProvider):
             elif show.anime:
                 post_data['tvdb'] = {
                     'id': show.indexerid,
-                    'season': "{0:02d}".format(season.scene_absolute_number),
+                    'season': "{0:d}".format(season.scene_absolute_number),
                 }
             else:
                 post_data['tvdb'] = {

--- a/sickrage/providers/GenericProvider.py
+++ b/sickrage/providers/GenericProvider.py
@@ -389,6 +389,7 @@ class GenericProvider(object):  # pylint: disable=too-many-instance-attributes
 
         for show_name in allPossibleShowNames(episode.show, season=episode.scene_season):
             episode_string = show_name + ' '
+            episode_string_fallback = None
 
             if episode.show.air_by_date:
                 episode_string += str(episode.airdate).replace('-', ' ')
@@ -397,7 +398,8 @@ class GenericProvider(object):  # pylint: disable=too-many-instance-attributes
                 episode_string += ('|', ' ')[len(self.proper_strings) > 1]
                 episode_string += episode.airdate.strftime('%b')
             elif episode.show.anime:
-                episode_string += '{0:02d}'.format(int(episode.scene_absolute_number))
+                episode_string_fallback = episode_string + '{0:02d}'.format(int(episode.scene_absolute_number))
+                episode_string += '{0:03d}'.format(int(episode.scene_absolute_number))
             else:
                 episode_string += sickbeard.config.naming_ep_type[2] % {
                     'seasonnumber': episode.scene_season,
@@ -406,8 +408,12 @@ class GenericProvider(object):  # pylint: disable=too-many-instance-attributes
 
             if add_string:
                 episode_string += ' ' + add_string
+                if episode_string_fallback:
+                    episode_string_fallback += ' ' + add_string
 
             search_string['Episode'].append(episode_string.encode('utf-8').strip())
+            if episode_string_fallback:
+                search_string['Episode'].append(episode_string_fallback.encode('utf-8').strip())
 
         return [search_string]
 
@@ -417,20 +423,18 @@ class GenericProvider(object):  # pylint: disable=too-many-instance-attributes
         }
 
         for show_name in allPossibleShowNames(episode.show, season=episode.scene_season):
-            episode_string = show_name + ' '
+            season_string = show_name + ' '
 
             if episode.show.air_by_date or episode.show.sports:
-                episode_string += str(episode.airdate).split('-')[0]
+                season_string += str(episode.airdate).split('-')[0]
             elif episode.show.anime:
-                episode_string += '{0:02d}'.format(int(episode.scene_absolute_number))
+                # use string below if you really want to search on season with number
+                # season_string += 'Season ' + '{0:d}'.format(int(episode.scene_season))
+                season_string += 'Season'  # ignore season number to get all seasons in all formats
             else:
-                episode_string += 'S{0:02d}'.format(int(episode.scene_season))
+                season_string += 'S{0:02d}'.format(int(episode.scene_season))
 
-            search_string['Season'].append(episode_string.encode('utf-8').strip())
-
-            if not (episode.show.air_by_date or episode.show.sports or episode.show.anime):
-                season_string = show_name + ' Season {0:d}'.format(int(episode.scene_season))
-                search_string['Season'].append(season_string.encode('utf-8').strip())
+            search_string['Season'].append(season_string.encode('utf-8').strip())
 
         return [search_string]
 

--- a/sickrage/providers/torrent/TorrentProvider.py
+++ b/sickrage/providers/torrent/TorrentProvider.py
@@ -63,10 +63,11 @@ class TorrentProvider(GenericProvider):
                 for term in self.proper_strings:
                     search_strings = self._get_episode_search_strings(episode, add_string=term)
 
-                    for item in self.search(search_strings[0]):
-                        title, url = self._get_title_and_url(item)
+                    for search_string in search_strings:
+                        for item in self.search(search_string):
+                            title, url = self._get_title_and_url(item)
 
-                        results.append(Proper(title, url, datetime.today(), show))
+                            results.append(Proper(title, url, datetime.today(), show))
 
         return results
 


### PR DESCRIPTION
Fix anime episode search (part 3)

Some extra optimizations and fixes (it seems that season search was also wronly implemented)

Proposed changes in this pull request:
- Adapt anime episode search to search for both 01 an 001 formats.
- Fix season search for anime
- Revert btn and hdbits back to their original episode format (no prefix with 0). (Other forks are also using episode format without prefix)
- Adapt torrent proper finder for multiple search strings.

- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read [contribution guide](https://github.com/SickRage/SickRage/blob/master/.github/CONTRIBUTING.md)
