### PR TITLE
Show floating notification badge in small views

### DIFF
--- a/gui/slick/css/style.css
+++ b/gui/slick/css/style.css
@@ -2367,6 +2367,20 @@ pre {
     padding: 0;
 }
 
+.floating-badge {
+    position: absolute;
+    top: -5px;
+    right: -8px;
+    padding: 0px 4px;
+    background-color: #777777;
+    border: 2px solid #959595;
+    border-radius: 100px;
+    font-size: 12px;
+    font-weight: bold;
+    text-decoration: none;
+    color: white;
+}
+
 /* navbar styling */
 .navbar-default {
     background-color: #333333;

--- a/gui/slick/views/layouts/main.mako
+++ b/gui/slick/views/layouts/main.mako
@@ -107,8 +107,21 @@
     <body data-controller="${controller}" data-action="${action}">
         <nav class="navbar navbar-default navbar-fixed-top hidden-print" role="navigation">
             <div class="container-fluid">
+                <%
+                    numCombined = numErrors + numWarnings + sickbeard.NEWS_UNREAD
+                    if numCombined:
+                        if numErrors:
+                            toolsBadgeClass = ' btn-danger'
+                        elif numWarnings:
+                            toolsBadgeClass = ' btn-warning'
+                        else:
+                            toolsBadgeClass = ''
+                %>
                 <div class="navbar-header">
                     <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#collapsible-navbar">
+                        % if numCombined:
+                            <span class="floating-badge${ toolsBadgeClass }">${ str(numCombined) }</span>
+                        % endif
                         <span class="sr-only">Toggle navigation</span>
                         <span class="icon-bar"></span>
                         <span class="icon-bar"></span>
@@ -200,15 +213,7 @@
                                 else:
                                     newsBadge = ''
 
-                                numCombined = numErrors + numWarnings + sickbeard.NEWS_UNREAD
                                 if numCombined:
-                                    if numErrors:
-                                        toolsBadgeClass = ' btn-danger'
-                                    elif numWarnings:
-                                        toolsBadgeClass = ' btn-warning'
-                                    else:
-                                        toolsBadgeClass = ''
-
                                     toolsBadge = ' <span class="badge'+toolsBadgeClass+'">'+str(numCombined)+'</span>'
                                 else:
                                     toolsBadge = ''


### PR DESCRIPTION
Show a floating notification badge (for errors / warnings / news)
on the navbar toggle button in when using small views.

Needs a browser cache reset / page hard-refresh / server-restart for it to show correctly
because of the static files caching bug (addressed with #3873)

### Preview:
![image](https://user-images.githubusercontent.com/10238474/27262640-99e22248-5463-11e7-97f8-66591684fc61.png)

![image](https://user-images.githubusercontent.com/10238474/27262643-a9dfe34c-5463-11e7-91c3-7a0b6a02d7e8.png)

![image](https://user-images.githubusercontent.com/10238474/27262645-b930f958-5463-11e7-862e-71e57f48fa56.png)

### Vertical navbar unaffected:
![image](https://user-images.githubusercontent.com/10238474/27262579-5fcaf270-5462-11e7-8357-b643c858e030.png)

### Large views unaffected:
![image](https://user-images.githubusercontent.com/10238474/27262581-719a78b8-5462-11e7-8e94-25f62d0ffacb.png)
