### PR TITLE
Re-apply isort

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -4,8 +4,8 @@ combine_as_imports = true
 order_by_type = false
 add_imports = from __future__ import unicode_literals
 known_first_party = sickbeard, sickrage
-# Fixes sections for vendored packages, when lib/ is (first) in $PATH
-# default_section = THIRDPARTY
+# Fixes sections for vendored packages, when lib/ is first in $PATH
+default_section = THIRDPARTY
 
 [extract_messages]
 width = 80

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,6 +5,8 @@ order_by_type = false
 add_imports = from __future__ import unicode_literals
 known_first_party = sickbeard, sickrage
 not_skip = __init__.py
+# We skip this file because the pytz needs to be before sickbeard.subtitles
+skip_glob = */sickbeard/__init__.py
 # Fixes sections for vendored packages, when lib/ is first in $PATH
 default_section = THIRDPARTY
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,6 +4,7 @@ combine_as_imports = true
 order_by_type = false
 add_imports = from __future__ import unicode_literals
 known_first_party = sickbeard, sickrage
+not_skip = __init__.py
 # Fixes sections for vendored packages, when lib/ is first in $PATH
 default_section = THIRDPARTY
 

--- a/sickbeard/__init__.py
+++ b/sickbeard/__init__.py
@@ -31,6 +31,9 @@ import sys
 from threading import Lock
 
 import rarfile
+import requests
+from configobj import ConfigObj
+from tornado.locale import load_gettext_translations
 
 try:
     import pytz  # pylint: disable=unused-import
@@ -40,33 +43,22 @@ except ImportError:
     require('pytz')
 
 
+from sickbeard import (auto_postprocessor, dailysearcher, db, helpers, logger, metadata, naming, post_processing_queue, properFinder, providers, scheduler,
+                       search_queue, searchBacklog, show_queue, showUpdater, subtitles, traktChecker, versionChecker)
+from sickbeard.common import ARCHIVED, IGNORED, MULTI_EP_STRINGS, SD, SKIPPED, WANTED
+from sickbeard.config import check_section, check_setting_bool, check_setting_float, check_setting_int, check_setting_str, ConfigMigrator
+from sickbeard.databases import cache_db, failed_db, mainDB
 from sickbeard.indexers import indexer_api
-from sickbeard.common import SD, SKIPPED, ARCHIVED, IGNORED, WANTED, MULTI_EP_STRINGS
-from sickbeard.databases import mainDB, cache_db, failed_db
+from sickbeard.indexers.indexer_exceptions import (indexer_attributenotfound, indexer_episodenotfound, indexer_error, indexer_exception, indexer_seasonnotfound,
+                                                   indexer_showincomplete, indexer_shownotfound, indexer_userabort)
 from sickbeard.providers.newznab import NewznabProvider
 from sickbeard.providers.rsstorrent import TorrentRssProvider
-from sickbeard.config import check_section, check_setting_int, check_setting_str, \
-    check_setting_float, check_setting_bool, ConfigMigrator
-from sickbeard import db, helpers, scheduler, search_queue, show_queue, logger, \
-    naming, dailysearcher, metadata, providers
-from sickbeard import searchBacklog, showUpdater, versionChecker, properFinder, \
-    auto_postprocessor, post_processing_queue, subtitles, traktChecker
-from sickbeard.indexers.indexer_exceptions import indexer_shownotfound, \
-    indexer_showincomplete, indexer_exception, indexer_error, \
-    indexer_episodenotfound, indexer_attributenotfound, indexer_seasonnotfound, \
-    indexer_userabort
-
 from sickrage.helper import setup_github
 from sickrage.helper.encoding import ek
 from sickrage.helper.exceptions import ex
 from sickrage.providers.GenericProvider import GenericProvider
 from sickrage.system.Shutdown import Shutdown
 
-from configobj import ConfigObj
-
-import requests
-
-from tornado.locale import load_gettext_translations
 
 gettext.install('messages', unicode=1, codeset='UTF-8', names=["ngettext"])
 

--- a/sickbeard/blackandwhitelist.py
+++ b/sickbeard/blackandwhitelist.py
@@ -20,8 +20,9 @@
 
 from __future__ import print_function, unicode_literals
 
-import sickbeard
 from adba.aniDBerrors import AniDBCommandTimeoutError
+
+import sickbeard
 from sickbeard import db, helpers, logger
 
 

--- a/sickbeard/browser.py
+++ b/sickbeard/browser.py
@@ -24,8 +24,9 @@ import os
 import string
 from operator import itemgetter
 
-import sickbeard
 import six
+
+import sickbeard
 from sickbeard import logger
 from sickrage.helper.encoding import ek
 

--- a/sickbeard/classes.py
+++ b/sickbeard/classes.py
@@ -23,10 +23,11 @@ from __future__ import print_function, unicode_literals
 import datetime
 import sys
 
+from six.moves import urllib
+
 import sickbeard
 from sickbeard.common import Quality, USER_AGENT
 from sickrage.helper.common import dateTimeFormat
-from six.moves import urllib
 
 
 class SickBeardURLopener(urllib.request.FancyURLopener, object):

--- a/sickbeard/clients/deluged_client.py
+++ b/sickbeard/clients/deluged_client.py
@@ -9,10 +9,11 @@ from __future__ import print_function, unicode_literals
 
 from base64 import b64encode
 
+from synchronousdeluge import DelugeClient
+
 import sickbeard
 from sickbeard import logger
 from sickbeard.clients.generic import GenericClient
-from synchronousdeluge import DelugeClient
 
 
 class DelugeDAPI(GenericClient):

--- a/sickbeard/clients/download_station_client.py
+++ b/sickbeard/clients/download_station_client.py
@@ -23,9 +23,10 @@ from __future__ import unicode_literals
 import os
 import re
 
-import sickbeard
 import six
 from requests.compat import urljoin
+
+import sickbeard
 from sickbeard import logger
 from sickbeard.clients.generic import GenericClient
 

--- a/sickbeard/clients/generic.py
+++ b/sickbeard/clients/generic.py
@@ -25,10 +25,11 @@ from base64 import b16encode, b32decode
 from hashlib import sha1
 
 import bencode
-import sickbeard
 import six
 from requests.compat import urlencode
 from requests.models import HTTPError
+
+import sickbeard
 from sickbeard import helpers, logger
 
 

--- a/sickbeard/clients/putio_client.py
+++ b/sickbeard/clients/putio_client.py
@@ -20,6 +20,7 @@
 from __future__ import unicode_literals
 
 from putiopy import Client as PutioClient, ClientError
+
 from sickbeard import helpers
 from sickbeard.clients.generic import GenericClient
 

--- a/sickbeard/clients/qbittorrent_client.py
+++ b/sickbeard/clients/qbittorrent_client.py
@@ -22,9 +22,10 @@ from __future__ import unicode_literals
 
 from time import sleep
 
-import sickbeard
 from requests.auth import HTTPDigestAuth
 from requests.compat import urljoin
+
+import sickbeard
 from sickbeard.clients.generic import GenericClient
 
 

--- a/sickbeard/clients/rtorrent_client.py
+++ b/sickbeard/clients/rtorrent_client.py
@@ -26,8 +26,9 @@
 
 from __future__ import print_function, unicode_literals
 
-import sickbeard
 from rtorrent import RTorrent  # pylint: disable=import-error
+
+import sickbeard
 from sickbeard import ex, logger
 from sickbeard.clients.generic import GenericClient
 

--- a/sickbeard/clients/utorrent_client.py
+++ b/sickbeard/clients/utorrent_client.py
@@ -22,9 +22,10 @@ from __future__ import unicode_literals
 import re
 from collections import OrderedDict
 
-import sickbeard
 import six
 from requests.compat import urljoin
+
+import sickbeard
 from sickbeard.clients.generic import GenericClient
 
 

--- a/sickbeard/common.py
+++ b/sickbeard/common.py
@@ -33,13 +33,14 @@ import uuid
 from os import path
 
 from fake_useragent import settings as UA_SETTINGS, UserAgent
+# noinspection PyUnresolvedReferences
+from six.moves import reduce
+
 from sickbeard.numdict import NumDict
 from sickrage.helper import video_screen_size
 from sickrage.helper.encoding import ek
 from sickrage.recompiled import tags
 from sickrage.tagger.episode import EpisodeTags
-# noinspection PyUnresolvedReferences
-from six.moves import reduce
 
 gettext.install('messages', unicode=1, codeset='UTF-8', names=["ngettext"])
 

--- a/sickbeard/config.py
+++ b/sickbeard/config.py
@@ -26,13 +26,14 @@ import platform
 import re
 
 import rarfile
-import sickbeard
 import six
+# noinspection PyUnresolvedReferences
+from six.moves.urllib import parse
+
+import sickbeard
 from sickbeard import db, helpers, logger, naming
 from sickrage.helper.common import try_int
 from sickrage.helper.encoding import ek
-# noinspection PyUnresolvedReferences
-from six.moves.urllib import parse
 
 # Address poor support for scgi over unix domain sockets
 # this is not nicely handled by python currently

--- a/sickbeard/databases/__init__.py
+++ b/sickbeard/databases/__init__.py
@@ -1,5 +1,4 @@
 # coding=utf-8
-
 # Author: Nic Wolfe <nic@wolfeden.ca>
 # URL: https://sickrage.github.io
 #
@@ -17,5 +16,6 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+from __future__ import unicode_literals
 
 __all__ = ["mainDB", "cache", "failed"]

--- a/sickbeard/databases/mainDB.py
+++ b/sickbeard/databases/mainDB.py
@@ -25,8 +25,9 @@ import datetime
 import os.path
 import warnings
 
-import sickbeard
 import six
+
+import sickbeard
 from sickbeard import common, db, helpers, logger, subtitles
 from sickbeard.name_parser.parser import InvalidNameException, InvalidShowException, NameParser
 from sickrage.helper.common import dateTimeFormat, episode_num

--- a/sickbeard/db.py
+++ b/sickbeard/db.py
@@ -28,8 +28,9 @@ import time
 import warnings
 from sqlite3 import OperationalError
 
-import sickbeard
 import six
+
+import sickbeard
 from sickbeard import logger
 from sickrage.helper.encoding import ek
 from sickrage.helper.exceptions import ex

--- a/sickbeard/event_queue.py
+++ b/sickbeard/event_queue.py
@@ -5,9 +5,10 @@ from __future__ import print_function, unicode_literals
 import threading
 import traceback
 
+from six.moves.queue import Empty, Queue
+
 from sickbeard import logger
 from sickrage.helper.exceptions import ex
-from six.moves.queue import Empty, Queue
 
 
 class Event(object):

--- a/sickbeard/failed_history.py
+++ b/sickbeard/failed_history.py
@@ -23,12 +23,13 @@ from __future__ import print_function, unicode_literals
 import datetime
 import re
 
+from six.moves import urllib
+
 from sickbeard import db, logger
 from sickbeard.common import FAILED, Quality, WANTED
 from sickrage.helper.encoding import ss
 from sickrage.helper.exceptions import EpisodeNotFoundException, ex
 from sickrage.show.History import History
-from six.moves import urllib
 
 
 def prepareFailedName(release):

--- a/sickbeard/helpers.py
+++ b/sickbeard/helpers.py
@@ -50,21 +50,22 @@ import certifi
 import cfscrape
 import rarfile
 import requests
-import sickbeard
 import six
 from cachecontrol import CacheControl
 from requests.compat import urljoin
 from requests.utils import urlparse
+# noinspection PyUnresolvedReferences
+from six.moves import urllib
+# noinspection PyProtectedMember
+from tornado._locale_data import LOCALE_NAMES
+
+import sickbeard
 from sickbeard import classes, db, logger
 from sickbeard.common import USER_AGENT
 from sickrage.helper import episode_num, MEDIA_EXTENSIONS, pretty_file_size, SUBTITLE_EXTENSIONS
 from sickrage.helper.encoding import ek
 from sickrage.helper.exceptions import ex
 from sickrage.show.Show import Show
-# noinspection PyUnresolvedReferences
-from six.moves import urllib
-# noinspection PyProtectedMember
-from tornado._locale_data import LOCALE_NAMES
 
 # Add some missing languages
 LOCALE_NAMES.update({

--- a/sickbeard/history.py
+++ b/sickbeard/history.py
@@ -23,6 +23,7 @@ from __future__ import unicode_literals
 import datetime
 
 import db
+
 from sickbeard.common import FAILED, Quality, SNATCHED, SUBTITLED
 from sickrage.helper.encoding import ss
 from sickrage.show.History import History

--- a/sickbeard/image_cache.py
+++ b/sickbeard/image_cache.py
@@ -22,10 +22,11 @@ from __future__ import print_function, unicode_literals
 
 import os.path
 
-import sickbeard
 from hachoir_core.log import log
 from hachoir_metadata import extractMetadata
 from hachoir_parser import createParser
+
+import sickbeard
 from sickbeard import helpers, logger
 from sickbeard.metadata.generic import GenericMetadata
 from sickrage.helper.encoding import ek

--- a/sickbeard/imdbPopular.py
+++ b/sickbeard/imdbPopular.py
@@ -7,8 +7,9 @@ import posixpath
 import re
 from datetime import date
 
-import sickbeard
 from bs4 import BeautifulSoup
+
+import sickbeard
 from sickbeard import helpers
 from sickrage.helper.encoding import ek
 

--- a/sickbeard/indexers/__init__.py
+++ b/sickbeard/indexers/__init__.py
@@ -18,5 +18,6 @@
 # You should have received a copy of the GNU General Public License
 # along with SickRage. If not, see <http://www.gnu.org/licenses/>.
 
-from . import indexer_api
-from . import indexer_exceptions
+from __future__ import unicode_literals
+
+from . import indexer_api, indexer_exceptions

--- a/sickbeard/indexers/indexer_api.py
+++ b/sickbeard/indexers/indexer_api.py
@@ -22,8 +22,9 @@ from __future__ import unicode_literals
 
 import os
 
-import sickbeard
 from indexer_config import indexerConfig, initConfig
+
+import sickbeard
 from sickrage.helper.common import try_int
 from sickrage.helper.encoding import ek
 

--- a/sickbeard/indexers/indexer_config.py
+++ b/sickbeard/indexers/indexer_config.py
@@ -2,8 +2,9 @@
 
 from __future__ import unicode_literals
 
-from sickbeard import helpers
 from tvdb_api.tvdb_api import Tvdb
+
+from sickbeard import helpers
 
 initConfig = {
     'valid_languages': [

--- a/sickbeard/logger.py
+++ b/sickbeard/logger.py
@@ -36,16 +36,17 @@ import threading
 import traceback
 from logging import NullHandler
 
-import sickbeard
 import six
 from github import InputFileContent
 from github.GithubException import RateLimitExceededException, TwoFactorException
+# noinspection PyUnresolvedReferences
+from six.moves.urllib.parse import quote
+
+import sickbeard
 from sickbeard import classes
 from sickrage.helper.common import dateTimeFormat
 from sickrage.helper.encoding import ek, ss
 from sickrage.helper.exceptions import ex
-# noinspection PyUnresolvedReferences
-from six.moves.urllib.parse import quote
 
 # pylint: disable=line-too-long
 

--- a/sickbeard/metadata/__init__.py
+++ b/sickbeard/metadata/__init__.py
@@ -18,10 +18,13 @@
 # You should have received a copy of the GNU General Public License
 # along with SickRage. If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import unicode_literals
+
 import sys
-from sickbeard.metadata import kodi, kodi_12plus, mediabrowser, ps3, wdtv, tivo, mede8er, generic, helpers
 
 __all__ = ['generic', 'helpers', 'kodi', 'kodi_12plus', 'mediabrowser', 'ps3', 'wdtv', 'tivo', 'mede8er']
+from sickbeard.metadata import generic, helpers, kodi, kodi_12plus, mede8er, mediabrowser, ps3, tivo, wdtv
+
 
 
 def available_generators():

--- a/sickbeard/metadata/__init__.py
+++ b/sickbeard/metadata/__init__.py
@@ -22,9 +22,9 @@ from __future__ import unicode_literals
 
 import sys
 
-__all__ = ['generic', 'helpers', 'kodi', 'kodi_12plus', 'mediabrowser', 'ps3', 'wdtv', 'tivo', 'mede8er']
 from sickbeard.metadata import generic, helpers, kodi, kodi_12plus, mede8er, mediabrowser, ps3, tivo, wdtv
 
+__all__ = ['generic', 'helpers', 'kodi', 'kodi_12plus', 'mede8er', 'mediabrowser', 'ps3', 'tivo', 'wdtv']
 
 
 def available_generators():

--- a/sickbeard/metadata/generic.py
+++ b/sickbeard/metadata/generic.py
@@ -25,16 +25,17 @@ import os
 import re
 
 import fanart as fanart_module
-import sickbeard
 import six
 from fanart.core import Request as fanartRequest
+from tmdb_api.tmdb_api import TMDB
+
+import sickbeard
 from sickbeard import helpers, logger
 from sickbeard.metadata import helpers as metadata_helpers
 from sickbeard.show_name_helpers import allPossibleShowNames
 from sickrage.helper.common import replace_extension, try_int
 from sickrage.helper.encoding import ek
 from sickrage.helper.exceptions import ex
-from tmdb_api.tmdb_api import TMDB
 
 try:
     import xml.etree.cElementTree as etree

--- a/sickbeard/metadata/kodi_12plus.py
+++ b/sickbeard/metadata/kodi_12plus.py
@@ -22,9 +22,10 @@ from __future__ import print_function, unicode_literals
 import datetime
 import re
 
-import sickbeard
 import six
 from babelfish import Country
+
+import sickbeard
 from sickbeard import helpers, logger
 from sickbeard.metadata import generic
 from sickrage.helper.common import dateFormat

--- a/sickbeard/metadata/mede8er.py
+++ b/sickbeard/metadata/mede8er.py
@@ -24,8 +24,9 @@ import datetime
 import io
 import os
 
-import sickbeard
 import six
+
+import sickbeard
 from sickbeard import helpers, logger
 from sickbeard.metadata import mediabrowser
 from sickrage.helper.common import dateFormat, replace_extension

--- a/sickbeard/metadata/mediabrowser.py
+++ b/sickbeard/metadata/mediabrowser.py
@@ -24,8 +24,9 @@ import datetime
 import os
 import re
 
-import sickbeard
 import six
+
+import sickbeard
 from sickbeard import helpers, logger
 from sickbeard.metadata import generic
 from sickrage.helper.common import dateFormat, replace_extension

--- a/sickbeard/name_cache.py
+++ b/sickbeard/name_cache.py
@@ -21,8 +21,9 @@ from __future__ import unicode_literals
 
 import threading
 
-import sickbeard
 import six
+
+import sickbeard
 from sickbeard import db
 
 # from sickbeard import logger

--- a/sickbeard/name_parser/__init__.py
+++ b/sickbeard/name_parser/__init__.py
@@ -1,1 +1,2 @@
 # coding=utf-8
+from __future__ import unicode_literals

--- a/sickbeard/name_parser/parser.py
+++ b/sickbeard/name_parser/parser.py
@@ -27,8 +27,9 @@ from collections import OrderedDict
 from threading import Lock
 
 import dateutil
-import sickbeard
 import six
+
+import sickbeard
 from sickbeard import common, db, helpers, logger, scene_exceptions, scene_numbering
 from sickbeard.name_parser import regexes
 from sickrage.helper.common import remove_extension

--- a/sickbeard/network_timezones.py
+++ b/sickbeard/network_timezones.py
@@ -25,6 +25,7 @@ import re
 
 import six
 from dateutil import tz
+
 from sickbeard import db, helpers, logger
 from sickrage.helper.common import try_int
 

--- a/sickbeard/notifiers/__init__.py
+++ b/sickbeard/notifiers/__init__.py
@@ -21,11 +21,8 @@
 from __future__ import print_function, unicode_literals
 
 import sickbeard
-
-from sickbeard.notifiers import kodi, plex, emby, nmj, nmjv2, synoindex, \
-    synologynotifier, pytivo, growl, prowl, libnotify, pushover, boxcar2, \
-    nma, pushalot, pushbullet, freemobile, telegram, tweet, trakt, emailnotify, \
-    slack, discord, join, twilio_notify
+from sickbeard.notifiers import (boxcar2, discord, emailnotify, emby, freemobile, growl, join, kodi, libnotify, nma, nmj, nmjv2, plex, prowl, pushalot,
+                                 pushbullet, pushover, pytivo, slack, synoindex, synologynotifier, telegram, trakt, tweet, twilio_notify)
 
 # home theater / nas
 kodi_notifier = kodi.Notifier()

--- a/sickbeard/notifiers/discord.py
+++ b/sickbeard/notifiers/discord.py
@@ -21,8 +21,9 @@ from __future__ import unicode_literals
 import json
 
 import requests
-import sickbeard
 import six
+
+import sickbeard
 from sickbeard import common, logger
 from sickrage.helper.exceptions import ex
 

--- a/sickbeard/notifiers/emby.py
+++ b/sickbeard/notifiers/emby.py
@@ -20,10 +20,11 @@
 
 from __future__ import print_function, unicode_literals
 
+from six.moves import urllib
+
 import sickbeard
 from sickbeard import logger
 from sickrage.helper.exceptions import ex
-from six.moves import urllib
 
 try:
     import json

--- a/sickbeard/notifiers/freemobile.py
+++ b/sickbeard/notifiers/freemobile.py
@@ -22,12 +22,13 @@
 
 from __future__ import print_function, unicode_literals
 
-import sickbeard
 import six
+from six.moves import urllib
+
+import sickbeard
 from sickbeard import logger
 from sickbeard.common import (NOTIFY_DOWNLOAD, NOTIFY_GIT_UPDATE, NOTIFY_GIT_UPDATE_TEXT, NOTIFY_LOGIN, NOTIFY_LOGIN_TEXT, NOTIFY_SNATCH,
                               NOTIFY_SUBTITLE_DOWNLOAD, notifyStrings)
-from six.moves import urllib
 
 
 class Notifier(object):

--- a/sickbeard/notifiers/growl.py
+++ b/sickbeard/notifiers/growl.py
@@ -22,8 +22,9 @@ from __future__ import print_function, unicode_literals
 
 import socket
 
-import sickbeard
 from libgrowl import gntp
+
+import sickbeard
 from sickbeard import common, logger
 from sickrage.helper.exceptions import ex
 

--- a/sickbeard/notifiers/join.py
+++ b/sickbeard/notifiers/join.py
@@ -19,11 +19,12 @@
 
 from __future__ import unicode_literals
 
+from six.moves import urllib
+
 import sickbeard
 from sickbeard import logger
 from sickbeard.common import (NOTIFY_DOWNLOAD, NOTIFY_GIT_UPDATE, NOTIFY_GIT_UPDATE_TEXT, NOTIFY_LOGIN, NOTIFY_LOGIN_TEXT, NOTIFY_SNATCH,
                               NOTIFY_SUBTITLE_DOWNLOAD, notifyStrings)
-from six.moves import urllib
 
 
 class Notifier(object):

--- a/sickbeard/notifiers/kodi.py
+++ b/sickbeard/notifiers/kodi.py
@@ -24,12 +24,13 @@ import base64
 import socket
 import time
 
-import sickbeard
 import six
+from six.moves import http_client, urllib
+
+import sickbeard
 from sickbeard import common, logger
 from sickrage.helper.encoding import ss
 from sickrage.helper.exceptions import ex
-from six.moves import http_client, urllib
 
 try:
     import xml.etree.cElementTree as etree

--- a/sickbeard/notifiers/nma.py
+++ b/sickbeard/notifiers/nma.py
@@ -2,8 +2,9 @@
 
 from __future__ import print_function, unicode_literals
 
-import sickbeard
 from pynma import pynma
+
+import sickbeard
 from sickbeard import common, logger
 
 

--- a/sickbeard/notifiers/nmj.py
+++ b/sickbeard/notifiers/nmj.py
@@ -23,10 +23,11 @@ from __future__ import print_function, unicode_literals
 import re
 import telnetlib
 
+from six.moves import urllib
+
 import sickbeard
 from sickbeard import logger
 from sickrage.helper.exceptions import ex
-from six.moves import urllib
 
 try:
     import xml.etree.cElementTree as etree

--- a/sickbeard/notifiers/nmjv2.py
+++ b/sickbeard/notifiers/nmjv2.py
@@ -24,9 +24,10 @@ from __future__ import print_function, unicode_literals
 import time
 from xml.dom.minidom import parseString
 
+from six.moves import urllib
+
 import sickbeard
 from sickbeard import logger
-from six.moves import urllib
 
 try:
     import xml.etree.cElementTree as etree

--- a/sickbeard/notifiers/plex.py
+++ b/sickbeard/notifiers/plex.py
@@ -22,8 +22,9 @@ from __future__ import print_function, unicode_literals
 
 import re
 
-import sickbeard
 import six
+
+import sickbeard
 from sickbeard import common, logger
 from sickbeard.helpers import getURL, make_session
 from sickrage.helper.exceptions import ex

--- a/sickbeard/notifiers/prowl.py
+++ b/sickbeard/notifiers/prowl.py
@@ -26,11 +26,12 @@ import ast
 import socket
 import time
 
-import sickbeard
 from requests.compat import urlencode
+from six.moves.http_client import HTTPException, HTTPSConnection
+
+import sickbeard
 from sickbeard import common, db, logger
 from sickrage.helper.encoding import ss
-from six.moves.http_client import HTTPException, HTTPSConnection
 
 try:
     # this only exists in 2.6

--- a/sickbeard/notifiers/pushbullet.py
+++ b/sickbeard/notifiers/pushbullet.py
@@ -22,8 +22,9 @@ from __future__ import unicode_literals
 
 import re
 
-import sickbeard
 from requests.compat import urljoin
+
+import sickbeard
 from sickbeard import common, helpers, logger
 
 

--- a/sickbeard/notifiers/pushover.py
+++ b/sickbeard/notifiers/pushover.py
@@ -23,12 +23,13 @@ from __future__ import print_function, unicode_literals
 
 import time
 
+from six.moves import http_client, urllib
+
 import sickbeard
 from sickbeard import logger
 from sickbeard.common import (NOTIFY_DOWNLOAD, NOTIFY_GIT_UPDATE, NOTIFY_GIT_UPDATE_TEXT, NOTIFY_LOGIN, NOTIFY_LOGIN_TEXT, NOTIFY_SNATCH,
                               NOTIFY_SUBTITLE_DOWNLOAD, notifyStrings)
 from sickrage.helper.exceptions import ex
-from six.moves import http_client, urllib
 
 API_URL = "https://api.pushover.net/1/messages.json"
 

--- a/sickbeard/notifiers/pytivo.py
+++ b/sickbeard/notifiers/pytivo.py
@@ -22,13 +22,14 @@ from __future__ import print_function, unicode_literals
 
 import os
 
-import sickbeard
 from requests.compat import urlencode
+from six.moves.urllib.error import HTTPError
+from six.moves.urllib.request import Request, urlopen
+
+import sickbeard
 from sickbeard import logger
 from sickrage.helper.encoding import ek
 from sickrage.helper.exceptions import ex
-from six.moves.urllib.error import HTTPError
-from six.moves.urllib.request import Request, urlopen
 
 
 class Notifier(object):

--- a/sickbeard/notifiers/slack.py
+++ b/sickbeard/notifiers/slack.py
@@ -21,8 +21,9 @@ from __future__ import unicode_literals
 import json
 
 import requests
-import sickbeard
 import six
+
+import sickbeard
 from sickbeard import common, logger
 from sickrage.helper.exceptions import ex
 

--- a/sickbeard/notifiers/telegram.py
+++ b/sickbeard/notifiers/telegram.py
@@ -21,12 +21,13 @@
 
 from __future__ import unicode_literals
 
+from six.moves import urllib
+
 import sickbeard
 from sickbeard import logger
 from sickbeard.common import (NOTIFY_DOWNLOAD, NOTIFY_GIT_UPDATE, NOTIFY_GIT_UPDATE_TEXT, NOTIFY_LOGIN, NOTIFY_LOGIN_TEXT, NOTIFY_SNATCH,
                               NOTIFY_SUBTITLE_DOWNLOAD, notifyStrings)
 from sickrage.helper import HTTP_STATUS_CODES
-from six.moves import urllib
 
 
 class Notifier(object):

--- a/sickbeard/notifiers/trakt.py
+++ b/sickbeard/notifiers/trakt.py
@@ -20,9 +20,10 @@
 
 from __future__ import print_function, unicode_literals
 
-import sickbeard
 from libtrakt import TraktAPI
 from libtrakt.exceptions import traktAuthException, traktException, traktServerBusy
+
+import sickbeard
 from sickbeard import logger
 from sickrage.helper.exceptions import ex
 

--- a/sickbeard/notifiers/tweet.py
+++ b/sickbeard/notifiers/tweet.py
@@ -20,10 +20,11 @@
 
 from __future__ import print_function, unicode_literals
 
-import sickbeard
 import twitter
 from requests.exceptions import RequestException
 from requests_oauthlib import OAuth1Session
+
+import sickbeard
 from sickbeard import common, logger
 from sickrage.helper.exceptions import ex
 

--- a/sickbeard/notifiers/twilio_notify.py
+++ b/sickbeard/notifiers/twilio_notify.py
@@ -22,8 +22,9 @@ from __future__ import print_function, unicode_literals
 
 import re
 
-import sickbeard
 import twilio
+
+import sickbeard
 from sickbeard import common, logger
 from sickrage.helper.exceptions import ex
 

--- a/sickbeard/nzbget.py
+++ b/sickbeard/nzbget.py
@@ -23,11 +23,12 @@ from __future__ import unicode_literals
 import datetime
 from base64 import standard_b64encode
 
+from six.moves import http_client, xmlrpc_client
+
 import sickbeard
 from sickbeard import logger
 from sickbeard.common import Quality
 from sickrage.helper.common import try_int
-from six.moves import http_client, xmlrpc_client
 
 
 def sendNZB(nzb, proper=False):  # pylint: disable=too-many-locals, too-many-statements, too-many-branches, too-many-return-statements

--- a/sickbeard/postProcessor.py
+++ b/sickbeard/postProcessor.py
@@ -28,8 +28,9 @@ import stat
 import subprocess
 
 import adba
-import sickbeard
 import six
+
+import sickbeard
 from sickbeard import common, db, failed_history, helpers, history, logger, notifiers, show_name_helpers
 from sickbeard.helpers import verify_freespace
 from sickbeard.name_parser.parser import InvalidNameException, InvalidShowException, NameParser

--- a/sickbeard/processTV.py
+++ b/sickbeard/processTV.py
@@ -24,10 +24,11 @@ import os
 import shutil
 import stat
 
-import sickbeard
 from rarfile import (BadRarFile, BadRarName, Error, NeedFirstVolume, NoCrypto, NoRarEntry, NotRarFile, PasswordRequired, RarCannotExec, RarCRCError,
                      RarCreateError, RarExecError, RarFatalError, RarFile, RarLockedArchiveError, RarMemoryError, RarNoFilesError, RarOpenError, RarSignalExit,
                      RarUnknownError, RarUserBreak, RarUserError, RarWarning, RarWriteError, RarWrongPassword)
+
+import sickbeard
 from sickbeard import common, db, failedProcessor, helpers, logger, postProcessor
 from sickbeard.name_parser.parser import InvalidNameException, InvalidShowException, NameParser
 from sickrage.helper.common import is_sync_file, is_torrent_or_nzb_file

--- a/sickbeard/providers/__init__.py
+++ b/sickbeard/providers/__init__.py
@@ -18,15 +18,17 @@
 # You should have received a copy of the GNU General Public License
 # along with SickRage. If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import unicode_literals
+
 from os import sys
 from random import shuffle
 
 import sickbeard
-from sickbeard.providers import btn, thepiratebay, torrentleech, iptorrents, torrentz, \
-    omgwtfnzbs, scc, hdtorrents, torrentday, hdbits, hounddawgs, speedcd, nyaa, xthor, abnormal, torrentbytes, cpasbien, \
-    torrent9, morethantv, t411, tokyotoshokan, shazbat, rarbg, alpharatio, tntvillage, binsearch, torrentproject, \
-    scenetime, nebulance, tvchaosuk, bitcannon, pretome, gftracker, hdspace, newpct, elitetorrent, danishbits, hd4free, limetorrents, \
-    norbits, horriblesubs, filelist, skytorrents, ncore, archetorrent, hdtorrents_it, immortalseed, ilcorsaronero
+from sickbeard.providers import (abnormal, alpharatio, archetorrent, binsearch, bitcannon, btn, cpasbien, danishbits, elitetorrent, filelist, gftracker,
+                                 hd4free, hdbits, hdspace, hdtorrents, hdtorrents_it, horriblesubs, hounddawgs, ilcorsaronero, immortalseed, iptorrents,
+                                 limetorrents, morethantv, ncore, nebulance, newpct, norbits, nyaa, omgwtfnzbs, pretome, rarbg, scc, scenetime, shazbat,
+                                 skytorrents, speedcd, t411, thepiratebay, tntvillage, tokyotoshokan, torrent9, torrentbytes, torrentday, torrentleech,
+                                 torrentproject, torrentz, tvchaosuk, xthor)
 
 __all__ = [
     'btn', 'thepiratebay', 'torrentleech', 'scc', 'hdtorrents',

--- a/sickbeard/providers/__init__.py
+++ b/sickbeard/providers/__init__.py
@@ -31,16 +31,12 @@ from sickbeard.providers import (abnormal, alpharatio, archetorrent, binsearch, 
                                  torrentproject, torrentz, tvchaosuk, xthor)
 
 __all__ = [
-    'btn', 'thepiratebay', 'torrentleech', 'scc', 'hdtorrents',
-    'torrentday', 'hdbits', 'hounddawgs', 'iptorrents', 'omgwtfnzbs',
-    'speedcd', 'nyaa', 'torrentbytes', 'cpasbien',
-    'torrent9','morethantv', 't411', 'tokyotoshokan', 'alpharatio',
-    'shazbat', 'rarbg', 'tntvillage', 'binsearch',
-    'xthor', 'abnormal', 'scenetime', 'nebulance', 'tvchaosuk',
-    'torrentproject', 'bitcannon', 'torrentz', 'pretome', 'gftracker',
-    'hdspace', 'newpct', 'elitetorrent', 'danishbits', 'hd4free', 'limetorrents',
-    'norbits', 'horriblesubs', 'filelist', 'skytorrents', 'ncore', 'archetorrent', 'hdtorrents_it',
-    'immortalseed', 'ilcorsaronero'
+    'abnormal', 'alpharatio', 'archetorrent', 'binsearch', 'bitcannon', 'btn', 'cpasbien', 'danishbits',
+    'elitetorrent', 'filelist', 'gftracker', 'hd4free', 'hdbits', 'hdspace', 'hdtorrents', 'hdtorrents_it',
+    'horriblesubs', 'hounddawgs', 'ilcorsaronero', 'immortalseed', 'iptorrents', 'limetorrents', 'morethantv',
+    'ncore', 'nebulance', 'newpct', 'norbits', 'nyaa', 'omgwtfnzbs', 'pretome', 'rarbg', 'scc', 'scenetime',
+    'shazbat', 'skytorrents', 'speedcd', 't411', 'thepiratebay', 'tntvillage', 'tokyotoshokan', 'torrent9',
+    'torrentbytes', 'torrentday', 'torrentleech', 'torrentproject', 'torrentz', 'tvchaosuk', 'xthor'
 ]
 
 

--- a/sickbeard/providers/abnormal.py
+++ b/sickbeard/providers/abnormal.py
@@ -24,6 +24,7 @@ import re
 
 from requests.compat import urljoin
 from requests.utils import dict_from_cookiejar
+
 from sickbeard import logger, tvcache
 from sickbeard.bs4_parser import BS4Parser
 from sickrage.helper.common import convert_size, try_int

--- a/sickbeard/providers/alpharatio.py
+++ b/sickbeard/providers/alpharatio.py
@@ -24,6 +24,7 @@ import re
 
 from requests.compat import urljoin
 from requests.utils import dict_from_cookiejar
+
 from sickbeard import logger, tvcache
 from sickbeard.bs4_parser import BS4Parser
 from sickrage.helper.common import convert_size, try_int

--- a/sickbeard/providers/archetorrent.py
+++ b/sickbeard/providers/archetorrent.py
@@ -25,6 +25,7 @@ import re
 
 from requests.compat import urljoin
 from requests.utils import dict_from_cookiejar
+
 from sickbeard import logger, tvcache
 from sickbeard.bs4_parser import BS4Parser
 from sickrage.helper.common import convert_size, try_int

--- a/sickbeard/providers/binsearch.py
+++ b/sickbeard/providers/binsearch.py
@@ -23,6 +23,7 @@ from __future__ import unicode_literals
 import re
 
 from requests.compat import urljoin
+
 from sickbeard import logger, tvcache
 from sickrage.providers.nzb.NZBProvider import NZBProvider
 

--- a/sickbeard/providers/bitcannon.py
+++ b/sickbeard/providers/bitcannon.py
@@ -22,6 +22,7 @@ from __future__ import unicode_literals
 
 import validators
 from requests.compat import urljoin
+
 from sickbeard import logger, tvcache
 from sickrage.helper.common import convert_size, try_int
 from sickrage.providers.torrent.TorrentProvider import TorrentProvider

--- a/sickbeard/providers/btn.py
+++ b/sickbeard/providers/btn.py
@@ -26,8 +26,9 @@ import time
 from datetime import datetime
 
 import jsonrpclib
-import sickbeard
 import six
+
+import sickbeard
 from sickbeard import classes, logger, scene_exceptions, tvcache
 from sickbeard.common import cpu_presets
 from sickbeard.helpers import sanitizeSceneName

--- a/sickbeard/providers/danishbits.py
+++ b/sickbeard/providers/danishbits.py
@@ -23,6 +23,7 @@ from __future__ import print_function, unicode_literals
 import json
 
 from requests.utils import dict_from_cookiejar
+
 from sickbeard import logger, tvcache
 from sickbeard.bs4_parser import BS4Parser
 from sickrage.helper.common import convert_size, try_int

--- a/sickbeard/providers/elitetorrent.py
+++ b/sickbeard/providers/elitetorrent.py
@@ -24,8 +24,9 @@ import re
 import time
 import traceback
 
-import sickbeard
 import six
+
+import sickbeard
 from sickbeard import logger, tvcache
 from sickbeard.bs4_parser import BS4Parser
 from sickbeard.common import cpu_presets

--- a/sickbeard/providers/filelist.py
+++ b/sickbeard/providers/filelist.py
@@ -23,6 +23,7 @@ import re
 
 from requests.compat import urljoin
 from requests.utils import dict_from_cookiejar
+
 from sickbeard import logger, tvcache
 from sickbeard.bs4_parser import BS4Parser
 from sickrage.helper.common import convert_size, try_int

--- a/sickbeard/providers/gftracker.py
+++ b/sickbeard/providers/gftracker.py
@@ -23,6 +23,7 @@ from __future__ import print_function, unicode_literals
 import re
 
 from requests.utils import dict_from_cookiejar
+
 from sickbeard import logger, tvcache
 from sickbeard.bs4_parser import BS4Parser
 from sickrage.helper.common import convert_size, try_int

--- a/sickbeard/providers/hd4free.py
+++ b/sickbeard/providers/hd4free.py
@@ -21,6 +21,7 @@
 from __future__ import print_function, unicode_literals
 
 from requests.compat import urljoin
+
 from sickbeard import logger, tvcache
 from sickrage.helper.common import convert_size, try_int
 from sickrage.providers.torrent.TorrentProvider import TorrentProvider

--- a/sickbeard/providers/hdbits.py
+++ b/sickbeard/providers/hdbits.py
@@ -22,6 +22,7 @@ from __future__ import print_function, unicode_literals
 import datetime
 
 from requests.compat import urlencode, urljoin
+
 from sickbeard import classes, logger, tvcache
 from sickrage.helper.exceptions import AuthException
 from sickrage.providers.torrent.TorrentProvider import TorrentProvider

--- a/sickbeard/providers/hdspace.py
+++ b/sickbeard/providers/hdspace.py
@@ -25,10 +25,11 @@ import re
 
 from bs4 import BeautifulSoup
 from requests.utils import dict_from_cookiejar
+from six.moves.urllib.parse import quote_plus
+
 from sickbeard import logger, tvcache
 from sickrage.helper.common import convert_size, try_int
 from sickrage.providers.torrent.TorrentProvider import TorrentProvider
-from six.moves.urllib.parse import quote_plus
 
 
 class HDSpaceProvider(TorrentProvider):  # pylint: disable=too-many-instance-attributes

--- a/sickbeard/providers/hdtorrents.py
+++ b/sickbeard/providers/hdtorrents.py
@@ -23,11 +23,12 @@ from __future__ import print_function, unicode_literals
 import re
 
 from requests.utils import dict_from_cookiejar
+from six.moves.urllib.parse import quote_plus
+
 from sickbeard import logger, tvcache
 from sickbeard.bs4_parser import BS4Parser
 from sickrage.helper.common import convert_size, try_int
 from sickrage.providers.torrent.TorrentProvider import TorrentProvider
-from six.moves.urllib.parse import quote_plus
 
 
 class HDTorrentsProvider(TorrentProvider):  # pylint: disable=too-many-instance-attributes

--- a/sickbeard/providers/hdtorrents_it.py
+++ b/sickbeard/providers/hdtorrents_it.py
@@ -23,11 +23,12 @@ from __future__ import print_function, unicode_literals
 import re
 
 from requests.utils import dict_from_cookiejar
+from six.moves.urllib.parse import quote_plus
+
 from sickbeard import logger, tvcache
 from sickbeard.bs4_parser import BS4Parser
 from sickrage.helper.common import convert_size, try_int
 from sickrage.providers.torrent.TorrentProvider import TorrentProvider
-from six.moves.urllib.parse import quote_plus
 
 
 class HDTorrentsProvider_IT(TorrentProvider):  # pylint: disable=too-many-instance-attributes

--- a/sickbeard/providers/hounddawgs.py
+++ b/sickbeard/providers/hounddawgs.py
@@ -24,6 +24,7 @@ import re
 import traceback
 
 from requests.utils import dict_from_cookiejar
+
 from sickbeard import logger, tvcache
 from sickbeard.bs4_parser import BS4Parser
 from sickrage.helper.common import convert_size, try_int

--- a/sickbeard/providers/ilcorsaronero.py
+++ b/sickbeard/providers/ilcorsaronero.py
@@ -23,6 +23,7 @@ import re
 
 import six
 from requests.compat import quote_plus, urljoin
+
 from sickbeard import db, logger, tvcache
 from sickbeard.bs4_parser import BS4Parser
 from sickbeard.common import Quality

--- a/sickbeard/providers/immortalseed.py
+++ b/sickbeard/providers/immortalseed.py
@@ -24,6 +24,7 @@ import re
 
 from requests.compat import urljoin
 from requests.utils import dict_from_cookiejar
+
 from sickbeard import logger, tvcache
 from sickbeard.bs4_parser import BS4Parser
 from sickrage.helper.common import convert_size, try_int

--- a/sickbeard/providers/iptorrents.py
+++ b/sickbeard/providers/iptorrents.py
@@ -25,6 +25,7 @@ import re
 import validators
 from requests.compat import urljoin
 from requests.utils import dict_from_cookiejar
+
 from sickbeard import logger, tvcache
 from sickbeard.bs4_parser import BS4Parser
 from sickrage.helper.common import convert_size, try_int

--- a/sickbeard/providers/kat.py
+++ b/sickbeard/providers/kat.py
@@ -19,9 +19,10 @@
 
 from __future__ import unicode_literals
 
-import sickbeard
 import validators
 from requests.compat import urljoin
+
+import sickbeard
 from sickbeard import logger, tvcache
 from sickbeard.bs4_parser import BS4Parser
 from sickrage.helper.common import convert_size, try_int

--- a/sickbeard/providers/limetorrents.py
+++ b/sickbeard/providers/limetorrents.py
@@ -23,8 +23,9 @@ from __future__ import print_function, unicode_literals
 import re
 import traceback
 
-import sickbeard
 from bs4 import BeautifulSoup
+
+import sickbeard
 from sickbeard import logger, tvcache
 from sickrage.helper.common import convert_size, try_int
 from sickrage.providers.torrent.TorrentProvider import TorrentProvider

--- a/sickbeard/providers/morethantv.py
+++ b/sickbeard/providers/morethantv.py
@@ -24,6 +24,7 @@ import re
 
 from requests.compat import urljoin
 from requests.utils import dict_from_cookiejar
+
 from sickbeard import logger, tvcache
 from sickbeard.bs4_parser import BS4Parser
 from sickbeard.show_name_helpers import allPossibleShowNames

--- a/sickbeard/providers/nebulance.py
+++ b/sickbeard/providers/nebulance.py
@@ -24,6 +24,7 @@ import traceback
 
 from requests.compat import urljoin
 from requests.utils import dict_from_cookiejar
+
 from sickbeard import logger, tvcache
 from sickbeard.bs4_parser import BS4Parser
 from sickrage.helper.common import try_int

--- a/sickbeard/providers/newpct.py
+++ b/sickbeard/providers/newpct.py
@@ -23,6 +23,7 @@ from __future__ import print_function, unicode_literals
 import re
 
 from requests.compat import urljoin
+
 from sickbeard import helpers, logger, tvcache
 from sickbeard.bs4_parser import BS4Parser
 from sickrage.helper.common import convert_size

--- a/sickbeard/providers/newznab.py
+++ b/sickbeard/providers/newznab.py
@@ -24,9 +24,10 @@ import os
 import re
 import time
 
-import sickbeard
 import validators
 from requests.compat import urljoin
+
+import sickbeard
 from sickbeard import logger, tvcache
 from sickbeard.bs4_parser import BS4Parser
 from sickbeard.common import cpu_presets

--- a/sickbeard/providers/norbits.py
+++ b/sickbeard/providers/norbits.py
@@ -21,6 +21,7 @@
 from __future__ import unicode_literals
 
 from requests.compat import urlencode
+
 from sickbeard import logger, tvcache
 from sickrage.helper.common import convert_size, try_int
 from sickrage.helper.exceptions import AuthException

--- a/sickbeard/providers/pretome.py
+++ b/sickbeard/providers/pretome.py
@@ -24,12 +24,13 @@ import re
 import traceback
 
 from requests.utils import dict_from_cookiejar
+# noinspection PyUnresolvedReferences
+from six.moves.urllib.parse import quote
+
 from sickbeard import logger, tvcache
 from sickbeard.bs4_parser import BS4Parser
 from sickrage.helper.common import convert_size, try_int
 from sickrage.providers.torrent.TorrentProvider import TorrentProvider
-# noinspection PyUnresolvedReferences
-from six.moves.urllib.parse import quote
 
 
 class PretomeProvider(TorrentProvider):  # pylint: disable=too-many-instance-attributes

--- a/sickbeard/providers/rsstorrent.py
+++ b/sickbeard/providers/rsstorrent.py
@@ -24,9 +24,10 @@ import io
 import os
 import re
 
-import sickbeard
 from bencode.BTL import BTFailure
 from requests.utils import add_dict_to_cookiejar
+
+import sickbeard
 from sickbeard import helpers, logger, tvcache
 from sickrage.helper.encoding import ek
 from sickrage.helper.exceptions import ex

--- a/sickbeard/providers/scc.py
+++ b/sickbeard/providers/scc.py
@@ -23,15 +23,16 @@ from __future__ import print_function, unicode_literals
 import re
 import time
 
-import sickbeard
 from requests.compat import urljoin
 from requests.utils import dict_from_cookiejar
+from six.moves.urllib.parse import quote
+
+import sickbeard
 from sickbeard import logger, tvcache
 from sickbeard.bs4_parser import BS4Parser
 from sickbeard.common import cpu_presets
 from sickrage.helper.common import convert_size, try_int
 from sickrage.providers.torrent.TorrentProvider import TorrentProvider
-from six.moves.urllib.parse import quote
 
 
 class SCCProvider(TorrentProvider):  # pylint: disable=too-many-instance-attributes

--- a/sickbeard/providers/scenetime.py
+++ b/sickbeard/providers/scenetime.py
@@ -21,6 +21,7 @@
 from __future__ import print_function, unicode_literals
 
 from requests.utils import dict_from_cookiejar
+
 from sickbeard import logger, tvcache
 from sickbeard.bs4_parser import BS4Parser
 from sickrage.helper.common import convert_size, try_int

--- a/sickbeard/providers/shazbat.py
+++ b/sickbeard/providers/shazbat.py
@@ -21,6 +21,7 @@
 from __future__ import unicode_literals
 
 from requests.compat import urljoin
+
 from sickbeard import logger, tvcache
 from sickrage.helper.exceptions import AuthException
 from sickrage.providers.torrent.TorrentProvider import TorrentProvider

--- a/sickbeard/providers/skytorrents.py
+++ b/sickbeard/providers/skytorrents.py
@@ -23,6 +23,7 @@ import re
 
 import validators
 from requests.compat import urljoin
+
 from sickbeard import logger, tvcache
 from sickrage.helper.common import convert_size, try_int
 from sickrage.providers.torrent.TorrentProvider import TorrentProvider

--- a/sickbeard/providers/speedcd.py
+++ b/sickbeard/providers/speedcd.py
@@ -24,6 +24,7 @@ import re
 
 from requests.compat import urljoin
 from requests.utils import dict_from_cookiejar
+
 from sickbeard import logger, tvcache
 from sickbeard.bs4_parser import BS4Parser
 from sickrage.helper.common import convert_size, try_int

--- a/sickbeard/providers/t411.py
+++ b/sickbeard/providers/t411.py
@@ -25,6 +25,7 @@ import traceback
 
 import six
 from requests.auth import AuthBase
+
 from sickbeard import logger, tvcache
 from sickrage.helper.common import convert_size, try_int
 from sickrage.providers.torrent.TorrentProvider import TorrentProvider

--- a/sickbeard/providers/thepiratebay.py
+++ b/sickbeard/providers/thepiratebay.py
@@ -24,6 +24,7 @@ import re
 
 import validators
 from requests.compat import urljoin
+
 from sickbeard import logger, tvcache
 from sickbeard.bs4_parser import BS4Parser
 from sickrage.helper.common import convert_size, try_int

--- a/sickbeard/providers/torrentbytes.py
+++ b/sickbeard/providers/torrentbytes.py
@@ -24,6 +24,7 @@ import re
 
 from requests.compat import urljoin
 from requests.utils import dict_from_cookiejar
+
 from sickbeard import logger, tvcache
 from sickbeard.bs4_parser import BS4Parser
 from sickrage.helper.common import convert_size, try_int

--- a/sickbeard/providers/torrentday.py
+++ b/sickbeard/providers/torrentday.py
@@ -25,6 +25,7 @@ import re
 import validators
 from requests.compat import urljoin
 from requests.utils import dict_from_cookiejar
+
 from sickbeard import logger, tvcache
 from sickrage.helper.common import convert_size, try_int
 from sickrage.providers.torrent.TorrentProvider import TorrentProvider

--- a/sickbeard/providers/torrentleech.py
+++ b/sickbeard/providers/torrentleech.py
@@ -24,6 +24,7 @@ import re
 
 from requests.compat import urljoin
 from requests.utils import dict_from_cookiejar
+
 from sickbeard import logger, tvcache
 from sickbeard.bs4_parser import BS4Parser
 from sickrage.helper.common import convert_size, try_int

--- a/sickbeard/providers/torrentproject.py
+++ b/sickbeard/providers/torrentproject.py
@@ -21,6 +21,7 @@
 from __future__ import print_function, unicode_literals
 
 import validators
+
 from sickbeard import logger, tvcache
 from sickrage.helper.common import convert_size, try_int
 from sickrage.providers.torrent.TorrentProvider import TorrentProvider

--- a/sickbeard/rssfeeds.py
+++ b/sickbeard/rssfeeds.py
@@ -2,6 +2,7 @@
 from __future__ import print_function, unicode_literals
 
 from feedparser.api import parse
+
 from sickbeard import logger
 from sickrage.helper.exceptions import ex
 

--- a/sickbeard/sab.py
+++ b/sickbeard/sab.py
@@ -22,8 +22,9 @@ from __future__ import unicode_literals
 
 import datetime
 
-import sickbeard
 from requests.compat import urljoin
+
+import sickbeard
 from sickbeard import helpers, logger
 
 session = helpers.make_session()

--- a/sickbeard/scene_exceptions.py
+++ b/sickbeard/scene_exceptions.py
@@ -25,8 +25,9 @@ import threading
 import time
 
 import adba
-import sickbeard
 import six
+
+import sickbeard
 from sickbeard import db, helpers, logger
 from sickbeard.indexers.indexer_config import INDEXER_TVDB
 

--- a/sickbeard/searchBacklog.py
+++ b/sickbeard/searchBacklog.py
@@ -22,8 +22,9 @@ from __future__ import print_function, unicode_literals
 import datetime
 import threading
 
-import sickbeard
 import six
+
+import sickbeard
 from sickbeard import common, db, logger, scheduler, search_queue, ui
 
 

--- a/sickbeard/show_name_helpers.py
+++ b/sickbeard/show_name_helpers.py
@@ -23,8 +23,9 @@ import fnmatch
 import os
 import re
 
-import sickbeard
 import six
+
+import sickbeard
 from sickbeard import common, logger
 from sickbeard.name_parser.parser import InvalidNameException, InvalidShowException, NameParser
 from sickbeard.scene_exceptions import get_scene_exceptions

--- a/sickbeard/show_queue.py
+++ b/sickbeard/show_queue.py
@@ -23,10 +23,11 @@ import os
 import traceback
 from collections import namedtuple
 
-import sickbeard
 import six
 from imdb import _exceptions as imdb_exceptions
 from libtrakt import TraktAPI
+
+import sickbeard
 from sickbeard import generic_queue, logger, name_cache, notifiers, ui
 from sickbeard.blackandwhitelist import BlackAndWhiteList
 from sickbeard.common import WANTED

--- a/sickbeard/subtitles.py
+++ b/sickbeard/subtitles.py
@@ -28,18 +28,19 @@ import subprocess
 import threading
 import traceback
 
-import sickbeard
 import six
 import subliminal
 from babelfish import Language, language_converters
 from guessit import guessit
+from subliminal import Episode, provider_manager, ProviderPool
+
+import sickbeard
 from sickbeard import db, history, logger
 from sickbeard.common import Quality
 from sickbeard.helpers import is_media_file
 from sickrage.helper.common import dateTimeFormat, episode_num
 from sickrage.helper.exceptions import ex
 from sickrage.show.Show import Show
-from subliminal import Episode, provider_manager, ProviderPool
 
 # https://github.com/Diaoul/subliminal/issues/536
 # provider_manager.register('napiprojekt = subliminal.providers.napiprojekt:NapiProjektProvider')

--- a/sickbeard/traktChecker.py
+++ b/sickbeard/traktChecker.py
@@ -23,9 +23,10 @@ import datetime
 import os
 import traceback
 
-import sickbeard
 from libtrakt import TraktAPI
 from libtrakt.exceptions import traktException
+
+import sickbeard
 from sickbeard import db, helpers, logger, search_queue
 from sickbeard.common import Quality, SKIPPED, UNKNOWN, WANTED
 from sickrage.helper.common import episode_num, sanitize_filename

--- a/sickbeard/traktTrending.py
+++ b/sickbeard/traktTrending.py
@@ -5,9 +5,10 @@ from __future__ import print_function, unicode_literals
 import os
 import posixpath
 
-import sickbeard
 from libtrakt.exceptions import traktException
 from libtrakt.trakt import TraktAPI
+
+import sickbeard
 from sickbeard import helpers, logger
 from sickbeard.indexers.indexer_config import INDEXER_TVDB
 from sickrage.helper.encoding import ek

--- a/sickbeard/tv.py
+++ b/sickbeard/tv.py
@@ -28,9 +28,11 @@ import stat
 import threading
 import traceback
 
-import sickbeard
 import six
 from imdb import imdb
+from unidecode import unidecode
+
+import sickbeard
 from sickbeard import db, helpers, image_cache, logger, network_timezones, notifiers, postProcessor, subtitles
 from sickbeard.blackandwhitelist import BlackAndWhiteList
 from sickbeard.common import (ARCHIVED, DOWNLOADED, FAILED, IGNORED, NAMING_DUPLICATE, NAMING_EXTEND, NAMING_LIMITED_EXTEND, NAMING_LIMITED_EXTEND_E_PREFIXED,
@@ -44,7 +46,6 @@ from sickrage.helper.exceptions import (EpisodeDeletedException, EpisodeNotFound
                                         MultipleShowObjectsException, MultipleShowsInDatabaseException, NoNFOException, ShowDirectoryNotFoundException,
                                         ShowNotFoundException)
 from sickrage.show.Show import Show
-from unidecode import unidecode
 
 try:
     import xml.etree.cElementTree as etree

--- a/sickbeard/tvcache.py
+++ b/sickbeard/tvcache.py
@@ -23,8 +23,9 @@ import datetime
 import itertools
 import time
 
-import sickbeard
 import six
+
+import sickbeard
 from sickbeard import db, logger, show_name_helpers
 from sickbeard.name_parser.parser import InvalidNameException, InvalidShowException, NameParser
 from sickbeard.rssfeeds import getFeed

--- a/sickbeard/versionChecker.py
+++ b/sickbeard/versionChecker.py
@@ -30,8 +30,9 @@ import tarfile
 import time
 import traceback
 
-import sickbeard
 import six
+
+import sickbeard
 from sickbeard import db, helpers, logger, notifiers, ui
 from sickrage.helper.encoding import ek
 from sickrage.helper.exceptions import ex

--- a/sickbeard/webapi.py
+++ b/sickbeard/webapi.py
@@ -31,8 +31,12 @@ import re
 import time
 import traceback
 
-import sickbeard
 import six
+# noinspection PyUnresolvedReferences
+from six.moves import urllib
+from tornado.web import RequestHandler
+
+import sickbeard
 from sickbeard import classes, db, helpers, image_cache, logger, network_timezones, sbdatetime, search_queue, ui
 from sickbeard.common import (ARCHIVED, DOWNLOADED, FAILED, IGNORED, Overview, Quality, SKIPPED, SNATCHED, SNATCHED_PROPER, statusStrings, UNAIRED, UNKNOWN,
                               WANTED)
@@ -51,10 +55,6 @@ from sickrage.show.History import History
 from sickrage.show.Show import Show
 from sickrage.system.Restart import Restart
 from sickrage.system.Shutdown import Shutdown
-# noinspection PyUnresolvedReferences
-from six.moves import urllib
-# pylint: disable=import-error
-from tornado.web import RequestHandler
 
 try:
     import json

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -34,7 +34,6 @@ from operator import attrgetter
 
 import adba
 import markdown2
-import sickbeard
 import six
 from dateutil import tz
 from libtrakt import TraktAPI
@@ -44,6 +43,18 @@ from mako.lookup import TemplateLookup
 from mako.runtime import UNDEFINED
 from mako.template import Template as MakoTemplate
 from requests.compat import urljoin
+# noinspection PyUnresolvedReferences
+from six.moves import urllib
+# noinspection PyUnresolvedReferences
+from six.moves.urllib.parse import unquote_plus
+from tornado.concurrent import run_on_executor
+from tornado.gen import coroutine
+from tornado.ioloop import IOLoop
+from tornado.process import cpu_count
+from tornado.routes import route
+from tornado.web import authenticated, HTTPError, RequestHandler, StaticFileHandler
+
+import sickbeard
 from sickbeard import classes, clients, config, db, helpers, logger, naming, network_timezones, notifiers, sab, search_queue, subtitles as subtitle_module, ui
 from sickbeard.blackandwhitelist import BlackAndWhiteList, short_group_names
 from sickbeard.browser import foldersAtPath
@@ -72,16 +83,6 @@ from sickrage.show.History import History as HistoryTool
 from sickrage.show.Show import Show
 from sickrage.system.Restart import Restart
 from sickrage.system.Shutdown import Shutdown
-# noinspection PyUnresolvedReferences
-from six.moves import urllib
-# noinspection PyUnresolvedReferences
-from six.moves.urllib.parse import unquote_plus
-from tornado.concurrent import run_on_executor
-from tornado.gen import coroutine
-from tornado.ioloop import IOLoop
-from tornado.process import cpu_count
-from tornado.routes import route
-from tornado.web import authenticated, HTTPError, RequestHandler, StaticFileHandler
 
 try:
     import json

--- a/sickbeard/webserveInit.py
+++ b/sickbeard/webserveInit.py
@@ -6,15 +6,16 @@ import os
 import threading
 from socket import errno, error as SocketError
 
+from tornado.ioloop import IOLoop
+from tornado.routes import route
+from tornado.web import Application, RedirectHandler, StaticFileHandler
+
 import sickbeard
 from sickbeard import logger
 from sickbeard.helpers import create_https_certificates, generateApiKey
 from sickbeard.webapi import ApiHandler
 from sickbeard.webserve import CalendarHandler, KeyHandler, LoginHandler, LogoutHandler
 from sickrage.helper.encoding import ek
-from tornado.ioloop import IOLoop
-from tornado.routes import route
-from tornado.web import Application, RedirectHandler, StaticFileHandler
 
 
 class SRWebServer(threading.Thread):  # pylint: disable=too-many-instance-attributes

--- a/sickrage/__init__.py
+++ b/sickrage/__init__.py
@@ -1,1 +1,2 @@
 # coding=utf-8
+from __future__ import unicode_literals

--- a/sickrage/helper/__init__.py
+++ b/sickrage/helper/__init__.py
@@ -1,4 +1,6 @@
 # coding=utf-8
-from common import setup_github, pretty_file_size, episode_num, CUSTOM_GLOB as glob, \
-    HTTP_STATUS_CODES, MEDIA_EXTENSIONS, SUBTITLE_EXTENSIONS, try_int, sanitize_filename
+from __future__ import unicode_literals
+
+from common import (CUSTOM_GLOB as glob, episode_num, HTTP_STATUS_CODES, MEDIA_EXTENSIONS, pretty_file_size, sanitize_filename, setup_github,
+                    SUBTITLE_EXTENSIONS, try_int)
 from media_info import video_screen_size

--- a/sickrage/helper/common.py
+++ b/sickrage/helper/common.py
@@ -28,10 +28,11 @@ import os
 import re
 from fnmatch import fnmatch
 
-import sickbeard
 import six
 from github import Github
 from github.GithubException import BadCredentialsException, TwoFactorException
+
+import sickbeard
 
 dateFormat = '%Y-%m-%d'
 dateTimeFormat = '%Y-%m-%d %H:%M:%S'

--- a/sickrage/helper/encoding.py
+++ b/sickrage/helper/encoding.py
@@ -22,9 +22,10 @@ from __future__ import unicode_literals
 
 from os import name
 
-import sickbeard
 import six
 from chardet import detect
+
+import sickbeard
 
 
 def ek(function, *args, **kwargs):

--- a/sickrage/helper/exceptions.py
+++ b/sickrage/helper/exceptions.py
@@ -20,6 +20,7 @@
 from __future__ import print_function, unicode_literals
 
 import six
+
 from sickrage.helper.encoding import ss
 
 

--- a/sickrage/helper/media_info.py
+++ b/sickrage/helper/media_info.py
@@ -23,11 +23,11 @@ from __future__ import print_function, unicode_literals
 import binascii
 import io
 
+import six
+from enzyme import MKV
 from pkg_resources import DistributionNotFound, get_distribution
 
 import sickbeard
-import six
-from enzyme import MKV
 
 try:
     get_distribution('pymediainfo')

--- a/sickrage/media/__init__.py
+++ b/sickrage/media/__init__.py
@@ -1,2 +1,4 @@
 # coding=utf-8
+from __future__ import unicode_literals
+
 __all__ = ['ShowBanner', 'ShowFanArt', 'ShowNetworkLogo', 'ShowPoster']

--- a/sickrage/providers/GenericProvider.py
+++ b/sickrage/providers/GenericProvider.py
@@ -26,9 +26,10 @@ from itertools import chain
 from os.path import join
 from random import shuffle
 
-import sickbeard
 import six
 from requests.utils import add_dict_to_cookiejar
+
+import sickbeard
 from sickbeard import logger
 from sickbeard.classes import Proper, SearchResult
 from sickbeard.common import MULTI_EP_RESULT, Quality, SEASON_RESULT, UA_POOL

--- a/sickrage/providers/__init__.py
+++ b/sickrage/providers/__init__.py
@@ -1,2 +1,4 @@
 # coding=utf-8
+from __future__ import unicode_literals
+
 __all__ = []

--- a/sickrage/providers/torrent/TorrentProvider.py
+++ b/sickrage/providers/torrent/TorrentProvider.py
@@ -21,9 +21,10 @@ from __future__ import unicode_literals
 
 from datetime import datetime
 
-import sickbeard
 from feedparser.util import FeedParserDict
 from hachoir_parser import createParser
+
+import sickbeard
 from sickbeard import logger
 from sickbeard.classes import Proper, TorrentSearchResult
 from sickbeard.common import Quality

--- a/sickrage/show/History.py
+++ b/sickrage/show/History.py
@@ -22,6 +22,7 @@ from __future__ import unicode_literals
 from datetime import datetime, timedelta
 
 import six
+
 from sickbeard.common import Quality
 from sickbeard.db import DBConnection
 from sickrage.helper.common import try_int

--- a/sickrage/show/__init__.py
+++ b/sickrage/show/__init__.py
@@ -1,2 +1,4 @@
 # coding=utf-8
+from __future__ import unicode_literals
+
 __all__ = ['ComingEpisodes', 'History', 'Show']

--- a/sickrage/show/recommendations/__init__.py
+++ b/sickrage/show/recommendations/__init__.py
@@ -1,3 +1,4 @@
 # coding=utf-8
+from __future__ import unicode_literals
 
 __all__ = ['anidb', 'imdb', 'trakt']

--- a/sickrage/show/recommendations/anidb.py
+++ b/sickrage/show/recommendations/anidb.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 from anidbhttp import anidbquery
 from anidbhttp.query import QUERY_HOT
 from recommended import RecommendedShow
+
 from sickbeard import helpers
 from sickrage.helper.common import try_int
 

--- a/sickrage/show/recommendations/imdb.py
+++ b/sickrage/show/recommendations/imdb.py
@@ -7,8 +7,9 @@ import posixpath
 import re
 from datetime import date
 
-import sickbeard
 from bs4 import BeautifulSoup
+
+import sickbeard
 from sickbeard import helpers
 from sickrage.helper.encoding import ek
 

--- a/sickrage/system/__init__.py
+++ b/sickrage/system/__init__.py
@@ -1,2 +1,4 @@
 # coding=utf-8
+from __future__ import unicode_literals
+
 __all__ = ['Restart', 'Shutdown']


### PR DESCRIPTION
Proposed changes in this pull request:
- Fix vendored libs being in the same section as `sickbeard` and `sickrage`
**need to sort in a virtual-env like TOX
or add the `/lib` folder to the start of $PATH in order for it to work properly**
- Enable import sorting on `__init__.py` files
- Sort `sickbeard/__init__.py` then disable sorting for that file, because of pytz import (see commit)
- Sort `__all__`'s in `sickbeard.providers` and `sickbeard.metadata`

Biggest changes are in `sickbeard/__init__.py` and `sickbeard/webserve.py`