### PR TITLE
Fix mass edit season folders

### DIFF
--- a/gui/slick/views/manage_massEdit.mako
+++ b/gui/slick/views/manage_massEdit.mako
@@ -149,8 +149,8 @@
                     <div class="col-lg-9 col-md-8 col-sm-7 col-xs-12 component-desc">
                         <select id="flatten_folders" name="flatten_folders" class="form-control form-control-inline input-sm">
                             <option value="keep" ${('', 'selected="selected"')[flatten_folders_value is None]}>&lt; ${_('Keep')} &gt;</option>
-                            <option value="enable" ${('', 'selected="selected"')[flatten_folders_value == 0]}>${_('Yes')}</option>
-                            <option value="disable" ${('', 'selected="selected"')[flatten_folders_value == 1]}>${_('No')}</option>
+                            <option value="disable" ${('', 'selected="selected"')[flatten_folders_value == 0]}>${_('Yes')}</option>
+                            <option value="enable" ${('', 'selected="selected"')[flatten_folders_value == 1]}>${_('No')}</option>
                         </select>
                         <label for="flatten_folders">${_('Group episodes by season folder (set to "No" to store in a single folder).')}</label>
                     </div>

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -3457,7 +3457,7 @@ class Manage(Home, WebRoot):
                 new_air_by_date = show_obj.air_by_date
             else:
                 new_air_by_date = True if air_by_date == 'enable' else False
-            new_air_by_date = 'on' if new_air_by_date else 'off'
+            new_air_by_date = 'off' if new_air_by_date else 'on'
 
             if flatten_folders == 'keep':
                 new_flatten_folders = show_obj.flatten_folders

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -3457,13 +3457,13 @@ class Manage(Home, WebRoot):
                 new_air_by_date = show_obj.air_by_date
             else:
                 new_air_by_date = True if air_by_date == 'enable' else False
-            new_air_by_date = 'off' if new_air_by_date else 'on'
+            new_air_by_date = 'on' if new_air_by_date else 'off'
 
             if flatten_folders == 'keep':
                 new_flatten_folders = show_obj.flatten_folders
             else:
                 new_flatten_folders = True if flatten_folders == 'enable' else False
-            new_flatten_folders = 'on' if new_flatten_folders else 'off'
+            new_flatten_folders = 'off' if new_flatten_folders else 'on'
 
             if subtitles == 'keep':
                 new_subtitles = show_obj.subtitles


### PR DESCRIPTION
Fixes Mass Edit inverting/setting wrong values into Season Folders/flatten_folders

Proposed changes in this pull request:
- Invert flatten_folders value in massEditSubmit [webserve.py]
- Fix massEdit setting the wrong 'Season Folders' value [manage_massEdit.mako]

See commits descriptions for explanations.