### PR TITLE
Only delete RAR files after they're processed. +1

### DIFF
--- a/sickbeard/postProcessor.py
+++ b/sickbeard/postProcessor.py
@@ -223,7 +223,6 @@ class PostProcessor(object):  # pylint: disable=too-many-instance-attributes
             self._log("Found the following associated files for {0}: {1}".format(file_path, file_path_list_to_allow + file_path_list_to_delete), logger.DEBUG)
             if file_path_list_to_allow:
                 self._log("Associated files to allow for {0}: {1}".format(file_path, file_path_list_to_allow), logger.DEBUG)
-                # Rebuild the 'file_path_list' list only with the extensions the user allows
             if file_path_list_to_delete:
                 self._log("Associated files to delete for {0}: {1}".format(file_path, file_path_list_to_delete), logger.DEBUG)
                 # Delete all extensions the user doesn't allow

--- a/tests/pp_tests.py
+++ b/tests/pp_tests.py
@@ -134,16 +134,6 @@ class ListAssociatedFiles(unittest.TestCase):
         # Test no associated files:
         associated_files = self.post_processor.list_associated_files('Fools Quest.avi', subfolders=True)
 
-        # Test delete non-associated files
-        value_keep = sickbeard.DELETE_NON_ASSOCIATED_FILES
-        sickbeard.DELETE_NON_ASSOCIATED_FILES = True
-        sickbeard.ALLOWED_EXTENSIONS = u'srt'
-        associated_files = self.post_processor.list_associated_files(self.file_list[0], subfolders=True)
-        out_list = sorted(file_name for file_name in self.file_list[1:] if '.srt' in file_name and 'Non-Associated' not in file_name)
-        self.assertEqual(out_list, associated_files)
-        sickbeard.DELETE_NON_ASSOCIATED_FILES = value_keep
-        sickbeard.ALLOWED_EXTENSIONS = u''
-
     def test_no_subfolders(self):
         associated_files = self.post_processor.list_associated_files(self.file_list[0], subfolders=False)
 

--- a/tests/pp_tests.py
+++ b/tests/pp_tests.py
@@ -106,6 +106,8 @@ class ListAssociatedFiles(unittest.TestCase):
         self.file_list = [os.path.join('Show Name', f) for f in file_names] + [os.path.join(self.test_tree, f) for f in file_names]
         self.post_processor = PostProcessor('Show Name')
         self.maxDiff = None
+        sickbeard.MOVE_ASSOCIATED_FILES = True
+        sickbeard.ALLOWED_EXTENSIONS = u''
 
     def setUp(self):
         make_dirs(self.test_tree)
@@ -116,12 +118,31 @@ class ListAssociatedFiles(unittest.TestCase):
         shutil.rmtree('Show Name')
 
     def test_subfolders(self):
+        # Test edge cases first:
+        self.assertEqual([], # empty file_path
+            self.post_processor.list_associated_files('', subfolders=True))
+        self.assertEqual([], # no file name
+                         self.post_processor.list_associated_files('\\Show Name\\.nomedia', subfolders=True))
+
         associated_files = self.post_processor.list_associated_files(self.file_list[0], subfolders=True)
 
         associated_files = sorted(file_name.lstrip('./') for file_name in associated_files)
         out_list = sorted(file_name for file_name in self.file_list[1:] if 'Non-Associated' not in file_name)
 
         self.assertEqual(out_list, associated_files)
+
+        # Test no associated files:
+        associated_files = self.post_processor.list_associated_files('Fools Quest.avi', subfolders=True)
+
+        # Test delete non-associated files
+        value_keep = sickbeard.DELETE_NON_ASSOCIATED_FILES
+        sickbeard.DELETE_NON_ASSOCIATED_FILES = True
+        sickbeard.ALLOWED_EXTENSIONS = u'srt'
+        associated_files = self.post_processor.list_associated_files(self.file_list[0], subfolders=True)
+        out_list = sorted(file_name for file_name in self.file_list[1:] if '.srt' in file_name and 'Non-Associated' not in file_name)
+        self.assertEqual(out_list, associated_files)
+        sickbeard.DELETE_NON_ASSOCIATED_FILES = value_keep
+        sickbeard.ALLOWED_EXTENSIONS = u''
 
     def test_no_subfolders(self):
         associated_files = self.post_processor.list_associated_files(self.file_list[0], subfolders=False)


### PR DESCRIPTION
- Moved deleting RARs to only _**after**_ they are _**successfully**_ processed.

- Fixes an issue where,
when running Manual Post-Processing with 'Delete RAR Contents' (from the config) _**enabled**_ and 'Delete files and folders' (from Manual PostProcess page) _**unselected**_,
it would **still delete the RAR contents**.
- Fixes Travis builds failing after changing list_associated_files,
also removed an old comment from list_associated_files

*[Note]* Running Manual Post Processing with **'Delete files and folders' unselected** also deletes all associated files that are not in your allowed files list. I don't think it should, but that's enough meddling in postprocess for today.