### PR TITLE
Adapt anime SxxExx regex

### DIFF
--- a/sickbeard/name_parser/regexes.py
+++ b/sickbeard/name_parser/regexes.py
@@ -349,13 +349,15 @@ anime_regexes = [
      # Show.Name.S01E02E03.Source.Quality.Etc-Group
      # Show Name - S01E02-03 - My Ep Name
      # Show.Name.S01.E02.E03
+     # Show Name - S01E02
+     # Show Name - S01E02-03
      r'''
      ^((?P<series_name>.+?)[. _-]+)?             # Show_Name and separator
      (\()?s(?P<season_num>\d+)[. _-]*            # S01 and optional separator
      e(?P<ep_num>\d+)(\))?                       # E02 and separator
      (([. _-]*e|-)                               # linking e/- char
      (?P<extra_ep_num>(?!(1080|720|480)[pi])\d+)(\))?)*   # additional E03/etc
-     [. _-]+((?P<extra_info>.+?)                 # Source_Quality_Etc-
+     ([. _-]+((?P<extra_info>.+?))?              # Source_Quality_Etc-
      ((?<![. _-])(?<!WEB)                        # Make sure this is really the release group
      -(?P<release_group>[^ -]+([. _-]\[.*\])?))?)?$              # Group
      '''),

--- a/tests/name_parser_tests.py
+++ b/tests/name_parser_tests.py
@@ -508,7 +508,7 @@ class AnimeTests(test.SickbeardTestDBCase):
         Test anime SxxExx file names
         """
         name_parser = parser.NameParser(parse_method='anime')
-        self._test_names(name_parser, 'anime_SxxExx', lambda x: x + '.avi', True)
+        self._test_names(name_parser, 'anime_SxxExx', lambda x: x + '.avi')
 
 
 # TODO: Make these work or document why they shouldn't


### PR DESCRIPTION
Allow anime SxxExx file names without episode info and other info. (f.e. Show Name - S01E02)

This fixes https://github.com/SickRage/SickRage/issues/3201

- [ ] PR is based on the DEVELOP branch
- [ ] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [ ] Read [contribution guide](https://github.com/SickRage/SickRage/blob/master/.github/CONTRIBUTING.md)
