### PR TITLE
Change format pattern for anime_type = 2 and ep_only_match

### DIFF
--- a/sickbeard/tv.py
+++ b/sickbeard/tv.py
@@ -2335,7 +2335,7 @@ class TVEpisode(object):  # pylint: disable=too-many-instance-attributes, too-ma
                             ep_string += '-' + "{#:03d}".format(**{"#": relEp.episode})
 
             regex_replacement = None
-            if anime_type == 2:
+            if anime_type == 2 and not ep_only_match:
                 regex_replacement = r'\g<pre_sep>' + ep_string + r'\g<post_sep>'
             elif season_ep_match:
                 regex_replacement = r'\g<pre_sep>\g<2>\g<3>' + ep_string + r'\g<post_sep>'


### PR DESCRIPTION
Possible fix for https://github.com/SickRage/SickRage/issues/2371.
anime_type = 2 and ep_only_match does have <pre_sep> and <post_sep> in regex.
In this case we should fall back to ep_string for regex_replacement.

- [ ] PR is based on the DEVELOP branch
- [ ] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [ ] Read [contribution guide](https://github.com/SickRage/SickRage/blob/master/.github/CONTRIBUTING.md)
