### PR TITLE
Properly escape sender email in notifications page

### DIFF
--- a/gui/slick/views/config_notifications.mako
+++ b/gui/slick/views/config_notifications.mako
@@ -2940,7 +2940,7 @@
                                 <div class="col-lg-9 col-md-8 col-sm-7 col-xs-12 component-desc">
                                     <div class="row">
                                         <div class="col-md-12">
-                                            <input type="text" name="email_from" id="email_from" value="${sickbeard.EMAIL_FROM}" class="form-control input-sm input250" autocapitalize="off" />
+                                            <input type="text" name="email_from" id="email_from" value="${sickbeard.EMAIL_FROM | h}" class="form-control input-sm input250" autocapitalize="off" />
                                         </div>
                                     </div>
                                     <div class="row">


### PR DESCRIPTION
In the configuration page for Email Notifications:

When using the `"Name" <email@example.com>` syntax for the `SMTP From` field, everything works fine (sent emails and config file are correct), except when the notifications page gets displayed later on.
The HTML gets all messed up due to the unescaped double quotes.

Having no experience with mako, I have no idea whether this is a good way to fix this, but it seems to work.