### PR TITLE
Fix for WebAPI Log command

### DIFF
--- a/sickbeard/webapi.py
+++ b/sickbeard/webapi.py
@@ -1211,8 +1211,8 @@ class CMDLogs(ApiCall):
         min_level = logger.LOGGING_LEVELS[str(self.min_level).upper()]
 
         data = []
-        if ek(os.path.isfile, logger.log_file):
-            with io.open(logger.log_file, 'r', encoding='utf-8') as f:
+        if ek(os.path.isfile, logger.instance.log_file):
+            with io.open(logger.instance.log_file, 'r', encoding='utf-8') as f:
                 data = f.readlines()
 
         regex = r"^(\d\d\d\d)\-(\d\d)\-(\d\d)\s*(\d\d)\:(\d\d):(\d\d)\s*([A-Z]+)\s*(.+?)\s*\:\:\s*(.*)$"


### PR DESCRIPTION
When trying to pull logs via WebAPI, an error was thrown:
```
ERROR    TORNADO :: [d202200] API :: coercing to Unicode: need string or buffer, NoneType found
TypeError: coercing to Unicode: need string or buffer, NoneType found
```

(Fixes https://github.com/MGaetan89/ShowsRage/issues/132)