### PR TITLE
Fix #3795 + added test for cert generation

### DIFF
--- a/sickbeard/helpers.py
+++ b/sickbeard/helpers.py
@@ -860,12 +860,12 @@ def create_https_certificates(ssl_cert, ssl_key):
     # Create the CA Certificate
     cakey = createKeyPair(TYPE_RSA, 4096)
     careq = createCertRequest(cakey, CN='Certificate Authority')
-    cacert = createCertificate(careq, (careq, cakey), serial, validity_period, 'sha256')
+    cacert = createCertificate(careq, (careq, cakey), serial, validity_period, b'sha256')
 
     cname = 'SickRage'
     pkey = createKeyPair(TYPE_RSA, 4096)
     req = createCertRequest(pkey, CN=cname)
-    cert = createCertificate(req, (cacert, cakey), serial, validity_period, 'sha256')
+    cert = createCertificate(req, (cacert, cakey), serial, validity_period, b'sha256')
 
     # Save the key and certificate to disk
     try:

--- a/tests/helpers_tests.py
+++ b/tests/helpers_tests.py
@@ -504,12 +504,12 @@ class HelpersEncryptionTests(unittest.TestCase):
     """
     Test encryption and decryption
     """
-    @unittest.skip('Not yet implemented')
     def test_create_https_certificates(self):
         """
         Test create_https_certificates
         """
-        pass
+        # very basic!
+        self.assertTrue(helpers.create_https_certificates('test.crt', 'test.key'))
 
     @unittest.skip('Not yet implemented')
     def test_encrypt(self):

--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,7 @@ deps =
     mock
     vcrpy-unittest
     pytz
+    pyopenssl
 commands =
     /bin/rm -f {toxinidir}/tests/sickbeard.db
     /bin/rm -f {toxinidir}/tests/cache.db
@@ -33,6 +34,7 @@ deps =
     mock
     vcrpy-unittest
     pytz
+    pyopenssl
 commands =
     cmd /c del /f /q {toxinidir}\tests\sickbeard.db {toxinidir}\tests\cache.db {toxinidir}\tests\failed.db 2> nul
     nosetests -c nose.cfg --nocapture


### PR DESCRIPTION
* Fixes #3795, self-signed certification generation, again.
Need to use bytes object instead of unicode for the hash parameter.

* Added test for certificate/key generation