### PR TITLE
Fix some lgtm alerts

### DIFF
--- a/lib/cachecontrol/cache.py
+++ b/lib/cachecontrol/cache.py
@@ -8,13 +8,13 @@ from threading import Lock
 class BaseCache(object):
 
     def get(self, key):
-        raise NotImplemented()
+        raise NotImplementedError("implement in subclass")
 
     def set(self, key, value):
-        raise NotImplemented()
+        raise NotImplementedError("implement in subclass")
 
     def delete(self, key):
-        raise NotImplemented()
+        raise NotImplementedError("implement in subclass")
 
     def close(self):
         pass

--- a/lib/lockfile/__init__.py
+++ b/lib/lockfile/__init__.py
@@ -174,7 +174,7 @@ class _SharedBase(object):
         * If timeout <= 0, raise AlreadyLocked immediately if the file is
           already locked.
         """
-        raise NotImplemented("implement in subclass")
+        raise NotImplementedError("implement in subclass")
 
     def release(self):
         """
@@ -182,7 +182,7 @@ class _SharedBase(object):
 
         If the file is not locked, raise NotLocked.
         """
-        raise NotImplemented("implement in subclass")
+        raise NotImplementedError("implement in subclass")
 
     def __enter__(self):
         """
@@ -239,19 +239,19 @@ class LockBase(_SharedBase):
         """
         Tell whether or not the file is locked.
         """
-        raise NotImplemented("implement in subclass")
+        raise NotImplementedError("implement in subclass")
 
     def i_am_locking(self):
         """
         Return True if this object is locking the file.
         """
-        raise NotImplemented("implement in subclass")
+        raise NotImplementedError("implement in subclass")
 
     def break_lock(self):
         """
         Remove a lock.  Useful if a locking thread failed to unlock.
         """
-        raise NotImplemented("implement in subclass")
+        raise NotImplementedError("implement in subclass")
 
     def __repr__(self):
         return "<%s: %r -- %r>" % (self.__class__.__name__, self.unique_name,

--- a/lib/pgi/cffilib/gir/giunioninfo.py
+++ b/lib/pgi/cffilib/gir/giunioninfo.py
@@ -30,8 +30,8 @@ class GIUnionInfo(GIRegisteredTypeInfo):
     def n_methods(self):
         return lib.g_union_info_get_n_methods(self._ptr)
 
-    def get_method(self):
-        return lib.g_union_info_get_method(self._ptr)
+    def get_method(self, n):
+        return lib.g_union_info_get_method(self._ptr, n)
 
     def get_methods(self):
         for i in xrange(self.n_methods):

--- a/lib/sqlalchemy/dialects/firebird/base.py
+++ b/lib/sqlalchemy/dialects/firebird/base.py
@@ -331,10 +331,10 @@ class FBDDLCompiler(sql.compiler.DDLCompiler):
         # no syntax for these
         # http://www.firebirdsql.org/manual/generatorguide-sqlsyntax.html
         if create.element.start is not None:
-            raise NotImplemented(
+            raise NotImplementedError(
                         "Firebird SEQUENCE doesn't support START WITH")
         if create.element.increment is not None:
-            raise NotImplemented(
+            raise NotImplementedError(
                         "Firebird SEQUENCE doesn't support INCREMENT BY")
 
         if self.dialect._version_two:

--- a/sickbeard/databases/__init__.py
+++ b/sickbeard/databases/__init__.py
@@ -18,4 +18,4 @@
 # You should have received a copy of the GNU General Public License
 # along with SickRage. If not, see <http://www.gnu.org/licenses/>.
 
-__all__ = ["mainDB", "cache", "failed"]
+__all__ = ["mainDB", "cache_db", "failed_db"]

--- a/sickbeard/name_parser/parser.py
+++ b/sickbeard/name_parser/parser.py
@@ -534,6 +534,9 @@ class ParseResult(object):  # pylint: disable=too-many-instance-attributes
             self.quality == other.quality,
             self.version == other.version
         ])
+        
+    def __ne__(self, other):
+        return not self == other        
 
     def __unicode__(self):
         if self.series_name is not None:


### PR DESCRIPTION
This PR fixes some issues flagged by lgtm.com code queries. Some are minor improvements suggestions and some should fix errors or unintentional code behaviour.

The standard lgtm engineering analytics highlights dependencies, vulnerabilities and currently flag [670 alerts](https://lgtm.com/projects/g/SickRage/SickRage/alerts/) but you can investigate further by writing [your own custom queries](https://lgtm.com/docs/ql/about-ql) to explore your code base.

I personally find lgtm alerts most useful when using [PR integration](https://lgtm.com/docs/lgtm/config/pr-integration) as it allows to check and deal with potential issues before they find their way into master. For instance most of the alerts seem to occur in `/lib` and could be addressed when vendoring a new package (e.g. see pic in alerts following the addition of `cloudflare-scrape` in 433fd54986ca7d855c022a0fdc0a64a7ed0f7e1a).

Full disclosure: I work on lgtm.com , hence my interest! Hope that helps, any question please ask.

- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read [contribution guide](https://github.com/SickRage/SickRage/blob/master/.github/CONTRIBUTING.md)