### PR TITLE
Switch to new BTN api hostname

### DIFF
--- a/sickbeard/providers/btn.py
+++ b/sickbeard/providers/btn.py
@@ -46,7 +46,7 @@ class BTNProvider(TorrentProvider):
 
         self.cache = BTNCache(self, min_time=15)  # Only poll BTN every 15 minutes max
 
-        self.urls = {'base_url': u'http://api.btnapps.net',
+        self.urls = {'base_url': u'http://api.broadcasthe.net',
                      'website': u'http://broadcasthe.net/', }
 
         self.url = self.urls['website']


### PR DESCRIPTION
Fixes #3156

Proposed changes in this pull request:
- Switch BTN api to new hostname

- [X] PR is based on the DEVELOP branch
- [X] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [X] Read [contribution guide](https://github.com/SickRage/SickRage/blob/master/.github/CONTRIBUTING.md)
