### PR TITLE
Fix show size diff between Show List and displayShow

### DIFF
--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -742,7 +742,7 @@ class Home(WebRoot):
         sql_statement += ' (SELECT airdate FROM tv_episodes WHERE showid=tv_eps.showid AND airdate >= ' + today
         sql_statement += ' AND (status = ' + str(UNAIRED) + ' OR status = ' + str(WANTED) + ') ORDER BY airdate ASC LIMIT 1) AS ep_airs_next, '
         sql_statement += ' (SELECT airdate FROM tv_episodes WHERE showid=tv_eps.showid AND airdate > 1 AND status <> ' + str(UNAIRED) + ' ORDER BY airdate DESC LIMIT 1) AS ep_airs_prev, '
-        sql_statement += ' (SELECT SUM(file_size) FROM tv_episodes WHERE showid=tv_eps.showid) AS show_size'
+        sql_statement += ' (SELECT SUM(file_size) FROM (SELECT file_size FROM tv_episodes WHERE showid=tv_eps.showid GROUP BY location)) AS show_size'
         sql_statement += ' FROM tv_episodes tv_eps GROUP BY showid'
 
         sql_result = main_db_con.select(sql_statement)


### PR DESCRIPTION
It's a different approach to fix https://github.com/SickRage/old-sickrage-issues/issues/596
Because the **[SQL `DISTINCT` clause](https://github.com/SickRage/SickRage/pull/821/files#diff-357efeabeb6d6921e8196af70c431bebR726)** apparently **[caused issues for some people](https://github.com/SickRage/old-sickrage-issues/issues/596#issuecomment-174449947)**.

To be clear:
This difference only occurs when you have a show with at least one multi-episode file.