### PR TITLE
Add min/max values for check_setting_int/float

### DIFF
--- a/gui/slick/views/config_postProcessing.mako
+++ b/gui/slick/views/config_postProcessing.mako
@@ -1335,7 +1335,7 @@
                                     </div>
                                     <div class="row">
                                         <div class="col-md-12">
-                                            <label>${_('only applies to animes. (eg. S15E45 - 310 vs S15E45)')}</label>
+                                            <label>${_('only applies to anime. (eg. S15E45 - 310 vs S15E45)')}</label>
                                         </div>
                                     </div>
                                 </div>
@@ -1354,7 +1354,7 @@
                                     </div>
                                     <div class="row">
                                         <div class="col-md-12">
-                                            <label>${_('only applies to animes.')}</label>
+                                            <label>${_('only applies to anime.')}</label>
                                         </div>
                                     </div>
                                 </div>
@@ -1367,13 +1367,13 @@
                                 <div class="col-lg-9 col-md-9 col-sm-8 col-xs-12 pull-right component-desc">
                                     <div class="row">
                                         <div class="col-md-12">
-                                            <input type="radio" name="naming_anime" id="naming_anime_none" value="3" ${('', 'checked="checked"')[sickbeard.NAMING_ANIME == 3]}/>
+                                            <input type="radio" name="naming_anime" id="naming_anime_none" value="3" ${('', 'checked="checked"')[sickbeard.NAMING_ANIME in (3, None)]}/>
                                             <label for="naming_anime_none">${_('don\'t include the absolute number')}</label>
                                         </div>
                                     </div>
                                     <div class="row">
                                         <div class="col-md-12">
-                                            <label>${_('only applies to animes.')}</label>
+                                            <label>${_('only applies to anime.')}</label>
                                         </div>
                                     </div>
                                 </div>

--- a/sickbeard/__init__.py
+++ b/sickbeard/__init__.py
@@ -742,11 +742,11 @@ def initialize(consoleLogging=True):  # pylint: disable=too-many-locals, too-man
         check_section(CFG, 'Discord')
 
         # Need to be before any passwords
-        ENCRYPTION_VERSION = check_setting_int(CFG, 'General', 'encryption_version', min=0, max=2)
+        ENCRYPTION_VERSION = check_setting_int(CFG, 'General', 'encryption_version', min_val=0, max_val=2)
         ENCRYPTION_SECRET = check_setting_str(CFG, 'General', 'encryption_secret', helpers.generateCookieSecret(), censor_log=True)
 
         # git login info
-        GIT_AUTH_TYPE = check_setting_int(CFG, 'General', 'git_auth_type', min=0, max=1)
+        GIT_AUTH_TYPE = check_setting_int(CFG, 'General', 'git_auth_type', min_val=0, max_val=1)
         GIT_USERNAME = check_setting_str(CFG, 'General', 'git_username')
         GIT_PASSWORD = check_setting_str(CFG, 'General', 'git_password', censor_log=True)
         GIT_TOKEN = check_setting_str(CFG, 'General', 'git_token_password', censor_log=True) # encryption needed
@@ -762,8 +762,8 @@ def initialize(consoleLogging=True):  # pylint: disable=too-many-locals, too-man
 
         ACTUAL_LOG_DIR = check_setting_str(CFG, 'General', 'log_dir', 'Logs')
         LOG_DIR = ek(os.path.normpath, ek(os.path.join, DATA_DIR, ACTUAL_LOG_DIR))
-        LOG_NR = check_setting_int(CFG, 'General', 'log_nr', 5, min=1)  # Default to 5 backup file (sickrage.log.x)
-        LOG_SIZE = check_setting_float(CFG, 'General', 'log_size', 10.0, min=0.5)  # Default to max 10MB per logfile
+        LOG_NR = check_setting_int(CFG, 'General', 'log_nr', 5, min_val=1)  # Default to 5 backup file (sickrage.log.x)
+        LOG_SIZE = check_setting_float(CFG, 'General', 'log_size', 10.0, min_val=0.5)  # Default to max 10MB per logfile
 
         if LOG_SIZE > 100:
             LOG_SIZE = 10.0
@@ -855,7 +855,7 @@ def initialize(consoleLogging=True):  # pylint: disable=too-many-locals, too-man
         SICKRAGE_BACKGROUND = check_setting_bool(CFG, 'GUI', 'sickrage_background')
         SICKRAGE_BACKGROUND_PATH = check_setting_str(CFG, 'GUI', 'sickrage_background_path')
         FANART_BACKGROUND = check_setting_bool(CFG, 'GUI', 'fanart_background', True)
-        FANART_BACKGROUND_OPACITY = check_setting_float(CFG, 'GUI', 'fanart_background_opacity', 0.4, min=0.1, max=1.0)
+        FANART_BACKGROUND_OPACITY = check_setting_float(CFG, 'GUI', 'fanart_background_opacity', 0.4, min_val=0.1, max_val=1.0)
 
         GUI_NAME = check_setting_str(CFG, 'GUI', 'gui_name', 'slick')
         GUI_LANG = check_setting_str(CFG, 'GUI', 'language')
@@ -867,11 +867,11 @@ def initialize(consoleLogging=True):  # pylint: disable=too-many-locals, too-man
 
         load_gettext_translations(LOCALE_DIR, 'messages')
 
-        SOCKET_TIMEOUT = check_setting_int(CFG, 'General', 'socket_timeout', 30, min=0)
+        SOCKET_TIMEOUT = check_setting_int(CFG, 'General', 'socket_timeout', 30, min_val=0)
         socket.setdefaulttimeout(SOCKET_TIMEOUT)
 
         try:
-            WEB_PORT = check_setting_int(CFG, 'General', 'web_port', 8081, min=21, max=65535)
+            WEB_PORT = check_setting_int(CFG, 'General', 'web_port', 8081, min_val=21, max_val=65535)
         except Exception:
             WEB_PORT = 8081
 
@@ -941,8 +941,8 @@ def initialize(consoleLogging=True):  # pylint: disable=too-many-locals, too-man
         AUTO_UPDATE = check_setting_bool(CFG, 'General', 'auto_update')
         NOTIFY_ON_UPDATE = check_setting_bool(CFG, 'General', 'notify_on_update', True)
         SEASON_FOLDERS_DEFAULT = check_setting_bool(CFG, 'General', 'season_folders_default', True)
-        INDEXER_DEFAULT = check_setting_int(CFG, 'General', 'indexer_default', min=min(indexerApi().indexers), max=max(indexerApi().indexers))
-        INDEXER_TIMEOUT = check_setting_int(CFG, 'General', 'indexer_timeout', 20, min=0)
+        INDEXER_DEFAULT = check_setting_int(CFG, 'General', 'indexer_default', min_val=min(indexerApi().indexers), max_val=max(indexerApi().indexers))
+        INDEXER_TIMEOUT = check_setting_int(CFG, 'General', 'indexer_timeout', 20, min_val=0)
         ANIME_DEFAULT = check_setting_bool(CFG, 'General', 'anime_default')
         SCENE_DEFAULT = check_setting_bool(CFG, 'General', 'scene_default')
 
@@ -954,11 +954,11 @@ def initialize(consoleLogging=True):  # pylint: disable=too-many-locals, too-man
         NAMING_SPORTS_PATTERN = check_setting_str(CFG, 'General', 'naming_sports_pattern', '%SN - %A-D - %EN')
         NAMING_ANIME_PATTERN = check_setting_str(CFG, 'General', 'naming_anime_pattern',
                                                  'Season %0S/%SN - S%0SE%0E - %EN')
-        NAMING_ANIME = check_setting_int(CFG, 'General', 'naming_anime', 3, min=1, max=3)
+        NAMING_ANIME = check_setting_int(CFG, 'General', 'naming_anime', 3, min_val=1, max_val=3)
         NAMING_CUSTOM_SPORTS = check_setting_bool(CFG, 'General', 'naming_custom_sports')
         NAMING_CUSTOM_ANIME = check_setting_bool(CFG, 'General', 'naming_custom_anime')
-        NAMING_MULTI_EP = check_setting_int(CFG, 'General', 'naming_multi_ep', 1, min=1, max=max(MULTI_EP_STRINGS))
-        NAMING_ANIME_MULTI_EP = check_setting_int(CFG, 'General', 'naming_anime_multi_ep', 1, min=1, max=max(MULTI_EP_STRINGS))
+        NAMING_MULTI_EP = check_setting_int(CFG, 'General', 'naming_multi_ep', 1, min_val=1, max_val=max(MULTI_EP_STRINGS))
+        NAMING_ANIME_MULTI_EP = check_setting_int(CFG, 'General', 'naming_anime_multi_ep', 1, min_val=1, max_val=max(MULTI_EP_STRINGS))
         NAMING_FORCE_FOLDERS = naming.check_force_season_folders()
         NAMING_STRIP_YEAR = check_setting_bool(CFG, 'General', 'naming_strip_year')
 
@@ -990,21 +990,21 @@ def initialize(consoleLogging=True):  # pylint: disable=too-many-locals, too-man
 
         AUTOPOSTPROCESSOR_FREQUENCY = check_setting_int(CFG, 'General', 'autopostprocessor_frequency',
                                                         DEFAULT_AUTOPOSTPROCESSOR_FREQUENCY,
-                                                        min=MIN_AUTOPOSTPROCESSOR_FREQUENCY, fallback_def=False)
+                                                        min_val=MIN_AUTOPOSTPROCESSOR_FREQUENCY, fallback_def=False)
 
         DAILYSEARCH_FREQUENCY = check_setting_int(CFG, 'General', 'dailysearch_frequency',
                                                   DEFAULT_DAILYSEARCH_FREQUENCY,
-                                                  min=MIN_DAILYSEARCH_FREQUENCY, fallback_def=False)
+                                                  min_val=MIN_DAILYSEARCH_FREQUENCY, fallback_def=False)
 
         MIN_BACKLOG_FREQUENCY = get_backlog_cycle_time()
         BACKLOG_FREQUENCY = check_setting_int(CFG, 'General', 'backlog_frequency', DEFAULT_BACKLOG_FREQUENCY,
-                                              min=MIN_BACKLOG_FREQUENCY, fallback_def=False)
+                                              min_val=MIN_BACKLOG_FREQUENCY, fallback_def=False)
 
         UPDATE_FREQUENCY = check_setting_int(CFG, 'General', 'update_frequency', DEFAULT_UPDATE_FREQUENCY,
-                                             min=MIN_UPDATE_FREQUENCY, fallback_def=False)
+                                             min_val=MIN_UPDATE_FREQUENCY, fallback_def=False)
 
         SHOWUPDATE_HOUR = check_setting_int(CFG, 'General', 'showupdate_hour', DEFAULT_SHOWUPDATE_HOUR,
-                                            min=0, max=23)
+                                            min_val=0, max_val=23)
 
         BACKLOG_DAYS = check_setting_int(CFG, 'General', 'backlog_days', 7)
 
@@ -1018,7 +1018,7 @@ def initialize(consoleLogging=True):  # pylint: disable=too-many-locals, too-man
         PROCESS_AUTOMATICALLY = check_setting_bool(CFG, 'General', 'process_automatically')
         NO_DELETE = check_setting_bool(CFG, 'General', 'no_delete')
         USE_ICACLS = check_setting_bool(CFG, 'General', 'use_icacls', True)
-        UNPACK = check_setting_int(CFG, 'General', 'unpack', min=0, max=2)
+        UNPACK = check_setting_int(CFG, 'General', 'unpack', min_val=0, max_val=2)
         UNPACK_DIR = check_setting_str(CFG, 'General', 'unpack_dir')
 
         config.change_unrar_tool(
@@ -1076,7 +1076,7 @@ def initialize(consoleLogging=True):  # pylint: disable=too-many-locals, too-man
         TORRENT_PASSWORD = check_setting_str(CFG, 'TORRENT', 'torrent_password', censor_log=True)
         TORRENT_HOST = check_setting_str(CFG, 'TORRENT', 'torrent_host')
         TORRENT_PATH = check_setting_str(CFG, 'TORRENT', 'torrent_path')
-        TORRENT_SEED_TIME = check_setting_int(CFG, 'TORRENT', 'torrent_seed_time', min=-1)
+        TORRENT_SEED_TIME = check_setting_int(CFG, 'TORRENT', 'torrent_seed_time', min_val=-1)
         TORRENT_PAUSED = check_setting_bool(CFG, 'TORRENT', 'torrent_paused')
         TORRENT_HIGH_BANDWIDTH = check_setting_bool(CFG, 'TORRENT', 'torrent_high_bandwidth')
         TORRENT_LABEL = check_setting_str(CFG, 'TORRENT', 'torrent_label')
@@ -1231,13 +1231,13 @@ def initialize(consoleLogging=True):  # pylint: disable=too-many-locals, too-man
         TRAKT_REMOVE_SERIESLIST = check_setting_bool(CFG, 'Trakt', 'trakt_remove_serieslist')
         TRAKT_REMOVE_SHOW_FROM_SICKRAGE = check_setting_bool(CFG, 'Trakt', 'trakt_remove_show_from_sickrage')
         TRAKT_SYNC_WATCHLIST = check_setting_bool(CFG, 'Trakt', 'trakt_sync_watchlist')
-        TRAKT_METHOD_ADD = check_setting_int(CFG, 'Trakt', 'trakt_method_add', min=0, max=2)
+        TRAKT_METHOD_ADD = check_setting_int(CFG, 'Trakt', 'trakt_method_add', min_val=0, max_val=2)
         TRAKT_START_PAUSED = check_setting_bool(CFG, 'Trakt', 'trakt_start_paused')
         TRAKT_USE_RECOMMENDED = check_setting_bool(CFG, 'Trakt', 'trakt_use_recommended')
         TRAKT_SYNC = check_setting_bool(CFG, 'Trakt', 'trakt_sync')
         TRAKT_SYNC_REMOVE = check_setting_bool(CFG, 'Trakt', 'trakt_sync_remove')
-        TRAKT_DEFAULT_INDEXER = check_setting_int(CFG, 'Trakt', 'trakt_default_indexer', 1, min=min(indexerApi().indexers), max=max(indexerApi().indexers))
-        TRAKT_TIMEOUT = check_setting_int(CFG, 'Trakt', 'trakt_timeout', 30, min=0)
+        TRAKT_DEFAULT_INDEXER = check_setting_int(CFG, 'Trakt', 'trakt_default_indexer', 1, min_val=min(indexerApi().indexers), max_val=max(indexerApi().indexers))
+        TRAKT_TIMEOUT = check_setting_int(CFG, 'Trakt', 'trakt_timeout', 30, min_val=0)
         TRAKT_BLACKLIST_NAME = check_setting_str(CFG, 'Trakt', 'trakt_blacklist_name')
 
         USE_PYTIVO = check_setting_bool(CFG, 'pyTivo', 'use_pytivo')
@@ -1275,7 +1275,7 @@ def initialize(consoleLogging=True):  # pylint: disable=too-many-locals, too-man
         EMAIL_NOTIFY_ONDOWNLOAD = check_setting_bool(CFG, 'Email', 'email_notify_ondownload')
         EMAIL_NOTIFY_ONSUBTITLEDOWNLOAD = check_setting_bool(CFG, 'Email', 'email_notify_onsubtitledownload')
         EMAIL_HOST = check_setting_str(CFG, 'Email', 'email_host')
-        EMAIL_PORT = check_setting_int(CFG, 'Email', 'email_port', 25, min=21, max=65535)
+        EMAIL_PORT = check_setting_int(CFG, 'Email', 'email_port', 25, min_val=21, max_val=65535)
         EMAIL_TLS = check_setting_bool(CFG, 'Email', 'email_tls')
         EMAIL_USER = check_setting_str(CFG, 'Email', 'email_user', censor_log=True)
         EMAIL_PASSWORD = check_setting_str(CFG, 'Email', 'email_password', censor_log=True)
@@ -1298,7 +1298,7 @@ def initialize(consoleLogging=True):  # pylint: disable=too-many-locals, too-man
         SUBTITLES_PERFECT_MATCH = check_setting_bool(CFG, 'Subtitles', 'subtitles_perfect_match', True)
         EMBEDDED_SUBTITLES_ALL = check_setting_bool(CFG, 'Subtitles', 'embedded_subtitles_all')
         SUBTITLES_HEARING_IMPAIRED = check_setting_bool(CFG, 'Subtitles', 'subtitles_hearing_impaired')
-        SUBTITLES_FINDER_FREQUENCY = check_setting_int(CFG, 'Subtitles', 'subtitles_finder_frequency', 1, min=1)
+        SUBTITLES_FINDER_FREQUENCY = check_setting_int(CFG, 'Subtitles', 'subtitles_finder_frequency', 1, min_val=1)
         SUBTITLES_MULTI = check_setting_bool(CFG, 'Subtitles', 'subtitles_multi', True)
         SUBTITLES_KEEP_ONLY_WANTED = check_setting_bool(CFG, 'Subtitles', 'subtitles_keep_only_wanted')
         SUBTITLES_EXTRA_SCRIPTS = [x.strip() for x in check_setting_str(CFG, 'Subtitles', 'subtitles_extra_scripts').split('|') if x.strip()]
@@ -1366,7 +1366,7 @@ def initialize(consoleLogging=True):  # pylint: disable=too-many-locals, too-man
         TIME_PRESET = TIME_PRESET_W_SECONDS.replace(":%S", "")
         TIMEZONE_DISPLAY = check_setting_str(CFG, 'GUI', 'timezone_display', 'local')
         POSTER_SORTBY = check_setting_str(CFG, 'GUI', 'poster_sortby', 'name')
-        POSTER_SORTDIR = check_setting_int(CFG, 'GUI', 'poster_sortdir', 1, min=0, max=1)
+        POSTER_SORTDIR = check_setting_int(CFG, 'GUI', 'poster_sortdir', 1, min_val=0, max_val=1)
         DISPLAY_ALL_SEASONS = check_setting_bool(CFG, 'General', 'display_all_seasons', True)
 
         # initialize NZB and TORRENT providers
@@ -1430,10 +1430,10 @@ def initialize(consoleLogging=True):  # pylint: disable=too-many-locals, too-man
                                                              curTorrentProvider.get_id() + '_ratio', '')
             if hasattr(curTorrentProvider, 'minseed'):
                 curTorrentProvider.minseed = check_setting_int(CFG, curTorrentProvider.get_id().upper(),
-                                                               curTorrentProvider.get_id() + '_minseed', 1, min=0)
+                                                               curTorrentProvider.get_id() + '_minseed', 1, min_val=0)
             if hasattr(curTorrentProvider, 'minleech'):
                 curTorrentProvider.minleech = check_setting_int(CFG, curTorrentProvider.get_id().upper(),
-                                                                curTorrentProvider.get_id() + '_minleech', 0, min=0)
+                                                                curTorrentProvider.get_id() + '_minleech', 0, min_val=0)
             if hasattr(curTorrentProvider, 'freeleech'):
                 curTorrentProvider.freeleech = check_setting_bool(CFG, curTorrentProvider.get_id().upper(), curTorrentProvider.get_id() + '_freeleech')
             if hasattr(curTorrentProvider, 'search_mode'):

--- a/sickbeard/__init__.py
+++ b/sickbeard/__init__.py
@@ -41,12 +41,12 @@ except ImportError:
 
 
 from sickbeard.indexers import indexer_api
-from sickbeard.common import SD, SKIPPED, WANTED, MULTI_EP_STRINGS
+from sickbeard.common import SD, SKIPPED, ARCHIVED, IGNORED, WANTED, MULTI_EP_STRINGS
 from sickbeard.databases import mainDB, cache_db, failed_db
 from sickbeard.providers.newznab import NewznabProvider
 from sickbeard.providers.rsstorrent import TorrentRssProvider
 from sickbeard.config import check_section, check_setting_int, check_setting_str, \
-    check_setting_float, check_setting_bool, min_max, ConfigMigrator
+    check_setting_float, check_setting_bool, ConfigMigrator
 from sickbeard import db, helpers, scheduler, search_queue, show_queue, logger, \
     naming, dailysearcher, metadata, providers
 from sickbeard import searchBacklog, showUpdater, versionChecker, properFinder, \
@@ -742,11 +742,11 @@ def initialize(consoleLogging=True):  # pylint: disable=too-many-locals, too-man
         check_section(CFG, 'Discord')
 
         # Need to be before any passwords
-        ENCRYPTION_VERSION = check_setting_int(CFG, 'General', 'encryption_version')
+        ENCRYPTION_VERSION = check_setting_int(CFG, 'General', 'encryption_version', min=0, max=2)
         ENCRYPTION_SECRET = check_setting_str(CFG, 'General', 'encryption_secret', helpers.generateCookieSecret(), censor_log=True)
 
         # git login info
-        GIT_AUTH_TYPE = check_setting_int(CFG, 'General', 'git_auth_type')
+        GIT_AUTH_TYPE = check_setting_int(CFG, 'General', 'git_auth_type', min=0, max=1)
         GIT_USERNAME = check_setting_str(CFG, 'General', 'git_username')
         GIT_PASSWORD = check_setting_str(CFG, 'General', 'git_password', censor_log=True)
         GIT_TOKEN = check_setting_str(CFG, 'General', 'git_token_password', censor_log=True) # encryption needed
@@ -762,8 +762,8 @@ def initialize(consoleLogging=True):  # pylint: disable=too-many-locals, too-man
 
         ACTUAL_LOG_DIR = check_setting_str(CFG, 'General', 'log_dir', 'Logs')
         LOG_DIR = ek(os.path.normpath, ek(os.path.join, DATA_DIR, ACTUAL_LOG_DIR))
-        LOG_NR = check_setting_int(CFG, 'General', 'log_nr', 5)  # Default to 5 backup file (sickrage.log.x)
-        LOG_SIZE = check_setting_float(CFG, 'General', 'log_size', 10.0)  # Default to max 10MB per logfile
+        LOG_NR = check_setting_int(CFG, 'General', 'log_nr', 5, min=1)  # Default to 5 backup file (sickrage.log.x)
+        LOG_SIZE = check_setting_float(CFG, 'General', 'log_size', 10.0, min=0.5)  # Default to max 10MB per logfile
 
         if LOG_SIZE > 100:
             LOG_SIZE = 10.0
@@ -855,7 +855,7 @@ def initialize(consoleLogging=True):  # pylint: disable=too-many-locals, too-man
         SICKRAGE_BACKGROUND = check_setting_bool(CFG, 'GUI', 'sickrage_background')
         SICKRAGE_BACKGROUND_PATH = check_setting_str(CFG, 'GUI', 'sickrage_background_path')
         FANART_BACKGROUND = check_setting_bool(CFG, 'GUI', 'fanart_background', True)
-        FANART_BACKGROUND_OPACITY = check_setting_float(CFG, 'GUI', 'fanart_background_opacity', 0.4)
+        FANART_BACKGROUND_OPACITY = check_setting_float(CFG, 'GUI', 'fanart_background_opacity', 0.4, min=0.1, max=1.0)
 
         GUI_NAME = check_setting_str(CFG, 'GUI', 'gui_name', 'slick')
         GUI_LANG = check_setting_str(CFG, 'GUI', 'language')
@@ -867,15 +867,12 @@ def initialize(consoleLogging=True):  # pylint: disable=too-many-locals, too-man
 
         load_gettext_translations(LOCALE_DIR, 'messages')
 
-        SOCKET_TIMEOUT = check_setting_int(CFG, 'General', 'socket_timeout', 30)
+        SOCKET_TIMEOUT = check_setting_int(CFG, 'General', 'socket_timeout', 30, min=0)
         socket.setdefaulttimeout(SOCKET_TIMEOUT)
 
         try:
-            WEB_PORT = check_setting_int(CFG, 'General', 'web_port', 8081)
+            WEB_PORT = check_setting_int(CFG, 'General', 'web_port', 8081, min=21, max=65535)
         except Exception:
-            WEB_PORT = 8081
-
-        if 21 > WEB_PORT > 65535:
             WEB_PORT = 8081
 
         WEB_HOST = check_setting_str(CFG, 'General', 'web_host', '0.0.0.0')
@@ -893,7 +890,9 @@ def initialize(consoleLogging=True):  # pylint: disable=too-many-locals, too-man
         SSL_VERIFY = check_setting_bool(CFG, 'General', 'ssl_verify', True)
 
         INDEXER_DEFAULT_LANGUAGE = check_setting_str(CFG, 'General', 'indexerDefaultLang', 'en')
-        EP_DEFAULT_DELETED_STATUS = check_setting_int(CFG, 'General', 'ep_default_deleted_status', 6)
+        EP_DEFAULT_DELETED_STATUS = check_setting_int(CFG, 'General', 'ep_default_deleted_status', ARCHIVED)
+        if EP_DEFAULT_DELETED_STATUS not in (SKIPPED, ARCHIVED, IGNORED):
+            EP_DEFAULT_DELETED_STATUS = ARCHIVED
 
         LAUNCH_BROWSER = check_setting_bool(CFG, 'General', 'launch_browser', True)
 
@@ -905,7 +904,7 @@ def initialize(consoleLogging=True):  # pylint: disable=too-many-locals, too-man
 
         ANON_REDIRECT = check_setting_str(CFG, 'General', 'anon_redirect', 'http://dereferer.org/?')
         PROXY_SETTING = check_setting_str(CFG, 'General', 'proxy_setting')
-        PROXY_INDEXERS = check_setting_int(CFG, 'General', 'proxy_indexers', 1)
+        PROXY_INDEXERS = check_setting_bool(CFG, 'General', 'proxy_indexers', True)
 
         # attempt to help prevent users from breaking links by using a bad url
         if not ANON_REDIRECT.endswith('?'):
@@ -933,13 +932,17 @@ def initialize(consoleLogging=True):  # pylint: disable=too-many-locals, too-man
 
         QUALITY_DEFAULT = check_setting_int(CFG, 'General', 'quality_default', SD)
         STATUS_DEFAULT = check_setting_int(CFG, 'General', 'status_default', SKIPPED)
+        if STATUS_DEFAULT not in (SKIPPED, WANTED, IGNORED):
+            STATUS_DEFAULT = SKIPPED
         STATUS_DEFAULT_AFTER = check_setting_int(CFG, 'General', 'status_default_after', WANTED)
+        if STATUS_DEFAULT_AFTER not in (SKIPPED, WANTED, IGNORED):
+            STATUS_DEFAULT_AFTER = WANTED
         VERSION_NOTIFY = check_setting_bool(CFG, 'General', 'version_notify', True)
         AUTO_UPDATE = check_setting_bool(CFG, 'General', 'auto_update')
         NOTIFY_ON_UPDATE = check_setting_bool(CFG, 'General', 'notify_on_update', True)
         SEASON_FOLDERS_DEFAULT = check_setting_bool(CFG, 'General', 'season_folders_default', True)
-        INDEXER_DEFAULT = check_setting_int(CFG, 'General', 'indexer_default')
-        INDEXER_TIMEOUT = check_setting_int(CFG, 'General', 'indexer_timeout', 20)
+        INDEXER_DEFAULT = check_setting_int(CFG, 'General', 'indexer_default', min=min(indexerApi().indexers), max=max(indexerApi().indexers))
+        INDEXER_TIMEOUT = check_setting_int(CFG, 'General', 'indexer_timeout', 20, min=0)
         ANIME_DEFAULT = check_setting_bool(CFG, 'General', 'anime_default')
         SCENE_DEFAULT = check_setting_bool(CFG, 'General', 'scene_default')
 
@@ -951,11 +954,11 @@ def initialize(consoleLogging=True):  # pylint: disable=too-many-locals, too-man
         NAMING_SPORTS_PATTERN = check_setting_str(CFG, 'General', 'naming_sports_pattern', '%SN - %A-D - %EN')
         NAMING_ANIME_PATTERN = check_setting_str(CFG, 'General', 'naming_anime_pattern',
                                                  'Season %0S/%SN - S%0SE%0E - %EN')
-        NAMING_ANIME = min_max(check_setting_int(CFG, 'General', 'naming_anime', 3), default=3, low=1, high=3)
+        NAMING_ANIME = check_setting_int(CFG, 'General', 'naming_anime', 3, min=1, max=3)
         NAMING_CUSTOM_SPORTS = check_setting_bool(CFG, 'General', 'naming_custom_sports')
         NAMING_CUSTOM_ANIME = check_setting_bool(CFG, 'General', 'naming_custom_anime')
-        NAMING_MULTI_EP = min_max(check_setting_int(CFG, 'General', 'naming_multi_ep', 1), default=1, low=1, high=max(MULTI_EP_STRINGS))
-        NAMING_ANIME_MULTI_EP = min_max(check_setting_int(CFG, 'General', 'naming_anime_multi_ep', 1), default=1, low=1, high=max(MULTI_EP_STRINGS))
+        NAMING_MULTI_EP = check_setting_int(CFG, 'General', 'naming_multi_ep', 1, min=1, max=max(MULTI_EP_STRINGS))
+        NAMING_ANIME_MULTI_EP = check_setting_int(CFG, 'General', 'naming_anime_multi_ep', 1, min=1, max=max(MULTI_EP_STRINGS))
         NAMING_FORCE_FOLDERS = naming.check_force_season_folders()
         NAMING_STRIP_YEAR = check_setting_bool(CFG, 'General', 'naming_strip_year')
 
@@ -986,29 +989,22 @@ def initialize(consoleLogging=True):  # pylint: disable=too-many-locals, too-man
         USENET_RETENTION = check_setting_int(CFG, 'General', 'usenet_retention', 500)
 
         AUTOPOSTPROCESSOR_FREQUENCY = check_setting_int(CFG, 'General', 'autopostprocessor_frequency',
-                                                        DEFAULT_AUTOPOSTPROCESSOR_FREQUENCY)
-        if AUTOPOSTPROCESSOR_FREQUENCY < MIN_AUTOPOSTPROCESSOR_FREQUENCY:
-            AUTOPOSTPROCESSOR_FREQUENCY = MIN_AUTOPOSTPROCESSOR_FREQUENCY
+                                                        DEFAULT_AUTOPOSTPROCESSOR_FREQUENCY,
+                                                        min=MIN_AUTOPOSTPROCESSOR_FREQUENCY, fallback_def=False)
 
         DAILYSEARCH_FREQUENCY = check_setting_int(CFG, 'General', 'dailysearch_frequency',
-                                                  DEFAULT_DAILYSEARCH_FREQUENCY)
-        if DAILYSEARCH_FREQUENCY < MIN_DAILYSEARCH_FREQUENCY:
-            DAILYSEARCH_FREQUENCY = MIN_DAILYSEARCH_FREQUENCY
+                                                  DEFAULT_DAILYSEARCH_FREQUENCY,
+                                                  min=MIN_DAILYSEARCH_FREQUENCY, fallback_def=False)
 
         MIN_BACKLOG_FREQUENCY = get_backlog_cycle_time()
-        BACKLOG_FREQUENCY = check_setting_int(CFG, 'General', 'backlog_frequency', DEFAULT_BACKLOG_FREQUENCY)
-        if BACKLOG_FREQUENCY < MIN_BACKLOG_FREQUENCY:
-            BACKLOG_FREQUENCY = MIN_BACKLOG_FREQUENCY
+        BACKLOG_FREQUENCY = check_setting_int(CFG, 'General', 'backlog_frequency', DEFAULT_BACKLOG_FREQUENCY,
+                                              min=MIN_BACKLOG_FREQUENCY, fallback_def=False)
 
-        UPDATE_FREQUENCY = check_setting_int(CFG, 'General', 'update_frequency', DEFAULT_UPDATE_FREQUENCY)
-        if UPDATE_FREQUENCY < MIN_UPDATE_FREQUENCY:
-            UPDATE_FREQUENCY = MIN_UPDATE_FREQUENCY
+        UPDATE_FREQUENCY = check_setting_int(CFG, 'General', 'update_frequency', DEFAULT_UPDATE_FREQUENCY,
+                                             min=MIN_UPDATE_FREQUENCY, fallback_def=False)
 
-        SHOWUPDATE_HOUR = check_setting_int(CFG, 'General', 'showupdate_hour', DEFAULT_SHOWUPDATE_HOUR)
-        if SHOWUPDATE_HOUR > 23:
-            SHOWUPDATE_HOUR = 0
-        elif SHOWUPDATE_HOUR < 0:
-            SHOWUPDATE_HOUR = 0
+        SHOWUPDATE_HOUR = check_setting_int(CFG, 'General', 'showupdate_hour', DEFAULT_SHOWUPDATE_HOUR,
+                                            min=0, max=23)
 
         BACKLOG_DAYS = check_setting_int(CFG, 'General', 'backlog_days', 7)
 
@@ -1022,7 +1018,7 @@ def initialize(consoleLogging=True):  # pylint: disable=too-many-locals, too-man
         PROCESS_AUTOMATICALLY = check_setting_bool(CFG, 'General', 'process_automatically')
         NO_DELETE = check_setting_bool(CFG, 'General', 'no_delete')
         USE_ICACLS = check_setting_bool(CFG, 'General', 'use_icacls', True)
-        UNPACK = check_setting_int(CFG, 'General', 'unpack')
+        UNPACK = check_setting_int(CFG, 'General', 'unpack', min=0, max=2)
         UNPACK_DIR = check_setting_str(CFG, 'General', 'unpack_dir')
 
         config.change_unrar_tool(
@@ -1073,12 +1069,14 @@ def initialize(consoleLogging=True):  # pylint: disable=too-many-locals, too-man
         NZBGET_HOST = check_setting_str(CFG, 'NZBget', 'nzbget_host')
         NZBGET_USE_HTTPS = check_setting_bool(CFG, 'NZBget', 'nzbget_use_https')
         NZBGET_PRIORITY = check_setting_int(CFG, 'NZBget', 'nzbget_priority', 100)
+        if NZBGET_PRIORITY not in (-100, -50, 0, 50, 100, 900):
+            NZBGET_PRIORITY = 100
 
         TORRENT_USERNAME = check_setting_str(CFG, 'TORRENT', 'torrent_username', censor_log=True)
         TORRENT_PASSWORD = check_setting_str(CFG, 'TORRENT', 'torrent_password', censor_log=True)
         TORRENT_HOST = check_setting_str(CFG, 'TORRENT', 'torrent_host')
         TORRENT_PATH = check_setting_str(CFG, 'TORRENT', 'torrent_path')
-        TORRENT_SEED_TIME = check_setting_int(CFG, 'TORRENT', 'torrent_seed_time')
+        TORRENT_SEED_TIME = check_setting_int(CFG, 'TORRENT', 'torrent_seed_time', min=-1)
         TORRENT_PAUSED = check_setting_bool(CFG, 'TORRENT', 'torrent_paused')
         TORRENT_HIGH_BANDWIDTH = check_setting_bool(CFG, 'TORRENT', 'torrent_high_bandwidth')
         TORRENT_LABEL = check_setting_str(CFG, 'TORRENT', 'torrent_label')
@@ -1233,13 +1231,13 @@ def initialize(consoleLogging=True):  # pylint: disable=too-many-locals, too-man
         TRAKT_REMOVE_SERIESLIST = check_setting_bool(CFG, 'Trakt', 'trakt_remove_serieslist')
         TRAKT_REMOVE_SHOW_FROM_SICKRAGE = check_setting_bool(CFG, 'Trakt', 'trakt_remove_show_from_sickrage')
         TRAKT_SYNC_WATCHLIST = check_setting_bool(CFG, 'Trakt', 'trakt_sync_watchlist')
-        TRAKT_METHOD_ADD = check_setting_int(CFG, 'Trakt', 'trakt_method_add')
+        TRAKT_METHOD_ADD = check_setting_int(CFG, 'Trakt', 'trakt_method_add', min=0, max=2)
         TRAKT_START_PAUSED = check_setting_bool(CFG, 'Trakt', 'trakt_start_paused')
         TRAKT_USE_RECOMMENDED = check_setting_bool(CFG, 'Trakt', 'trakt_use_recommended')
         TRAKT_SYNC = check_setting_bool(CFG, 'Trakt', 'trakt_sync')
         TRAKT_SYNC_REMOVE = check_setting_bool(CFG, 'Trakt', 'trakt_sync_remove')
-        TRAKT_DEFAULT_INDEXER = check_setting_int(CFG, 'Trakt', 'trakt_default_indexer', 1)
-        TRAKT_TIMEOUT = check_setting_int(CFG, 'Trakt', 'trakt_timeout', 30)
+        TRAKT_DEFAULT_INDEXER = check_setting_int(CFG, 'Trakt', 'trakt_default_indexer', 1, min=min(indexerApi().indexers), max=max(indexerApi().indexers))
+        TRAKT_TIMEOUT = check_setting_int(CFG, 'Trakt', 'trakt_timeout', 30, min=0)
         TRAKT_BLACKLIST_NAME = check_setting_str(CFG, 'Trakt', 'trakt_blacklist_name')
 
         USE_PYTIVO = check_setting_bool(CFG, 'pyTivo', 'use_pytivo')
@@ -1277,7 +1275,7 @@ def initialize(consoleLogging=True):  # pylint: disable=too-many-locals, too-man
         EMAIL_NOTIFY_ONDOWNLOAD = check_setting_bool(CFG, 'Email', 'email_notify_ondownload')
         EMAIL_NOTIFY_ONSUBTITLEDOWNLOAD = check_setting_bool(CFG, 'Email', 'email_notify_onsubtitledownload')
         EMAIL_HOST = check_setting_str(CFG, 'Email', 'email_host')
-        EMAIL_PORT = check_setting_int(CFG, 'Email', 'email_port', 25)
+        EMAIL_PORT = check_setting_int(CFG, 'Email', 'email_port', 25, min=21, max=65535)
         EMAIL_TLS = check_setting_bool(CFG, 'Email', 'email_tls')
         EMAIL_USER = check_setting_str(CFG, 'Email', 'email_user', censor_log=True)
         EMAIL_PASSWORD = check_setting_str(CFG, 'Email', 'email_password', censor_log=True)
@@ -1300,7 +1298,7 @@ def initialize(consoleLogging=True):  # pylint: disable=too-many-locals, too-man
         SUBTITLES_PERFECT_MATCH = check_setting_bool(CFG, 'Subtitles', 'subtitles_perfect_match', True)
         EMBEDDED_SUBTITLES_ALL = check_setting_bool(CFG, 'Subtitles', 'embedded_subtitles_all')
         SUBTITLES_HEARING_IMPAIRED = check_setting_bool(CFG, 'Subtitles', 'subtitles_hearing_impaired')
-        SUBTITLES_FINDER_FREQUENCY = check_setting_int(CFG, 'Subtitles', 'subtitles_finder_frequency', 1)
+        SUBTITLES_FINDER_FREQUENCY = check_setting_int(CFG, 'Subtitles', 'subtitles_finder_frequency', 1, min=1)
         SUBTITLES_MULTI = check_setting_bool(CFG, 'Subtitles', 'subtitles_multi', True)
         SUBTITLES_KEEP_ONLY_WANTED = check_setting_bool(CFG, 'Subtitles', 'subtitles_keep_only_wanted')
         SUBTITLES_EXTRA_SCRIPTS = [x.strip() for x in check_setting_str(CFG, 'Subtitles', 'subtitles_extra_scripts').split('|') if x.strip()]
@@ -1368,7 +1366,7 @@ def initialize(consoleLogging=True):  # pylint: disable=too-many-locals, too-man
         TIME_PRESET = TIME_PRESET_W_SECONDS.replace(":%S", "")
         TIMEZONE_DISPLAY = check_setting_str(CFG, 'GUI', 'timezone_display', 'local')
         POSTER_SORTBY = check_setting_str(CFG, 'GUI', 'poster_sortby', 'name')
-        POSTER_SORTDIR = check_setting_int(CFG, 'GUI', 'poster_sortdir', 1)
+        POSTER_SORTDIR = check_setting_int(CFG, 'GUI', 'poster_sortdir', 1, min=0, max=1)
         DISPLAY_ALL_SEASONS = check_setting_bool(CFG, 'General', 'display_all_seasons', True)
 
         # initialize NZB and TORRENT providers
@@ -1432,10 +1430,10 @@ def initialize(consoleLogging=True):  # pylint: disable=too-many-locals, too-man
                                                              curTorrentProvider.get_id() + '_ratio', '')
             if hasattr(curTorrentProvider, 'minseed'):
                 curTorrentProvider.minseed = check_setting_int(CFG, curTorrentProvider.get_id().upper(),
-                                                               curTorrentProvider.get_id() + '_minseed', 1)
+                                                               curTorrentProvider.get_id() + '_minseed', 1, min=0)
             if hasattr(curTorrentProvider, 'minleech'):
                 curTorrentProvider.minleech = check_setting_int(CFG, curTorrentProvider.get_id().upper(),
-                                                                curTorrentProvider.get_id() + '_minleech', 0)
+                                                                curTorrentProvider.get_id() + '_minleech', 0, min=0)
             if hasattr(curTorrentProvider, 'freeleech'):
                 curTorrentProvider.freeleech = check_setting_bool(CFG, curTorrentProvider.get_id().upper(), curTorrentProvider.get_id() + '_freeleech')
             if hasattr(curTorrentProvider, 'search_mode'):

--- a/sickbeard/__init__.py
+++ b/sickbeard/__init__.py
@@ -41,12 +41,12 @@ except ImportError:
 
 
 from sickbeard.indexers import indexer_api
-from sickbeard.common import SD, SKIPPED, WANTED
+from sickbeard.common import SD, SKIPPED, WANTED, MULTI_EP_STRINGS
 from sickbeard.databases import mainDB, cache_db, failed_db
 from sickbeard.providers.newznab import NewznabProvider
 from sickbeard.providers.rsstorrent import TorrentRssProvider
 from sickbeard.config import check_section, check_setting_int, check_setting_str, \
-    check_setting_float, check_setting_bool, ConfigMigrator
+    check_setting_float, check_setting_bool, min_max, ConfigMigrator
 from sickbeard import db, helpers, scheduler, search_queue, show_queue, logger, \
     naming, dailysearcher, metadata, providers
 from sickbeard import searchBacklog, showUpdater, versionChecker, properFinder, \
@@ -951,11 +951,11 @@ def initialize(consoleLogging=True):  # pylint: disable=too-many-locals, too-man
         NAMING_SPORTS_PATTERN = check_setting_str(CFG, 'General', 'naming_sports_pattern', '%SN - %A-D - %EN')
         NAMING_ANIME_PATTERN = check_setting_str(CFG, 'General', 'naming_anime_pattern',
                                                  'Season %0S/%SN - S%0SE%0E - %EN')
-        NAMING_ANIME = check_setting_int(CFG, 'General', 'naming_anime', 3)
+        NAMING_ANIME = min_max(check_setting_int(CFG, 'General', 'naming_anime', 3), default=3, low=1, high=3)
         NAMING_CUSTOM_SPORTS = check_setting_bool(CFG, 'General', 'naming_custom_sports')
         NAMING_CUSTOM_ANIME = check_setting_bool(CFG, 'General', 'naming_custom_anime')
-        NAMING_MULTI_EP = check_setting_int(CFG, 'General', 'naming_multi_ep', 1)
-        NAMING_ANIME_MULTI_EP = check_setting_int(CFG, 'General', 'naming_anime_multi_ep', 1)
+        NAMING_MULTI_EP = min_max(check_setting_int(CFG, 'General', 'naming_multi_ep', 1), default=1, low=1, high=max(MULTI_EP_STRINGS))
+        NAMING_ANIME_MULTI_EP = min_max(check_setting_int(CFG, 'General', 'naming_anime_multi_ep', 1), default=1, low=1, high=max(MULTI_EP_STRINGS))
         NAMING_FORCE_FOLDERS = naming.check_force_season_folders()
         NAMING_STRIP_YEAR = check_setting_bool(CFG, 'General', 'naming_strip_year')
 

--- a/sickbeard/config.py
+++ b/sickbeard/config.py
@@ -703,8 +703,8 @@ def check_setting_int(config, cfg_name, item_name, def_val=0, min_val=None, max_
 
     if not (min_val is None or isinstance(min_val, int)):
         logger.log(
-            "{dom}:{key} min value is not the correct type. Expected {t}, got {dt}".format(
-                dom=cfg_name, key=item_name, t='int', dt=type(min)), logger.ERROR)
+            "{dom}:{key} min_val value is not the correct type. Expected {t}, got {dt}".format(
+                dom=cfg_name, key=item_name, t='int', dt=type(min_val)), logger.ERROR)
 
     if not (max_val is None or isinstance(max_val, int)):
         logger.log(
@@ -773,8 +773,8 @@ def check_setting_float(config, cfg_name, item_name, def_val=0.0, min_val=None, 
 
     if not (min_val is None or isinstance(min_val, float)):
         logger.log(
-            "{dom}:{key} min value is not the correct type. Expected {t}, got {dt}".format(
-                dom=cfg_name, key=item_name, t='float', dt=type(min)), logger.ERROR)
+            "{dom}:{key} min_val value is not the correct type. Expected {t}, got {dt}".format(
+                dom=cfg_name, key=item_name, t='float', dt=type(min_val)), logger.ERROR)
 
     if not (max_val is None or isinstance(max_val, float)):
         logger.log(
@@ -788,7 +788,7 @@ def check_setting_float(config, cfg_name, item_name, def_val=0.0, min_val=None, 
         my_val = float(config[cfg_name][item_name])
 
         if isinstance(min_val, float) and my_val < min_val:
-            my_val = config[cfg_name][item_name] = (min, def_val)[fallback_def]
+            my_val = config[cfg_name][item_name] = (min_val, def_val)[fallback_def]
         if isinstance(max_val, float) and my_val > max_val:
             my_val = config[cfg_name][item_name] = (max_val, def_val)[fallback_def]
     except (ValueError, IndexError, KeyError, TypeError):

--- a/sickbeard/config.py
+++ b/sickbeard/config.py
@@ -676,7 +676,7 @@ def min_max(val, default, low, high):
 ################################################################################
 # check_setting_int                                                            #
 ################################################################################
-def check_setting_int(config, cfg_name, item_name, def_val=0, min=None, max=None, fallback_def=True, silent=True):
+def check_setting_int(config, cfg_name, item_name, def_val=0, min_val=None, max_val=None, fallback_def=True, silent=True):
     """
     Checks config setting of integer type
 
@@ -686,14 +686,14 @@ def check_setting_int(config, cfg_name, item_name, def_val=0, min=None, max=None
     :param item_name: item name of section
     :param def_val: default value to return in case a value can't be retrieved from config,
                     or in case value couldn't be converted,
-                    or if `value < min` or `value > max` (default: 0)
-    :param min: force value to be greater than or equal to `min` (optional)
-    :param max: force value to be lesser than or equal to `max` (optional)
-    :param fallback_def: if True, `def_val` will be returned when value not in range of `min` and `max`.
-                         otherwise, `min`/`max` value will be returned respectively (default: True)
+                    or if `value < min_val` or `value > max_val` (default: 0)
+    :param min_val: force value to be greater than or equal to `min_val` (optional)
+    :param max_val: force value to be lesser than or equal to `max_val` (optional)
+    :param fallback_def: if True, `def_val` will be returned when value not in range of `min_val` and `max_val`.
+                         otherwise, `min_val`/`max_val` value will be returned respectively (default: True)
     :param silent: don't log result to debug log (default: True)
 
-    :return: value of `config[cfg_name][item_name]` or `min`/`max` (see def_low_high) `def_val` (see def_val)
+    :return: value of `config[cfg_name][item_name]` or `min_val`/`max_val` (see def_low_high) `def_val` (see def_val)
     :rtype: int
     """
     if not isinstance(def_val, int):
@@ -701,15 +701,15 @@ def check_setting_int(config, cfg_name, item_name, def_val=0, min=None, max=None
             "{dom}:{key} default value is not the correct type. Expected {t}, got {dt}".format(
                 dom=cfg_name, key=item_name, t='int', dt=type(def_val)), logger.ERROR)
 
-    if not (min is None or isinstance(min, int)):
+    if not (min_val is None or isinstance(min_val, int)):
         logger.log(
             "{dom}:{key} min value is not the correct type. Expected {t}, got {dt}".format(
                 dom=cfg_name, key=item_name, t='int', dt=type(min)), logger.ERROR)
 
-    if not (max is None or isinstance(max, int)):
+    if not (max_val is None or isinstance(max_val, int)):
         logger.log(
-            "{dom}:{key} max value is not the correct type. Expected {t}, got {dt}".format(
-                dom=cfg_name, key=item_name, t='int', dt=type(max)), logger.ERROR)
+            "{dom}:{key} max_val value is not the correct type. Expected {t}, got {dt}".format(
+                dom=cfg_name, key=item_name, t='int', dt=type(max_val)), logger.ERROR)
 
     try:
         if not (check_section(config, cfg_name) and check_section(config[cfg_name], item_name)):
@@ -724,10 +724,10 @@ def check_setting_int(config, cfg_name, item_name, def_val=0, min=None, max=None
 
         my_val = int(my_val)
 
-        if isinstance(min, int) and my_val < min:
-            my_val = config[cfg_name][item_name] = (min, def_val)[fallback_def]
-        if isinstance(max, int) and my_val > max:
-            my_val = config[cfg_name][item_name] = (max, def_val)[fallback_def]
+        if isinstance(min_val, int) and my_val < min_val:
+            my_val = config[cfg_name][item_name] = (min_val, def_val)[fallback_def]
+        if isinstance(max_val, int) and my_val > max_val:
+            my_val = config[cfg_name][item_name] = (max_val, def_val)[fallback_def]
 
     except (ValueError, IndexError, KeyError, TypeError):
         my_val = def_val
@@ -746,7 +746,7 @@ def check_setting_int(config, cfg_name, item_name, def_val=0, min=None, max=None
 ################################################################################
 # check_setting_float                                                          #
 ################################################################################
-def check_setting_float(config, cfg_name, item_name, def_val=0.0, min=None, max=None, fallback_def=True, silent=True):
+def check_setting_float(config, cfg_name, item_name, def_val=0.0, min_val=None, max_val=None, fallback_def=True, silent=True):
     """
     Checks config setting of float type
 
@@ -756,14 +756,14 @@ def check_setting_float(config, cfg_name, item_name, def_val=0.0, min=None, max=
     :param item_name: item name of section
     :param def_val: default value to return in case a value can't be retrieved from config
                     or if couldn't be converted,
-                    or if `value < min` or `value > max` (default: 0.0)
-    :param min: force value to be greater than or equal to `min` (optional)
-    :param max: force value to be lesser than or equal to `max (optional)
-    :param fallback_def: if True, `def_val` will be returned when value not in range of `min` and `max`.
-                         otherwise, `min`/`max` value will be returned respectively (default: True)
+                    or if `value < min_val` or `value > max_val` (default: 0.0)
+    :param min_val: force value to be greater than or equal to `min_val` (optional)
+    :param max_val: force value to be lesser than or equal to `max_val` (optional)
+    :param fallback_def: if True, `def_val` will be returned when value not in range of `min_val` and `max_val`.
+                         otherwise, `min_val`/`max_val` value will be returned respectively (default: True)
     :param silent: don't log result to debug log (default: True)
 
-    :return: value of `config[cfg_name][item_name]` or `min`/`max` (see def_low_high) `def_val` (see def_val)
+    :return: value of `config[cfg_name][item_name]` or `min_val`/`max_val` (see def_low_high) `def_val` (see def_val)
     :rtype: float
     """
     if not isinstance(def_val, float):
@@ -771,15 +771,15 @@ def check_setting_float(config, cfg_name, item_name, def_val=0.0, min=None, max=
             "{dom}:{key} default value is not the correct type. Expected {t}, got {dt}".format(
                 dom=cfg_name, key=item_name, t='float', dt=type(def_val)), logger.ERROR)
 
-    if not (min is None or isinstance(min, float)):
+    if not (min_val is None or isinstance(min_val, float)):
         logger.log(
             "{dom}:{key} min value is not the correct type. Expected {t}, got {dt}".format(
                 dom=cfg_name, key=item_name, t='float', dt=type(min)), logger.ERROR)
 
-    if not (max is None or isinstance(max, float)):
+    if not (max_val is None or isinstance(max_val, float)):
         logger.log(
-            "{dom}:{key} max value is not the correct type. Expected {t}, got {dt}".format(
-                dom=cfg_name, key=item_name, t='float', dt=type(max)), logger.ERROR)
+            "{dom}:{key} max_val value is not the correct type. Expected {t}, got {dt}".format(
+                dom=cfg_name, key=item_name, t='float', dt=type(max_val)), logger.ERROR)
 
     try:
         if not (check_section(config, cfg_name) and check_section(config[cfg_name], item_name)):
@@ -787,10 +787,10 @@ def check_setting_float(config, cfg_name, item_name, def_val=0.0, min=None, max=
 
         my_val = float(config[cfg_name][item_name])
 
-        if isinstance(min, float) and my_val < min:
+        if isinstance(min_val, float) and my_val < min_val:
             my_val = config[cfg_name][item_name] = (min, def_val)[fallback_def]
-        if isinstance(max, float) and my_val > max:
-            my_val = config[cfg_name][item_name] = (max, def_val)[fallback_def]
+        if isinstance(max_val, float) and my_val > max_val:
+            my_val = config[cfg_name][item_name] = (max_val, def_val)[fallback_def]
     except (ValueError, IndexError, KeyError, TypeError):
         my_val = def_val
 

--- a/tests/config_tests.py
+++ b/tests/config_tests.py
@@ -166,15 +166,30 @@ class ConfigTestBasic(unittest.TestCase):
         CFG['General']['status_default'] = None
         # normal
         self.assertEqual(config.check_setting_int(CFG, 'General', 'indexer_timeout', 30), 60)
+        self.assertEqual(CFG['General']['indexer_timeout'], 60)
+        # force min/max
+        self.assertEqual(config.check_setting_int(CFG, 'General', 'indexer_timeout', 150, 100, 200), 150)
+        self.assertEqual(CFG['General']['indexer_timeout'], 150)
+        self.assertEqual(config.check_setting_int(CFG, 'General', 'indexer_timeout', 250, 200, 300, False), 200)
+        self.assertEqual(CFG['General']['indexer_timeout'], 200)
+        self.assertEqual(config.check_setting_int(CFG, 'General', 'indexer_timeout', 90, 50, 100), 90)
+        self.assertEqual(CFG['General']['indexer_timeout'], 90)
+        self.assertEqual(config.check_setting_int(CFG, 'General', 'indexer_timeout', 20, 10, 30, False), 30)
+        self.assertEqual(CFG['General']['indexer_timeout'], 30)
         # true/false => int
         self.assertEqual(config.check_setting_int(CFG, 'General', 'use_icacls', 1), 1)
+        self.assertEqual(CFG['General']['use_icacls'], 'True')
         self.assertEqual(config.check_setting_int(CFG, 'General', 'use_nzbs', 0), 0)
+        self.assertEqual(CFG['General']['use_nzbs'], 'False')
         # None value type + silent off
         self.assertEqual(config.check_setting_int(CFG, 'General', 'status_default', 5, silent=False), 5)
+        self.assertEqual(CFG['General']['status_default'], 5)
         # unmatched section
         self.assertEqual(config.check_setting_int(CFG, 'Subtitles', 'subtitles_finder_frequency', 1), 1)
-        # wrong def_val type
-        self.assertEqual(config.check_setting_int(CFG, 'General', 'indexer_timeout', 'ba'), 60)
+        self.assertEqual(CFG['Subtitles']['subtitles_finder_frequency'], 1)
+        # wrong def_val/min/max type
+        self.assertEqual(config.check_setting_int(CFG, 'General', 'indexer_timeout', 'ba', 'min', 'max'), 30)
+        self.assertEqual(CFG['General']['indexer_timeout'], 30)
 
     def test_check_setting_float(self):
         """
@@ -183,16 +198,29 @@ class ConfigTestBasic(unittest.TestCase):
         # setup
         CFG = ConfigObj('config.ini', encoding='UTF-8')
         config.check_section(CFG, 'General')
-        CFG['General']['fanart_background_opacity'] = 0.2
+        CFG['General']['fanart_background_opacity'] = 0.5
         CFG['General']['log_size'] = None
         # normal
-        self.assertEqual(config.check_setting_float(CFG, 'General', 'fanart_background_opacity', 0.4), 0.2)
+        self.assertEqual(config.check_setting_float(CFG, 'General', 'fanart_background_opacity', 0.4), 0.5)
+        self.assertEqual(CFG['General']['fanart_background_opacity'], 0.5)
+        # force min/max
+        self.assertEqual(config.check_setting_float(CFG, 'General', 'fanart_background_opacity', 0.7, 0.6, 1.0), 0.7)
+        self.assertEqual(CFG['General']['fanart_background_opacity'], 0.7)
+        self.assertEqual(config.check_setting_float(CFG, 'General', 'fanart_background_opacity', 0.7, 0.8, 1.0, False), 0.8)
+        self.assertEqual(CFG['General']['fanart_background_opacity'], 0.8)
+        self.assertEqual(config.check_setting_float(CFG, 'General', 'fanart_background_opacity', 0.3, 0.1, 0.4), 0.3)
+        self.assertEqual(CFG['General']['fanart_background_opacity'], 0.3)
+        self.assertEqual(config.check_setting_float(CFG, 'General', 'fanart_background_opacity', 0.1, 0.1, 0.2, False), 0.2)
+        self.assertEqual(CFG['General']['fanart_background_opacity'], 0.2)
         # None value type + silent off
         self.assertEqual(config.check_setting_float(CFG, 'General', 'log_size', 10.0, silent=False), 10.0)
+        self.assertEqual(CFG['General']['log_size'], 10.0)
         # unmatched section
         self.assertEqual(config.check_setting_float(CFG, 'Kodi', 'log_size', 2.5), 2.5)
-        # wrong def_val type
-        self.assertEqual(config.check_setting_float(CFG, 'General', 'fanart_background_opacity', 'ba'), 0.2)
+        self.assertEqual(CFG['Kodi']['log_size'], 2.5)
+        # wrong def_val/min/max type
+        self.assertEqual(config.check_setting_float(CFG, 'General', 'fanart_background_opacity', 'ba', 'min', 'max'), 0.2)
+        self.assertEqual(CFG['General']['fanart_background_opacity'], 0.2)
 
     def test_check_setting_str(self):
         """


### PR DESCRIPTION
It started out with trying to fix https://github.com/SickRage/SickRage/issues/1373#issuecomment-286937172
But there's so many other variables that need this, so I just added it to the function.

Users shouldn't edit config.ini values on their own, but for when they do,
we should check values are within the specified ranges.

**Note:** _This will **block** currently available workaround to change some settings, like autopostprocessor_frequency, to a value lower than the minimum of 10 minutes._