### PR TITLE
Genres bug FIX

### DIFF
--- a/gui/slick/views/displayShow.mako
+++ b/gui/slick/views/displayShow.mako
@@ -156,11 +156,11 @@
                                 <ul class="tags">
                                     % if show.genre and not show.imdb_info.get('genres'):
                                         % for genre in show.genre[1:-1].split('|'):
-                                            <a href="${anon_url('http://trakt.tv/shows/popular/?genres=', genre.lower())}" target="_blank" title="${_('View other popular {genre} shows on trakt.tv.').format(genre=genre)}"><li>${_('genre')}</li></a>
+                                            <a href="${anon_url('http://trakt.tv/shows/popular/?genres=', genre.lower())}" target="_blank" title="${_('View other popular {genre} shows on trakt.tv.').format(genre=_(genre))}"><li>${_(genre)}</li></a>
                                         % endfor
                                     % elif show.imdb_info.get('genres'):
                                         % for imdbgenre in show.imdb_info['genres'].replace('Sci-Fi','Science-Fiction').split('|'):
-                                            <a href="${anon_url('http://www.imdb.com/search/title?count=100&title_type=tv_series&genres=', imdbgenre.lower())}" target="_blank" title="${_('View other popular {imdbgenre} shows on IMDB.').format(imdbgenre=imdbgenre)}"><li>${imdbgenre}</li></a>
+                                            <a href="${anon_url('http://www.imdb.com/search/title?count=100&title_type=tv_series&genres=', imdbgenre.lower())}" target="_blank" title="${_('View other popular {imdbgenre} shows on IMDB.').format(imdbgenre=_(imdbgenre))}"><li>${_(imdbgenre)}</li></a>
                                         % endfor
                                     % endif
                                 </ul>


### PR DESCRIPTION
Fixes a bug where if a show's metadata language wasn't English,
the genres section would display the word genre instead of the genre itself.
![image](https://cloud.githubusercontent.com/assets/10238474/22867231/c56ddaf4-f18c-11e6-9024-d3aaf1bc4096.png)