### PR TITLE
Support adding LabelPlus labels to Deluge client torrents.

### DIFF
--- a/sickbeard/clients/deluged_client.py
+++ b/sickbeard/clients/deluged_client.py
@@ -179,7 +179,11 @@ class DelugeRPC(object):
             self.connect()
             self.client.label.set_torrent(torrent_id, label).get()  # pylint:disable=no-member
         except Exception:
-            return False
+            try:
+                self.connect()
+                self.client.labelplus.set_torrent_labels([torrent_id], label).get() # pylint:disable=no-member
+            except Exception:
+                return False
         finally:
             if self.client:
                 self.disconnect()


### PR DESCRIPTION
Simple fix to enable setting of LabelPlus labels from SickRage.