### PR TITLE
XThor: Fix KeyError(u'torrents',) + logger.submit_errors()

### DIFF
--- a/sickbeard/logger.py
+++ b/sickbeard/logger.py
@@ -411,10 +411,10 @@ class Logger(object):  # pylint: disable=too-many-instance-attributes
                 if issue_id and cur_error in classes.ErrorViewer.errors:
                     # clear error from error list
                     classes.ErrorViewer.errors.remove(cur_error)
-        except GhEx.RateLimitExceededException as ex:
+        except GhEx.RateLimitExceededException:
             submitter_result = 'Your Github user has exceeded its API rate limit, please try again later'
             issue_id = None
-        except GhEx.TwoFactorException as ex:
+        except GhEx.TwoFactorException:
             submitter_result = ('Your Github account requires Two-Factor Authentication, '
                                 'please change your auth method in the config')
             issue_id = None

--- a/sickbeard/providers/xthor.py
+++ b/sickbeard/providers/xthor.py
@@ -73,19 +73,19 @@ class XThorProvider(TorrentProvider):
                     logger.log('No data returned from provider', logger.DEBUG)
                     continue
 
-                error_code = jdata.pop('error')
-                if error_code['code']:
-                    if error_code['code'] != 2:
-                        logger.log('{0}'.format(error_code['descr']), logger.WARNING)
+                error_code = jdata.pop('error', {})
+                if error_code.get('code'):
+                    if error_code.get('code') != 2:
+                        logger.log('{0}'.format(error_code.get('descr', 'Error code 2 - no description available')), logger.WARNING)
                         return results
                     continue
 
-                account_ok = jdata.pop('user')['can_leech']
+                account_ok = jdata.pop('user', {}).get('can_leech')
                 if not account_ok:
                     logger.log('Sorry, your account is not allowed to download, check your ratio', logger.WARNING)
                     return results
 
-                torrents = jdata.pop('torrents')
+                torrents = jdata.pop('torrents', None)
                 if not torrents:
                     logger.log('Provider has no results for this search', logger.DEBUG)
                     continue


### PR DESCRIPTION
Fixes #3516

Line 88 generated KeyError on 'torrents' for some reason,
maybe XThor changed the API and now omits the 'torrents' key altogether if there are no results (it's only a guess, unable to verify just yet)

We should wait and see if the issue was indeed no results.

---
Commit 89fc387 should fix #3585