### PR TITLE
A workaround for #1377

### DIFF
--- a/sickbeard/naming.py
+++ b/sickbeard/naming.py
@@ -296,4 +296,4 @@ def generate_sample_ep(multi=None, abd=False, sports=False, anime_type=None):
 def test_name(pattern, multi=None, abd=False, sports=False, anime_type=None):
     ep = generate_sample_ep(multi, abd, sports, anime_type)
 
-    return {'name': ep.formatted_filename(pattern, multi, anime_type), 'dir': ep.formatted_dir(pattern, multi)}
+    return {'name': ep.formatted_filename(pattern, multi, anime_type), 'dir': ep.formatted_dir(pattern, multi, anime_type)}

--- a/sickbeard/naming.py
+++ b/sickbeard/naming.py
@@ -205,7 +205,7 @@ def validate_name(pattern, multi=None, anime_type=None,  # pylint: disable=too-m
     ep = generate_sample_ep(multi, abd, sports, anime_type)
 
     new_name = ep.formatted_filename(pattern, multi, anime_type) + '.ext'
-    new_path = ep.formatted_dir(pattern, multi)
+    new_path = ep.formatted_dir(pattern, multi, anime_type)
     if not file_only:
         new_name = ek(os.path.join, new_path, new_name)
 

--- a/sickbeard/tv.py
+++ b/sickbeard/tv.py
@@ -2369,7 +2369,7 @@ class TVEpisode(object):  # pylint: disable=too-many-instance-attributes, too-ma
 
         return result
 
-    def formatted_dir(self, pattern=None, multi=None):
+    def formatted_dir(self, pattern=None, multi=None, anime_type=None):
         """
         Just the folder name of the episode
         """
@@ -2391,7 +2391,9 @@ class TVEpisode(object):  # pylint: disable=too-many-instance-attributes, too-ma
         if len(name_groups) == 1:
             return ''
         else:
-            return self._format_pattern(os.sep.join(name_groups[:-1]), multi)
+            if not self.show.anime:
+                anime_type = 3
+            return self._format_pattern(os.sep.join(name_groups[:-1]), multi, anime_type)
 
     def formatted_filename(self, pattern=None, multi=None, anime_type=None):
         """

--- a/sickbeard/tv.py
+++ b/sickbeard/tv.py
@@ -2365,7 +2365,7 @@ class TVEpisode(object):  # pylint: disable=too-many-instance-attributes, too-ma
 
         # if not we append the folder on and use that
         else:
-            result = ek(os.path.join, self.formatted_dir(), result)
+            result = ek(os.path.join, self.formatted_dir(anime_type=anime_type), result)
 
         return result
 
@@ -2391,8 +2391,6 @@ class TVEpisode(object):  # pylint: disable=too-many-instance-attributes, too-ma
         if len(name_groups) == 1:
             return ''
         else:
-            if not self.show.anime:
-                anime_type = 3
             return self._format_pattern(os.sep.join(name_groups[:-1]), multi, anime_type)
 
     def formatted_filename(self, pattern=None, multi=None, anime_type=None):


### PR DESCRIPTION
Fixes #1377

When trying to use an episode naming pattern in the following scenario:

- **Pattern:** `Season %S/%SN - Season %S, Episode %E - %EN/%RN` (_notice there are two directories_)
- **Custom Anime Naming:** Selected (_otherwise known as NAMING_CUSTOM_ANIME=1_)
- **Anime Absolute Number:** [Add/Only](https://cloud.githubusercontent.com/assets/10238474/23103252/e149c0f6-f6c0-11e6-8d7b-1a01c4051dfe.png) (_otherwise known as anime_type=1 or anime_type=2_)

You would get
`Season 2/Show Name - 003 - Ep Name/Show.Name.S02E03.HDTV.XviD-RLSGROUP.ext`
**for a normal (non-anime) episode**,
instead of
`Season 2/Show Name - S02E03 - Ep Name/Show.Name.S02E03.HDTV.XviD-RLSGROUP.ext`

This is a 'hacky' fix, a workaround for this problem.
Any suggestions for a better one are welcome.

EDIT:
Looks like it will also fix #2545.
