### PR TITLE
Fix 'Unknown' in every 'Downloaded' history entry log, Fixes #2965 + #1789

### DIFF
--- a/gui/slick/views/history.mako
+++ b/gui/slick/views/history.mako
@@ -85,8 +85,8 @@
                                             % if hItem["provider"] != "-1":
                                                 <span style="vertical-align:middle;"><i>${hItem["provider"]}</i></span>
                                             % else:
-                                            % endif
                                                 <span style="vertical-align:middle;"><i>${_('Unknown')}</i></span>
+                                            % endif
                                         % else:
                                             % if hItem["provider"] > 0:
                                                 % if curStatus in [SNATCHED, FAILED]:


### PR DESCRIPTION
'Unknown' is shown on every 'Downloaded' log entry regardless of hItem["provider"] value.
![image](https://cloud.githubusercontent.com/assets/10238474/22867242/1af4f584-f18d-11e6-8517-442c757847a4.png)
