### PR TITLE
Fixes #2967

### DIFF
--- a/sickbeard/show_queue.py
+++ b/sickbeard/show_queue.py
@@ -146,6 +146,9 @@ class ShowQueue(generic_queue.GenericQueue):
         if lang is None:
             lang = sickbeard.INDEXER_DEFAULT_LANGUAGE
 
+        if default_status_after is None:
+            default_status_after = sickbeard.STATUS_DEFAULT_AFTER
+
         queueItemObj = QueueItemAdd(indexer, indexer_id, showDir, default_status, quality, flatten_folders, lang,
                                     subtitles, subtitles_sr_metadata, anime, scene, paused, blacklist, whitelist,
                                     default_status_after, root_dir)


### PR DESCRIPTION
Ensure that default_status_after is not None.
Otherwise a show's default_ep_status is set to None in QueueItemAdd when a new show is added.