### PR TITLE
Quote showname when it is being used in url parameter

### DIFF
--- a/gui/slick/views/inc_home_showList.mako
+++ b/gui/slick/views/inc_home_showList.mako
@@ -6,6 +6,7 @@
     from sickrage.helper.common import pretty_file_size
     import os
     import re
+    from six.moves import urllib
 
     ## Need to initialize these for gettext, they are done dynamically in the ui
     _('Continuing')
@@ -34,7 +35,7 @@
                         if not sickbeard.SORT_ARTICLE:
                             loading_show_sort_name = re.sub(r'(?:The|A|An)\s', '', loading_show_sort_name, flags=re.I)
 
-                        loading_show_id = curLoadingShow.show_name
+                        loading_show_id = urllib.parse.quote_plus(curLoadingShow.show_name)
                         loading_show_network = _('Loading')
                         loading_show_quality = 0
                 %>
@@ -225,7 +226,7 @@
                                 loading_show_id = curLoadingShow.show.indexerid
                             else:
                                 loading_show_name = curLoadingShow.show_name.rsplit(os.sep)[-1]
-                                loading_show_id = curLoadingShow.show_name
+                                loading_show_id = urllib.parse.quote_plus(curLoadingShow.show_name)
                         %>
                         <tr>
                             <td align="center">(${_('loading')})</td><td align="center"></td>

--- a/gui/slick/views/inc_home_showList.mako
+++ b/gui/slick/views/inc_home_showList.mako
@@ -6,7 +6,6 @@
     from sickrage.helper.common import pretty_file_size
     import os
     import re
-    from six.moves import urllib
 
     ## Need to initialize these for gettext, they are done dynamically in the ui
     _('Continuing')
@@ -35,7 +34,7 @@
                         if not sickbeard.SORT_ARTICLE:
                             loading_show_sort_name = re.sub(r'(?:The|A|An)\s', '', loading_show_sort_name, flags=re.I)
 
-                        loading_show_id = urllib.parse.quote_plus(curLoadingShow.show_name)
+                        loading_show_id = curLoadingShow.show_name
                         loading_show_network = _('Loading')
                         loading_show_quality = 0
                 %>
@@ -226,7 +225,7 @@
                                 loading_show_id = curLoadingShow.show.indexerid
                             else:
                                 loading_show_name = curLoadingShow.show_name.rsplit(os.sep)[-1]
-                                loading_show_id = urllib.parse.quote_plus(curLoadingShow.show_name)
+                                loading_show_id = curLoadingShow.show_name
                         %>
                         <tr>
                             <td align="center">(${_('loading')})</td><td align="center"></td>

--- a/gui/slick/views/inc_home_showList.mako
+++ b/gui/slick/views/inc_home_showList.mako
@@ -40,9 +40,9 @@
                 %>
                 <div class="show-container" data-name="${loading_show_sort_name}" data-date="1" data-network="0" data-progress="0">
                     <div class="show-image">
-                        <img alt="" title="${loading_show_name}" class="show-image" style="border-bottom: 1px solid #111;" src="" data-src="${srRoot}/showPoster/?show=${loading_show_id}&amp;which=poster_thumb" />
+                        <img alt="" title="${loading_show_name}" class="show-image" style="border-bottom: 1px solid #111;" src="" data-src="${srRoot}/showPoster/?show=${loading_show_id | u}&amp;which=poster_thumb" />
                     </div>
-                    <div class="progressbar hidden-print" style="position:relative;" data-show-id="${loading_show_id}" data-progress-percentage="0"></div>
+                    <div class="progressbar hidden-print" style="position:relative;" data-show-id="${loading_show_id | u}" data-progress-percentage="0"></div>
                     <div class="show-title">${_('Loading')} (${loading_show_name})</div>
                     <div class="show-date">&nbsp;</div>
                     <div class="show-details">
@@ -52,7 +52,7 @@
                                     <span class="show-dlstats" title="${'Loading'}">${'Loading'}</span>
                                 </td>
                                 <td class="show-table">
-                                    <span title="${loading_show_network}"><img class="show-network-image" src="" data-src="${srRoot}/showPoster/?show=${loading_show_id}&amp;which=network" alt="${loading_show_network}" title="${loading_show_network}" /></span>
+                                    <span title="${loading_show_network}"><img class="show-network-image" src="" data-src="${srRoot}/showPoster/?show=${loading_show_id | u}&amp;which=network" alt="${loading_show_network}" title="${loading_show_network}" /></span>
                                 </td>
                                 <td class="show-table">
                                     ${renderQualityPill(loading_show_quality, showTitle=True, overrideClass="show-quality")}
@@ -233,14 +233,14 @@
                                 <td class="tvShow">
                                     <div class="imgsmallposter ${sickbeard.HOME_LAYOUT}">
                                         % if curLoadingShow.show:
-                                            <a href="${srRoot}/home/displayShow?show=${loading_show_id}" title="${loading_show_name}">
+                                            <a href="${srRoot}/home/displayShow?show=${loading_show_id | u}" title="${loading_show_name}">
                                         % else:
                                             <span title="${loading_show_name}">
                                         % endif
-                                        <img src="" data-src="${srRoot}/showPoster/?show=${loading_show_id}&amp;which=poster_thumb" class="${sickbeard.HOME_LAYOUT}" alt="${loading_show_id}"/>
+                                        <img src="" data-src="${srRoot}/showPoster/?show=${loading_show_id | u}&amp;which=poster_thumb" class="${sickbeard.HOME_LAYOUT}" alt="${loading_show_name}"/>
                                         % if curLoadingShow.show:
                                             </a>
-                                            <a href="${srRoot}/home/displayShow?show=${loading_show_id}" style="vertical-align: middle;">${loading_show_name}</a>
+                                            <a href="${srRoot}/home/displayShow?show=${loading_show_id | u}" style="vertical-align: middle;">${loading_show_name}</a>
                                         % else:
                                             </span>
                                             <span style="vertical-align: middle;">${_('Loading...')} (${loading_show_name})</span>
@@ -252,9 +252,9 @@
                                     <span style="display: none;">${_('Loading...')} (${loading_show_name})</span>
                                     <div class="imgbanner ${sickbeard.HOME_LAYOUT}">
                                         % if curLoadingShow.show:
-                                            <a href="${srRoot}/home/displayShow?show=${loading_show_id}">
+                                            <a href="${srRoot}/home/displayShow?show=${loading_show_id | u}">
                                         % endif
-                                        <img src="" data-src="${srRoot}/showPoster/?show=${loading_show_id}&amp;which=banner" class="${sickbeard.HOME_LAYOUT}" alt="${loading_show_id}" title="${loading_show_name}"/>
+                                        <img src="" data-src="${srRoot}/showPoster/?show=${loading_show_id | u}&amp;which=banner" class="${sickbeard.HOME_LAYOUT}" alt="${loading_show_name}" title="${loading_show_name}"/>
                                         % if curLoadingShow.show:
                                             </a>
                                         % endif
@@ -263,7 +263,7 @@
                             % elif sickbeard.HOME_LAYOUT == 'simple':
                                 <td class="tvShow">
                                     % if curLoadingShow.show:
-                                        <a href="${srRoot}/home/displayShow?show=${loading_show_id}">${loading_show_name}</a>
+                                        <a href="${srRoot}/home/displayShow?show=${loading_show_id | u}">${loading_show_name}</a>
                                     % else:
                                         <span title="">${_('Loading...')} (${loading_show_name})</span>
                                     % endif


### PR DESCRIPTION
Fixes #3394 and #3411 

~~Uses `urllib.parse.quote_plus()` to ensure that showname is properly escaped when used as `show` url parameter to `showPoster()`.~~

Use Mako expression filtering to ensure that showname is quoted properly. Also use `loading_show_name` as alt value in img tags instead of `loading_show_id`, as it is more concise in the case where  `loading_show_id` is set the show's path.
