### PR TITLE
Fix for accents on elitetorrent

### DIFF
--- a/sickbeard/providers/elitetorrent.py
+++ b/sickbeard/providers/elitetorrent.py
@@ -107,7 +107,21 @@ class EliteTorrentProvider(TorrentProvider):
                         for row in torrent_rows[1:]:
                             try:
                                 download_url = self.urls['base_url'] + row.find('a')['href']
-                                title = self._processTitle(row.find('a', class_='nombre')['title'])
+                                """
+                                Trick for accents for this provider.
+                                
+                                - data = self.get_url(self.urls['search'], params=search_params, returns='text') - 
+                                returns latin1 coded text and this makes that the title used for the search 
+                                and the title retrieved from the parsed web page doesn't match so I get 
+                                "No needed episodes found during backlog search for: XXXX"
+                                
+                                This is not the best solution but it works.
+                                
+                                First encode latin1 and then decode utf8 to remains unicode
+                                """
+                                row_title = row.find('a', class_='nombre')['title']
+                                title = self._processTitle(row_title.encode('latin-1').decode('utf8'))
+                                
                                 seeders = try_int(row.find('td', class_='semillas').get_text(strip=True))
                                 leechers = try_int(row.find('td', class_='clientes').get_text(strip=True))
                                 


### PR DESCRIPTION
Trick for accents for this provider.
                                
I realised that - data = self.get_url(self.urls['search'], params=search_params, returns='text') - 
returns latin1 coded text and this makes that the title used for the search 
and the title retrieved from the parsed web page doesn't match so I get 
"No needed episodes found during backlog search for: XXXX"

This is not the best solution but it works.

First encode latin1 and then decode utf8 to remains unicode

Related to #3169

**Proposed changes in this pull request:**
- Fix for accents on titles on this provider reencoding the string.

- [x] PR is based on the DEVELOP branch
- [ ] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read [contribution guide](https://github.com/SickRage/SickRage/blob/master/.github/CONTRIBUTING.md)
