### PR TITLE
Rework on post processing logic for associated files

### DIFF
--- a/gui/slick/views/config_postProcessing.mako
+++ b/gui/slick/views/config_postProcessing.mako
@@ -207,7 +207,7 @@
 
                         <div class="field-pair row">
                             <div class="col-lg-3 col-md-3 col-sm-4 col-xs-12">
-                                <label class="component-title">${_('Delete leftover files')}</label>
+                                <label class="component-title">${_('Delete non associated files')}</label>
                             </div>
                             <div class="col-lg-9 col-md-9 col-sm-8 col-xs-12 pull-right component-desc">
                                 <input type="checkbox" name="delete_non_associated_files" id="delete_non_associated_files" ${('', 'checked="checked"')[bool(sickbeard.DELETE_NON_ASSOCIATED_FILES)]}/>

--- a/gui/slick/views/config_postProcessing.mako
+++ b/gui/slick/views/config_postProcessing.mako
@@ -178,17 +178,17 @@
 
                         <div class="field-pair row">
                             <div class="col-lg-3 col-md-3 col-sm-4 col-xs-12">
-                                <label class="component-title">${_('Delete associated files')}</label>
+                                <label class="component-title">${_('Move associated files')}</label>
                             </div>
                             <div class="col-lg-9 col-md-9 col-sm-8 col-xs-12 pull-right component-desc">
                                 <input type="checkbox" name="move_associated_files" id="move_associated_files" ${('', 'checked="checked"')[bool(sickbeard.MOVE_ASSOCIATED_FILES)]}/>
-                                <label for="move_associated_files">${_('delete srt/srr/sfv/etc files while post processing?')}</label>
+                                <label for="move_associated_files">${_('move associated (srt/srr/sfv/etc) files while post processing?')}</label>
                             </div>
                         </div>
 
                         <div class="field-pair row">
                             <div class="col-lg-3 col-md-3 col-sm-4 col-xs-12">
-                                <label class="component-title">${_('Keep associated file extensions')}</label>
+                                <label class="component-title">${_('Associated file extensions')}</label>
                             </div>
                             <div class="col-lg-9 col-md-9 col-sm-8 col-xs-12 pull-right component-desc">
                                 <div class="row">
@@ -199,9 +199,19 @@
                                 </div>
                                 <div class="row">
                                     <div class="col-md-12">
-                                        <label for="allowed_extensions">${_('leaving it empty means all associated files will be deleted')}</label>
+                                        <label for="allowed_extensions">${_('leaving it empty means no associated files will be post processed')}</label>
                                     </div>
                                 </div>
+                            </div>
+                        </div>
+
+                        <div class="field-pair row">
+                            <div class="col-lg-3 col-md-3 col-sm-4 col-xs-12">
+                                <label class="component-title">${_('Delete leftover files')}</label>
+                            </div>
+                            <div class="col-lg-9 col-md-9 col-sm-8 col-xs-12 pull-right component-desc">
+                                <input type="checkbox" name="delete_non_associated_files" id="delete_non_associated_files" ${('', 'checked="checked"')[bool(sickbeard.DELETE_NON_ASSOCIATED_FILES)]}/>
+                                <label for="delete_non_associated_files">${_('delete non associated files while post processing?')}</label>
                             </div>
                         </div>
 

--- a/sickbeard/__init__.py
+++ b/sickbeard/__init__.py
@@ -1023,7 +1023,7 @@ def initialize(consoleLogging=True):  # pylint: disable=too-many-locals, too-man
         PROCESS_METHOD = check_setting_str(CFG, 'General', 'process_method', 'copy' if KEEP_PROCESSED_DIR else 'move')
         DELRARCONTENTS = bool(check_setting_int(CFG, 'General', 'del_rar_contents', 0))
         MOVE_ASSOCIATED_FILES = bool(check_setting_int(CFG, 'General', 'move_associated_files', 0))
-        DELETE_NON_ASSOCIATED_FILES = bool(check_setting_int(CFG, 'General', 'delete_non_associated_files', 0))
+        DELETE_NON_ASSOCIATED_FILES = bool(check_setting_int(CFG, 'General', 'delete_non_associated_files', 1))
         POSTPONE_IF_SYNC_FILES = bool(check_setting_int(CFG, 'General', 'postpone_if_sync_files', 1))
         SYNC_FILES = check_setting_str(CFG, 'General', 'sync_files', SYNC_FILES)
         NFO_RENAME = bool(check_setting_int(CFG, 'General', 'nfo_rename', 1))

--- a/sickbeard/__init__.py
+++ b/sickbeard/__init__.py
@@ -292,6 +292,7 @@ KEEP_PROCESSED_DIR = False
 PROCESS_METHOD = None
 DELRARCONTENTS = False
 MOVE_ASSOCIATED_FILES = False
+DELETE_NON_ASSOCIATED_FILES = False
 POSTPONE_IF_SYNC_FILES = True
 NFO_RENAME = True
 TV_DOWNLOAD_DIR = None
@@ -685,7 +686,7 @@ def initialize(consoleLogging=True):  # pylint: disable=too-many-locals, too-man
             USE_SYNOLOGYNOTIFIER, SYNOLOGYNOTIFIER_NOTIFY_ONSNATCH, SYNOLOGYNOTIFIER_NOTIFY_ONDOWNLOAD, SYNOLOGYNOTIFIER_NOTIFY_ONSUBTITLEDOWNLOAD, \
             USE_EMAIL, EMAIL_HOST, EMAIL_PORT, EMAIL_TLS, EMAIL_USER, EMAIL_PASSWORD, EMAIL_FROM, EMAIL_NOTIFY_ONSNATCH, EMAIL_NOTIFY_ONDOWNLOAD, EMAIL_NOTIFY_ONSUBTITLEDOWNLOAD, EMAIL_LIST, EMAIL_SUBJECT, \
             USE_LISTVIEW, METADATA_KODI, METADATA_KODI_12PLUS, METADATA_MEDIABROWSER, METADATA_PS3, metadata_provider_dict, \
-            NEWZBIN, NEWZBIN_USERNAME, NEWZBIN_PASSWORD, GIT_PATH, MOVE_ASSOCIATED_FILES, SYNC_FILES, POSTPONE_IF_SYNC_FILES, dailySearchScheduler, NFO_RENAME, \
+            NEWZBIN, NEWZBIN_USERNAME, NEWZBIN_PASSWORD, GIT_PATH, MOVE_ASSOCIATED_FILES, DELETE_NON_ASSOCIATED_FILES, SYNC_FILES, POSTPONE_IF_SYNC_FILES, dailySearchScheduler, NFO_RENAME, \
             GUI_NAME, HOME_LAYOUT, HISTORY_LAYOUT, DISPLAY_SHOW_SPECIALS, COMING_EPS_LAYOUT, COMING_EPS_SORT, COMING_EPS_DISPLAY_PAUSED, COMING_EPS_MISSED_RANGE, FUZZY_DATING, TRIM_ZERO, DATE_PRESET, TIME_PRESET, TIME_PRESET_W_SECONDS, THEME_NAME, \
             POSTER_SORTBY, POSTER_SORTDIR, HISTORY_LIMIT, CREATE_MISSING_SHOW_DIRS, ADD_SHOWS_WO_DIR, USE_FREE_SPACE_CHECK, \
             METADATA_WDTV, METADATA_TIVO, METADATA_MEDE8ER, IGNORE_WORDS, TRACKERS_LIST, IGNORED_SUBS_LIST, REQUIRE_WORDS, CALENDAR_UNPROTECTED, CALENDAR_ICONS, NO_RESTART, \
@@ -1022,6 +1023,7 @@ def initialize(consoleLogging=True):  # pylint: disable=too-many-locals, too-man
         PROCESS_METHOD = check_setting_str(CFG, 'General', 'process_method', 'copy' if KEEP_PROCESSED_DIR else 'move')
         DELRARCONTENTS = bool(check_setting_int(CFG, 'General', 'del_rar_contents', 0))
         MOVE_ASSOCIATED_FILES = bool(check_setting_int(CFG, 'General', 'move_associated_files', 0))
+        DELETE_NON_ASSOCIATED_FILES = bool(check_setting_int(CFG, 'General', 'delete_non_associated_files', 0))
         POSTPONE_IF_SYNC_FILES = bool(check_setting_int(CFG, 'General', 'postpone_if_sync_files', 1))
         SYNC_FILES = check_setting_str(CFG, 'General', 'sync_files', SYNC_FILES)
         NFO_RENAME = bool(check_setting_int(CFG, 'General', 'nfo_rename', 1))
@@ -1955,6 +1957,7 @@ def save_config():  # pylint: disable=too-many-statements, too-many-branches
             'process_method': PROCESS_METHOD,
             'del_rar_contents': int(DELRARCONTENTS),
             'move_associated_files': int(MOVE_ASSOCIATED_FILES),
+            'delete_non_associated_files': int(DELETE_NON_ASSOCIATED_FILES),
             'sync_files': SYNC_FILES,
             'postpone_if_sync_files': int(POSTPONE_IF_SYNC_FILES),
             'nfo_rename': int(NFO_RENAME),

--- a/sickbeard/postProcessor.py
+++ b/sickbeard/postProcessor.py
@@ -162,6 +162,7 @@ class PostProcessor(object):  # pylint: disable=too-many-instance-attributes
             return []
 
         file_path_list = []
+        extensions_to_allow = []
         extensions_to_delete = []
 
         if subfolders:
@@ -207,8 +208,15 @@ class PostProcessor(object):  # pylint: disable=too-many-instance-attributes
             if re.search(r'(^.+\.(rar|r\d+)$)', associated_file_path):
                 continue
 
-            # Add the extensions that the user doesn't allow to the 'extensions_to_delete' list
+            # Add the extensions that the user allows to the 'extensions_to_allow' list
             if sickbeard.MOVE_ASSOCIATED_FILES:
+                allowed_extensions = sickbeard.ALLOWED_EXTENSIONS.split(",")
+                if associated_file_path.rpartition('.')[2] in allowed_extensions:
+                    if ek(os.path.isfile, associated_file_path):
+                        extensions_to_allow.append(associated_file_path)
+
+            # Add the extensions that the user doesn't allow to the 'extensions_to_delete' list
+            if sickbeard.DELETE_NON_ASSOCIATED_FILES:
                 allowed_extensions = sickbeard.ALLOWED_EXTENSIONS.split(",")
                 if not associated_file_path.rpartition('.')[2] in allowed_extensions:
                     if ek(os.path.isfile, associated_file_path):
@@ -219,9 +227,13 @@ class PostProcessor(object):  # pylint: disable=too-many-instance-attributes
 
         if file_path_list:
             self._log(u"Found the following associated files for {0}: {1}".format(file_path, file_path_list), logger.DEBUG)
-            if extensions_to_delete:
+            if extensions_to_allow:
+                self._log(u"Associated files to allow for {0}: {1}".format(file_path, extensions_to_allow), logger.DEBUG)
                 # Rebuild the 'file_path_list' list only with the extensions the user allows
-                file_path_list = [associated_file for associated_file in file_path_list if associated_file not in extensions_to_delete]
+                file_path_list = extensions_to_allow
+            if extensions_to_delete:
+                self._log(u"Associated files to delete for {0}: {1}".format(file_path, extensions_to_delete), logger.DEBUG)
+                # Delete all extensions the user doesn't allow
                 self._delete(extensions_to_delete)
         else:
             self._log(u"No associated files for {0} were found during this pass".format(file_path), logger.DEBUG)

--- a/sickbeard/postProcessor.py
+++ b/sickbeard/postProcessor.py
@@ -162,8 +162,8 @@ class PostProcessor(object):  # pylint: disable=too-many-instance-attributes
             return []
 
         file_path_list = []
-        extensions_to_allow = []
-        extensions_to_delete = []
+        file_path_list_to_allow = []
+        file_path_list_to_delete = []
 
         if subfolders:
             base_name = ek(os.path.basename, file_path).rpartition('.')[0]
@@ -208,33 +208,25 @@ class PostProcessor(object):  # pylint: disable=too-many-instance-attributes
             if re.search(r'(^.+\.(rar|r\d+)$)', associated_file_path):
                 continue
 
-            # Add the extensions that the user allows to the 'extensions_to_allow' list
-            if sickbeard.MOVE_ASSOCIATED_FILES:
-                allowed_extensions = sickbeard.ALLOWED_EXTENSIONS.split(",")
-                if associated_file_path.rpartition('.')[2] in allowed_extensions:
-                    if ek(os.path.isfile, associated_file_path):
-                        extensions_to_allow.append(associated_file_path)
-
-            # Add the extensions that the user doesn't allow to the 'extensions_to_delete' list
-            if sickbeard.DELETE_NON_ASSOCIATED_FILES:
-                allowed_extensions = sickbeard.ALLOWED_EXTENSIONS.split(",")
-                if not associated_file_path.rpartition('.')[2] in allowed_extensions:
-                    if ek(os.path.isfile, associated_file_path):
-                        extensions_to_delete.append(associated_file_path)
-
+            # Define associated files (all, allowed and non allowed)
+            allowed_extensions = sickbeard.ALLOWED_EXTENSIONS.split(",")
             if ek(os.path.isfile, associated_file_path):
+                if sickbeard.MOVE_ASSOCIATED_FILES and associated_file_path.rpartition('.')[2] in allowed_extensions:
+                    file_path_list_to_allow.append(associated_file_path)
+                elif sickbeard.DELETE_NON_ASSOCIATED_FILES:
+                    file_path_list_to_delete.append(associated_file_path)
                 file_path_list.append(associated_file_path)
 
         if file_path_list:
             self._log(u"Found the following associated files for {0}: {1}".format(file_path, file_path_list), logger.DEBUG)
-            if extensions_to_allow:
-                self._log(u"Associated files to allow for {0}: {1}".format(file_path, extensions_to_allow), logger.DEBUG)
+            if file_path_list_to_allow:
+                self._log(u"Associated files to allow for {0}: {1}".format(file_path, file_path_list_to_allow), logger.DEBUG)
                 # Rebuild the 'file_path_list' list only with the extensions the user allows
-                file_path_list = extensions_to_allow
-            if extensions_to_delete:
-                self._log(u"Associated files to delete for {0}: {1}".format(file_path, extensions_to_delete), logger.DEBUG)
+                file_path_list = file_path_list_to_allow
+            if file_path_list_to_delete:
+                self._log(u"Associated files to delete for {0}: {1}".format(file_path, file_path_list_to_delete), logger.DEBUG)
                 # Delete all extensions the user doesn't allow
-                self._delete(extensions_to_delete)
+                self._delete(file_path_list_to_delete)
         else:
             self._log(u"No associated files for {0} were found during this pass".format(file_path), logger.DEBUG)
 

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -4262,7 +4262,7 @@ class ConfigPostProcessing(Config):
                            no_delete=None, rename_episodes=None, airdate_episodes=None,
                            file_timestamp_timezone=None,
                            unpack=None, unrar_tool=None, alt_unrar_tool=None,
-                           move_associated_files=None, sync_files=None,
+                           move_associated_files=None, delete_non_associated_files=None, sync_files=None,
                            postpone_if_sync_files=None,
                            allowed_extensions=None, tv_download_dir=None,
                            create_missing_show_dirs=None, add_shows_wo_dir=None,
@@ -4307,6 +4307,7 @@ class ConfigPostProcessing(Config):
         sickbeard.AIRDATE_EPISODES = config.checkbox_to_value(airdate_episodes)
         sickbeard.FILE_TIMESTAMP_TIMEZONE = file_timestamp_timezone
         sickbeard.MOVE_ASSOCIATED_FILES = config.checkbox_to_value(move_associated_files)
+        sickbeard.DELETE_NON_ASSOCIATED_FILES = config.checkbox_to_value(delete_non_associated_files)
         sickbeard.SYNC_FILES = sync_files
         sickbeard.POSTPONE_IF_SYNC_FILES = config.checkbox_to_value(postpone_if_sync_files)
 


### PR DESCRIPTION
Add separate flag to move associated files and to delete non associated files.

Related to discussion in #3183 

Proposed changes in this pull request:
- split logic to move and delete associated files
![image](https://cloud.githubusercontent.com/assets/1945295/23183917/fac0c052-f87d-11e6-900b-3e56fe90ca01.png)

- with delete enabled
![image](https://cloud.githubusercontent.com/assets/1945295/23183922/020e1ba2-f87e-11e6-93f9-bfaf09cf6e50.png)

- with delete disabled
![image](https://cloud.githubusercontent.com/assets/1945295/23183948/1270bec8-f87e-11e6-8eb1-46ac08c6041c.png)

- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read [contribution guide](https://github.com/SickRage/SickRage/blob/master/.github/CONTRIBUTING.md)
