### PR TITLE
Check if is video_files empty in process_media()

### DIFF
--- a/sickbeard/processTV.py
+++ b/sickbeard/processTV.py
@@ -484,6 +484,10 @@ def process_media(process_path, video_files, release_name, process_method, force
     :param result: Previous results
     """
 
+    if not video_files:
+        result.result = False
+        return
+
     processor = None
     for cur_video_file in video_files:
         cur_video_file_path = ek(os.path.join, process_path, cur_video_file)


### PR DESCRIPTION
Fixes #3259

Proposed changes in this pull request:
- Check if `video_files` is empty when processing. If it is, set `result.result` to False and return.
This should stop directories being deleted prematurely when processing directory has files in sub directories.
