### PR TITLE
Auto download UnRAR.exe for Windows users (revisited)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,7 +58,7 @@ Thumbs.db
 
 # Unrar Executable   #
 ######################
-lib/unrar2/UnRAR.exe
+unrar/*
 
 # Grunt #
 ######################

--- a/sickbeard/config.py
+++ b/sickbeard/config.py
@@ -132,11 +132,12 @@ def change_unrar_tool(unrar_tool, alt_unrar_tool):
             # Look for WinRAR installations
             found = False
             winrar_path = 'WinRAR\\UnRAR.exe'
-            for check in (
-                os.path.join(os.environ["ProgramFiles(x86)"], winrar_path),
-                os.path.join(os.environ["ProgramW6432"], winrar_path),
-
-            ):
+            # Make a set of unique paths to check from existing environment variables
+            for check in {
+                os.path.join(location, winrar_path) for location in (
+                    os.environ.get("ProgramFiles(x86)"), os.environ.get("ProgramW6432"), os.environ.get("ProgramFiles")
+                ) if location
+            }:
                 if ek(os.path.isfile, check):
                     # Can use it?
                     try:

--- a/sickbeard/config.py
+++ b/sickbeard/config.py
@@ -133,11 +133,14 @@ def change_unrar_tool(unrar_tool, alt_unrar_tool):
             found = False
             winrar_path = 'WinRAR\\UnRAR.exe'
             # Make a set of unique paths to check from existing environment variables
-            for check in {
+            check_locations = {
                 os.path.join(location, winrar_path) for location in (
                     os.environ.get("ProgramFiles(x86)"), os.environ.get("ProgramW6432"), os.environ.get("ProgramFiles")
                 ) if location
-            }:
+            }
+            check_locations.add(os.path.join(sickbeard.PROG_DIR, 'unrar\\unrar.exe'))
+
+            for check in check_locations:
                 if ek(os.path.isfile, check):
                     # Can use it?
                     try:

--- a/sickbeard/config.py
+++ b/sickbeard/config.py
@@ -131,20 +131,17 @@ def change_unrar_tool(unrar_tool, alt_unrar_tool):
         if platform.system() == 'Windows':
             # Look for WinRAR installations
             found = False
-            install_paths = set()
+            winrar_path = 'WinRAR\\UnRAR.exe'
             # Make a set of unique paths to check from existing environment variables
-            if "ProgramW6432" in os.environ:  # it's simpler in Vista or newer
-                install_paths.update([os.environ["ProgramW6432"],  # Program Files
-                                      os.environ["ProgramFiles(x86)"]]),  # Program Files (x86)
-            else:
-                install_paths.add(os.environ["ProgramFiles"])  # Program Files / Program Files (x86)
-                if "ProgramFiles(x86)" in os.environ:  # is Windows 64 bit
-                    install_paths.update([os.environ["ProgramFiles(x86)"],  # Program Files (x86)
-                                          re.sub(r'\s?\(x86\)', '', os.environ["ProgramFiles(x86)"])])  # Program Files
-            install_paths = { os.path.join(location, 'WinRAR\\UnRAR.exe') for location in install_paths }
-            install_paths.add(os.path.join(sickbeard.PROG_DIR, 'unrar\\unrar.exe'))
+            check_locations = {
+                os.path.join(location, winrar_path) for location in (
+                    os.environ.get("ProgramW6432"), os.environ.get("ProgramFiles(x86)"),
+                    os.environ.get("ProgramFiles"), re.sub(r'\s?\(x86\)', '', os.environ["ProgramFiles"])
+                ) if location
+            }
+            check_locations.add(os.path.join(sickbeard.PROG_DIR, 'unrar\\unrar.exe'))
 
-            for check in install_paths:
+            for check in check_locations:
                 if ek(os.path.isfile, check):
                     # Can use it?
                     try:

--- a/sickbeard/config.py
+++ b/sickbeard/config.py
@@ -131,16 +131,20 @@ def change_unrar_tool(unrar_tool, alt_unrar_tool):
         if platform.system() == 'Windows':
             # Look for WinRAR installations
             found = False
-            winrar_path = 'WinRAR\\UnRAR.exe'
+            install_paths = set()
             # Make a set of unique paths to check from existing environment variables
-            check_locations = {
-                os.path.join(location, winrar_path) for location in (
-                    os.environ.get("ProgramFiles(x86)"), os.environ.get("ProgramW6432"), os.environ.get("ProgramFiles")
-                ) if location
-            }
-            check_locations.add(os.path.join(sickbeard.PROG_DIR, 'unrar\\unrar.exe'))
+            if "ProgramW6432" in os.environ:  # it's simpler in Vista or newer
+                install_paths.update([os.environ["ProgramW6432"],  # Program Files
+                                      os.environ["ProgramFiles(x86)"]]),  # Program Files (x86)
+            else:
+                install_paths.add(os.environ["ProgramFiles"])  # Program Files / Program Files (x86)
+                if "ProgramFiles(x86)" in os.environ:  # is Windows 64 bit
+                    install_paths.update([os.environ["ProgramFiles(x86)"],  # Program Files (x86)
+                                          re.sub(r'\s?\(x86\)', '', os.environ["ProgramFiles(x86)"])])  # Program Files
+            install_paths = { os.path.join(location, 'WinRAR\\UnRAR.exe') for location in install_paths }
+            install_paths.add(os.path.join(sickbeard.PROG_DIR, 'unrar\\unrar.exe'))
 
-            for check in check_locations:
+            for check in install_paths:
                 if ek(os.path.isfile, check):
                     # Can use it?
                     try:

--- a/sickbeard/config.py
+++ b/sickbeard/config.py
@@ -116,7 +116,7 @@ def change_unrar_tool(unrar_tool, alt_unrar_tool):
         rarfile.ORIG_UNRAR_TOOL = unrar_tool
     except (rarfile.RarCannotExec, rarfile.RarExecError, OSError, IOError):
         if platform.system() == 'Windows':
-            for unrar_tool in ('C:\\Program Files\WinRAR\\UnRAR.exe', 'C:\\Program Files (x86)\WinRAR\\UnRAR.exe'):
+            for unrar_tool in ('C:\\Program Files\\WinRAR\\UnRAR.exe', 'C:\\Program Files (x86)\\WinRAR\\UnRAR.exe'):
                 try:
                     rarfile.custom_check(unrar_tool)
                     sickbeard.UNRAR_TOOL = unrar_tool

--- a/sickbeard/config.py
+++ b/sickbeard/config.py
@@ -115,10 +115,19 @@ def change_unrar_tool(unrar_tool, alt_unrar_tool):
 
     try:
         rarfile.custom_check(unrar_tool)
-        sickbeard.UNRAR_TOOL = unrar_tool
-        rarfile.UNRAR_TOOL = unrar_tool
-        rarfile.ORIG_UNRAR_TOOL = unrar_tool
     except (rarfile.RarCannotExec, rarfile.RarExecError, OSError, IOError):
+        # Let's just return right now if the defaults work
+        try:
+            # noinspection PyProtectedMember
+            test = rarfile._check_unrar_tool()
+            if test:
+                # These must always be set to something before returning
+                sickbeard.UNRAR_TOOL = rarfile.UNRAR_TOOL
+                sickbeard.ALT_UNRAR_TOOL = rarfile.ALT_TOOL
+                return True
+        except (rarfile.RarCannotExec, rarfile.RarExecError, OSError, IOError):
+            pass
+
         if platform.system() == 'Windows':
             # Look for WinRAR installations
             found = False
@@ -162,20 +171,9 @@ def change_unrar_tool(unrar_tool, alt_unrar_tool):
                 else:
                     logger.log('Unable to download unrar.exe')
 
-    try:
-        rarfile.custom_check(unrar_tool)
-        sickbeard.UNRAR_TOOL = unrar_tool
-        rarfile.UNRAR_TOOL = unrar_tool
-        rarfile.ORIG_UNRAR_TOOL = unrar_tool
-    except (rarfile.RarCannotExec, rarfile.RarExecError, OSError, IOError):
-        pass
-
-    try:
-        rarfile.custom_check(alt_unrar_tool)
-        sickbeard.ALT_UNRAR_TOOL = alt_unrar_tool
-        rarfile.ALT_TOOL = alt_unrar_tool
-    except (rarfile.RarCannotExec, rarfile.RarExecError, OSError, IOError):
-        pass
+    # These must always be set to something before returning
+    sickbeard.UNRAR_TOOL = rarfile.UNRAR_TOOL = rarfile.ORIG_UNRAR_TOOL = unrar_tool
+    sickbeard.ALT_UNRAR_TOOL = rarfile.ALT_TOOL = alt_unrar_tool
 
     try:
         # noinspection PyProtectedMember

--- a/tests/config_tests.py
+++ b/tests/config_tests.py
@@ -64,6 +64,7 @@ sys.path.insert(1, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')
 
 from sickbeard import config, scheduler
 from configobj import ConfigObj
+from rarfile import RarExecError
 import sickbeard
 
 class ConfigTestBasic(unittest.TestCase):
@@ -271,16 +272,31 @@ class ConfigTestChanges(unittest.TestCase):
         """
         Test change_unrar_tool
         """
-        my_environ = mock.patch.dict(os.environ,
-                                     { 'ProgramFiles': 'C:\\Program Files (x86)\\',
-                                       'ProgramFiles(x86)': 'C:\\Program Files (x86)\\',
-                                       'ProgramW6432': 'C:\\Program Files\\' }, clear=True)
-        with my_environ:
-            self.assertFalse(config.change_unrar_tool('unrar', 'bsdtar'))
+        custom_check_mock = mock.patch('rarfile.custom_check', mock.MagicMock())
+        custom_check_mock.new.side_effect = [RarExecError(), True]
 
-        # with mock.patch.dict(os.environ, { 'ProgramFiles': '/C/Program Files/',
-        #                                    'ProgramFiles(x86)': '/C/Program Files (x86)/' }, clear=True):
-        #     self.assertTrue(config.change_unrar_tool('unrar', 'bsdtar'))
+        with custom_check_mock,\
+              mock.patch('os.path.exists', mock.MagicMock(return_value=True)),\
+              mock.patch('os.path.getsize', mock.MagicMock(return_value=447440)),\
+              mock.patch('os.remove'):
+            self.assertTrue(config.change_unrar_tool('unrar', 'bsdtar'))
+
+        my_environ = mock.patch.dict(os.environ,
+                                     {'ProgramFiles': 'C:\\Program Files (x86)\\'}, clear=True)
+        with my_environ:
+             self.assertFalse(config.change_unrar_tool('unrar', 'bsdtar'))
+
+        sickbeard.PROG_DIR = 'C:\\SickRage'
+        my_environ = mock.patch.dict(os.environ,
+                                     {'ProgramFiles': 'C:\\Program Files (x86)\\',
+                                      'ProgramFiles(x86)': 'C:\\Program Files (x86)\\',
+                                      'ProgramW6432': 'C:\\Program Files\\'}, clear=True)
+        custom_check_mock.new.side_effect = [RarExecError(), RarExecError(), True, True, True, True]
+        isfile_mock = mock.patch('os.path.isfile', mock.MagicMock())
+        isfile_mock.new.side_effect = [True, False, True]
+
+        with custom_check_mock, isfile_mock, my_environ:
+            self.assertTrue(config.change_unrar_tool('unrar', 'bsdtar'))
 
     def test_change_sickrage_background(self):
         """

--- a/tests/config_tests.py
+++ b/tests/config_tests.py
@@ -20,6 +20,7 @@ Classes:
 Methods
     change_https_cert
     change_https_key
+    change_unrar_tool
     change_sickrage_background
     change_log_dir
     change_nzb_dir
@@ -55,6 +56,7 @@ import logging
 import os.path
 import sys
 import unittest
+import mock
 from collections import namedtuple
 
 sys.path.insert(1, os.path.abspath(os.path.join(os.path.dirname(__file__), '../lib')))
@@ -261,6 +263,24 @@ class ConfigTestChanges(unittest.TestCase):
         self.assertTrue(config.change_https_key('server.key'))
         self.assertFalse(config.change_https_key('/:/server.key')) # INVALID
         sickbeard.HTTPS_KEY = ''
+
+    @mock.patch('platform.system', mock.MagicMock(return_value="Windows"))
+    @mock.patch('sickbeard.helpers.download_file', mock.MagicMock(return_value=True))
+    @mock.patch('sickbeard.helpers.extractZip', mock.MagicMock(return_value=True))
+    def test_change_unrar_tool(self):
+        """
+        Test change_unrar_tool
+        """
+        my_environ = mock.patch.dict(os.environ,
+                                     { 'ProgramFiles': 'C:\\Program Files (x86)\\',
+                                       'ProgramFiles(x86)': 'C:\\Program Files (x86)\\',
+                                       'ProgramW6432': 'C:\\Program Files\\' }, clear=True)
+        with my_environ:
+            self.assertFalse(config.change_unrar_tool('unrar', 'bsdtar'))
+
+        # with mock.patch.dict(os.environ, { 'ProgramFiles': '/C/Program Files/',
+        #                                    'ProgramFiles(x86)': '/C/Program Files (x86)/' }, clear=True):
+        #     self.assertTrue(config.change_unrar_tool('unrar', 'bsdtar'))
 
     def test_change_sickrage_background(self):
         """

--- a/tests/config_tests.py
+++ b/tests/config_tests.py
@@ -284,7 +284,7 @@ class ConfigTestChanges(unittest.TestCase):
         my_environ = mock.patch.dict(os.environ,
                                      {'ProgramFiles': 'C:\\Program Files (x86)\\'}, clear=True)
         with my_environ:
-             self.assertFalse(config.change_unrar_tool('unrar', 'bsdtar'))
+            self.assertFalse(config.change_unrar_tool('unrar', 'bsdtar'))
 
         sickbeard.PROG_DIR = 'C:\\SickRage'
         my_environ = mock.patch.dict(os.environ,


### PR DESCRIPTION
* Reintegrate #3321 (disabled in https://github.com/SickRage/SickRage/commit/3cf9d37986f04186cec555c4d4e30f4ff79d2f97) - **Automate UnRAR.exe downloading for Windows**
Original unrar.exe (+licence.txt) from RARLab.com will be hosted at sickrage.github.io as a compressed zip file (reduces size in half...)
* Change the method for finding a WinRAR installation (I needed it to report whether a tool was found)
### The following PR needs to merge before this PR goes live: https://github.com/SickRage/sickrage.github.io/pull/230