### PR TITLE
Fix for Post Processing extracted folder deletion

### DIFF
--- a/sickbeard/processTV.py
+++ b/sickbeard/processTV.py
@@ -200,7 +200,7 @@ def process_dir(process_path, release_name=None, process_method=None, force=Fals
             if delete_folder(current_directory, check_empty=True):
                 result.output += log_helper(u"Deleted folder: {0}".format(current_directory), logger.DEBUG)
 
-	for directory_from_rar in directories_from_rars:
+    for directory_from_rar in directories_from_rars:
         # Only allow methods 'move' and 'copy'. On different method fall back to 'move'.
         method_fallback = ('move', process_method)[process_method in ('move', 'copy')]
 

--- a/sickbeard/processTV.py
+++ b/sickbeard/processTV.py
@@ -200,11 +200,14 @@ def process_dir(process_path, release_name=None, process_method=None, force=Fals
             if delete_folder(current_directory, check_empty=True):
                 result.output += log_helper(u"Deleted folder: {0}".format(current_directory), logger.DEBUG)
 
-    for directory_from_rar in directories_from_rars:
+	for directory_from_rar in directories_from_rars:
+        # Only allow methods 'move' and 'copy'. On different method fall back to 'move'.
+        method_fallback = ('move', process_method)[process_method in ('move', 'copy')]
+
         process_dir(
             process_path=directory_from_rar,
             release_name=ek(os.path.basename, directory_from_rar),
-            process_method=('move', process_method)[process_method in ('move', 'copy')],
+            process_method=method_fallback,
             force=force,
             is_priority=is_priority,
             delete_on=sickbeard.DELRARCONTENTS,
@@ -212,7 +215,12 @@ def process_dir(process_path, release_name=None, process_method=None, force=Fals
             mode=mode
         )
 
-        if sickbeard.DELRARCONTENTS:
+        # auto post-processing deletes rar content by default if method is 'move',
+        # sickbeard.DELRARCONTENTS allows to override even if method is NOT 'move'
+        # manual post-processing will only delete when prompted by delete_on
+        if sickbeard.DELRARCONTENTS \
+            or not sickbeard.DELRARCONTENTS and mode == 'auto' and method_fallback == 'move' \
+            or mode == 'manual' and delete_on:
             delete_folder(directory_from_rar, False)
 
     result.output += log_helper((u"Processing Failed", u"Successfully processed")[result.aggresult], (logger.WARNING, logger.INFO)[result.aggresult])


### PR DESCRIPTION
Fixes #3206

Post processor would only delete extracted files when `sickbeard.DELRARCONTENTS == True`, which is wrong,
as explained in the code:
> **auto post-processing deletes rar content by default if method is 'move',
> sickbeard.DELRARCONTENTS allows to override even if method is NOT 'move'
> manual post-processing will only delete when prompted by delete_on**

@miigotu 
I believe that this is a priority, however if you cherry pick it to master, I should note that
the types of `delete_on` and `sickbeard.DELRARCONTENTS` when I tested on master were **integers**.
On develop the types are already **boolean** due the changes we made today to `checkbox_to_value()` and `config.check_setting_bool()`. Keep that in mind.