### PR TITLE
Revert most consecutive `if`s fixes

### DIFF
--- a/sickbeard/clients/download_station_client.py
+++ b/sickbeard/clients/download_station_client.py
@@ -160,8 +160,9 @@ class DownloadStationAPI(GenericClient):
         data = self._task_post_data
         data['uri'] = result.url
 
-        if result.resultType == 'torrent' and sickbeard.TORRENT_PATH:
-            data['destination'] = sickbeard.TORRENT_PATH
+        if result.resultType == 'torrent':
+            if sickbeard.TORRENT_PATH:
+                data['destination'] = sickbeard.TORRENT_PATH
         elif sickbeard.SYNOLOGY_DSM_PATH:
             data['destination'] = sickbeard.SYNOLOGY_DSM_PATH
 

--- a/sickbeard/config.py
+++ b/sickbeard/config.py
@@ -433,11 +433,12 @@ def change_version_notify(version_notify):
         return True
 
     sickbeard.VERSION_NOTIFY = version_notify
-    if sickbeard.VERSION_NOTIFY and not sickbeard.versionCheckScheduler.enable:
-        logger.log("Starting VERSIONCHECK thread", logger.INFO)
-        sickbeard.versionCheckScheduler.silent = False
-        sickbeard.versionCheckScheduler.enable = True
-        sickbeard.versionCheckScheduler.forceRun()
+    if sickbeard.VERSION_NOTIFY:
+        if not sickbeard.versionCheckScheduler.enable:
+            logger.log("Starting VERSIONCHECK thread", logger.INFO)
+            sickbeard.versionCheckScheduler.silent = False
+            sickbeard.versionCheckScheduler.enable = True
+            sickbeard.versionCheckScheduler.forceRun()
     else:
         sickbeard.versionCheckScheduler.enable = False
         sickbeard.versionCheckScheduler.silent = True
@@ -458,10 +459,11 @@ def change_download_propers(download_propers):
         return True
 
     sickbeard.DOWNLOAD_PROPERS = download_propers
-    if sickbeard.DOWNLOAD_PROPERS and not sickbeard.properFinderScheduler.enable:
-        logger.log("Starting PROPERFINDER thread", logger.INFO)
-        sickbeard.properFinderScheduler.silent = False
-        sickbeard.properFinderScheduler.enable = True
+    if sickbeard.DOWNLOAD_PROPERS:
+        if not sickbeard.properFinderScheduler.enable:
+            logger.log("Starting PROPERFINDER thread", logger.INFO)
+            sickbeard.properFinderScheduler.silent = False
+            sickbeard.properFinderScheduler.enable = True
     else:
         sickbeard.properFinderScheduler.enable = False
         sickbeard.properFinderScheduler.silent = True
@@ -482,10 +484,11 @@ def change_use_trakt(use_trakt):
         return True
 
     sickbeard.USE_TRAKT = use_trakt
-    if sickbeard.USE_TRAKT and not sickbeard.traktCheckerScheduler.enable:
-        logger.log("Starting TRAKTCHECKER thread", logger.INFO)
-        sickbeard.traktCheckerScheduler.silent = False
-        sickbeard.traktCheckerScheduler.enable = True
+    if sickbeard.USE_TRAKT:
+        if not sickbeard.traktCheckerScheduler.enable:
+            logger.log("Starting TRAKTCHECKER thread", logger.INFO)
+            sickbeard.traktCheckerScheduler.silent = False
+            sickbeard.traktCheckerScheduler.enable = True
     else:
         sickbeard.traktCheckerScheduler.enable = False
         sickbeard.traktCheckerScheduler.silent = True
@@ -506,10 +509,11 @@ def change_use_subtitles(use_subtitles):
         return True
 
     sickbeard.USE_SUBTITLES = use_subtitles
-    if sickbeard.USE_SUBTITLES and not sickbeard.subtitlesFinderScheduler.enable:
-        logger.log("Starting SUBTITLESFINDER thread", logger.INFO)
-        sickbeard.subtitlesFinderScheduler.silent = False
-        sickbeard.subtitlesFinderScheduler.enable = True
+    if sickbeard.USE_SUBTITLES:
+        if not sickbeard.subtitlesFinderScheduler.enable:
+            logger.log("Starting SUBTITLESFINDER thread", logger.INFO)
+            sickbeard.subtitlesFinderScheduler.silent = False
+            sickbeard.subtitlesFinderScheduler.enable = True
     else:
         sickbeard.subtitlesFinderScheduler.enable = False
         sickbeard.subtitlesFinderScheduler.silent = True
@@ -530,10 +534,11 @@ def change_process_automatically(process_automatically):
         return True
 
     sickbeard.PROCESS_AUTOMATICALLY = process_automatically
-    if sickbeard.PROCESS_AUTOMATICALLY and not sickbeard.autoPostProcessorScheduler.enable:
-        logger.log("Starting POSTPROCESSOR thread", logger.INFO)
-        sickbeard.autoPostProcessorScheduler.silent = False
-        sickbeard.autoPostProcessorScheduler.enable = True
+    if sickbeard.PROCESS_AUTOMATICALLY:
+        if not sickbeard.autoPostProcessorScheduler.enable:
+            logger.log("Starting POSTPROCESSOR thread", logger.INFO)
+            sickbeard.autoPostProcessorScheduler.silent = False
+            sickbeard.autoPostProcessorScheduler.enable = True
     else:
         logger.log("Stopping POSTPROCESSOR thread", logger.INFO)
         sickbeard.autoPostProcessorScheduler.enable = False

--- a/sickbeard/helpers.py
+++ b/sickbeard/helpers.py
@@ -388,9 +388,9 @@ def link(src, dst):
     :param dst: Destination file
     """
 
-    if (platform.system() == 'Windows' and ctypes.windll.kernel32.CreateHardLinkW(ctypes.c_wchar_p(six.text_type(dst)),
-        ctypes.c_wchar_p(six.text_type(src)), None) == 0):
-        raise ctypes.WinError()
+    if platform.system() == 'Windows':
+        if ctypes.windll.kernel32.CreateHardLinkW(ctypes.c_wchar_p(six.text_type(dst)), ctypes.c_wchar_p(six.text_type(src)), None) == 0:
+            raise ctypes.WinError()
     else:
         ek(os.link, src, dst)
 

--- a/sickbeard/helpers.py
+++ b/sickbeard/helpers.py
@@ -420,10 +420,9 @@ def symlink(src, dst):
     :param dst: Destination file
     """
 
-    if (platform.system() == 'Windows' and
-        ctypes.windll.kernel32.CreateSymbolicLinkW(ctypes.c_wchar_p(six.text_type(dst)),
-            ctypes.c_wchar_p(six.text_type(src)), (0, 1)[ek(os.path.isdir, src)]) in [0, 1280]):
-        raise ctypes.WinError()
+    if platform.system() == 'Windows':
+        if ctypes.windll.kernel32.CreateSymbolicLinkW(ctypes.c_wchar_p(six.text_type(dst)), ctypes.c_wchar_p(six.text_type(src)), 1 if ek(os.path.isdir, src) else 0) in [0, 1280]:
+            raise ctypes.WinError()
     else:
         ek(os.symlink, src, dst)
 

--- a/sickbeard/naming.py
+++ b/sickbeard/naming.py
@@ -211,13 +211,14 @@ def validate_name(pattern, multi=None, anime_type=None,  # pylint: disable=too-m
 
     logger.log("The name " + new_name + " parsed into " + str(result), logger.DEBUG)
 
-    if abd or sports and result.air_date != ep.airdate:
-        logger.log("Air date incorrect in parsed episode, pattern isn't valid", logger.DEBUG)
-        return False
-    elif (anime_type != 3 and len(result.ab_episode_numbers)
-          and result.ab_episode_numbers != [x.absolute_number for x in [ep] + ep.relatedEps]):
-        logger.log("Absolute numbering incorrect in parsed episode, pattern isn't valid", logger.DEBUG)
-        return False
+    if abd or sports:
+        if result.air_date != ep.airdate:
+            logger.log("Air date incorrect in parsed episode, pattern isn't valid", logger.DEBUG)
+            return False
+    elif anime_type != 3:
+        if len(result.ab_episode_numbers) and result.ab_episode_numbers != [x.absolute_number for x in [ep] + ep.relatedEps]:
+            logger.log("Absolute numbering incorrect in parsed episode, pattern isn't valid", logger.DEBUG)
+            return False
     else:
         if result.season_number != ep.season:
             logger.log("Season number incorrect in parsed episode, pattern isn't valid", logger.DEBUG)

--- a/sickbeard/notifiers/kodi.py
+++ b/sickbeard/notifiers/kodi.py
@@ -568,9 +568,10 @@ class Notifier(object):
             # either update each host, or only attempt to update until one successful result
             result = 0
             for host in [x.strip() for x in sickbeard.KODI_HOST.split(",")]:
-                if self._send_update_library(host, showName) and sickbeard.KODI_UPDATE_ONLYFIRST:
-                    logger.log("Successfully updated '" + host + "', stopped sending update library commands.", logger.DEBUG)
-                    return True
+                if self._send_update_library(host, showName):
+                    if sickbeard.KODI_UPDATE_ONLYFIRST:
+                        logger.log("Successfully updated '" + host + "', stopped sending update library commands.", logger.DEBUG)
+                        return True
                 else:
                     if sickbeard.KODI_ALWAYS_ON:
                         logger.log("Failed to detect KODI version for '" + host + "', check configuration and try again.", logger.WARNING)

--- a/sickbeard/postProcessor.py
+++ b/sickbeard/postProcessor.py
@@ -536,8 +536,9 @@ class PostProcessor(object):  # pylint: disable=too-many-instance-attributes
 
         # if the result is complete then remember that for later
         # if the result is complete then set release name
-        if (parse_result.series_name and ((parse_result.season_number is not None and parse_result.episode_numbers)
-            or parse_result.air_date) and parse_result.release_group):
+        if (parse_result.series_name and
+                ((parse_result.season_number is not None and parse_result.episode_numbers) or parse_result.air_date) and
+                parse_result.release_group):
 
             if not self.release_name:
                 self.release_name = helpers.remove_non_release_groups(remove_extension(ek(os.path.basename, parse_result.original_name)))
@@ -1039,12 +1040,13 @@ class PostProcessor(object):  # pylint: disable=too-many-instance-attributes
                 "This download is marked a priority download so I'm going to replace an existing file if I find one")
 
         # try to find out if we have enough space to perform the copy or move action.
-        if sickbeard.USE_FREE_SPACE_CHECK and not helpers.is_file_locked(self.file_path):
-            if not verify_freespace(self.file_path, ep_obj.show._location, [ep_obj] + ep_obj.relatedEps, method=self.process_method):  # pylint: disable=protected-access
-                self._log("Not enough space to continue PP, exiting", logger.WARNING)
-                return False
-        else:
-            self._log("Unable to determine needed file space as the source file is locked for access")
+        if sickbeard.USE_FREE_SPACE_CHECK:
+            if not helpers.is_file_locked(self.file_path):
+                if not verify_freespace(self.file_path, ep_obj.show._location, [ep_obj] + ep_obj.relatedEps, method=self.process_method):  # pylint: disable=protected-access
+                    self._log("Not enough space to continue PP, exiting", logger.WARNING)
+                    return False
+            else:
+                self._log("Unable to determine needed file space as the source file is locked for access")
 
         # delete the existing file (and company)
         for cur_ep in [ep_obj] + ep_obj.relatedEps:

--- a/sickbeard/processTV.py
+++ b/sickbeard/processTV.py
@@ -533,7 +533,8 @@ def process_failed(process_path, release_name, result):
         if processor:
             result.output += processor.log
 
-        if sickbeard.DELETE_FAILED and result.result and delete_folder(process_path, check_empty=False):
+        if sickbeard.DELETE_FAILED and result.result:
+            if delete_folder(process_path, check_empty=False):
                 result.output += log_helper("Deleted folder: {0}".format(process_path), logger.DEBUG)
 
         if result.result:

--- a/sickbeard/providers/filelist.py
+++ b/sickbeard/providers/filelist.py
@@ -136,9 +136,10 @@ class FileListProvider(TorrentProvider):  # pylint: disable=too-many-instance-at
                             labels.append(str(lbl))
                         else:
                             lbl = column.find("img")
-                            if lbl and lbl.has_attr("alt"):
-                                lbl = lbl['alt']
-                                labels.append(str(lbl))
+                            if lbl:
+                                if lbl.has_attr("alt"):
+                                    lbl = lbl['alt']
+                                    labels.append(str(lbl))
                             else:
                                 if index == 3:
                                     lbl = "Download"

--- a/sickbeard/providers/newznab.py
+++ b/sickbeard/providers/newznab.py
@@ -346,8 +346,8 @@ class NewznabProvider(NZBProvider):  # pylint: disable=too-many-instance-attribu
                                 elif validators.url(item.link.next.strip(), require_tld=False):
                                     download_url = item.link.next.strip()
 
-                            if all([not download_url, item.enclosure,
-                                validators.url(item.enclosure.get('url', '').strip(), require_tld=False)]):
+                            if (not download_url, item.enclosure and
+                                    validators.url(item.enclosure.get('url', '').strip(), require_tld=False)):
                                 download_url = item.enclosure.get('url', '').strip()
 
                             if not (title and download_url):


### PR DESCRIPTION
Looks like #3451 broke some stuff 😞 see [my next comment](https://github.com/SickRage/SickRage/pull/3467#issuecomment-288335203)

This fixes #3464 - broken naming validity checker
and fixes #3463 - broken hard-linking on Windows, which for some weird reason was deleted from GitHub as soon as I changed its labels 😕 
But anyway I could confirm it was happening because of this my changes so I reverted them...
