### PR TITLE
Fallback for anime search on absolute numbering

### DIFF
--- a/sickrage/providers/GenericProvider.py
+++ b/sickrage/providers/GenericProvider.py
@@ -214,6 +214,12 @@ class GenericProvider(object):  # pylint: disable=too-many-instance-attributes
                         [ep for ep in episodes if (ep.season, ep.scene_season)[ep.show.is_scene] ==
                         (parse_result.season_number, parse_result.scene_season)[ep.show.is_scene] and
                         (ep.episode, ep.scene_episode)[ep.show.is_scene] in parse_result.episode_numbers]
+                    ]) and not all([
+                        # fallback for anime on absolute numbering
+                        parse_result.is_anime,
+                        parse_result.ab_episode_numbers is not None,
+                        [ep for ep in episodes if ep.show.is_anime and
+                        ep.absolute_number in parse_result.ab_episode_numbers]
                     ]):
 
                         logger.log(


### PR DESCRIPTION
Proposed changes in this pull request:
- Fallback for anime to get a search result based on absolute numbering
- Should fix the scenario's where an initial search for anime does not get results explained at https://github.com/SickRage/SickRage/issues/3649
