### PR TITLE
Fix travis:update task

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -70,7 +70,7 @@ install:
   - bower install
 
 test_script:
-  - grunt travis
+  - grunt ci
   - tox -v --recreate
 
 before_test:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ env:
   - TRAVIS_NODE_VERSION="5.6.0"
 
 before_install:
+  - git --version
   - rm -rf ~/.nvm && git clone https://github.com/creationix/nvm.git ~/.nvm && (cd ~/.nvm &&
     git checkout `git describe --abbrev=0 --tags`) && source ~/.nvm/nvm.sh && nvm install $TRAVIS_NODE_VERSION
   - npm install -g grunt-cli

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ install:
 
 script:
   - grunt ci
-  - tox -v --recreate
+#  - tox -v --recreate
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ install:
   - pip install --upgrade babel mako crowdin-cli-py
 
 script:
-  # - grunt ci
+  - grunt ci
   # - tox -v --recreate
 
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,8 +23,8 @@ install:
   - pip install --upgrade babel mako crowdin-cli-py
 
 script:
-  - grunt ci
-  - tox -v --recreate
+  # - grunt ci
+  # - tox -v --recreate
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ install:
 
 script:
   - grunt ci
-#  - tox -v --recreate
+  - tox -v --recreate
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,11 +39,13 @@ after_failure:
 after_success:
   - if ! { [[ ! -z "$CROWDIN_API_KEY" ]] && [[ "$GH_CRED" =~ ^.+:.+$ ]] && [[ "$TRAVIS_PULL_REQUEST" == "false" ]]
     && [[ "$TRAVIS_BRANCH" != "master" ]]; }; then exit 0; fi;
+  # travis git version is 1.8.5.6 (as of 2017-04-15)
   - git config --global user.name "SickRage"
   - git config --global user.email sickrage2@gmail.com
   - git config --global push.default current
   - git remote rm origin
   - git remote add origin https://$GH_CRED@github.com/SickRage/SickRage.git
+  - git fetch origin
   - grunt ci:update
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ after_success:
   - git config --global user.email sickrage2@gmail.com
   - git config --global push.default current
   - git remote rm origin
-  - git remote add origin https://$GH_CRED@github.com/SickRage/SickRage.git
+  - git remote add origin https://$GH_CRED@github.com/$TRAVIS_REPO_SLUG.git
   - git fetch origin master develop --no-tags
   - grunt ci:update
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ install:
   - pip install --upgrade babel mako crowdin-cli-py
 
 script:
-  - grunt travis
+  - grunt ci
   - tox -v --recreate
 
 cache:
@@ -43,7 +43,7 @@ after_success:
   - git config --global push.default current
   - git remote rm origin
   - git remote add origin https://$GH_CRED@github.com/SickRage/SickRage.git
-  - grunt travis:update
+  - grunt ci:update
 
 notifications:
   irc: "irc.freenode.net#sickrage-builds"

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ install:
 
 script:
   - grunt ci
-  # - tox -v --recreate
+  - tox -v --recreate
 
 cache:
   directories:
@@ -36,8 +36,9 @@ after_failure:
   - cat ./Logs/sickrage.log
 
 after_success:
+  # don't run if any of these are NOT met
   - if ! { [[ ! -z "$CROWDIN_API_KEY" ]] && [[ "$GH_CRED" =~ ^.+:.+$ ]] && [[ "$TRAVIS_PULL_REQUEST" == "false" ]]
-    && [[ "$TRAVIS_BRANCH" != "master" ]]; }; then exit 0; fi;
+    && [[ "$TRAVIS_BRANCH" == "master" ]]; }; then exit 0; fi;
   - git --version
   - git config --global user.name "SickRage"
   - git config --global user.email sickrage2@gmail.com

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ after_failure:
 
 after_success:
   - if ! { [[ ! -z "$CROWDIN_API_KEY" ]] && [[ "$GH_CRED" =~ ^.+:.+$ ]] && [[ "$TRAVIS_PULL_REQUEST" == "false" ]]
-    && [[ "$TRAVIS_BRANCH" == "master" ]]; }; then exit 0; fi;
+    && [[ "$TRAVIS_BRANCH" != "master" ]]; }; then exit 0; fi;
   - git config --global user.name "SickRage"
   - git config --global user.email sickrage2@gmail.com
   - git config --global push.default current

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ env:
   - TRAVIS_NODE_VERSION="5.6.0"
 
 before_install:
-  - git --version
   - rm -rf ~/.nvm && git clone https://github.com/creationix/nvm.git ~/.nvm && (cd ~/.nvm &&
     git checkout `git describe --abbrev=0 --tags`) && source ~/.nvm/nvm.sh && nvm install $TRAVIS_NODE_VERSION
   - npm install -g grunt-cli
@@ -39,13 +38,13 @@ after_failure:
 after_success:
   - if ! { [[ ! -z "$CROWDIN_API_KEY" ]] && [[ "$GH_CRED" =~ ^.+:.+$ ]] && [[ "$TRAVIS_PULL_REQUEST" == "false" ]]
     && [[ "$TRAVIS_BRANCH" != "master" ]]; }; then exit 0; fi;
-  # travis git version is 1.8.5.6 (as of 2017-04-15)
+  - git --version
   - git config --global user.name "SickRage"
   - git config --global user.email sickrage2@gmail.com
   - git config --global push.default current
   - git remote rm origin
   - git remote add origin https://$GH_CRED@github.com/SickRage/SickRage.git
-  - git fetch origin
+  - git fetch origin master develop --no-tags
   - grunt ci:update
 
 notifications:

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -311,11 +311,11 @@ module.exports = function(grunt) {
                     }
                     return 'git add -- ' + paths;
                 },
-				callback: function(err) {
-					if (!err) {
-						grunt.task.run('exec:git:commit:-m "' + grunt.config('commit_msg') + '"');
-					}
-				}
+                callback: function(err) {
+                    if (!err) {
+                        grunt.task.run('exec:git:commit:-m "' + grunt.config('commit_msg') + '"');
+                    }
+                }
             },
             'git_get_last_tag': {
                 cmd: 'git for-each-ref --sort=-refname --count=1 --format "%(refname:short)" refs/tags/v20[0-9][0-9]*',
@@ -360,6 +360,14 @@ module.exports = function(grunt) {
                         pushCmd += ' --dry-run';
                     }
                     return pushCmd;
+                },
+                stderr: false,
+                callback: function(err, stdout, stderr) {
+                    if (err && err.code == 128 || stderr.includes('Authentication failed for')) {
+                        grunt.fatal('Git remote config contains invalid credentials.');
+                    } else {
+						grunt.fatal(stderr);
+					}
                 }
             },
             'git_list_tags': {

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -363,11 +363,11 @@ module.exports = function(grunt) {
                 },
                 stderr: false,
                 callback: function(err, stdout, stderr) {
-                    if (err && err.code == 128 || stderr.includes('Authentication failed for')) {
+                    if (err && err.code == 128 || stderr.includes(process.env.GH_CRED)) {
                         grunt.fatal('Git remote config contains invalid credentials.');
                     } else {
-						grunt.fatal(stderr);
-					}
+                        grunt.log.write(stderr);
+                    }
                 }
             },
             'git_list_tags': {

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -23,7 +23,7 @@ module.exports = function(grunt) {
             if (process.env.TRAVIS) {
                 grunt.log.writeln('Running grunt and updating translations...'.magenta);
                 grunt.task.run([
-                    // 'exec:git:checkout:master', // should be on 'master' branch
+                    'exec:git:checkout:master', // should be on 'master' branch
                     'default', // Run default task
                     'update_trans', // Update translations
                     'exec:commit_changed_files:yes', // Determine what we need to commit if needed, stop if nothing to commit.

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -313,7 +313,7 @@ module.exports = function(grunt) {
                 },
                 callback: function(err) {
                     if (!err) {
-                        grunt.task.run('exec:git:commit:-m "' + grunt.config('commit_msg') + '"');
+                        grunt.task.run('exec:git:commit:-m \'' + grunt.config('commit_msg') + '\'');
                     }
                 }
             },

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -2,7 +2,7 @@
 
 module.exports = function(grunt) {
     var IsTravis = Boolean(process.env.TRAVIS);
-    
+
     grunt.registerTask('default', [
         'clean',
         'bower',
@@ -318,13 +318,9 @@ module.exports = function(grunt) {
                         if (!IsTravis) {
                             grunt.task.run('exec:git:commit:-m "' + grunt.config('commit_msg') + '"');
                         } else { // Workaround for Travis (with -m "text" the quotes are within the message)
-                            var done = this.async();
                             var msgFilePath = 'commit-msg.txt';
                             grunt.file.write(msgFilePath, grunt.config('commit_msg'));
                             grunt.task.run('exec:git:commit:-F ' + msgFilePath);
-                            grunt.file.delete(msgFilePath);
-                            console.log('[DEBUG] I have arrived!');
-                            done();
                         }
                     }
                 }

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -13,7 +13,7 @@ module.exports = function(grunt) {
         'mocha'
     ]);
 
-    grunt.registerTask('travis', 'Alias for "jshint", "mocha" tasks.', function(update) {
+    grunt.registerTask('ci', 'Alias for "jshint", "mocha" tasks.', function(update) {
         if (!update) {
             grunt.task.run([
                 'jshint',
@@ -59,7 +59,7 @@ module.exports = function(grunt) {
     *  Admin only tasks                     *
     ****************************************/
     grunt.registerTask('publish', 'ADMIN: Create a new release tag and generate new CHANGES.md', [
-        'travis',
+        'ci',
         'newrelease', // Pull and merge develop to master, create and push a new release
         'genchanges' // Update CHANGES.md
     ]);

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -23,7 +23,7 @@ module.exports = function(grunt) {
             if (process.env.TRAVIS) {
                 grunt.log.writeln('Running grunt and updating translations...'.magenta);
                 grunt.task.run([
-                    'exec:git:checkout:master', // should be on 'master' branch
+                    'exec:git:checkout:master',
                     'default', // Run default task
                     'update_trans', // Update translations
                     'exec:commit_changed_files:yes', // Determine what we need to commit if needed, stop if nothing to commit.
@@ -364,7 +364,7 @@ module.exports = function(grunt) {
                 stderr: false,
                 callback: function(err, stdout, stderr) {
                     if (err && err.code == 128 || stderr.includes(process.env.GH_CRED)) {
-                        grunt.fatal('Git remote config contains invalid credentials.');
+                        grunt.fatal('Git remote contains invalid credentials.');
                     } else {
                         grunt.log.write(stderr);
                     }

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -363,11 +363,7 @@ module.exports = function(grunt) {
                 },
                 stderr: false,
                 callback: function(err, stdout, stderr) {
-                    if (err && err.code == 128 || stderr.includes(process.env.GH_CRED)) {
-                        grunt.fatal('Git remote contains invalid credentials.');
-                    } else {
-                        grunt.log.write(stderr);
-                    }
+                    grunt.log.write(stderr.replace(process.env.GH_CRED, '[censored]'));
                 }
             },
             'git_list_tags': {

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -27,9 +27,9 @@ module.exports = function(grunt) {
                     'default', // Run default task
                     'update_trans', // Update translations
                     'exec:commit_changed_files:yes', // Determine what we need to commit if needed, stop if nothing to commit.
-                    'exec:git:"reset --hard"', // Reset unstaged changes (to allow for a rebase)
+                    'exec:git:reset --hard', // Reset unstaged changes (to allow for a rebase)
                     'exec:git:checkout:develop', 'exec:git:rebase:master', // FF develop to the updated master
-                    'exec:git_push:origin:"master develop"' // Push master and develop
+                    'exec:git_push:origin:master develop' // Push master and develop
                 ]);
             } else {
                 grunt.fatal('This task is only for Travis-CI!');
@@ -309,8 +309,13 @@ module.exports = function(grunt) {
                     if (!message || !paths) {
                         grunt.fatal('Call exec:commit_changed_files instead!');
                     }
-                    return ['git add -- ' + paths, 'git commit -m "' + message + '"'].join(' && ');
-                }
+                    return 'git add -- ' + paths;
+                },
+				callback: function(err) {
+					if (!err) {
+						grunt.task.run('exec:git:commit:-m "' + grunt.config('commit_msg') + '"');
+					}
+				}
             },
             'git_get_last_tag': {
                 cmd: 'git for-each-ref --sort=-refname --count=1 --format "%(refname:short)" refs/tags/v20[0-9][0-9]*',


### PR DESCRIPTION
- Incorrect syntax in grunt.run.task()
- Because Travis uses Git v1.8.x, I needed to remove '&&',
  so I split the 'git add' and 'git commit' commands.
- `git checkout branch` didn't work because Travis checks out the commit hash,
  fixed it by adding `git fetch`.
- It's a good thing I tested it again...
because **git credentials were exposed ~if `git push` failed~ on git push**
It will now censor the credentials:
```
Running "exec:git_push:test:develop" (exec) task
>> Exited with code: 128.
remote: Invalid username or password.
fatal: Authentication failed for 'https://[censored]@github.com/SickRage/SickRage.git/'
Warning: Task "exec:git_push:test:develop" failed. Use --force to continue.

Aborted due to warnings.
```
```
Running "exec:git_push:origin:master develop" (exec) task
To https://[censored]@github.com/sharkykh/SickRage.git
   5a74b96..d31ca27  develop -> develop
   5a74b96..d31ca27  master -> master
```
- Change task name from `travis` to `ci`.