### PR TITLE
Fix Network column width in Mass Update

### DIFF
--- a/gui/slick/css/style.css
+++ b/gui/slick/css/style.css
@@ -1225,6 +1225,11 @@ td.col-name {
     text-align: left;
 }
 
+th.col-network,
+td.col-network {
+    width: 95px;
+}
+
 th.col-subtitles,
 td.col-subtitles {
     width: 150px;


### PR DESCRIPTION
Set a fixed width to the Network column in the Mass Update table
(when filtering columns)

Before:
![image](https://user-images.githubusercontent.com/10238474/27469315-9067e094-57f7-11e7-828b-55ecc61cea70.png)

After:
![image](https://user-images.githubusercontent.com/10238474/27469379-ebd10a46-57f7-11e7-8462-7a83d2d572d7.png)
