### PR TITLE
Faster helpers.py file functions

### DIFF
--- a/sickbeard/helpers.py
+++ b/sickbeard/helpers.py
@@ -81,6 +81,14 @@ if socket.getaddrinfo.__module__ in ('socket', '_socket'):
     logger.log("Patching socket to IPv4 only", logger.DEBUG)
     socket.getaddrinfo = getaddrinfo_wrapper
 
+# Override original shutil function to increase its speed by increasing its buffer to 10MB (optimal)
+copyfileobj_orig = shutil.copyfileobj
+
+def _copyfileobj(fsrc, fdst, length=10485760):
+    """ Run shutil.copyfileobj with a bigger buffer """
+    return copyfileobj_orig(fsrc, fdst, length)
+shutil.copyfileobj = _copyfileobj
+
 
 def indentXML(elem, level=0):
     """
@@ -362,17 +370,6 @@ def copyFile(srcFile, destFile):
     except ImportError:
         from shutil import Error
         SpecialFileError = Error
-
-    copyfileobj_orig = shutil.copyfileobj
-
-    def copyfileobj(fsrc, fdst, length=10485760):
-        """
-        Override original shutil function to increase its speed
-        by increasing its buffer to 10MB (optimal)
-        """
-        return copyfileobj_orig(fsrc, fdst, length)
-
-    shutil.copyfileobj = copyfileobj
 
     try:
         ek(shutil.copyfile, srcFile, destFile)

--- a/sickbeard/helpers.py
+++ b/sickbeard/helpers.py
@@ -363,6 +363,17 @@ def copyFile(srcFile, destFile):
         from shutil import Error
         SpecialFileError = Error
 
+    copyfileobj_orig = shutil.copyfileobj
+
+    def copyfileobj(fsrc, fdst, length=10485760):
+        """
+        Override original shutil function to increase its speed
+        by increasing its buffer to 10MB (optimal)
+        """
+        return copyfileobj_orig(fsrc, fdst, length)
+
+    shutil.copyfileobj = copyfileobj
+
     try:
         ek(shutil.copyfile, srcFile, destFile)
     except (SpecialFileError, Error) as error:


### PR DESCRIPTION
Fixes #3292 

This fix will affect `helpers.copyFile()` , `helpers.moveFile()` and `helpers.extractZip()`.
Thanks @miigotu for the simple idea.

### Needs testing!
I did test it by copying a ~1.10GB file over a network from Windows 7 to Windows 10,
and it took about the same time as copying it manually, so it looks good.
But that's probably not enough to be sure.

---

My first test, using this fix:
---
**File size:** 1.10 GB
**Method:** Copy over network (from HDD to SSD)
**Time:** ~40s