### PR TITLE
Fix for 'Shows' page progress bars' tooltips in 'List' mode

### DIFF
--- a/gui/slick/views/home.mako
+++ b/gui/slick/views/home.mako
@@ -345,7 +345,7 @@
                                                     den = cur_total
                                                 else:
                                                     den = 1
-                                                download_stat_tip = _('Unaired')
+                                                    download_stat_tip = _('Unaired')
 
                                                 progressbar_percent = nom * 100 / den
                                             %>


### PR DESCRIPTION
Fixes an minor bug on the home page show list.
Every progress bar has a tooltip that explains the episode download progress (Downloaded: X, Snatched: Y, Total: Z) for the show.
When you're in "List" display mode the tooltip shows 'Unaired' for every progress bar, no matter the real progress that is displayed.