### PR TITLE
Fix notifications overwriting each-other because of duplicate ids

### DIFF
--- a/gui/slick/js/ajaxNotifications.js
+++ b/gui/slick/js/ajaxNotifications.js
@@ -31,7 +31,7 @@ function displayPNotify(type, title, message, id) {
 function check_notifications() {
     $.getJSON(message_url, function (data) {
         $.each(data, function (name, data) {
-            displayPNotify(data.type, data.title, data.message, name);
+            displayPNotify(data.type, data.title, data.message, data.hash);
         });
     });
     setTimeout(function () {

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -608,13 +608,15 @@ class UI(WebRoot):
     def get_messages(self):
         self.set_header('Cache-Control', 'max-age=0,no-cache,no-store')
         self.set_header('Content-Type', 'application/json')
+        notifications = ui.notifications.get_notifications(self.request.remote_ip)
         messages = {}
-        cur_notification_num = 1
-        for cur_notification in ui.notifications.get_notifications(self.request.remote_ip):
-            messages['notification-' + str(cur_notification_num)] = {'title': cur_notification.title,
-                                                                     'message': cur_notification.message,
-                                                                     'type': cur_notification.type}
-            cur_notification_num += 1
+        for index, cur_notification in enumerate(notifications, 1):
+            messages['notification-' + str(index)] = {
+                'hash': hash(cur_notification),
+                'title': cur_notification.title,
+                'message': cur_notification.message,
+                'type': cur_notification.type
+            }
 
         return json.dumps(messages)
 


### PR DESCRIPTION
Use Notification object hash as unique indentifiers instead.
This happens for instance when you update - with the backup notifications.

@miigotu Please merge this before releasing.

Sorry for modifying `ajaxNotifications.js` again, @OmgImAlexis 

Build isn't broken, ThePirateBay is