### PR TITLE
Update ilcorsaronero (+isort config)

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,10 @@
+[isort]
+line_length = 160
+combine_as_imports = true
+order_by_type = false
+add_imports = from __future__ import unicode_literals
+known_first_party = sickbeard, sickrage
+
 [extract_messages]
 width = 80
 charset = utf-8

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,6 +4,8 @@ combine_as_imports = true
 order_by_type = false
 add_imports = from __future__ import unicode_literals
 known_first_party = sickbeard, sickrage
+# Fixes sections for vendored packages, when lib/ is (first) in $PATH
+# default_section = THIRDPARTY
 
 [extract_messages]
 width = 80

--- a/sickbeard/providers/ilcorsaronero.py
+++ b/sickbeard/providers/ilcorsaronero.py
@@ -20,9 +20,9 @@
 from __future__ import unicode_literals
 
 import re
-import traceback
-import urllib
 
+import six
+from requests.compat import quote_plus, urljoin
 from sickbeard import db, logger, tvcache
 from sickbeard.bs4_parser import BS4Parser
 from sickbeard.common import Quality
@@ -30,41 +30,36 @@ from sickbeard.name_parser.parser import InvalidNameException, InvalidShowExcept
 from sickrage.helper.common import convert_size, try_int
 from sickrage.providers.torrent.TorrentProvider import TorrentProvider
 
-category_excluded = {
-    'Screener': 19, #shit
-    'Musica': 2,
-    'Audiolibri': 18,
-    'Ebooks': 6,
-    'App Win': 7,
-    'App Linux': 8,
-    'App Mac': 9,
-    'PlayStation': 13,
-    'XBOX': 14,
-    'PC Games': 3,
-    'H4cikn9': 16,
-    'Altro': 4,
-}
-
-#'BDRiP': 2,
-#'Anime': 5,
-#'DVD': 20,
-#'SerieTv': 15
 
 class ilCorsaroNeroProvider(TorrentProvider):  # pylint: disable=too-many-instance-attributes
 
     def __init__(self):
-
         TorrentProvider.__init__(self, 'ilCorsaroNero')
 
+        categories = [  # Categories included in searches
+            15,  # Serie TV
+            5,  # Anime
+            1,  # BDRip
+            20,  # DVD
+            19,  # Screener
+        ]
+        categories = ','.join(map(six.text_type, categories))
+
+        self.url = 'https://ilcorsaronero.info'
+        self.urls = {
+            'search': urljoin(self.url, 'advsearch.php?search={0}&order=data&by=DESC&page={1}&category=' + categories),
+        }
+
         self.public = True
-        self._uid = None
-        self._hash = None
-        self.cat = None
-        self.engrelease = None
-        self.page = 10
-        self.subtitle = None
         self.minseed = None
         self.minleech = None
+
+        self.engrelease = None
+        self.subtitle = None
+        self.max_pages = 10
+
+        self.proper_strings = ['PROPER', 'REPACK']
+        self.sub_string = ['sub', 'softsub']
 
         self.hdtext = [
             ' - Versione 720p',
@@ -78,29 +73,8 @@ class ilCorsaroNeroProvider(TorrentProvider):  # pylint: disable=too-many-instan
             ' 720p HEVC',
             ' Ver 720',
             ' 720p HEVC',
-            ' 720p']
-
-        self.category_dict = {
-            'Serie TV': 15,
-            'BDRip': 1,
-            'DVD': 20,
-            'Anime': 5,
-            'Screener': 19
-        }
-
-        self.urls = {
-            'base_url': 'http://ilcorsaronero.info',
-            'detail': 'http://ilcorsaronero.info/tor/%s/',
-            'search': 'http://ilcorsaronero.info/argh.php?search=%s',
-            'search_page': 'http://ilcorsaronero.info/advsearch.php?search={0}&order=data&by=DESC&page={1}',
-            'download': 'http://itorrents.org/torrent/%s.torrent'
-        }
-
-        self.url = self.urls['base_url']
-
-        self.sub_string = ['sub', 'softsub']
-
-        self.proper_strings = ['PROPER', 'REPACK']
+            ' 720p',
+        ]
 
         self.cache = tvcache.TVCache(self, min_time=30)  # only poll ilCorsaroNero every 30 minutes max
 
@@ -181,12 +155,12 @@ class ilCorsaroNeroProvider(TorrentProvider):  # pylint: disable=too-many-instan
                 continue
 
             if re.search('ita', name.split(sub)[0], re.I):
-                logger.log(u'Found Italian release:  ' + name, logger.DEBUG)
+                logger.log(u'Found Italian release: ' + name, logger.DEBUG)
                 italian = True
                 break
 
         if not subFound and re.search('ita', name, re.I):
-            logger.log(u'Found Italian release:  ' + name, logger.DEBUG)
+            logger.log(u'Found Italian release: ' + name, logger.DEBUG)
             italian = True
 
         return italian
@@ -199,7 +173,7 @@ class ilCorsaroNeroProvider(TorrentProvider):  # pylint: disable=too-many-instan
 
         english = False
         if re.search('eng', name, re.I):
-            logger.log(u'Found English release:  ' + name, logger.DEBUG)
+            logger.log(u'Found English release: ' + name, logger.DEBUG)
             english = True
 
         return english
@@ -219,6 +193,13 @@ class ilCorsaroNeroProvider(TorrentProvider):  # pylint: disable=too-many-instan
         if int(episodes[0][b'count']) == len(parse_result.episode_numbers):
             return True
 
+    @staticmethod
+    def _magnet_from_result(info_hash, title):
+        return 'magnet:?xt=urn:btih:{hash}&dn={title}&tr={trackers}'.format(
+            hash=info_hash,
+            title=quote_plus(title),
+            trackers='http://tracker.tntvillage.scambioetico.org:2710/announce')
+
     def search(self, search_params, age=0, ep_obj=None):  # pylint: disable=too-many-locals, too-many-branches, too-many-statements
         results = []
 
@@ -226,24 +207,19 @@ class ilCorsaroNeroProvider(TorrentProvider):  # pylint: disable=too-many-instan
             items = []
             logger.log(u'Search Mode: {0}'.format(mode), logger.DEBUG)
             for search_string in search_params[mode]:
-
-                self.page = 1
-                last_page = 0
-                y = int(self.page)
-
                 if search_string == '':
                     continue
 
-                search_string = str(search_string).replace('.', ' ')
+                search_string = six.text_type(search_string).replace('.', ' ')
+                logger.log(u'Search string: {0}'.format(search_string.decode('utf-8')), logger.DEBUG)
 
-                for x in range(0, y):
-
+                last_page = False
+                for page in range(0, self.max_pages):
                     if last_page:
                         break
 
-                    search_url = self.urls['search_page'].format(search_string, x)
-
-                    logger.log(u'Search string: {0}'.format(search_string.decode('utf-8')), logger.DEBUG)
+                    logger.log('Processing page {0} of results'.format(page), logger.DEBUG)
+                    search_url = self.urls['search'].format(search_string, page)
 
                     data = self.get_url(search_url, returns='text')
                     if not data:
@@ -261,38 +237,28 @@ class ilCorsaroNeroProvider(TorrentProvider):  # pylint: disable=too-many-instan
                             torrent_rows = torrent_table('tr')
 
                             # Continue only if one Release is found
-                            if (len(torrent_rows) < 6) or (len(torrent_rows[2]('td')) == 1):
+                            if len(torrent_rows) < 6 or len(torrent_rows[2]('td')) == 1:
                                 logger.log(u'Data returned from provider does not contain any torrents', logger.DEBUG)
-                                last_page = 1
+                                last_page = True
                                 continue
 
                             if len(torrent_rows) < 45:
-                                last_page = 1
+                                last_page = True
 
                             for result in torrent_rows[2:-3]:
-
+                                result_cols = result('td')
+                                if len(result_cols) == 1:
+                                    # Ignore empty rows in the middle of the table
+                                    continue
                                 try:
-                                    link = result('td')[1].find('a')['href']
-                                    title = re.sub(' +',' ', link.rsplit('/', 1)[-1].replace('_', ' '))
-                                    hash = result('td')[3].find('input', class_='downarrow')['value'].upper()
+                                    info_link = result('td')[1].find('a')['href']
+                                    title = re.sub(' +', ' ', info_link.rsplit('/', 1)[-1].replace('_', ' '))
+                                    info_hash = result('td')[3].find('input', class_='downarrow')['value'].upper()
+                                    download_url = self._magnet_from_result(info_hash, title)
                                     seeders = try_int(result('td')[5].text)
                                     leechers = try_int(result('td')[6].text)
                                     torrent_size = result('td')[2].string
                                     size = convert_size(torrent_size) or -1
-
-                                    # Download Urls
-                                    download_url = self.urls['download'] % hash
-                                    if urllib.urlopen(download_url).getcode() == 404:
-                                        logger.log(u'Torrent hash not found in itorrents.org, searching for magnet',
-                                                   logger.DEBUG)
-                                        data_detail = self.get_url(link, returns='text')
-                                        with BS4Parser(data_detail, 'html5lib') as html_detail:
-                                            sources_row = html_detail.find('td', class_='header2').parent
-                                            source_magnet = sources_row('td')[1].find('a', class_='forbtn', title='Magnet')
-                                            if source_magnet and not source_magnet == 'None':
-                                                download_url = source_magnet['href']
-                                            else:
-                                                continue
 
                                 except (AttributeError, IndexError, TypeError):
                                     continue
@@ -308,11 +274,12 @@ class ilCorsaroNeroProvider(TorrentProvider):  # pylint: disable=too-many-instan
                                     title += filename_qt
 
                                 if not self._is_italian(title) and not self.subtitle:
-                                    logger.log(u'Torrent is subtitled, skipping: {0} '.format(title), logger.DEBUG)
+                                    logger.log(u'Torrent is subtitled, skipping: {0}'.format(title), logger.DEBUG)
                                     continue
 
                                 if self.engrelease and not self._is_english(title):
-                                    logger.log(u'Torrent isnt english audio/subtitled , skipping: {0} '.format(title), logger.DEBUG)
+                                    logger.log(u'Torrent isn\'t english audio/subtitled, skipping: {0}'.format(title),
+                                               logger.DEBUG)
                                     continue
 
                                 search_show = re.split(r'([Ss][\d{1,2}]+)', search_string)[0]
@@ -334,18 +301,21 @@ class ilCorsaroNeroProvider(TorrentProvider):  # pylint: disable=too-many-instan
 
                                 # Filter unseeded torrent
                                 if seeders < self.minseed or leechers < self.minleech:
-                                    logger.log(u'Discarding torrent because it doesn\'t meet the minimum seeders or leechers: {0} (S:{1} L:{2})'.format
-                                                   (title, seeders, leechers), logger.DEBUG)
+                                    logger.log(u'Discarding torrent because it doesn\'t meet the minimum'
+                                               u' seeders or leechers: {0} (S:{1} L:{2})'.format(
+                                        title, seeders, leechers), logger.DEBUG)
                                     continue
 
-                                item = {'title': title, 'link': download_url, 'size': size, 'seeders': seeders, 'leechers': leechers, 'hash': ''}
+                                item = {'title': title, 'link': download_url, 'size': size,
+                                        'seeders': seeders, 'leechers': leechers, 'hash': info_hash}
                                 if mode != 'RSS':
-                                    logger.log(u'Found result: {0} with {1} seeders and {2} leechers'.format(title, seeders, leechers), logger.DEBUG)
+                                    logger.log(u'Found result: {0} with {1} seeders and {2} leechers'.format(
+                                        title, seeders, leechers), logger.DEBUG)
 
                                 items.append(item)
 
-                    except Exception:
-                        logger.log(u'Failed parsing provider. Traceback: {0}'.format(traceback.format_exc()), logger.ERROR)
+                    except Exception as error:
+                        logger.log(u'Failed parsing provider. Error: {0}'.format(error), logger.ERROR)
 
                 # For each search mode sort all the items by seeders if available
                 items.sort(key=lambda d: try_int(d.get('seeders', 0)), reverse=True)

--- a/tests/sickrage_tests/providers/torrent/cassettes/ilcorsaronero.yaml
+++ b/tests/sickrage_tests/providers/torrent/cassettes/ilcorsaronero.yaml
@@ -1,0 +1,633 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: [!!python/unicode 'gzip,deflate']
+      Connection: [keep-alive]
+      User-Agent: [!!python/unicode 'Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36
+          (KHTML, like Gecko) Chrome/36.0.1985.67 Safari/537.36']
+    method: GET
+    uri: https://ilcorsaronero.info/advsearch.php?search=Game%20of%20Thrones%20S05E08&order=data&by=DESC&page=0&category=15,5,1,20,19
+  response:
+    body: {string: !!python/unicode "<!DOCTYPE html PUBLIC '-//W3C//DTD XHTML 1.0
+        Strict//EN' 'http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd'>\r\n<html
+        xmlns='http://www.w3.org/1999/xhtml'>\r\n<head>\r\n<meta http-equiv='Content-Type'
+        content='text/html; charset=utf-8' />\r\n<title>ilCorSaRoNeRo.info - just
+        Torrent iTALiANi - Game of Thrones S05E08 ita torrent</title>\r\n<META NAME=\"Description\"
+        CONTENT=\"Game of Thrones S05E08\">\r\n<META NAME=\"Keywords\" CONTENT=\"Game
+        of Thrones S05E08 ita torrent\">\r\n<meta name=\"googlebot\" content=\"noindex\"
+        />\r\n\r\n\t<link href='//s.ilcorsaronero.info/css/main.css' rel='stylesheet'
+        type='text/css' />\r\n\t<link rel='shortcut icon' href='//s.ilcorsaronero.info/favicon.ico'/>\r\n
+        \   <link rel='alternate' type='application/rss+xml' title='RSS' href='/rss'
+        />\r\n\r\n<script type=\"text/javascript\">\r\n(function(){\r\n    var arrElms
+        = {};\r\n    var ppblkUtil = {\r\n\tinit: function(){},\r\n\t\r\n\tonMouseEvent:
+        function(evt){ \r\n\t    switch (ppblkUtil.isMyClick(evt.target)){\r\n\t\tcase
+        0 : \r\n\t\t    var target = evt.target.id || 'body';\r\n\t\t    if(typeof
+        evt.target.id != 'string') target = 'body';\r\n\t\t    \r\n\t\t    if(window.currList[target]
+        && window.currList[target][evt.type])\r\n\t\t\tfor(var i = 0 ; i < window.currList[target][evt.type].length
+        ; i++)\r\n\t\t\t    window.currList[target][evt.type][i](evt); \r\n\t\t    break;\r\n\t\tcase
+        1: \r\n\t\t    evt.stopPropagation();\r\n\t\t    evt.cancelBubble = true;\r\n\t\t
+        \   break;\r\n\t    }\r\n\t}, \r\n\t\r\n\taddEvent: function(elm, name, handler){\r\n\t
+        \   if (document.addEventListener) document.addEventListener(name, handler,
+        false);\r\n\t    else if (document.attachEvent) document.attachEvent(\"on\"
+        + name, handler); \r\n\t},\r\n\t\r\n\tremoveEvent: function(name, handler){\r\n\t
+        \   if (document.addEventListener) document.removeEventListener(name, handler,
+        false);\r\n\t    else if (document.attachEvent) document.detachEvent(\"on\"
+        + name, handler); \r\n\t    else document[\"on\" + name] = null;\r\n\t},\r\n\t\r\n\tisMyClick:
+        function(elm){\r\n\t    if(typeof arrElms[elm] != 'undefined') return arrElms[elm];\r\n\t
+        \   var e = elm;\r\n\t    while(e && e.tagName != 'BODY'){\r\n\t\tif(e.tagName
+        == \"BUTTON\" && e.getAttribute('name') && e.getAttribute('name').indexOf('coolmir')
+        > -1){\r\n\t\t    arrElms[elm] = 1;\r\n\t\t    return 1;\r\n\t\t}\r\n\t\te
+        = e.parentNode;\r\n\t    }\r\n\t    arrElms[elm] = 0;\r\n\t    return 0;\r\n\t}\r\n
+        \   };\r\n    ppblkUtil.init();\r\n    \r\n    window.currList = {'body':
+        {'mouseup': new Array(),'click': new Array(),'mousedown': new Array()}};\r\n
+        \   var isAddExist = document.addEventListener ? true : false;\r\n    document.originalAddEventListener
+        = document.addEventListener || document.attachEvent;\r\n    document[isAddExist
+        ? 'addEventListener' : 'attachEvent'] = function(e, a, b){\r\n\tif(e == 'mouseup'
+        || e == 'click' || e == 'mousedown'){\r\n\t    window.currList['body'][e].push(a);\r\n\t
+        \   return document.originalAddEventListener(e, ppblkUtil.onMouseEvent, true);\r\n\t}\r\n\telse
+        return document.originalAddEventListener(e,a,b);\r\n    };\r\n    \r\n    ppblkUtil.addEvent(document,
+        navigator.userAgent.indexOf('Chrome') > -1 ? 'mouseup' : 'click', function(){});\r\n
+        \   ppblkUtil.addEvent(document, 'mousedown', function(){});\r\n    \r\n})();\r\n</script>\r\n\r\n</head>\r\n\r\n<body>\r\n<script
+        type=\"text/javascript\">\n\n  var _gaq = _gaq || [];\n  _gaq.push(['_setAccount',
+        'UA-16396970-1']);\n  _gaq.push(['_trackPageview']);\n\n  (function() {\n
+        \   var ga = document.createElement('script'); ga.type = 'text/javascript';
+        ga.async = true;\n    ga.src = ('https:' == document.location.protocol ? 'https://ssl'
+        : 'http://www') + '.google-analytics.com/ga.js';\n    var s = document.getElementsByTagName('script')[0];
+        s.parentNode.insertBefore(ga, s);\n  })();\n\n</script>\r\n<div class='network'>\r\n\t<div
+        class='network_links'>\r\n\t</div>\r\n</div>\r\n\t<div id='container'>\r\n\r\n\t\t<div
+        id='header'>\r\n\r\n\t\t\t<div id='logo'>\r\n\t\t\t\t<h1><a href='/'><img
+        src='//s.ilcorsaronero.info/images/h_logo.gif' alt='Torrent Italiano' title='Torrent
+        Italiano' /></a></h1>\r\n\t\t\t</div>\r\n\r\n\t\t\t<div id='call'>\r\n\t\t\t\r\n\t\t\t\t<h3><form
+        action='/argh.php' method='get'>\r\n\t\t\t\t\r\n      &nbsp;Cerca : <input
+        name='search' size='42' value='Game of Thrones S05E08' type='text'>  \r\n
+        \      <input type=\"submit\" value='cerca' alt=\"Submit\">\r\n</form></h3>\r\n&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a
+        href='/torrent-ita/iTALiAN.html'><img src='//s.ilcorsaronero.info/images/h_logo2.gif'
+        alt='' border='0'/></a>\r\n\t\t\t</div>\r\n\r\n\r\n\r\n\t\t\t<div id='menu'>\r\n\r\n\t\t\t\t<ul>\r\n\t\t\t\t\t<li
+        id='menu_home'><span></span></li>\r\n\t\t\t\t\t<li id='menu_stills'><a href='/cat/3'>giochi</a></li>\r\n\t\t\t\t\t<li
+        id='menu_video'><a href='/cat/1'>film</a></li>\r\n\t\t\t\t\t<li id='menu_audio'><a
+        href='/cat/2'>musica</a></li>\r\n\t\t\t\t\t<li id='menu_identity'><a href='/cat/7'>app</a></li>\r\n\t\t\t\t\t<li
+        id='menu_web'><a href='/sfoglia'>sfoglia</a></li>\r\n\t\t\t\t\t<li id='menu_gallery'><a
+        href='/recenti'>recenti</a></li>\r\n\t\t\t\t\t<li id='menu_about'><a href='/searchcloud'>cloud</a></li>\r\n\t\t\t\t\t<li
+        id='menu_contact'><a href='/upload'>upload</a></li>\r\n\t\t\t\t</ul>\r\n\t\t\t</div>\r\n\r\n\t\t\t<div
+        class='clear'></div>\r\n\r\n\t  </div>\r\n\r\n<div id=\"content\">\r\n    <div
+        id=\"body\">\r\n        <table width=100% border=0 cellpadding=0 cellspacing=0>\r\n
+        \           <tr>\r\n                <td>\r\n                    <font size=+1
+        color=\"#CC0000\">&nbsp;<b>* Ultimi Torrent</b></font>&nbsp;\r\n                </td>\r\n
+        \               <td align=right>\r\n                    <h3><span style=\"color:
+        yellow;\">iCN<br /></span></h3>                </td>\r\n            </tr>\r\n
+        \       </table>\r\n        <br/>\r\n        <span id=\"searchincat\"><a href=\"https://ilcorsaronero.info/rss\"><img
+        src=\"//s.ilcorsaronero.info/images/rss_icon.png\" border=\"0\"></a>filtra
+        risultati per categoria:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<br><br></span><br><ul
+        id=\"tabs\" ><li><a href='https://ilcorsaronero.info/adv/Game%20of%20Thrones%20S05E08.html'>All</a></li>
+        <li><a href='https://ilcorsaronero.info/adv/7/Game%20of%20Thrones%20S05E08.html'>App
+        Win</a></li> <li><a href='https://ilcorsaronero.info/adv/3/Game%20of%20Thrones%20S05E08.html'>PC
+        Games</a></li> <li><a href='https://ilcorsaronero.info/adv/2/Game%20of%20Thrones%20S05E08.html'>Musica</a></li>
+        <li><a href='https://ilcorsaronero.info/adv/19/Game%20of%20Thrones%20S05E08.html'>Screener</a></li>
+        <li><a href='https://ilcorsaronero.info/adv/1/Game%20of%20Thrones%20S05E08.html'>BDRiP</a></li>
+        <li><a href='https://ilcorsaronero.info/adv/20/Game%20of%20Thrones%20S05E08.html'>DVD</a></li>
+        <li><a href='https://ilcorsaronero.info/adv/13/Game%20of%20Thrones%20S05E08.html'>PlayStation</a></li>
+        <li><a href='https://ilcorsaronero.info/adv/14/Game%20of%20Thrones%20S05E08.html'>XboX</a></li>
+        <li><a href='https://ilcorsaronero.info/adv/6/Game%20of%20Thrones%20S05E08.html'>eBooks</a></li>
+        <li><a href='https://ilcorsaronero.info/adv/15/Game%20of%20Thrones%20S05E08.html'>SerieTv</a></li></ul>
+        <br><br>\r\n        <div id=\"left\" class=\"left\">\r\n            <table>\r\n
+        \               <tr>\r\n                    <td VALIGN=\"top\">\r\n                        <ul>\r\n
+        \                       </ul>\r\n                        <br/>\r\n                        <ul>\r\n
+        \                           <li><a href=\"https://ilcorsaronero.info/tagmovie\">Movie
+        Tag</a></li>\r\n                        </ul>\r\n                                                <br>\r\n\r\n
+        \                       <ul>\r\n                            <li><a href=\"https://feeds.feedburner.com/ilCorSaRoNero\"
+        target=\"_blank\"><img\r\n                                        src=\"https://feeds.feedburner.com/~fc/ilCorSaRoNero?bg=000000&amp;fg=FFFF00&amp;anim=0\"\r\n
+        \                                       height=\"26\" width=\"88\" style=\"border:0\"
+        alt=\"stai aggiornato via email\"\r\n                                        title=\"stai
+        aggiornato via email\"/></a></li>\r\n                        </ul>\r\n                        <center>\r\n
+        \                           <br/>\r\n                            <table><tbody><tr
+        attr=\"0\"><td><a href=\"/torrent-ita/pirati dei caraibi.html\"><img style=\"border-color:
+        black\" src=\"//s.ilcorsaronero.info/imgcp/piratesofthecaribbean5.jpg\" alt=\"pirati
+        dei caraibi\" title=\"pirati dei caraibi\" height=\"130\" width=\"90\" border=\"2\"></a></td><td><a
+        href=\"/torrent-ita/wonder woman.html\"><img style=\"border-color: black\"
+        src=\"//s.ilcorsaronero.info/imgcp/wonderwoman.jpg\" alt=\"wonder woman\"
+        title=\"wonder woman\" height=\"130\" width=\"90\" border=\"2\"></a></td></tr
+        attr=\\\"$pic\\\"><tr attr=\"2\"><td><a href=\"/torrent-ita/baywatch.html\"><img
+        style=\"border-color: black\" src=\"//s.ilcorsaronero.info/imgcp/53169.jpg\"
+        alt=\"baywatch\" title=\"baywatch\" height=\"130\" width=\"90\" border=\"2\"></a></td><td><a
+        href=\"/torrent-ita/mummia.html\"><img style=\"border-color: black\" src=\"//s.ilcorsaronero.info/imgcp/lamummia.jpg\"
+        alt=\"mummia\" title=\"mummia\" height=\"130\" width=\"90\" border=\"2\"></a></td></tr
+        attr=\\\"$pic\\\"><tr attr=\"4\"><td><a href=\"/torrent-ita/transformers.html\"><img
+        style=\"border-color: black\" src=\"//s.ilcorsaronero.info/imgcp/transformers-lultimo-cavaliere-spot-tv-big-game-trama-ufficiale-foto-e-locandina-2.jpg\"
+        alt=\"transformers\" title=\"transformers\" height=\"130\" width=\"90\" border=\"2\"></a></td><td><a
+        href=\"/torrent-ita/homecoming.html\"><img style=\"border-color: black\" src=\"//s.ilcorsaronero.info/imgcp/spider-man-homecoming-poster.jpg\"
+        alt=\"homecoming\" title=\"homecoming\" height=\"130\" width=\"90\" border=\"2\"></a></td></tr
+        attr=\\\"$pic\\\"></tbody></table>                        </center>\r\n                        <br/>\r\n
+        \                       <ul>\r\n                            <li><a href=\"https://ilcorsaronero.info/link\">Link</a></li>\r\n
+        \                       </ul>\r\n\r\n                        <img src=\"//s.ilcorsaronero.info/images/lloca.gif\"
+        alt=\"\">\r\n        </div>\r\n\r\n        \r\n\r\n        </td>\r\n        <td
+        VALIGN=\"top\">\r\n            <div align=\"left\">\r\n            </div>\r\n\r\n
+        \           <TABLE>\r\n                <tr>\r\n                    <td colspan='10'>\r\n
+        \                       <center>\r\n\r\n                        </center>\r\n\r\n\r\n
+        \                   </td>\r\n                </tr>\r\n\r\n                <TR
+        class=\"bordo\">\r\n\r\n\r\n                    <TD align=\"center\" class=\"header2\">\r\n
+        \                       Cat&nbsp;<br><img src='//s.ilcorsaronero.info/images/linean.gif'
+        border='0' alt=\"_\"></TD>\r\n\r\n                    <TD align=\"center\"
+        class=\"header2\">&nbsp;Name<br><img src='//s.ilcorsaronero.info/images/linean4.gif'\r\n
+        \                                                                         border='0'
+        alt=\"_\"></TD>\r\n\r\n                    <TD align=\"center\" class=\"header2\">Size<br><img
+        src='//s.ilcorsaronero.info/images/linean.gif' border='0'\r\n                                                                    alt=\"_\"></TD>\r\n\r\n
+        \                   <TD align=\"center\" class=\"header2\">Azione<br><img
+        src='//s.ilcorsaronero.info/images/linean2.gif'\r\n                                                                      border='0'
+        alt=\"_\"></TD>\r\n\r\n                    <TD align=\"center\" class=\"header2\">Data&nbsp;&#8595<br><img\r\n
+        \                           src='//s.ilcorsaronero.info/images/linean1.gif'
+        border='0' alt=\"_\"></TD>\r\n\r\n                    <TD align=\"center\"
+        class=\"header2\">S<br><img src='//s.ilcorsaronero.info/images/linean1.gif'
+        border='0'\r\n                                                                 alt=\"_\"></TD>\r\n\r\n
+        \                   <TD align=\"center\" class=\"header2\">L<br><img src='//s.ilcorsaronero.info/images/linean1.gif'
+        border='0'\r\n                                                                 alt=\"_\"></TD>\r\n
+        \                                   </TR>\r\n\r\n                <tr class=\"odd\">\t<td
+        align=\"center\" class=\"lista\" ><a class=\"red\" href=https://ilcorsaronero.info/cat/15>SerieTv</td>\t<TD
+        align=\"left\" ><A class=\"tab\" HREF=\"https://ilcorsaronero.info/tor/107632/Game_Of_Thrones___Il_Trono_Di_Spade_S05e08_09_Mux___720p___H264___Ita_Eng_Ac3___Sub_Ita_Eng__DLMux__\"
+        >Game Of Thrones - Il Trono Di Spade S05e08-09[Mux - 720..</A> <span style=\"color:red\"></span>
+        \t<td align=\"center\"   ><font size='-2' color='#FF6600'>3.51 GB</font></td>\n\t<TD
+        align=\"center\" class=\"lista\" ><form action=\"https://ilcorsaronero.info/tor/107632/Game_Of_Thrones___Il_Trono_Di_Spade_S05e08_09_Mux___720p___H264___Ita_Eng_Ac3___Sub_Ita_Eng__DLMux__\"
+        method=\"post\" target=\"_blank\" class=\"action\"><input type=\"submit\"
+        class=\"downarrow\" name=\"cerca\" value=\"8c14f66e8634ec43937742f67f3c34a8e0d1d439\"
+        title=\"Download\" /><A HREF=https://ilcorsaronero.info/tor/107632/Game_Of_Thrones___Il_Trono_Di_Spade_S05e08_09_Mux___720p___H264___Ita_Eng_Ac3___Sub_Ita_Eng__DLMux__><img
+        src='//s.ilcorsaronero.info/images/details.gif' class='details' title='Descrizione'
+        alt='Descrizione'></A></form></TD>\n\t<td align=\"center\"  ><font color='#669999'>18.06.15</font></td>\n\t<td
+        align=\"center\" ><font color='#00CC00'>192</font></td>\t<td align=\"center\"
+        ><font color='#0066CC'>309</font></td></TR><tr class=\"odd2\">\t<td align=\"center\"
+        class=\"lista\" ><a class=\"red\" href=https://ilcorsaronero.info/cat/15>SerieTv</td>\t<TD
+        align=\"left\" ><A class=\"tab\" HREF=\"https://ilcorsaronero.info/tor/107482/Trono_Di_Spade_Game_Of_Thrones_S05e08_Aspra_Dimora_ITA_ENG_1080p_x264_Subs_DLMux_BlackBIT\"
+        >Trono.Di.Spade-Game.Of.Thrones.S05e08.Aspra.Dimora.ITA...</A> <span style=\"color:red\"></span>
+        \t<td align=\"center\"   ><font size='-2' color='#FF6600'>2.30 GB</font></td>\n\t<TD
+        align=\"center\" class=\"lista\" ><form action=\"https://ilcorsaronero.info/tor/107482/Trono_Di_Spade_Game_Of_Thrones_S05e08_Aspra_Dimora_ITA_ENG_1080p_x264_Subs_DLMux_BlackBIT\"
+        method=\"post\" target=\"_blank\" class=\"action\"><input type=\"submit\"
+        class=\"downarrow\" name=\"cerca\" value=\"be3ec6eed35aaa1f3466d3c84441cd68de97366a\"
+        title=\"Download\" /><A HREF=https://ilcorsaronero.info/tor/107482/Trono_Di_Spade_Game_Of_Thrones_S05e08_Aspra_Dimora_ITA_ENG_1080p_x264_Subs_DLMux_BlackBIT><img
+        src='//s.ilcorsaronero.info/images/details.gif' class='details' title='Descrizione'
+        alt='Descrizione'></A></form></TD>\n\t<td align=\"center\"  ><font color='#669999'>10.06.15</font></td>\n\t<td
+        align=\"center\" ><font color='#00CC00'>445</font></td>\t<td align=\"center\"
+        ><font color='#0066CC'>59</font></td></TR><div align='left'>Torrent trovati
+        per <i>Game of Thrones S05E08</i> - 2 </div>\r\n<tr><td colspan='10'>\r\n<br>\r\n\r\n
+        \               <br/>\r\n\r\n                </TR>\r\n\r\n                <tr>\r\n
+        \                   <td colspan=\"5\" align=\"center\">\r\n                        <table>\r\n
+        \                           <TR>\r\n                                <TD> <p
+        align=\"center\"><b>0&nbsp;</b><br /><b>&lt;&lt; pagine precedenti&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;pagine
+        successive &gt;&gt</b></p>\n\r\n\r\n                                </td>\r\n
+        \                           </TR>\r\n\r\n                        </table>\r\n\r\n
+        \                   </td>\r\n                </tr>\r\n\r\n\r\n            </TABLE>\r\n\r\n\r\n
+        \       </td>\r\n        </table>\r\n\r\n    </div>\r\n\r\n\r\n    <div class=\"clear\"></div>\r\n\r\n</div>\r\n\r\n<br>\r\n\r\n\r\n\r\n</div
+        >\r\n\r\n</div>\r\n\r\n</div>\r\n</div>\r\n\r\n\t<div id='footer'>\r\n\r\n\r\n\t\t<div
+        id='copyright'>\r\n\r\n\t\t<div id='logos'>\r\n\r\n\t\t\t\t<ul>\r\n\t\t\t\t\t<li></li>\r\n\t\t\t\t</ul>\r\n\r\n\t\t\t</div>\r\n\r\n\t\t\t<div
+        id='copy'>\r\n\r\n\t\t\t\t<ul>\r\n\t\t\t\t\t<li><a href='http://torrent-finder.info/torrent-finder-domain-seizure.php'
+        target='_blank'>Salva Internet</a></li>\r\n\t\t\t\t\t<li><a href='/contatti'>Contatti</a></li>\r\n\t\t\t\t\t<li><a
+        href='/removal'>Removal</a></li>\r\n\t\t\t\t</ul>\r\n\r\n\t\t\t</div>\r\n\r\n\t\t\t<div
+        class='clear'></div>\r\n\r\n\t\t</div>\r\n\r\n\t\t<div class='clear'></div>\r\n\r\n\t</div>\r\n\r\n</body>\r\n</html>\r\n"}
+    headers:
+      content-type: [text/html]
+      date: ['Wed, 05 Jul 2017 19:43:37 GMT']
+      server: [lighttpd/1.4.35]
+      x-powered-by: [PHP/5.5.38]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: [!!python/unicode 'gzip,deflate']
+      Connection: [keep-alive]
+      User-Agent: [!!python/unicode 'Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36
+          (KHTML, like Gecko) Chrome/36.0.1985.67 Safari/537.36']
+    method: GET
+    uri: https://ilcorsaronero.info/advsearch.php?search=Game%20of%20Thrones%20S05&order=data&by=DESC&page=0&category=15,5,1,20,19
+  response:
+    body: {string: !!python/unicode "<!DOCTYPE html PUBLIC '-//W3C//DTD XHTML 1.0
+        Strict//EN' 'http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd'>\r\n<html
+        xmlns='http://www.w3.org/1999/xhtml'>\r\n<head>\r\n<meta http-equiv='Content-Type'
+        content='text/html; charset=utf-8' />\r\n<title>ilCorSaRoNeRo.info - just
+        Torrent iTALiANi - Game of Thrones S05 ita torrent</title>\r\n<META NAME=\"Description\"
+        CONTENT=\"Game of Thrones S05\">\r\n<META NAME=\"Keywords\" CONTENT=\"Game
+        of Thrones S05 ita torrent\">\r\n<meta name=\"googlebot\" content=\"noindex\"
+        />\r\n\r\n\t<link href='//s.ilcorsaronero.info/css/main.css' rel='stylesheet'
+        type='text/css' />\r\n\t<link rel='shortcut icon' href='//s.ilcorsaronero.info/favicon.ico'/>\r\n
+        \   <link rel='alternate' type='application/rss+xml' title='RSS' href='/rss'
+        />\r\n\r\n<script type=\"text/javascript\">\r\n(function(){\r\n    var arrElms
+        = {};\r\n    var ppblkUtil = {\r\n\tinit: function(){},\r\n\t\r\n\tonMouseEvent:
+        function(evt){ \r\n\t    switch (ppblkUtil.isMyClick(evt.target)){\r\n\t\tcase
+        0 : \r\n\t\t    var target = evt.target.id || 'body';\r\n\t\t    if(typeof
+        evt.target.id != 'string') target = 'body';\r\n\t\t    \r\n\t\t    if(window.currList[target]
+        && window.currList[target][evt.type])\r\n\t\t\tfor(var i = 0 ; i < window.currList[target][evt.type].length
+        ; i++)\r\n\t\t\t    window.currList[target][evt.type][i](evt); \r\n\t\t    break;\r\n\t\tcase
+        1: \r\n\t\t    evt.stopPropagation();\r\n\t\t    evt.cancelBubble = true;\r\n\t\t
+        \   break;\r\n\t    }\r\n\t}, \r\n\t\r\n\taddEvent: function(elm, name, handler){\r\n\t
+        \   if (document.addEventListener) document.addEventListener(name, handler,
+        false);\r\n\t    else if (document.attachEvent) document.attachEvent(\"on\"
+        + name, handler); \r\n\t},\r\n\t\r\n\tremoveEvent: function(name, handler){\r\n\t
+        \   if (document.addEventListener) document.removeEventListener(name, handler,
+        false);\r\n\t    else if (document.attachEvent) document.detachEvent(\"on\"
+        + name, handler); \r\n\t    else document[\"on\" + name] = null;\r\n\t},\r\n\t\r\n\tisMyClick:
+        function(elm){\r\n\t    if(typeof arrElms[elm] != 'undefined') return arrElms[elm];\r\n\t
+        \   var e = elm;\r\n\t    while(e && e.tagName != 'BODY'){\r\n\t\tif(e.tagName
+        == \"BUTTON\" && e.getAttribute('name') && e.getAttribute('name').indexOf('coolmir')
+        > -1){\r\n\t\t    arrElms[elm] = 1;\r\n\t\t    return 1;\r\n\t\t}\r\n\t\te
+        = e.parentNode;\r\n\t    }\r\n\t    arrElms[elm] = 0;\r\n\t    return 0;\r\n\t}\r\n
+        \   };\r\n    ppblkUtil.init();\r\n    \r\n    window.currList = {'body':
+        {'mouseup': new Array(),'click': new Array(),'mousedown': new Array()}};\r\n
+        \   var isAddExist = document.addEventListener ? true : false;\r\n    document.originalAddEventListener
+        = document.addEventListener || document.attachEvent;\r\n    document[isAddExist
+        ? 'addEventListener' : 'attachEvent'] = function(e, a, b){\r\n\tif(e == 'mouseup'
+        || e == 'click' || e == 'mousedown'){\r\n\t    window.currList['body'][e].push(a);\r\n\t
+        \   return document.originalAddEventListener(e, ppblkUtil.onMouseEvent, true);\r\n\t}\r\n\telse
+        return document.originalAddEventListener(e,a,b);\r\n    };\r\n    \r\n    ppblkUtil.addEvent(document,
+        navigator.userAgent.indexOf('Chrome') > -1 ? 'mouseup' : 'click', function(){});\r\n
+        \   ppblkUtil.addEvent(document, 'mousedown', function(){});\r\n    \r\n})();\r\n</script>\r\n\r\n</head>\r\n\r\n<body>\r\n<script
+        type=\"text/javascript\">\n\n  var _gaq = _gaq || [];\n  _gaq.push(['_setAccount',
+        'UA-16396970-1']);\n  _gaq.push(['_trackPageview']);\n\n  (function() {\n
+        \   var ga = document.createElement('script'); ga.type = 'text/javascript';
+        ga.async = true;\n    ga.src = ('https:' == document.location.protocol ? 'https://ssl'
+        : 'http://www') + '.google-analytics.com/ga.js';\n    var s = document.getElementsByTagName('script')[0];
+        s.parentNode.insertBefore(ga, s);\n  })();\n\n</script>\r\n<div class='network'>\r\n\t<div
+        class='network_links'>\r\n\t</div>\r\n</div>\r\n\t<div id='container'>\r\n\r\n\t\t<div
+        id='header'>\r\n\r\n\t\t\t<div id='logo'>\r\n\t\t\t\t<h1><a href='/'><img
+        src='//s.ilcorsaronero.info/images/h_logo.gif' alt='Torrent Italiano' title='Torrent
+        Italiano' /></a></h1>\r\n\t\t\t</div>\r\n\r\n\t\t\t<div id='call'>\r\n\t\t\t\r\n\t\t\t\t<h3><form
+        action='/argh.php' method='get'>\r\n\t\t\t\t\r\n      &nbsp;Cerca : <input
+        name='search' size='42' value='Game of Thrones S05' type='text'>  \r\n       <input
+        type=\"submit\" value='cerca' alt=\"Submit\">\r\n</form></h3>\r\n&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a
+        href='/torrent-ita/iTALiAN.html'><img src='//s.ilcorsaronero.info/images/h_logo2.gif'
+        alt='' border='0'/></a>\r\n\t\t\t</div>\r\n\r\n\r\n\r\n\t\t\t<div id='menu'>\r\n\r\n\t\t\t\t<ul>\r\n\t\t\t\t\t<li
+        id='menu_home'><span></span></li>\r\n\t\t\t\t\t<li id='menu_stills'><a href='/cat/3'>giochi</a></li>\r\n\t\t\t\t\t<li
+        id='menu_video'><a href='/cat/1'>film</a></li>\r\n\t\t\t\t\t<li id='menu_audio'><a
+        href='/cat/2'>musica</a></li>\r\n\t\t\t\t\t<li id='menu_identity'><a href='/cat/7'>app</a></li>\r\n\t\t\t\t\t<li
+        id='menu_web'><a href='/sfoglia'>sfoglia</a></li>\r\n\t\t\t\t\t<li id='menu_gallery'><a
+        href='/recenti'>recenti</a></li>\r\n\t\t\t\t\t<li id='menu_about'><a href='/searchcloud'>cloud</a></li>\r\n\t\t\t\t\t<li
+        id='menu_contact'><a href='/upload'>upload</a></li>\r\n\t\t\t\t</ul>\r\n\t\t\t</div>\r\n\r\n\t\t\t<div
+        class='clear'></div>\r\n\r\n\t  </div>\r\n\r\n<div id=\"content\">\r\n    <div
+        id=\"body\">\r\n        <table width=100% border=0 cellpadding=0 cellspacing=0>\r\n
+        \           <tr>\r\n                <td>\r\n                    <font size=+1
+        color=\"#CC0000\">&nbsp;<b>* Ultimi Torrent</b></font>&nbsp;\r\n                </td>\r\n
+        \               <td align=right>\r\n                    <h3><span style=\"color:
+        yellow;\">iCN<br /></span></h3>                </td>\r\n            </tr>\r\n
+        \       </table>\r\n        <br/>\r\n        <span id=\"searchincat\"><a href=\"https://ilcorsaronero.info/rss\"><img
+        src=\"//s.ilcorsaronero.info/images/rss_icon.png\" border=\"0\"></a>filtra
+        risultati per categoria:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<br><br></span><br><ul
+        id=\"tabs\" ><li><a href='https://ilcorsaronero.info/adv/Game%20of%20Thrones%20S05.html'>All</a></li>
+        <li><a href='https://ilcorsaronero.info/adv/7/Game%20of%20Thrones%20S05.html'>App
+        Win</a></li> <li><a href='https://ilcorsaronero.info/adv/3/Game%20of%20Thrones%20S05.html'>PC
+        Games</a></li> <li><a href='https://ilcorsaronero.info/adv/2/Game%20of%20Thrones%20S05.html'>Musica</a></li>
+        <li><a href='https://ilcorsaronero.info/adv/19/Game%20of%20Thrones%20S05.html'>Screener</a></li>
+        <li><a href='https://ilcorsaronero.info/adv/1/Game%20of%20Thrones%20S05.html'>BDRiP</a></li>
+        <li><a href='https://ilcorsaronero.info/adv/20/Game%20of%20Thrones%20S05.html'>DVD</a></li>
+        <li><a href='https://ilcorsaronero.info/adv/13/Game%20of%20Thrones%20S05.html'>PlayStation</a></li>
+        <li><a href='https://ilcorsaronero.info/adv/14/Game%20of%20Thrones%20S05.html'>XboX</a></li>
+        <li><a href='https://ilcorsaronero.info/adv/6/Game%20of%20Thrones%20S05.html'>eBooks</a></li>
+        <li><a href='https://ilcorsaronero.info/adv/15/Game%20of%20Thrones%20S05.html'>SerieTv</a></li></ul>
+        <br><br>\r\n        <div id=\"left\" class=\"left\">\r\n            <table>\r\n
+        \               <tr>\r\n                    <td VALIGN=\"top\">\r\n                        <ul>\r\n
+        \                       </ul>\r\n                        <br/>\r\n                        <ul>\r\n
+        \                           <li><a href=\"https://ilcorsaronero.info/tagmovie\">Movie
+        Tag</a></li>\r\n                        </ul>\r\n                                                <br>\r\n\r\n
+        \                       <ul>\r\n                            <li><a href=\"https://feeds.feedburner.com/ilCorSaRoNero\"
+        target=\"_blank\"><img\r\n                                        src=\"https://feeds.feedburner.com/~fc/ilCorSaRoNero?bg=000000&amp;fg=FFFF00&amp;anim=0\"\r\n
+        \                                       height=\"26\" width=\"88\" style=\"border:0\"
+        alt=\"stai aggiornato via email\"\r\n                                        title=\"stai
+        aggiornato via email\"/></a></li>\r\n                        </ul>\r\n                        <center>\r\n
+        \                           <br/>\r\n                            <table><tbody><tr
+        attr=\"0\"><td><a href=\"/torrent-ita/pirati dei caraibi.html\"><img style=\"border-color:
+        black\" src=\"//s.ilcorsaronero.info/imgcp/piratesofthecaribbean5.jpg\" alt=\"pirati
+        dei caraibi\" title=\"pirati dei caraibi\" height=\"130\" width=\"90\" border=\"2\"></a></td><td><a
+        href=\"/torrent-ita/wonder woman.html\"><img style=\"border-color: black\"
+        src=\"//s.ilcorsaronero.info/imgcp/wonderwoman.jpg\" alt=\"wonder woman\"
+        title=\"wonder woman\" height=\"130\" width=\"90\" border=\"2\"></a></td></tr
+        attr=\\\"$pic\\\"><tr attr=\"2\"><td><a href=\"/torrent-ita/baywatch.html\"><img
+        style=\"border-color: black\" src=\"//s.ilcorsaronero.info/imgcp/53169.jpg\"
+        alt=\"baywatch\" title=\"baywatch\" height=\"130\" width=\"90\" border=\"2\"></a></td><td><a
+        href=\"/torrent-ita/mummia.html\"><img style=\"border-color: black\" src=\"//s.ilcorsaronero.info/imgcp/lamummia.jpg\"
+        alt=\"mummia\" title=\"mummia\" height=\"130\" width=\"90\" border=\"2\"></a></td></tr
+        attr=\\\"$pic\\\"><tr attr=\"4\"><td><a href=\"/torrent-ita/transformers.html\"><img
+        style=\"border-color: black\" src=\"//s.ilcorsaronero.info/imgcp/transformers-lultimo-cavaliere-spot-tv-big-game-trama-ufficiale-foto-e-locandina-2.jpg\"
+        alt=\"transformers\" title=\"transformers\" height=\"130\" width=\"90\" border=\"2\"></a></td><td><a
+        href=\"/torrent-ita/homecoming.html\"><img style=\"border-color: black\" src=\"//s.ilcorsaronero.info/imgcp/spider-man-homecoming-poster.jpg\"
+        alt=\"homecoming\" title=\"homecoming\" height=\"130\" width=\"90\" border=\"2\"></a></td></tr
+        attr=\\\"$pic\\\"></tbody></table>                        </center>\r\n                        <br/>\r\n
+        \                       <ul>\r\n                            <li><a href=\"https://ilcorsaronero.info/link\">Link</a></li>\r\n
+        \                       </ul>\r\n\r\n                        <img src=\"//s.ilcorsaronero.info/images/lloca.gif\"
+        alt=\"\">\r\n        </div>\r\n\r\n        \r\n\r\n        </td>\r\n        <td
+        VALIGN=\"top\">\r\n            <div align=\"left\">\r\n            </div>\r\n\r\n
+        \           <TABLE>\r\n                <tr>\r\n                    <td colspan='10'>\r\n
+        \                       <center>\r\n\r\n                        </center>\r\n\r\n\r\n
+        \                   </td>\r\n                </tr>\r\n\r\n                <TR
+        class=\"bordo\">\r\n\r\n\r\n                    <TD align=\"center\" class=\"header2\">\r\n
+        \                       Cat&nbsp;<br><img src='//s.ilcorsaronero.info/images/linean.gif'
+        border='0' alt=\"_\"></TD>\r\n\r\n                    <TD align=\"center\"
+        class=\"header2\">&nbsp;Name<br><img src='//s.ilcorsaronero.info/images/linean4.gif'\r\n
+        \                                                                         border='0'
+        alt=\"_\"></TD>\r\n\r\n                    <TD align=\"center\" class=\"header2\">Size<br><img
+        src='//s.ilcorsaronero.info/images/linean.gif' border='0'\r\n                                                                    alt=\"_\"></TD>\r\n\r\n
+        \                   <TD align=\"center\" class=\"header2\">Azione<br><img
+        src='//s.ilcorsaronero.info/images/linean2.gif'\r\n                                                                      border='0'
+        alt=\"_\"></TD>\r\n\r\n                    <TD align=\"center\" class=\"header2\">Data&nbsp;&#8595<br><img\r\n
+        \                           src='//s.ilcorsaronero.info/images/linean1.gif'
+        border='0' alt=\"_\"></TD>\r\n\r\n                    <TD align=\"center\"
+        class=\"header2\">S<br><img src='//s.ilcorsaronero.info/images/linean1.gif'
+        border='0'\r\n                                                                 alt=\"_\"></TD>\r\n\r\n
+        \                   <TD align=\"center\" class=\"header2\">L<br><img src='//s.ilcorsaronero.info/images/linean1.gif'
+        border='0'\r\n                                                                 alt=\"_\"></TD>\r\n
+        \                                   </TR>\r\n\r\n                <tr class=\"odd\">\t<td
+        align=\"center\" class=\"lista\" ><a class=\"red\" href=https://ilcorsaronero.info/cat/15>SerieTv</td>\t<TD
+        align=\"left\" ><A class=\"tab\" HREF=\"https://ilcorsaronero.info/tor/113071/Game_Of_Thrones_S05e01_10__H264___Ita_Eng_Ac3_5_1_Subs__BDMux_by_Fratposa_COMPLETA_Il_Trono_di_Spade\"
+        >Game Of Thrones S05e01-10 [H264 - Ita Eng Ac3 5.1-Subs]..</A> <span style=\"color:red\"></span>
+        \t<td align=\"center\"   ><font size='-2' color='#FF6600'>6.07 GB</font></td>\n\t<TD
+        align=\"center\" class=\"lista\" ><form action=\"https://ilcorsaronero.info/tor/113071/Game_Of_Thrones_S05e01_10__H264___Ita_Eng_Ac3_5_1_Subs__BDMux_by_Fratposa_COMPLETA_Il_Trono_di_Spade\"
+        method=\"post\" target=\"_blank\" class=\"action\"><input type=\"submit\"
+        class=\"downarrow\" name=\"cerca\" value=\"70d10dc5efb7d4be13f0825f2f962540e5dd253c\"
+        title=\"Download\" /><A HREF=https://ilcorsaronero.info/tor/113071/Game_Of_Thrones_S05e01_10__H264___Ita_Eng_Ac3_5_1_Subs__BDMux_by_Fratposa_COMPLETA_Il_Trono_di_Spade><img
+        src='//s.ilcorsaronero.info/images/details.gif' class='details' title='Descrizione'
+        alt='Descrizione'></A></form></TD>\n\t<td align=\"center\"  ><font color='#669999'>14.01.16</font></td>\n\t<td
+        align=\"center\" ><font color='#00CC00'>147</font></td>\t<td align=\"center\"
+        ><font color='#0066CC'>137</font></td></TR><tr class=\"odd2\">\t<td align=\"center\"
+        class=\"lista\" ><a class=\"red\" href=https://ilcorsaronero.info/cat/15>SerieTv</td>\t<TD
+        align=\"left\" ><A class=\"tab\" HREF=\"https://ilcorsaronero.info/tor/107795/Game_Of_Thrones_Trono_Di_Spade_S05e10_Madre_Misericordiosa_ITA_ENG_1080p_x264_Subs_DLMux_BlackBIT\"
+        >Game.Of.Thrones-Trono.Di.Spade.S05e10.Madre.Misericordi..</A> <span style=\"color:red\"></span>
+        \t<td align=\"center\"   ><font size='-2' color='#FF6600'>6.04 GB</font></td>\n\t<TD
+        align=\"center\" class=\"lista\" ><form action=\"https://ilcorsaronero.info/tor/107795/Game_Of_Thrones_Trono_Di_Spade_S05e10_Madre_Misericordiosa_ITA_ENG_1080p_x264_Subs_DLMux_BlackBIT\"
+        method=\"post\" target=\"_blank\" class=\"action\"><input type=\"submit\"
+        class=\"downarrow\" name=\"cerca\" value=\"e68277a86c9062daccb0afffa7a1aa2813be5b51\"
+        title=\"Download\" /><A HREF=https://ilcorsaronero.info/tor/107795/Game_Of_Thrones_Trono_Di_Spade_S05e10_Madre_Misericordiosa_ITA_ENG_1080p_x264_Subs_DLMux_BlackBIT><img
+        src='//s.ilcorsaronero.info/images/details.gif' class='details' title='Descrizione'
+        alt='Descrizione'></A></form></TD>\n\t<td align=\"center\"  ><font color='#669999'>24.06.15</font></td>\n\t<td
+        align=\"center\" ><font color='#00CC00'>189</font></td>\t<td align=\"center\"
+        ><font color='#0066CC'>81</font></td></TR><tr class=\"odd\">\t<td align=\"center\"
+        class=\"lista\" ><a class=\"red\" href=https://ilcorsaronero.info/cat/15>SerieTv</td>\t<TD
+        align=\"left\" ><A class=\"tab\" HREF=\"https://ilcorsaronero.info/tor/107792/Game_Of_Thrones___Il_Trono_Di_Spade_S05e10_Mux___720p___H264___Ita_Eng_Ac3___Sub_Ita_Eng__DLMux___Gi\"
+        >Game Of Thrones - Il Trono Di Spade S05e10[Mux - 720p -..</A> <span style=\"color:red\"></span>
+        \t<td align=\"center\"   ><font size='-2' color='#FF6600'>1.88 GB</font></td>\n\t<TD
+        align=\"center\" class=\"lista\" ><form action=\"https://ilcorsaronero.info/tor/107792/Game_Of_Thrones___Il_Trono_Di_Spade_S05e10_Mux___720p___H264___Ita_Eng_Ac3___Sub_Ita_Eng__DLMux___Gi\"
+        method=\"post\" target=\"_blank\" class=\"action\"><input type=\"submit\"
+        class=\"downarrow\" name=\"cerca\" value=\"7a259e01cfcc94ff118a823559219f997281e11b\"
+        title=\"Download\" /><A HREF=https://ilcorsaronero.info/tor/107792/Game_Of_Thrones___Il_Trono_Di_Spade_S05e10_Mux___720p___H264___Ita_Eng_Ac3___Sub_Ita_Eng__DLMux___Gi><img
+        src='//s.ilcorsaronero.info/images/details.gif' class='details' title='Descrizione'
+        alt='Descrizione'></A></form></TD>\n\t<td align=\"center\"  ><font color='#669999'>24.06.15</font></td>\n\t<td
+        align=\"center\" ><font color='#00CC00'>313</font></td>\t<td align=\"center\"
+        ><font color='#0066CC'>81</font></td></TR><tr class=\"odd2\">\t<td align=\"center\"
+        class=\"lista\" ><a class=\"red\" href=https://ilcorsaronero.info/cat/15>SerieTv</td>\t<TD
+        align=\"left\" ><A class=\"tab\" HREF=\"https://ilcorsaronero.info/tor/107632/Game_Of_Thrones___Il_Trono_Di_Spade_S05e08_09_Mux___720p___H264___Ita_Eng_Ac3___Sub_Ita_Eng__DLMux__\"
+        >Game Of Thrones - Il Trono Di Spade S05e08-09[Mux - 720..</A> <span style=\"color:red\"></span>
+        \t<td align=\"center\"   ><font size='-2' color='#FF6600'>3.51 GB</font></td>\n\t<TD
+        align=\"center\" class=\"lista\" ><form action=\"https://ilcorsaronero.info/tor/107632/Game_Of_Thrones___Il_Trono_Di_Spade_S05e08_09_Mux___720p___H264___Ita_Eng_Ac3___Sub_Ita_Eng__DLMux__\"
+        method=\"post\" target=\"_blank\" class=\"action\"><input type=\"submit\"
+        class=\"downarrow\" name=\"cerca\" value=\"8c14f66e8634ec43937742f67f3c34a8e0d1d439\"
+        title=\"Download\" /><A HREF=https://ilcorsaronero.info/tor/107632/Game_Of_Thrones___Il_Trono_Di_Spade_S05e08_09_Mux___720p___H264___Ita_Eng_Ac3___Sub_Ita_Eng__DLMux__><img
+        src='//s.ilcorsaronero.info/images/details.gif' class='details' title='Descrizione'
+        alt='Descrizione'></A></form></TD>\n\t<td align=\"center\"  ><font color='#669999'>18.06.15</font></td>\n\t<td
+        align=\"center\" ><font color='#00CC00'>192</font></td>\t<td align=\"center\"
+        ><font color='#0066CC'>309</font></td></TR><tr class=\"odd\">\t<td align=\"center\"
+        class=\"lista\" ><a class=\"red\" href=https://ilcorsaronero.info/cat/15>SerieTv</td>\t<TD
+        align=\"left\" ><A class=\"tab\" HREF=\"https://ilcorsaronero.info/tor/107617/Il_Trono_Di_Spade_Game_Of_Thrones_S05e09_La_Danza_Dei_Draghi_ITA_ENG_1080p_x264_Subs_DLMux_BlackBIT\"
+        >Il.Trono.Di.Spade-Game.Of.Thrones.S05e09.La.Danza.Dei.D..</A> <span style=\"color:red\"></span>
+        \t<td align=\"center\"   ><font size='-2' color='#FF6600'>4.56 GB</font></td>\n\t<TD
+        align=\"center\" class=\"lista\" ><form action=\"https://ilcorsaronero.info/tor/107617/Il_Trono_Di_Spade_Game_Of_Thrones_S05e09_La_Danza_Dei_Draghi_ITA_ENG_1080p_x264_Subs_DLMux_BlackBIT\"
+        method=\"post\" target=\"_blank\" class=\"action\"><input type=\"submit\"
+        class=\"downarrow\" name=\"cerca\" value=\"36cf4d3e909989e3ef87eba06ec0b12caa250d46\"
+        title=\"Download\" /><A HREF=https://ilcorsaronero.info/tor/107617/Il_Trono_Di_Spade_Game_Of_Thrones_S05e09_La_Danza_Dei_Draghi_ITA_ENG_1080p_x264_Subs_DLMux_BlackBIT><img
+        src='//s.ilcorsaronero.info/images/details.gif' class='details' title='Descrizione'
+        alt='Descrizione'></A></form></TD>\n\t<td align=\"center\"  ><font color='#669999'>17.06.15</font></td>\n\t<td
+        align=\"center\" ><font color='#00CC00'>501</font></td>\t<td align=\"center\"
+        ><font color='#0066CC'>262</font></td></TR><tr class=\"odd2\">\t<td align=\"center\"
+        class=\"lista\" ><a class=\"red\" href=https://ilcorsaronero.info/cat/15>SerieTv</td>\t<TD
+        align=\"left\" ><A class=\"tab\" HREF=\"https://ilcorsaronero.info/tor/107482/Trono_Di_Spade_Game_Of_Thrones_S05e08_Aspra_Dimora_ITA_ENG_1080p_x264_Subs_DLMux_BlackBIT\"
+        >Trono.Di.Spade-Game.Of.Thrones.S05e08.Aspra.Dimora.ITA...</A> <span style=\"color:red\"></span>
+        \t<td align=\"center\"   ><font size='-2' color='#FF6600'>2.30 GB</font></td>\n\t<TD
+        align=\"center\" class=\"lista\" ><form action=\"https://ilcorsaronero.info/tor/107482/Trono_Di_Spade_Game_Of_Thrones_S05e08_Aspra_Dimora_ITA_ENG_1080p_x264_Subs_DLMux_BlackBIT\"
+        method=\"post\" target=\"_blank\" class=\"action\"><input type=\"submit\"
+        class=\"downarrow\" name=\"cerca\" value=\"be3ec6eed35aaa1f3466d3c84441cd68de97366a\"
+        title=\"Download\" /><A HREF=https://ilcorsaronero.info/tor/107482/Trono_Di_Spade_Game_Of_Thrones_S05e08_Aspra_Dimora_ITA_ENG_1080p_x264_Subs_DLMux_BlackBIT><img
+        src='//s.ilcorsaronero.info/images/details.gif' class='details' title='Descrizione'
+        alt='Descrizione'></A></form></TD>\n\t<td align=\"center\"  ><font color='#669999'>10.06.15</font></td>\n\t<td
+        align=\"center\" ><font color='#00CC00'>445</font></td>\t<td align=\"center\"
+        ><font color='#0066CC'>59</font></td></TR><tr class=\"odd\">\t<td align=\"center\"
+        class=\"lista\" ><a class=\"red\" href=https://ilcorsaronero.info/cat/15>SerieTv</td>\t<TD
+        align=\"left\" ><A class=\"tab\" HREF=\"https://ilcorsaronero.info/tor/107345/Trono_Di_Spade_Game_Of_Thrones_Il_Dono_S05e07_ITA_ENG_1080p_x264_Subs_DLMux_BlackBIT\"
+        >Trono.Di.Spade-Game.Of.Thrones.Il.Dono.S05e07.ITA.ENG.1..</A> <span style=\"color:red\"></span>
+        \t<td align=\"center\"   ><font size='-2' color='#FF6600'>5.44 GB</font></td>\n\t<TD
+        align=\"center\" class=\"lista\" ><form action=\"https://ilcorsaronero.info/tor/107345/Trono_Di_Spade_Game_Of_Thrones_Il_Dono_S05e07_ITA_ENG_1080p_x264_Subs_DLMux_BlackBIT\"
+        method=\"post\" target=\"_blank\" class=\"action\"><input type=\"submit\"
+        class=\"downarrow\" name=\"cerca\" value=\"84a532eab6aeab142b8ae9390e855a9d65391095\"
+        title=\"Download\" /><A HREF=https://ilcorsaronero.info/tor/107345/Trono_Di_Spade_Game_Of_Thrones_Il_Dono_S05e07_ITA_ENG_1080p_x264_Subs_DLMux_BlackBIT><img
+        src='//s.ilcorsaronero.info/images/details.gif' class='details' title='Descrizione'
+        alt='Descrizione'></A></form></TD>\n\t<td align=\"center\"  ><font color='#669999'>03.06.15</font></td>\n\t<td
+        align=\"center\" ><font color='#00CC00'>298</font></td>\t<td align=\"center\"
+        ><font color='#0066CC'>130</font></td></TR><tr class=\"odd2\">\t<td align=\"center\"
+        class=\"lista\" ><a class=\"red\" href=https://ilcorsaronero.info/cat/15>SerieTv</td>\t<TD
+        align=\"left\" ><A class=\"tab\" HREF=\"https://ilcorsaronero.info/tor/107339/Game_Of_Thrones___Il_Trono_Di_Spade_S05e07_Mux___720p___H264___Ita_Eng_Ac3___Sub_Ita_Eng__DLMux___Gi\"
+        >Game Of Thrones - Il Trono Di Spade S05e07[Mux - 720p -..</A> <span style=\"color:red\"></span>
+        \t<td align=\"center\"   ><font size='-2' color='#FF6600'>1.38 GB</font></td>\n\t<TD
+        align=\"center\" class=\"lista\" ><form action=\"https://ilcorsaronero.info/tor/107339/Game_Of_Thrones___Il_Trono_Di_Spade_S05e07_Mux___720p___H264___Ita_Eng_Ac3___Sub_Ita_Eng__DLMux___Gi\"
+        method=\"post\" target=\"_blank\" class=\"action\"><input type=\"submit\"
+        class=\"downarrow\" name=\"cerca\" value=\"2485dcbc9fdbe8e56936f097ffb05fa2a6893a4f\"
+        title=\"Download\" /><A HREF=https://ilcorsaronero.info/tor/107339/Game_Of_Thrones___Il_Trono_Di_Spade_S05e07_Mux___720p___H264___Ita_Eng_Ac3___Sub_Ita_Eng__DLMux___Gi><img
+        src='//s.ilcorsaronero.info/images/details.gif' class='details' title='Descrizione'
+        alt='Descrizione'></A></form></TD>\n\t<td align=\"center\"  ><font color='#669999'>03.06.15</font></td>\n\t<td
+        align=\"center\" ><font color='#00CC00'>460</font></td>\t<td align=\"center\"
+        ><font color='#0066CC'>115</font></td></TR><tr class=\"odd\">\t<td align=\"center\"
+        class=\"lista\" ><a class=\"red\" href=https://ilcorsaronero.info/cat/15>SerieTv</td>\t<TD
+        align=\"left\" ><A class=\"tab\" HREF=\"https://ilcorsaronero.info/tor/107184/Game_Of_Thrones_Trono_Di_Spade_S05e06_Le_Serpi_Delle_Sabbie_ITA_ENG_1080p_x264_Subs_DLMux_BlackBIT\"
+        >Game.Of.Thrones-Trono.Di.Spade.S05e06.Le.Serpi.Delle.Sa..</A> <span style=\"color:red\"></span>
+        \t<td align=\"center\"   ><font size='-2' color='#FF6600'>4.36 GB</font></td>\n\t<TD
+        align=\"center\" class=\"lista\" ><form action=\"https://ilcorsaronero.info/tor/107184/Game_Of_Thrones_Trono_Di_Spade_S05e06_Le_Serpi_Delle_Sabbie_ITA_ENG_1080p_x264_Subs_DLMux_BlackBIT\"
+        method=\"post\" target=\"_blank\" class=\"action\"><input type=\"submit\"
+        class=\"downarrow\" name=\"cerca\" value=\"9bf0ac1e169f0e1b7fa38b2c9ebad0ea4bede80f\"
+        title=\"Download\" /><A HREF=https://ilcorsaronero.info/tor/107184/Game_Of_Thrones_Trono_Di_Spade_S05e06_Le_Serpi_Delle_Sabbie_ITA_ENG_1080p_x264_Subs_DLMux_BlackBIT><img
+        src='//s.ilcorsaronero.info/images/details.gif' class='details' title='Descrizione'
+        alt='Descrizione'></A></form></TD>\n\t<td align=\"center\"  ><font color='#669999'>27.05.15</font></td>\n\t<td
+        align=\"center\" ><font color='#00CC00'>180</font></td>\t<td align=\"center\"
+        ><font color='#0066CC'>77</font></td></TR><tr class=\"odd2\">\t<td align=\"center\"
+        class=\"lista\" ><a class=\"red\" href=https://ilcorsaronero.info/cat/15>SerieTv</td>\t<TD
+        align=\"left\" ><A class=\"tab\" HREF=\"https://ilcorsaronero.info/tor/107181/Game_Of_Thrones___Il_Trono_Di_Spade_S05e06_Mux___720p___H264___Ita_Eng_Ac3___Sub_Ita_Eng__DLMux___Gi\"
+        >Game Of Thrones - Il Trono Di Spade S05e06[Mux - 720p -..</A> <span style=\"color:red\"></span>
+        \t<td align=\"center\"   ><font size='-2' color='#FF6600'>1.35 GB</font></td>\n\t<TD
+        align=\"center\" class=\"lista\" ><form action=\"https://ilcorsaronero.info/tor/107181/Game_Of_Thrones___Il_Trono_Di_Spade_S05e06_Mux___720p___H264___Ita_Eng_Ac3___Sub_Ita_Eng__DLMux___Gi\"
+        method=\"post\" target=\"_blank\" class=\"action\"><input type=\"submit\"
+        class=\"downarrow\" name=\"cerca\" value=\"e626d0ef6d1f1473295c943d83dbd211ae427fd9\"
+        title=\"Download\" /><A HREF=https://ilcorsaronero.info/tor/107181/Game_Of_Thrones___Il_Trono_Di_Spade_S05e06_Mux___720p___H264___Ita_Eng_Ac3___Sub_Ita_Eng__DLMux___Gi><img
+        src='//s.ilcorsaronero.info/images/details.gif' class='details' title='Descrizione'
+        alt='Descrizione'></A></form></TD>\n\t<td align=\"center\"  ><font color='#669999'>27.05.15</font></td>\n\t<td
+        align=\"center\" ><font color='#00CC00'>283</font></td>\t<td align=\"center\"
+        ><font color='#0066CC'>117</font></td></TR><tr class=\"odd\">\t<td align=\"center\"
+        class=\"lista\" ><a class=\"red\" href=https://ilcorsaronero.info/cat/15>SerieTv</td>\t<TD
+        align=\"left\" ><A class=\"tab\" HREF=\"https://ilcorsaronero.info/tor/107029/Game_Of_Thrones___Il_Trono_Di_Spade_S05e05_Mux___720p___H264___Ita_Eng_Ac3___Sub_Ita_Eng__DLMux___Gi\"
+        >Game Of Thrones - Il Trono Di Spade S05e05[Mux - 720p -..</A> <span style=\"color:red\"></span>
+        \t<td align=\"center\"   ><font size='-2' color='#FF6600'>1.21 GB</font></td>\n\t<TD
+        align=\"center\" class=\"lista\" ><form action=\"https://ilcorsaronero.info/tor/107029/Game_Of_Thrones___Il_Trono_Di_Spade_S05e05_Mux___720p___H264___Ita_Eng_Ac3___Sub_Ita_Eng__DLMux___Gi\"
+        method=\"post\" target=\"_blank\" class=\"action\"><input type=\"submit\"
+        class=\"downarrow\" name=\"cerca\" value=\"5fcc21a394b972bac3958474f508d2d5afe9ffce\"
+        title=\"Download\" /><A HREF=https://ilcorsaronero.info/tor/107029/Game_Of_Thrones___Il_Trono_Di_Spade_S05e05_Mux___720p___H264___Ita_Eng_Ac3___Sub_Ita_Eng__DLMux___Gi><img
+        src='//s.ilcorsaronero.info/images/details.gif' class='details' title='Descrizione'
+        alt='Descrizione'></A></form></TD>\n\t<td align=\"center\"  ><font color='#669999'>21.05.15</font></td>\n\t<td
+        align=\"center\" ><font color='#00CC00'>270</font></td>\t<td align=\"center\"
+        ><font color='#0066CC'>59</font></td></TR><tr class=\"odd2\">\t<td align=\"center\"
+        class=\"lista\" ><a class=\"red\" href=https://ilcorsaronero.info/cat/15>SerieTv</td>\t<TD
+        align=\"left\" ><A class=\"tab\" HREF=\"https://ilcorsaronero.info/tor/106989/Game_Of_Thrones_Trono_Di_Spade_S05e05_Uccidi_Il_Ragazzo_ITA_ENG_1080p_x264_Subs_DLMux_BlackBIT\"
+        >Game.Of.Thrones-Trono.Di.Spade.S05e05.Uccidi.Il.Ragazzo..</A> <span style=\"color:red\"></span>
+        \t<td align=\"center\"   ><font size='-2' color='#FF6600'>4.32 GB</font></td>\n\t<TD
+        align=\"center\" class=\"lista\" ><form action=\"https://ilcorsaronero.info/tor/106989/Game_Of_Thrones_Trono_Di_Spade_S05e05_Uccidi_Il_Ragazzo_ITA_ENG_1080p_x264_Subs_DLMux_BlackBIT\"
+        method=\"post\" target=\"_blank\" class=\"action\"><input type=\"submit\"
+        class=\"downarrow\" name=\"cerca\" value=\"48a3370b90db566365c6469864abc1bb02a8ec23\"
+        title=\"Download\" /><A HREF=https://ilcorsaronero.info/tor/106989/Game_Of_Thrones_Trono_Di_Spade_S05e05_Uccidi_Il_Ragazzo_ITA_ENG_1080p_x264_Subs_DLMux_BlackBIT><img
+        src='//s.ilcorsaronero.info/images/details.gif' class='details' title='Descrizione'
+        alt='Descrizione'></A></form></TD>\n\t<td align=\"center\"  ><font color='#669999'>20.05.15</font></td>\n\t<td
+        align=\"center\" ><font color='#00CC00'>235</font></td>\t<td align=\"center\"
+        ><font color='#0066CC'>45</font></td></TR><tr class=\"odd\">\t<td align=\"center\"
+        class=\"lista\" ><a class=\"red\" href=https://ilcorsaronero.info/cat/15>SerieTv</td>\t<TD
+        align=\"left\" ><A class=\"tab\" HREF=\"https://ilcorsaronero.info/tor/106828/Game_Of_Thrones_Trono_Di_Spade_S05e04_I_Figli_DellArpia_ITA_ENG_1080p_x264_Subs_HDTVMux_BlackBIT\"
+        >Game.Of.Thrones-Trono.Di.Spade.S05e04.I.Figli.DellArpia..</A> <span style=\"color:red\"></span>
+        \t<td align=\"center\"   ><font size='-2' color='#FF6600'>4.10 GB</font></td>\n\t<TD
+        align=\"center\" class=\"lista\" ><form action=\"https://ilcorsaronero.info/tor/106828/Game_Of_Thrones_Trono_Di_Spade_S05e04_I_Figli_DellArpia_ITA_ENG_1080p_x264_Subs_HDTVMux_BlackBIT\"
+        method=\"post\" target=\"_blank\" class=\"action\"><input type=\"submit\"
+        class=\"downarrow\" name=\"cerca\" value=\"d4430af58fb2c70fe11ee172fb8db2e927bd734b\"
+        title=\"Download\" /><A HREF=https://ilcorsaronero.info/tor/106828/Game_Of_Thrones_Trono_Di_Spade_S05e04_I_Figli_DellArpia_ITA_ENG_1080p_x264_Subs_HDTVMux_BlackBIT><img
+        src='//s.ilcorsaronero.info/images/details.gif' class='details' title='Descrizione'
+        alt='Descrizione'></A></form></TD>\n\t<td align=\"center\"  ><font color='#669999'>14.05.15</font></td>\n\t<td
+        align=\"center\" ><font color='#00CC00'>214</font></td>\t<td align=\"center\"
+        ><font color='#0066CC'>46</font></td></TR><tr class=\"odd2\">\t<td align=\"center\"
+        class=\"lista\" ><a class=\"red\" href=https://ilcorsaronero.info/cat/15>SerieTv</td>\t<TD
+        align=\"left\" ><A class=\"tab\" HREF=\"https://ilcorsaronero.info/tor/106793/Game_Of_Thrones___Il_Trono_Di_Spade_S05e04_Mux___720p___H264___Ita_Eng_Ac3___Sub_Ita_Eng__DLMux___Gi\"
+        >Game Of Thrones - Il Trono Di Spade S05e04[Mux - 720p -..</A> <span style=\"color:red\"></span>
+        \t<td align=\"center\"   ><font size='-2' color='#FF6600'>1.09 GB</font></td>\n\t<TD
+        align=\"center\" class=\"lista\" ><form action=\"https://ilcorsaronero.info/tor/106793/Game_Of_Thrones___Il_Trono_Di_Spade_S05e04_Mux___720p___H264___Ita_Eng_Ac3___Sub_Ita_Eng__DLMux___Gi\"
+        method=\"post\" target=\"_blank\" class=\"action\"><input type=\"submit\"
+        class=\"downarrow\" name=\"cerca\" value=\"9ef7b3da26b477ef2c106f8fc1cf879d165fa113\"
+        title=\"Download\" /><A HREF=https://ilcorsaronero.info/tor/106793/Game_Of_Thrones___Il_Trono_Di_Spade_S05e04_Mux___720p___H264___Ita_Eng_Ac3___Sub_Ita_Eng__DLMux___Gi><img
+        src='//s.ilcorsaronero.info/images/details.gif' class='details' title='Descrizione'
+        alt='Descrizione'></A></form></TD>\n\t<td align=\"center\"  ><font color='#669999'>13.05.15</font></td>\n\t<td
+        align=\"center\" ><font color='#00CC00'>247</font></td>\t<td align=\"center\"
+        ><font color='#0066CC'>70</font></td></TR><tr class=\"odd\">\t<td align=\"center\"
+        class=\"lista\" ><a class=\"red\" href=https://ilcorsaronero.info/cat/15>SerieTv</td>\t<TD
+        align=\"left\" ><A class=\"tab\" HREF=\"https://ilcorsaronero.info/tor/106622/Game_Of_Thrones___Il_Trono_Di_spade_S05e03_Mux___720p___H264___Ita_Eng_Ac3___Sub_Ita_Eng__DLMux___Gi\"
+        >Game Of Thrones - Il Trono Di spade S05e03[Mux - 720p -..</A> <span style=\"color:red\"></span>
+        \t<td align=\"center\"   ><font size='-2' color='#FF6600'>1.13 GB</font></td>\n\t<TD
+        align=\"center\" class=\"lista\" ><form action=\"https://ilcorsaronero.info/tor/106622/Game_Of_Thrones___Il_Trono_Di_spade_S05e03_Mux___720p___H264___Ita_Eng_Ac3___Sub_Ita_Eng__DLMux___Gi\"
+        method=\"post\" target=\"_blank\" class=\"action\"><input type=\"submit\"
+        class=\"downarrow\" name=\"cerca\" value=\"1df354eb1d44e09484db0c19cd459315eb41e567\"
+        title=\"Download\" /><A HREF=https://ilcorsaronero.info/tor/106622/Game_Of_Thrones___Il_Trono_Di_spade_S05e03_Mux___720p___H264___Ita_Eng_Ac3___Sub_Ita_Eng__DLMux___Gi><img
+        src='//s.ilcorsaronero.info/images/details.gif' class='details' title='Descrizione'
+        alt='Descrizione'></A></form></TD>\n\t<td align=\"center\"  ><font color='#669999'>07.05.15</font></td>\n\t<td
+        align=\"center\" ><font color='#00CC00'>128</font></td>\t<td align=\"center\"
+        ><font color='#0066CC'>9</font></td></TR><tr class=\"odd2\">\t<td align=\"center\"
+        class=\"lista\" ><a class=\"red\" href=https://ilcorsaronero.info/cat/15>SerieTv</td>\t<TD
+        align=\"left\" ><A class=\"tab\" HREF=\"https://ilcorsaronero.info/tor/106572/Il_Trono_Di_Spade_Game_Of_Thrones_S05e03_Lalto_Passero_ITA_ENG_1080p_x264_Subs_DLMux_BlackBIT\"
+        >Il.Trono.Di.Spade-Game.Of.Thrones.S05e03.Lalto.Passero...</A> <span style=\"color:red\"></span>
+        \t<td align=\"center\"   ><font size='-2' color='#FF6600'>4.85 GB</font></td>\n\t<TD
+        align=\"center\" class=\"lista\" ><form action=\"https://ilcorsaronero.info/tor/106572/Il_Trono_Di_Spade_Game_Of_Thrones_S05e03_Lalto_Passero_ITA_ENG_1080p_x264_Subs_DLMux_BlackBIT\"
+        method=\"post\" target=\"_blank\" class=\"action\"><input type=\"submit\"
+        class=\"downarrow\" name=\"cerca\" value=\"80900b7120bc75434779a9931db3a185714ffe85\"
+        title=\"Download\" /><A HREF=https://ilcorsaronero.info/tor/106572/Il_Trono_Di_Spade_Game_Of_Thrones_S05e03_Lalto_Passero_ITA_ENG_1080p_x264_Subs_DLMux_BlackBIT><img
+        src='//s.ilcorsaronero.info/images/details.gif' class='details' title='Descrizione'
+        alt='Descrizione'></A></form></TD>\n\t<td align=\"center\"  ><font color='#669999'>05.05.15</font></td>\n\t<td
+        align=\"center\" ><font color='#00CC00'>371</font></td>\t<td align=\"center\"
+        ><font color='#0066CC'>232</font></td></TR><tr class=\"odd\">\t<td align=\"center\"
+        class=\"lista\" ><a class=\"red\" href=https://ilcorsaronero.info/cat/15>SerieTv</td>\t<TD
+        align=\"left\" ><A class=\"tab\" HREF=\"https://ilcorsaronero.info/tor/106352/Game_of_Thrones___Il_Trono_di_Spade_S05e02_XviD___Ita_Eng_Mp3___Sub_Ita_Eng__DLMux_By_UnLEGIT\"
+        >Game of Thrones - Il Trono di Spade S05e02[XviD - Ita E..</A> <span style=\"color:red\"></span>
+        \t<td align=\"center\"   ><font size='-2' color='#FF6600'>639.19 MB</font></td>\n\t<TD
+        align=\"center\" class=\"lista\" ><form action=\"https://ilcorsaronero.info/tor/106352/Game_of_Thrones___Il_Trono_di_Spade_S05e02_XviD___Ita_Eng_Mp3___Sub_Ita_Eng__DLMux_By_UnLEGIT\"
+        method=\"post\" target=\"_blank\" class=\"action\"><input type=\"submit\"
+        class=\"downarrow\" name=\"cerca\" value=\"254f5d47b2753476a07858f1810dcae0d0a695ad\"
+        title=\"Download\" /><A HREF=https://ilcorsaronero.info/tor/106352/Game_of_Thrones___Il_Trono_di_Spade_S05e02_XviD___Ita_Eng_Mp3___Sub_Ita_Eng__DLMux_By_UnLEGIT><img
+        src='//s.ilcorsaronero.info/images/details.gif' class='details' title='Descrizione'
+        alt='Descrizione'></A></form></TD>\n\t<td align=\"center\"  ><font color='#669999'>29.04.15</font></td>\n\t<td
+        align=\"center\" ><font color='#00CC00'>610</font></td>\t<td align=\"center\"
+        ><font color='#0066CC'>67</font></td></TR><tr class=\"odd2\">\t<td align=\"center\"
+        class=\"lista\" ><a class=\"red\" href=https://ilcorsaronero.info/cat/15>SerieTv</td>\t<TD
+        align=\"left\" ><A class=\"tab\" HREF=\"https://ilcorsaronero.info/tor/106351/Game_Of_Thrones___Il_Trono_Di_spade_S05e02_Mux___720p___H264___Ita_Eng_Ac3___Sub_Ita_Eng__DLMux___Gi\"
+        >Game Of Thrones - Il Trono Di spade S05e02[Mux - 720p -..</A> <span style=\"color:red\"></span>
+        \t<td align=\"center\"   ><font size='-2' color='#FF6600'>1.55 GB</font></td>\n\t<TD
+        align=\"center\" class=\"lista\" ><form action=\"https://ilcorsaronero.info/tor/106351/Game_Of_Thrones___Il_Trono_Di_spade_S05e02_Mux___720p___H264___Ita_Eng_Ac3___Sub_Ita_Eng__DLMux___Gi\"
+        method=\"post\" target=\"_blank\" class=\"action\"><input type=\"submit\"
+        class=\"downarrow\" name=\"cerca\" value=\"bf43e494bc9c521d0b1f9f1a90c43ad100ca07ec\"
+        title=\"Download\" /><A HREF=https://ilcorsaronero.info/tor/106351/Game_Of_Thrones___Il_Trono_Di_spade_S05e02_Mux___720p___H264___Ita_Eng_Ac3___Sub_Ita_Eng__DLMux___Gi><img
+        src='//s.ilcorsaronero.info/images/details.gif' class='details' title='Descrizione'
+        alt='Descrizione'></A></form></TD>\n\t<td align=\"center\"  ><font color='#669999'>29.04.15</font></td>\n\t<td
+        align=\"center\" ><font color='#00CC00'>141</font></td>\t<td align=\"center\"
+        ><font color='#0066CC'>65</font></td></TR><tr class=\"odd\">\t<td align=\"center\"
+        class=\"lista\" ><a class=\"red\" href=https://ilcorsaronero.info/cat/15>SerieTv</td>\t<TD
+        align=\"left\" ><A class=\"tab\" HREF=\"https://ilcorsaronero.info/tor/106335/Game_Of_Thrones_Trono_Di_Spade_S05e02_Il_Nuovo_Commandante_ITA_ENG_1080p_x264_Subs_HDTVMux_BlackBIT\"
+        >Game.Of.Thrones-Trono.Di.Spade.S05e02.Il.Nuovo.Commanda..</A> <span style=\"color:red\"></span>
+        \t<td align=\"center\"   ><font size='-2' color='#FF6600'>2.93 GB</font></td>\n\t<TD
+        align=\"center\" class=\"lista\" ><form action=\"https://ilcorsaronero.info/tor/106335/Game_Of_Thrones_Trono_Di_Spade_S05e02_Il_Nuovo_Commandante_ITA_ENG_1080p_x264_Subs_HDTVMux_BlackBIT\"
+        method=\"post\" target=\"_blank\" class=\"action\"><input type=\"submit\"
+        class=\"downarrow\" name=\"cerca\" value=\"1472f31b276f34dc5c7a07b49bc6149dc558c3e6\"
+        title=\"Download\" /><A HREF=https://ilcorsaronero.info/tor/106335/Game_Of_Thrones_Trono_Di_Spade_S05e02_Il_Nuovo_Commandante_ITA_ENG_1080p_x264_Subs_HDTVMux_BlackBIT><img
+        src='//s.ilcorsaronero.info/images/details.gif' class='details' title='Descrizione'
+        alt='Descrizione'></A></form></TD>\n\t<td align=\"center\"  ><font color='#669999'>28.04.15</font></td>\n\t<td
+        align=\"center\" ><font color='#00CC00'>371</font></td>\t<td align=\"center\"
+        ><font color='#0066CC'>83</font></td></TR><tr class=\"odd2\">\t<td align=\"center\"
+        class=\"lista\" ><a class=\"red\" href=https://ilcorsaronero.info/cat/15>SerieTv</td>\t<TD
+        align=\"left\" ><A class=\"tab\" HREF=\"https://ilcorsaronero.info/tor/106112/Game_Of_Thrones_Trono_Di_Spade_S05e01_Guerre_Imminenti_ITA_ENG_1080p_x264_Subs_DLMux_BlackBIT\"
+        >Game.Of.Thrones-Trono.Di.Spade.S05e01.Guerre.Imminenti...</A> <span style=\"color:red\"></span>
+        \t<td align=\"center\"   ><font size='-2' color='#FF6600'>1.99 GB</font></td>\n\t<TD
+        align=\"center\" class=\"lista\" ><form action=\"https://ilcorsaronero.info/tor/106112/Game_Of_Thrones_Trono_Di_Spade_S05e01_Guerre_Imminenti_ITA_ENG_1080p_x264_Subs_DLMux_BlackBIT\"
+        method=\"post\" target=\"_blank\" class=\"action\"><input type=\"submit\"
+        class=\"downarrow\" name=\"cerca\" value=\"88d8222bd3b5c69497b74191621daa2ee2ab4353\"
+        title=\"Download\" /><A HREF=https://ilcorsaronero.info/tor/106112/Game_Of_Thrones_Trono_Di_Spade_S05e01_Guerre_Imminenti_ITA_ENG_1080p_x264_Subs_DLMux_BlackBIT><img
+        src='//s.ilcorsaronero.info/images/details.gif' class='details' title='Descrizione'
+        alt='Descrizione'></A></form></TD>\n\t<td align=\"center\"  ><font color='#669999'>21.04.15</font></td>\n\t<td
+        align=\"center\" ><font color='#00CC00'>262</font></td>\t<td align=\"center\"
+        ><font color='#0066CC'>72</font></td></TR>\r\n<tr><td colspan='10'>\r\n\r\n
+        \                           </td></tr><tr class=\"odd\">\t<td align=\"center\"
+        class=\"lista\" ><a class=\"red\" href=https://ilcorsaronero.info/cat/15>SerieTv</td>\t<TD
+        align=\"left\" ><A class=\"tab\" HREF=\"https://ilcorsaronero.info/tor/106106/Game_of_Thrones___Il_Trono_di_Spade_S05e01_XviD___Ita_Eng_Mp3___Sub_Ita_Eng__DLMux_By_UnLEGIT\"
+        >Game of Thrones - Il Trono di Spade S05e01[XviD - Ita E..</A> <span style=\"color:red\"></span>
+        \t<td align=\"center\"   ><font size='-2' color='#FF6600'>600.54 MB</font></td>\n\t<TD
+        align=\"center\" class=\"lista\" ><form action=\"https://ilcorsaronero.info/tor/106106/Game_of_Thrones___Il_Trono_di_Spade_S05e01_XviD___Ita_Eng_Mp3___Sub_Ita_Eng__DLMux_By_UnLEGIT\"
+        method=\"post\" target=\"_blank\" class=\"action\"><input type=\"submit\"
+        class=\"downarrow\" name=\"cerca\" value=\"a0c4f322db22131734f01f78b41e0b5fc12f55e8\"
+        title=\"Download\" /><A HREF=https://ilcorsaronero.info/tor/106106/Game_of_Thrones___Il_Trono_di_Spade_S05e01_XviD___Ita_Eng_Mp3___Sub_Ita_Eng__DLMux_By_UnLEGIT><img
+        src='//s.ilcorsaronero.info/images/details.gif' class='details' title='Descrizione'
+        alt='Descrizione'></A></form></TD>\n\t<td align=\"center\"  ><font color='#669999'>21.04.15</font></td>\n\t<td
+        align=\"center\" ><font color='#00CC00'>455</font></td>\t<td align=\"center\"
+        ><font color='#0066CC'>105</font></td></TR><tr class=\"odd2\">\t<td align=\"center\"
+        class=\"lista\" ><a class=\"red\" href=https://ilcorsaronero.info/cat/15>SerieTv</td>\t<TD
+        align=\"left\" ><A class=\"tab\" HREF=\"https://ilcorsaronero.info/tor/106103/Game_Of_Thrones___Il_Trono_Di_spade_S05e01_Mux___720p___H264___Ita_Eng_Ac3___Sub_Ita_Eng_DLMux_iGM_C\"
+        >Game Of Thrones - Il Trono Di spade S05e01[Mux - 720p -..</A> <span style=\"color:red\"></span>
+        \t<td align=\"center\"   ><font size='-2' color='#FF6600'>1.68 GB</font></td>\n\t<TD
+        align=\"center\" class=\"lista\" ><form action=\"https://ilcorsaronero.info/tor/106103/Game_Of_Thrones___Il_Trono_Di_spade_S05e01_Mux___720p___H264___Ita_Eng_Ac3___Sub_Ita_Eng_DLMux_iGM_C\"
+        method=\"post\" target=\"_blank\" class=\"action\"><input type=\"submit\"
+        class=\"downarrow\" name=\"cerca\" value=\"8213c08cf979a9e589762e7205362f3b3dfa245d\"
+        title=\"Download\" /><A HREF=https://ilcorsaronero.info/tor/106103/Game_Of_Thrones___Il_Trono_Di_spade_S05e01_Mux___720p___H264___Ita_Eng_Ac3___Sub_Ita_Eng_DLMux_iGM_C><img
+        src='//s.ilcorsaronero.info/images/details.gif' class='details' title='Descrizione'
+        alt='Descrizione'></A></form></TD>\n\t<td align=\"center\"  ><font color='#669999'>21.04.15</font></td>\n\t<td
+        align=\"center\" ><font color='#00CC00'>162</font></td>\t<td align=\"center\"
+        ><font color='#0066CC'>45</font></td></TR><tr class=\"odd\">\t<td align=\"center\"
+        class=\"lista\" ><a class=\"red\" href=https://ilcorsaronero.info/cat/15>SerieTv</td>\t<TD
+        align=\"left\" ><A class=\"tab\" HREF=\"https://ilcorsaronero.info/tor/104023/Game_of_Thrones___Il_Trono_di_Spade_S05e00_720p___H264___Eng_Ac3_5_0___Sub_Ita_Eng_\"
+        >Game of Thrones - Il Trono di Spade S05e00[720p - H264 ..</A> <span style=\"color:red\"></span>
+        \t<td align=\"center\"   ><font size='-2' color='#FF6600'>926.10 MB</font></td>\n\t<TD
+        align=\"center\" class=\"lista\" ><form action=\"https://ilcorsaronero.info/tor/104023/Game_of_Thrones___Il_Trono_di_Spade_S05e00_720p___H264___Eng_Ac3_5_0___Sub_Ita_Eng_\"
+        method=\"post\" target=\"_blank\" class=\"action\"><input type=\"submit\"
+        class=\"downarrow\" name=\"cerca\" value=\"10c6b15ed4545d59913465685690e898746afcd3\"
+        title=\"Download\" /><A HREF=https://ilcorsaronero.info/tor/104023/Game_of_Thrones___Il_Trono_di_Spade_S05e00_720p___H264___Eng_Ac3_5_0___Sub_Ita_Eng_><img
+        src='//s.ilcorsaronero.info/images/details.gif' class='details' title='Descrizione'
+        alt='Descrizione'></A></form></TD>\n\t<td align=\"center\"  ><font color='#669999'>15.02.15</font></td>\n\t<td
+        align=\"center\" ><font color='#00CC00'>105</font></td>\t<td align=\"center\"
+        ><font color='#0066CC'>7</font></td></TR><div align='left'>Torrent trovati
+        per <i>Game of Thrones S05</i> - 23 </div>\r\n<tr><td colspan='10'>\r\n<br>\r\n\r\n
+        \               <br/>\r\n\r\n                </TR>\r\n\r\n                <tr>\r\n
+        \                   <td colspan=\"5\" align=\"center\">\r\n                        <table>\r\n
+        \                           <TR>\r\n                                <TD> <p
+        align=\"center\"><b>0&nbsp;</b><br /><b>&lt;&lt; pagine precedenti&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;pagine
+        successive &gt;&gt</b></p>\n\r\n\r\n                                </td>\r\n
+        \                           </TR>\r\n\r\n                        </table>\r\n\r\n
+        \                   </td>\r\n                </tr>\r\n\r\n\r\n            </TABLE>\r\n\r\n\r\n
+        \       </td>\r\n        </table>\r\n\r\n    </div>\r\n\r\n\r\n    <div class=\"clear\"></div>\r\n\r\n</div>\r\n\r\n<br>\r\n\r\n\r\n\r\n</div
+        >\r\n\r\n</div>\r\n\r\n</div>\r\n</div>\r\n\r\n\t<div id='footer'>\r\n\r\n\r\n\t\t<div
+        id='copyright'>\r\n\r\n\t\t<div id='logos'>\r\n\r\n\t\t\t\t<ul>\r\n\t\t\t\t\t<li></li>\r\n\t\t\t\t</ul>\r\n\r\n\t\t\t</div>\r\n\r\n\t\t\t<div
+        id='copy'>\r\n\r\n\t\t\t\t<ul>\r\n\t\t\t\t\t<li><a href='http://torrent-finder.info/torrent-finder-domain-seizure.php'
+        target='_blank'>Salva Internet</a></li>\r\n\t\t\t\t\t<li><a href='/contatti'>Contatti</a></li>\r\n\t\t\t\t\t<li><a
+        href='/removal'>Removal</a></li>\r\n\t\t\t\t</ul>\r\n\r\n\t\t\t</div>\r\n\r\n\t\t\t<div
+        class='clear'></div>\r\n\r\n\t\t</div>\r\n\r\n\t\t<div class='clear'></div>\r\n\r\n\t</div>\r\n\r\n</body>\r\n</html>\r\n"}
+    headers:
+      content-type: [text/html]
+      date: ['Wed, 05 Jul 2017 19:43:39 GMT']
+      server: [lighttpd/1.4.35]
+      x-powered-by: [PHP/5.5.38]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/sickrage_tests/providers/torrent/parsing_tests.py
+++ b/tests/sickrage_tests/providers/torrent/parsing_tests.py
@@ -61,8 +61,6 @@ disabled_provider_tests = {
     'LimeTorrents': ['test_rss_search', 'test_episode_search', 'test_season_search'],
     # Not working on CIs for some weird unknown reason
     'SkyTorrents': ['test_rss_search', 'test_episode_search', 'test_season_search'],
-    # Not working on CIs because of a SSL error
-    'ilCorsaroNero': ['test_rss_search', 'test_episode_search', 'test_season_search'],
 }
 test_string_overrides = {
     'Cpasbien': {'Episode': ['The 100 S02E16'], 'Season': ['The 100 S02']},

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 skipsdist = true
-envlist = py27-{flake8,windows,linux}
+envlist = py27-{flake8,linux,windows}
 
 [testenv:py27-linux]
 platform = linux
@@ -42,8 +42,9 @@ commands =
 
 [testenv:py27-flake8]
 platform = linux
-envdir = {toxworkdir}/tox
+envdir = {toxworkdir}/flake8
 passenv = CI TRAVIS TRAVIS_*
+setenv = PATH = {toxinidir}/lib;{env:PATH:}
 deps =
     flake8-coding
     isort

--- a/tox.ini
+++ b/tox.ini
@@ -49,8 +49,7 @@ deps =
     isort
 commands =
     flake8 --select C101,C102,C103 sickbeard sickrage tests SickBeard.py setup.py
-    isort -rc -c -w 160 -ca -dt -a "from __future__ import unicode_literals" -df sickbeard sickrage
+    isort --check-only --diff --recursive sickbeard sickrage
 
 [flake8]
 accept-encodings = utf-8, latin-1
-


### PR DESCRIPTION
The gist of it...

- Remove traceback from exception handler. When logging an error, a traceback is automatically logged, so this caused duplicate tracebacks.
- Apply a fix to [the issue](https://github.com/SickRage/SickRage/pull/3890#issuecomment-313184082) described in #3890 & #3904 
- Add selected categories to the search (it will only search in the defined categories - **tested**)
- Generate the magnet link from hash, no need to fetch itorrents.org twice, just use the `bt_cache_urls`.
  The magnet link on the site only has that one tracker.
- Generic stuff (variable names and types, restructure/reformat class)

***

- Move isort configuration to `setup.cfg`