### PR TITLE
Fixed sorting error where double/triple headers with the same air dat…

### DIFF
--- a/sickrage/show/ComingEpisodes.py
+++ b/sickrage/show/ComingEpisodes.py
@@ -40,9 +40,9 @@ class ComingEpisodes(object):
     """
     categories = ['snatched', 'missed', 'today', 'soon', 'later']
     sorts = {
-        'date': itemgetter(b'snatchedsort', b'localtime'),
-        'network': itemgetter(b'network', b'localtime'),
-        'show': itemgetter(b'show_name', b'localtime'),
+        'date': itemgetter(b'snatchedsort', b'localtime', b'episode'),
+        'network': itemgetter(b'network', b'localtime', b'episode'),
+        'show': itemgetter(b'show_name', b'localtime', b'episode'),
     }
 
     def __init__(self):


### PR DESCRIPTION
Fixes #3775 

Proposed changes in this pull request:
- Add additional sorting to schedule screen to fix sorting of double/triple headers with same time for all episodes.
