### PR TITLE
Fix #3184. Setting locale when starting SR with upstart

### DIFF
--- a/runscripts/init.upstart
+++ b/runscripts/init.upstart
@@ -17,6 +17,10 @@ stop on runlevel [!2345]
 
 kill timeout 30
 
+# Setting the environment locale. 
+# You don't need to change this regardless of your language, but if you do, use a language in UTF-8
+env LANG=en_US.UTF-8
+
 setuid sickrage
 setgid sickrage
 


### PR DESCRIPTION
upstart scripts uses ascii by default. So when SR tries, for instance,  to save a file with accents, it crashes. 

The same effect should be obtained doing the same change in /etc/environment but impacting every script launched by upstart.

Fixes #3184

- [ ] PR is based on the DEVELOP branch
- [ ] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [ ] Read [contribution guide](https://github.com/SickRage/SickRage/blob/master/.github/CONTRIBUTING.md)
