### PR TITLE
btn: append quality on release name if not present

### DIFF
--- a/sickbeard/providers/btn.py
+++ b/sickbeard/providers/btn.py
@@ -180,14 +180,14 @@ class BTNProvider(TorrentProvider):
             if 'Codec' in parsed_json and parsed_json['Codec'].lower() not in title.lower():
                 append += parsed_json['Codec']
 
-            if len(append) > 0
+            if append:
                 title += ' [' + append + ']'
 
         else:
             # If we don't have a release name we need to get creative
-            title = None
+            title = ''
             if 'Series' in parsed_json:
-                title = parsed_json['Series']
+                title += parsed_json['Series']
             if 'GroupName' in parsed_json:
                 title += '.' + parsed_json['GroupName'] if title else parsed_json['GroupName']
             if 'Resolution' in parsed_json:

--- a/sickbeard/providers/btn.py
+++ b/sickbeard/providers/btn.py
@@ -172,12 +172,22 @@ class BTNProvider(TorrentProvider):
 
         if 'ReleaseName' in parsed_json and parsed_json['ReleaseName']:
             title = parsed_json['ReleaseName']
+            append = ''
+            if 'Resolution' in parsed_json and parsed_json['Resolution'].lower() not in title.lower():
+                append += parsed_json['Resolution']
+            if 'Source' in parsed_json and parsed_json['Source'].lower() not in title.lower():
+                append += parsed_json['Source']
+            if 'Codec' in parsed_json and parsed_json['Codec'].lower() not in title.lower():
+                append += parsed_json['Codec']
+
+            if len(append) > 0
+                title += ' [' + append + ']'
 
         else:
             # If we don't have a release name we need to get creative
-            title = ''
+            title = None
             if 'Series' in parsed_json:
-                title += parsed_json['Series']
+                title = parsed_json['Series']
             if 'GroupName' in parsed_json:
                 title += '.' + parsed_json['GroupName'] if title else parsed_json['GroupName']
             if 'Resolution' in parsed_json:
@@ -278,7 +288,8 @@ class BTNProvider(TorrentProvider):
 
                     if result_date and (not search_date or result_date > search_date):
                         title, url = self._get_title_and_url(item)
-                        results.append(classes.Proper(title, url, result_date, self.show))
+                        if title and url:
+                            results.append(classes.Proper(title, url, result_date, self.show))
 
         return results
 


### PR DESCRIPTION
This should prevent problems when release names do not include the quality for some reason on BTN.

Additionally clean up the results to not return results that had invalid
json returned while we are here.

Fixes #3852

Proposed changes in this pull request:
- Append quality if not present
- make 'creative' title None by default
- Add check when title or url is None. This was done prior in another place already.

- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read [contribution guide](https://github.com/SickRage/SickRage/blob/master/.github/CONTRIBUTING.md)
