### PR TITLE
Fix scene search

### DIFF
--- a/sickbeard/name_parser/parser.py
+++ b/sickbeard/name_parser/parser.py
@@ -269,14 +269,14 @@ class NameParser(object):
                     new_season_numbers.append(s)
 
             elif bestResult.show.is_anime and bestResult.ab_episode_numbers:
-                scene_season = scene_exceptions.get_scene_exception_by_name(bestResult.series_name)[1]
+                bestResult.scene_season = scene_exceptions.get_scene_exception_by_name(bestResult.series_name)[1]
                 for epAbsNo in bestResult.ab_episode_numbers:
                     a = epAbsNo
 
                     if bestResult.show.is_scene:
                         a = scene_numbering.get_indexer_absolute_numbering(bestResult.show.indexerid,
                                                                            bestResult.show.indexer, epAbsNo,
-                                                                           True, scene_season)
+                                                                           True, bestResult.scene_season)
 
                     (s, e) = helpers.get_all_episodes_from_absolute_number(bestResult.show, [a])
 
@@ -442,6 +442,7 @@ class NameParser(object):
         # season and episode numbers
         final_result.season_number = self._combine_results(file_name_result, dir_name_result, 'season_number')
         final_result.episode_numbers = self._combine_results(file_name_result, dir_name_result, 'episode_numbers')
+        final_result.scene_season = self._combine_results(file_name_result, dir_name_result, 'scene_season')
 
         # if the dirname has a release group/show name I believe it over the filename
         final_result.series_name = self._combine_results(dir_name_result, file_name_result, 'series_name')
@@ -514,6 +515,8 @@ class ParseResult(object):  # pylint: disable=too-many-instance-attributes
         self.score = score
 
         self.version = version
+
+        self.scene_season = None
 
     def __eq__(self, other):
         return other and all([

--- a/sickrage/providers/GenericProvider.py
+++ b/sickrage/providers/GenericProvider.py
@@ -209,7 +209,8 @@ class GenericProvider(object):  # pylint: disable=too-many-instance-attributes
                         parse_result.season_number is not None,
                         parse_result.episode_numbers,
                         [ep for ep in episodes if (ep.season, ep.scene_season)[ep.show.is_scene] ==
-                         parse_result.season_number and (ep.episode, ep.scene_episode)[ep.show.is_scene] in parse_result.episode_numbers]
+                        (parse_result.season_number, parse_result.scene_season)[ep.show.is_scene] and
+                        (ep.episode, ep.scene_episode)[ep.show.is_scene] in parse_result.episode_numbers]
                     ]):
 
                         logger.log(


### PR DESCRIPTION
Fix for scenario explained at

I'm not sure it this is the way to go, but I think we should compare the
scene season if we are searching in scene mode... otherwise you'll never
get a match during the initial search because the normal season is
compared with the scene season.

Hopefully this doesn't brake anything else... I only fixed this specific scenario... but I think it shoud no have impact on other scenario's...


- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read [contribution guide](https://github.com/SickRage/SickRage/blob/master/.github/CONTRIBUTING.md)
