### PR TITLE
Fixes: Season collapse & General config label typo

### DIFF
--- a/gui/slick/views/config_general.mako
+++ b/gui/slick/views/config_general.mako
@@ -382,7 +382,7 @@
                             <div class="col-lg-9 col-md-8 col-sm-7 col-xs-12 component-desc">
                                 <input type="checkbox" class="enabler" name="sickrage_background" id="sickrage_background"
                                     ${('', 'checked="checked"')[bool(sickbeard.SICKRAGE_BACKGROUND)]} />
-                                <label for="fanart_background">${_('use a custom image as background for SickRage')}</label>
+                                <label for="sickrage_background">${_('use a custom image as background for SickRage')}</label>
                             </div>
                         </div>
                         <div id="content_sickrage_background">

--- a/gui/slick/views/displayShow.mako
+++ b/gui/slick/views/displayShow.mako
@@ -406,8 +406,12 @@
                         <div class="col-md-12">
                             <br/>
                             <h3 style="display: inline;"><a name="season-${epResult["season"]}"></a>${(_("Specials"), _("Season") + ' ' + str(epResult["season"]))[int(epResult["season"]) > 0]}</h3>
-                            % if sickbeard.DISPLAY_ALL_SEASONS is False:
-                                <button id="showseason-${epResult['season']}" type="button" class="btn btn-xs pull-right" data-toggle="collapse" data-target="#collapseSeason-${epResult['season']}">${_('Show Episodes')}</button>
+                            % if not sickbeard.DISPLAY_ALL_SEASONS:
+                                % if curSeason == -1:
+                                    <button id="showseason-${epResult['season']}" type="button" class="btn btn-xs pull-right" data-toggle="collapse" data-target="#collapseSeason-${epResult['season']}" aria-expanded="true">${_('Hide Episodes')}</button>
+                                %else:
+                                    <button id="showseason-${epResult['season']}" type="button" class="btn btn-xs pull-right" data-toggle="collapse" data-target="#collapseSeason-${epResult['season']}">${_('Show Episodes')}</button>
+                                %endif
                             % endif
                         </div>
                     </div>
@@ -437,7 +441,7 @@
                                         </tr>
                                     </thead>
 
-                                % if sickbeard.DISPLAY_ALL_SEASONS is False:
+                                % if not sickbeard.DISPLAY_ALL_SEASONS:
                                     <tbody class="toggle collapse${("", " in")[curSeason == -1]}" id="collapseSeason-${epResult['season']}">
                                 % else:
                                     <tbody>

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -671,14 +671,14 @@ class Home(WebRoot):
         show_obj = Show.find(sickbeard.showList, int(show))
 
         if not show_obj:
-            return None, _("Invalid show paramaters")
+            return None, _("Invalid show parameters")
 
         if absolute:
             ep_obj = show_obj.getEpisode(absolute_number=absolute)
         elif season and episode:
             ep_obj = show_obj.getEpisode(season, episode)
         else:
-            return None, _("Invalid paramaters")
+            return None, _("Invalid parameters")
 
         if not ep_obj:
             return None, _("Episode couldn't be retrieved")


### PR DESCRIPTION
1. The seasons collapsing option (display all seasons config toggle) wasn't working.
The type of 'sickbeard.DISPLAY_ALL_SEASONS' was integer, not boolean.
Also, on current season the collapse button was showing 'Show Season' even though the season was already expanded.

2. In General -> Interface config, when clicking on the label for background image, the fanart option gets deselected.