### PR TITLE
Fix pid example for init.systemd

### DIFF
--- a/runscripts/init.systemd
+++ b/runscripts/init.systemd
@@ -23,6 +23,8 @@
 
 ### Example Using SickRage as daemon with pid file
 # Type=forking
+# RuntimeDirectory=sickrage
+# RuntimeDirectoryMode=0750
 # PIDFile=/var/run/sickrage/sickrage.pid
 # ExecStart=/usr/bin/python2.7 /opt/sickrage/SickBeard.py -q --daemon --nolaunch --pidfile=/var/run/sickrage/sickrage.pid --datadir=/opt/sickrage
 


### PR DESCRIPTION
Fixes the with-PID example in `runscripts/init.systemd` to avoid rights problem when accessing pid file.

Explanation:

The python script must be able to write to `/var/run/sickrage/sickrage.pid`, so we must ask Systemd to create `/var/run/sickrage` with the correct owner and rights before running sickrage.
This is a classic problem and apparently the preferred method nowadays is to use `RuntimeDirectory` (see [systemd manpage about that option](https://www.freedesktop.org/software/systemd/man/systemd.exec.html#RuntimeDirectory=)).