### PR TITLE
Fix for RAR contents not being deleted

### DIFF
--- a/sickbeard/processTV.py
+++ b/sickbeard/processTV.py
@@ -202,7 +202,7 @@ def process_dir(process_path, release_name=None, process_method=None, force=Fals
             result.result = False
 
         # Delete all file not needed and avoid deleting files if Manual PostProcessing
-        if not(process_method == "move" and result.result) or (mode == "manual" and not delete_on):
+        if not result.result or not delete_on and (process_method != "move" or mode == "manual"):
             continue
 
         # noinspection PyTypeChecker


### PR DESCRIPTION
RAR contents wasn't being deleted
**when the following criteria were met:** 

Setting | Value
------ | ---------
**Processing Mode** | is `Auto`
**Process Method** | _**not**_ `Move`
**Delete RAR Contents** | is `True` [selected]

It should be fine, not supposed to break anything.
All I did was add a check for the process_method.

[ #3345 ]