### PR TITLE
Clean up path building for transmission, fix bug for torrent download…

### DIFF
--- a/sickbeard/clients/deluged_client.py
+++ b/sickbeard/clients/deluged_client.py
@@ -101,14 +101,11 @@ class DelugeDAPI(GenericClient):
         return True
 
     def _set_torrent_path(self, result):
-
-        path = sickbeard.TORRENT_PATH
-        if path:
-            return self.drpc.set_torrent_path(result.hash, path)
+        if sickbeard.TORRENT_PATH:
+            return self.drpc.set_torrent_path(result.hash, sickbeard.TORRENT_PATH)
         return True
 
     def _set_torrent_pause(self, result):
-
         if sickbeard.TORRENT_PAUSED:
             return self.drpc.pause_torrent(result.hash)
         return True

--- a/sickbeard/clients/generic.py
+++ b/sickbeard/clients/generic.py
@@ -47,7 +47,6 @@ class GenericClient(object):  # pylint: disable=too-many-instance-attributes
         self.username = sickbeard.TORRENT_USERNAME if not username else username
         self.password = sickbeard.TORRENT_PASSWORD if not password else password
         self.host = sickbeard.TORRENT_HOST if not host else host
-        self.rpcurl = sickbeard.TORRENT_RPCURL
 
         self.url = None
         self.response = None

--- a/sickbeard/clients/transmission_client.py
+++ b/sickbeard/clients/transmission_client.py
@@ -18,10 +18,9 @@
 # You should have received a copy of the GNU General Public License
 # along with SickRage. If not, see <http://www.gnu.org/licenses/>.
 
-import os
-import re
-import json
 from base64 import b64encode
+import json
+import re
 
 import sickbeard
 from sickbeard.clients.generic import GenericClient
@@ -31,17 +30,7 @@ class TransmissionAPI(GenericClient):
     def __init__(self, host=None, username=None, password=None):
 
         super(TransmissionAPI, self).__init__('Transmission', host, username, password)
-
-        if not self.host.endswith('/'):
-            self.host += '/'
-
-        if self.rpcurl.startswith('/'):
-            self.rpcurl = self.rpcurl[1:]
-
-        if self.rpcurl.endswith('/'):
-            self.rpcurl = self.rpcurl[:-1]
-
-        self.url = self.host + self.rpcurl + '/rpc'
+        self.url = '/'.join((self.host.rstrip('/'), sickbeard.TORRENT_RPCURL.strip('/'), 'rpc'))
 
     def _get_auth(self):
 
@@ -68,9 +57,10 @@ class TransmissionAPI(GenericClient):
 
         arguments = {
             'filename': result.url,
-            'paused': 1 if sickbeard.TORRENT_PAUSED else 0
+            'paused': int(sickbeard.TORRENT_PAUSED)
         }
-        if os.path.isabs(sickbeard.TORRENT_PATH):
+
+        if sickbeard.TORRENT_PATH:
             arguments['download-dir'] = sickbeard.TORRENT_PATH
 
         post_data = json.dumps({'arguments': arguments,
@@ -87,7 +77,7 @@ class TransmissionAPI(GenericClient):
             'paused': 1 if sickbeard.TORRENT_PAUSED else 0
         }
 
-        if os.path.isabs(sickbeard.TORRENT_PATH):
+        if sickbeard.TORRENT_PATH:
             arguments['download-dir'] = sickbeard.TORRENT_PATH
 
         post_data = json.dumps({'arguments': arguments,


### PR DESCRIPTION
… path with transmission

os.path.isabs for paths to be used in an api call will fail if SR and the api are on a different machine when one is Windoze and the other is Linux
Example:
  - C:\Test is absolute for a windows destination, but it is not if SR is on Linux its fail
  - /Test is absolute for a Linux destination, but if SR is on Windows its fail

Fixes #

Proposed changes in this pull request:
-
-
-

- [ ] PR is based on the DEVELOP branch
- [ ] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [ ] Read [contribution guide](https://github.com/SickRage/SickRage/blob/master/.github/CONTRIBUTING.md)
