### PR TITLE
Fix for site_messages stacking update messages

### DIFF
--- a/sickbeard/helpers.py
+++ b/sickbeard/helpers.py
@@ -1755,7 +1755,7 @@ def add_site_message(message, level='danger'):
     to_add = dict(level=level, message=message)
 
     for index, existing in six.iteritems(sickbeard.SITE_MESSAGES):
-        if re.sub(r'\d+', '#', existing['message']) == re.sub(r'\d+', '#', message):
+        if re.search(r'\d+ commits', existing['message']) is not None and re.search(r'\d+ commits', message) is not None:
             sickbeard.SITE_MESSAGES[index] = to_add
             return
 


### PR DESCRIPTION
Apparently that check that was added in https://github.com/SickRage/SickRage/commit/325039e96b7bc77be9f089fed467170aa58b6a2c wasn't working.
The re.sub was replacing **_all of the numbers_** in the link,
instead of only that number in 'you're X commits behind')

Tested, should be good now.

Fixes #3268 + #3266