### PR TITLE
Update requirements list

### DIFF
--- a/lib/html5lib/__init__.py
+++ b/lib/html5lib/__init__.py
@@ -22,4 +22,4 @@ __all__ = ["HTMLParser", "parse", "parseFragment", "getTreeBuilder",
            "getTreeWalker", "serialize"]
 
 # this has to be at the top level, see how setup.py parses this
-__version__ = "0.999999999"
+__version__ = "1.0b10"

--- a/requirements/readme.md
+++ b/requirements/readme.md
@@ -41,7 +41,7 @@ List of dependencies [![Requirements Status](https://requires.io/github/SickRage
 :ok: | MarkupSafe | 1.0
 :ok: | ndg-httpsclient | 0.3.3
 :ok: | oauthlib | 2.0.2 | Added in [#3870](https://github.com/SickRage/SickRage/pull/3870)
-:question: | pgi | 0.0.11.1 | Can't verify, unable to install this using pip.<br>Only being used by `sickbeard.notifiers.libnotify` as far as I can tell.
+:warning: | pgi | [38f8349](https://github.com/pygobject/pgi/tree/38f834902247a5851cb4c72ba018f160ae26d612) | 
 :exclamation: | pkg_resources.py | - | Copied from setuptools and looks to be modified.<br>Maybe we don't really need this?<br>Used to load the egg files for `pymediainfo` and `pytz`.
 :ok: | profilehooks | 1.5
 :ok: | putio.py | 6.1.0

--- a/requirements/readme.md
+++ b/requirements/readme.md
@@ -4,7 +4,7 @@ List of dependencies [![Requirements Status](https://requires.io/github/SickRage
  Status   |  Package  |  Version / Commit  | Notes
 :-------: | :-------: | :----------------: | -----
 :exclamation: | adba | ??? | **Modified**<br>not on PYPI - [GH:lad1337/adba](https://github.com/lad1337/adba)
-:warning: | babelfish | 0.5.5-dev | we can use `0.5.5`.<br>The diff is that `-dev` includes `get_files.py`,<br>which isn't needed and doesn't even work anymore.
+:ok: | babelfish | 0.5.5 | Resolved by [#3877](https://github.com/SickRage/SickRage/pull/3877)
 :ok: | backports_abc | 0.5 | 
 :ok: | backports.ssl-match-hostname | 3.5.0.1 | 
 :ok: | beautifulsoup4 | 4.5.3 | 
@@ -21,7 +21,7 @@ List of dependencies [![Requirements Status](https://requires.io/github/SickRage
 :ok: | enum34 | 1.0.4
 :warning: | enzyme | [9572bea](https://github.com/Diaoul/enzyme/tree/9572bea606a6145dad153cd712653d6cf10ef18e)
 :ok: | fake-useragent | 0.1.2  | Note: There's a `ua.json` file that's used by `sickbeard.common`,<br>should be moved to a better location.
-:exclamation: | feedparser | [f1dd1bb](https://github.com/kurtmckee/feedparser/tree/f1dd1bb923ebfe6482fc2521c1f150b4032289ec) | **Modified**<br>See [#2957-`04fc020`](https://github.com/SickRage/SickRage/pull/2957/commits/04fc020d315acd4e947a30a5b7653c507b91b5ac)
+:warning: | feedparser | [f1dd1bb](https://github.com/kurtmckee/feedparser/tree/f1dd1bb923ebfe6482fc2521c1f150b4032289ec) | Vanilla'd by [#3877](https://github.com/SickRage/SickRage/pull/3877)
 :warning: | futures | [43bfc41](https://github.com/agronholm/pythonfutures/tree/43bfc41626208d78f4db1839e2808772defdfdca)
 :warning: | guessit | [a4fb286](https://github.com/guessit-io/guessit/tree/a4fb2865d4b697397aa976388bbd0edf558a24fb)
 :warning: | hachoir_core | [708fdf6](https://bitbucket.org/haypo/hachoir/src/708fdf64a982ba2e638aa59d94f143112066b8ce/hachoir-core/hachoir_core/)  | Bitbucket
@@ -30,14 +30,14 @@ List of dependencies [![Requirements Status](https://requires.io/github/SickRage
 :ok: | html5lib | 0.999999999
 :ok: | httplib2 | 0.9.2 | + tests folder from [cf631a7](https://github.com/httplib2/httplib2/tree/cf631a73e2f3f43897b65206127ced82382d35f5)
 :ok: | idna | 2.5 | Added in [#3870](https://github.com/SickRage/SickRage/pull/3870)
-:exclamation: | imdbpy | [aa68c6c](https://github.com/alberanid/imdbpy/tree/aa68c6c919eae91bbd5cebc49866a78ce67dc9ea)  | **Modified**<br>Only comments... See [#3697](https://github.com/SickRage/SickRage/pull/3697)
+:warning: | IMDbPY | 5.1.1 | Resolved by [#3877](https://github.com/SickRage/SickRage/pull/3877)<br>**Still can't install this from requirements.txt**,<br>because we need to be able to use `--no-deps`, but it's unsupported in the context of requirement files.<br>A workaround seems to be to use `pip install --no-deps -r requirements.txt`, which is fine as long as we list ALL dependencies (which is planned).<br>Also, I don't think `install_requires` in `setup.py` supports anything more than simple package version constraints, maybe VCS sources (git/mercurial/etc..) - untested.
 :warning: | js2py | [05e77f0](https://github.com/PiotrDabkowski/Js2Py/tree/05e77f0d4ffe91ef418a93860e666962cfd193b8)
 :warning: | jsonrpclib | [e3a3cde](https://github.com/joshmarshall/jsonrpclib/tree/e3a3cdedc9577b25b91274815b38ba7f3bc43c68)
 :warning: | libgrowl | - | **Custom by Sick-Beard's midgetspy**<br>Some of the code is from [GH:kfdm/gntp](https://github.com/kfdm/gntp)
 :warning: | libtrakt | - | **Custom**<br>Just a small note -<br>if needed, [GH:fuzeman/trakt.py](https://github.com/fuzeman/trakt.py) is a great implementation of Trakt.tv's API.
 :ok: | lockfile | 0.11.0
 :ok: | Mako | 1.0.6
-:warning: | markdown2 | [596d48b](https://github.com/trentm/python-markdown2/tree/596d48b4279259561ca96329538c65de4c00edde)
+:ok: | markdown2 | 2.3.4 | Resolved by [#3877](https://github.com/SickRage/SickRage/pull/3877)
 :ok: | MarkupSafe | 1.0
 :ok: | ndg-httpsclient | 0.3.3
 :ok: | oauthlib | 2.0.2 | Added in [#3870](https://github.com/SickRage/SickRage/pull/3870)
@@ -47,11 +47,13 @@ List of dependencies [![Requirements Status](https://requires.io/github/SickRage
 :ok: | profilehooks | 1.5
 :ok: | putio.py | 6.1.0
 :ok: | pyasn1 | 0.1.7 | + LICENSE
-:exclamation: | PyGithub | [5ad6918](https://github.com/PyGithub/PyGithub/tree/5ad69189ea527334a4501b73b6641a7757519e34) | **Modified**<br>See [#3185 `diff-b83eae1`](https://github.com/SickRage/SickRage/pull/3185/files#diff-b83eae1ebdf7d9aac4aedd1568ca6c8a)
+:ok: | PyGithub | 1.34 | Resolved by [#3877](https://github.com/SickRage/SickRage/pull/3877)
+:ok: | PyJWT | 1.5.0 | Added in [#3877](https://github.com/SickRage/SickRage/pull/3877)
 :ok: | pymediainfo | 2.0  | as an `.egg` file, loaded by `pkg_resources`
 :ok: | pynma | 1.0
+:ok: | PySocks | 1.6.7 | Added in [#3877](https://github.com/SickRage/SickRage/pull/3877)
 :warning: | pysrt | [47aaa59](https://github.com/byroot/pysrt/tree/47aaa592c3bc185cd2bc1d58d1451bf98be3c1ef)
-:warning: | python-dateutil | [d05b837](https://github.com/dateutil/dateutil/tree/d05b837d2b6ce2be8e6901ec2ccc4966cf0aae08)
+:ok: | python-dateutil | 2.6.0 | Resolved by [#3877](https://github.com/SickRage/SickRage/pull/3877)
 :exclamation: | python-fanart | 1.4.0 | **Modified**<br>API url was updated. No newer version.
 :ok: | python-twitter | 3.3 | Updated in [#3870](https://github.com/SickRage/SickRage/pull/3870)
 :ok: | pytz | 2016.4  | as an `.egg` file, loaded by `pkg_resources`
@@ -61,10 +63,10 @@ List of dependencies [![Requirements Status](https://requires.io/github/SickRage
 :ok: | requests-oauthlib | 0.8.0 | Added in [#3870](https://github.com/SickRage/SickRage/pull/3870)
 :exclamation: | rtorrent-python | 0.2.9  | **Modified**<br>See [commits log for `lib/rtorrent`](https://github.com/SickRage/SickRage/commits/master/lib/rtorrent)
 :exclamation: | send2trash | 1.3.0  | **Modified**<br>See [`9ad8114`](https://github.com/SickRage/SickRage/commit/9ad811432ab0ca3292410d29464ce2532361eb55)
-:ok: | simplejson | 2.0.9
+:heavy_minus_sign: | simplejson | - | Removed in [#3877](https://github.com/SickRage/SickRage/pull/3877)
 :ok: | singledispatch | 3.4.0.3
 :ok: | six | 1.10.0
-:warning: | SocksiPy | 1.00 | 1. Not sure if it's even being used.<br>2. Unmaintained, and not on PyPI - [SourceForge](https://sourceforge.net/projects/socksipy/files/socksipy/SocksiPy%201.00).<br>3. If it's still needed, there's httplib2.socks, requests[socks] and a new fork of the SF project @ [GH:Anorov/PySocks](https://github.com/Anorov/PySocks)
+:heavy_minus_sign: | SocksiPy | - | Replaced with PySocks in [#3877](https://github.com/SickRage/SickRage/pull/3877)
 :warning: | sqlalchemy | [ccc0c44](https://github.com/zzzeek/sqlalchemy/tree/ccc0c44c3a60fc4906e5e3b26cc6d2b7a69d33bf)
 :ok: | stevedore | 1.10.0
 :warning: | subliminal | [7eb7a53](https://github.com/Diaoul/subliminal/tree/7eb7a53fe6bcaf3e01a6b44c8366faf7c96f7f1b) | **Modified**<br>Subscenter provider disabled until fixed upstream, [#3825 `diff-ab7eb9b`](https://github.com/SickRage/SickRage/pull/3825/files#diff-ab7eb9ba0a2d4c74c16795ff40f2bd62)
@@ -74,9 +76,10 @@ List of dependencies [![Requirements Status](https://requires.io/github/SickRage
 :ok: | tus.py | 1.2.0
 :exclamation: | tvdb_api | 1.9  | **Heavily Modified**<br>Deprecated API, will be disabled by October 1st, 2017
 :warning: | twilio | [f91e1a9](https://github.com/twilio/twilio-python/tree/f91e1a9e6f4e0a60589b2b90cb66b89b879b9c3e)
-:warning: | tzlocal | [8e0a63d](https://github.com/regebro/tzlocal/tree/8e0a63ddbf50ff9e5b1d23b540cdc343efe1a4af)
-:ok: | unidecode | 0.04.12
+:ok: | tzlocal | 1.4 | Resolved by [#3877](https://github.com/SickRage/SickRage/pull/3877)
+:ok: | Unidecode | 0.04.20 | Updated in [#3877](https://github.com/SickRage/SickRage/pull/3877)
 :ok: | urllib3 | 1.21.1 | Added in [#3870](https://github.com/SickRage/SickRage/pull/3870)
 :ok: | validators | 0.10
 :ok: | webencodings | 0.5.1
-:warning: | xmltodict | [579a005](https://github.com/martinblech/xmltodict/tree/579a00520315e30681e0f0f81de645ce5680ed47)
+:ok: | win-inet-pton | 1.0.1 | Required for PySocks on Windows systems<br>Added in [#3877](https://github.com/SickRage/SickRage/pull/3877)
+:ok: | xmltodict | 0.11.0 | Resolved by [#3877](https://github.com/SickRage/SickRage/pull/3877)

--- a/requirements/readme.md
+++ b/requirements/readme.md
@@ -1,8 +1,8 @@
 List of dependencies [![Requirements Status](https://requires.io/github/SickRage/SickRage/requirements.svg?branch=develop)](https://requires.io/github/SickRage/SickRage/requirements/?branch=develop)
 ======================
 
- Status   |  Package  |  Version / Commit  | Notes
-:-------: | :-------: | :----------------: | -----
+ Status  |  Package  |  Version / Commit  | Notes
+:------: | :-------: | :----------------: | -----
 :exclamation: | adba | ??? | **Modified**<br>not on PYPI - [GH:lad1337/adba](https://github.com/lad1337/adba)
 :ok: | babelfish | 0.5.5 | Resolved by [#3877](https://github.com/SickRage/SickRage/pull/3877)
 :ok: | backports_abc | 0.5 | 
@@ -41,7 +41,6 @@ List of dependencies [![Requirements Status](https://requires.io/github/SickRage
 :ok: | MarkupSafe | 1.0
 :ok: | ndg-httpsclient | 0.3.3
 :ok: | oauthlib | 2.0.2 | Added in [#3870](https://github.com/SickRage/SickRage/pull/3870)
-:heavy_minus_sign: | oauth2 | - | Removed in [#3870](https://github.com/SickRage/SickRage/pull/3870)
 :question: | pgi | 0.0.11.1 | Can't verify, unable to install this using pip.<br>Only being used by `sickbeard.notifiers.libnotify` as far as I can tell.
 :exclamation: | pkg_resources.py | - | Copied from setuptools and looks to be modified.<br>Maybe we don't really need this?<br>Used to load the egg files for `pymediainfo` and `pytz`.
 :ok: | profilehooks | 1.5
@@ -63,10 +62,8 @@ List of dependencies [![Requirements Status](https://requires.io/github/SickRage
 :ok: | requests-oauthlib | 0.8.0 | Added in [#3870](https://github.com/SickRage/SickRage/pull/3870)
 :exclamation: | rtorrent-python | 0.2.9  | **Modified**<br>See [commits log for `lib/rtorrent`](https://github.com/SickRage/SickRage/commits/master/lib/rtorrent)
 :exclamation: | send2trash | 1.3.0  | **Modified**<br>See [`9ad8114`](https://github.com/SickRage/SickRage/commit/9ad811432ab0ca3292410d29464ce2532361eb55)
-:heavy_minus_sign: | simplejson | - | Removed in [#3877](https://github.com/SickRage/SickRage/pull/3877)
 :ok: | singledispatch | 3.4.0.3
 :ok: | six | 1.10.0
-:heavy_minus_sign: | SocksiPy | - | Replaced with PySocks in [#3877](https://github.com/SickRage/SickRage/pull/3877)
 :warning: | sqlalchemy | [ccc0c44](https://github.com/zzzeek/sqlalchemy/tree/ccc0c44c3a60fc4906e5e3b26cc6d2b7a69d33bf)
 :ok: | stevedore | 1.10.0
 :warning: | subliminal | [7eb7a53](https://github.com/Diaoul/subliminal/tree/7eb7a53fe6bcaf3e01a6b44c8366faf7c96f7f1b) | **Modified**<br>Subscenter provider disabled until fixed upstream, [#3825 `diff-ab7eb9b`](https://github.com/SickRage/SickRage/pull/3825/files#diff-ab7eb9ba0a2d4c74c16795ff40f2bd62)
@@ -83,3 +80,16 @@ List of dependencies [![Requirements Status](https://requires.io/github/SickRage
 :ok: | webencodings | 0.5.1
 :ok: | win-inet-pton | 1.0.1 | Required for PySocks on Windows systems<br>Added in [#3877](https://github.com/SickRage/SickRage/pull/3877)
 :ok: | xmltodict | 0.11.0 | Resolved by [#3877](https://github.com/SickRage/SickRage/pull/3877)
+
+***
+
+:heavy_minus_sign: Removed libs:
+-------------
+
+ Package  |  Reason  | Reference
+:-------: | :------: | ---------
+MultipartPostHandler.py | Unused | Removed in [#3716](https://github.com/SickRage/SickRage/pull/3716)
+oauth2 | Outdated | Removed in [#3870](https://github.com/SickRage/SickRage/pull/3870)
+simplejson | Unused | Removed in [#3877](https://github.com/SickRage/SickRage/pull/3877)
+SocksiPy | Outdated | Replaced with PySocks in [#3877](https://github.com/SickRage/SickRage/pull/3877)
+sqliteshelf.py | Unused | Removed in [#3716](https://github.com/SickRage/SickRage/pull/3716)

--- a/requirements/readme.md
+++ b/requirements/readme.md
@@ -27,7 +27,7 @@ List of dependencies [![Requirements Status](https://requires.io/github/SickRage
 :warning: | hachoir_core | [708fdf6](https://bitbucket.org/haypo/hachoir/src/708fdf64a982ba2e638aa59d94f143112066b8ce/hachoir-core/hachoir_core/)  | Bitbucket
 :warning: | hachoir_metadata | [708fdf6](https://bitbucket.org/haypo/hachoir/src/708fdf64a982ba2e638aa59d94f143112066b8ce/hachoir-metadata/hachoir_metadata/)  | Bitbucket
 :warning: | hachoir_parser | [708fdf6](https://bitbucket.org/haypo/hachoir/src/708fdf64a982ba2e638aa59d94f143112066b8ce/hachoir-parser/hachoir_parser/)  | Bitbucket
-:ok: | html5lib | 0.999999999
+:ok: | html5lib | 1.0b10
 :ok: | httplib2 | 0.9.2 | + tests folder from [cf631a7](https://github.com/httplib2/httplib2/tree/cf631a73e2f3f43897b65206127ced82382d35f5)
 :ok: | idna | 2.5 | Added in [#3870](https://github.com/SickRage/SickRage/pull/3870)
 :warning: | IMDbPY | 5.1.1 | Resolved by [#3877](https://github.com/SickRage/SickRage/pull/3877)<br>**Still can't install this from requirements.txt**,<br>because we need to be able to use `--no-deps`, but it's unsupported in the context of requirement files.<br>A workaround seems to be to use `pip install --no-deps -r requirements.txt`, which is fine as long as we list ALL dependencies (which is planned).<br>Also, I don't think `install_requires` in `setup.py` supports anything more than simple package version constraints, maybe VCS sources (git/mercurial/etc..) - untested.

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -11,23 +11,23 @@ cfscrape==1.7.1  # rq.filter: <1.8.0
 chardet==3.0.4
 configobj==4.6.0
 decorator==4.0.10
-# dogpile.cache==229615be466d00c9c135a90d8965679ab3e4edaa  # Ref: https://bitbucket.org/zzzeek/dogpile.cache/src/229615be466d00c9c135a90d8965679ab3e4edaa/dogpile/
+# git+https://bitbucket.org/zzzeek/dogpile.cache.git@229615be466d00c9c135a90d8965679ab3e4edaa#egg=dogpile.cache
 dogpile.core==0.4.1
 enum34==1.0.4
-# enzyme==9572bea606a6145dad153cd712653d6cf10ef18e
+# git+https://github.com/Diaoul/enzyme.git@9572bea606a6145dad153cd712653d6cf10ef18e#egg=enzyme
 fake-useragent==0.1.2  # [NOTE] there's a `ua.json` file that's used by sickbeard.common, should be moved to a better location.
 git+https://github.com/kurtmckee/feedparser.git@f1dd1bb923ebfe6482fc2521c1f150b4032289ec#egg=feedparser
-# futures==43bfc41626208d78f4db1839e2808772defdfdca
-# guessit==a4fb2865d4b697397aa976388bbd0edf558a24fb
-# hachoir_core==708fdf64a982ba2e638aa59d94f143112066b8ce  # On Bitbucket
-# hachoir_metadata==708fdf64a982ba2e638aa59d94f143112066b8ce  # On Bitbucket
-# hachoir_parser==708fdf64a982ba2e638aa59d94f143112066b8ce  # On Bitbucket
+# git+https://github.com/agronholm/pythonfutures.git@43bfc41626208d78f4db1839e2808772defdfdca#egg=futures
+# git+https://github.com/guessit-io/guessit.git@a4fb2865d4b697397aa976388bbd0edf558a24fb#egg=guessit
+# hg+https://bitbucket.org/haypo/hachoir@708fdf64a982ba2e638aa59d94f143112066b8ce#egg=hachoir-core&subdirectory=hachoir-core
+# hg+https://bitbucket.org/haypo/hachoir@708fdf64a982ba2e638aa59d94f143112066b8ce#egg=hachoir-metadata&subdirectory=hachoir-metadata
+# hg+https://bitbucket.org/haypo/hachoir@708fdf64a982ba2e638aa59d94f143112066b8ce#egg=hachoir-parser&subdirectory=hachoir-parser
 html5lib==0.999999999
 httplib2==0.9.2  # + tests folder from cf631a73e2f3f43897b65206127ced82382d35f5
 idna==2.5
 # IMDbPY==5.1.1 --no-deps --global-option="--without-sqlobject" --global-option="--without-sqlalchemy"  # doesn't work because --no-deps isn't supported in reqs file context
-# js2py==05e77f0d4ffe91ef418a93860e666962cfd193b8
-# jsonrpclib==e3a3cdedc9577b25b91274815b38ba7f3bc43c68
+# git+https://github.com/PiotrDabkowski/Js2Py.git@05e77f0d4ffe91ef418a93860e666962cfd193b8#egg=js2py
+# git+https://github.com/joshmarshall/jsonrpclib.git@e3a3cdedc9577b25b91274815b38ba7f3bc43c68#egg=jsonrpclib
 # libgrowl  # <Custom: by Sick-Beard's midgetspy. Some of the code is from https://github.com/kfdm/gntp>
 # libtrakt  # <Custom> Just a small note - https://github.com/fuzeman/trakt.py is a great implementation of Trakt.tv's API, if needed
 lockfile==0.11.0
@@ -46,28 +46,28 @@ PyJWT==1.5.0
 pymediainfo==2.0  # as an .egg file, loaded by pkg_resources
 pynma==1.0
 PySocks==1.6.7
-# pysrt==47aaa592c3bc185cd2bc1d58d1451bf98be3c1ef
+# git+https://github.com/byroot/pysrt.git@47aaa592c3bc185cd2bc1d58d1451bf98be3c1ef#egg=pysrt
 python-dateutil==2.6.0
 #! python-fanart==1.4.0  # <Modified: API url was updated. No newer version>
 python-twitter==3.3
 pytz==2016.4  # as an .egg file, loaded by pkg_resources
-#! rarfile==3e54b222c8703eea64cd07102df7bb9408b582b3  # v3.0 Github release <Modified: See https://github.com/SickRage/SickRage/commit/059dd933b9da3a0f83c6cbb4f47c198e5a957fc6#diff-c1f4e968aa545d42d2e462672169da4a>
-# rebulk==42d0a58af9d793334616a6582f2a83b0fae0dd5f
+#! git+https://github.com/markokr/rarfile.git@3e54b222c8703eea64cd07102df7bb9408b582b3#egg=rarfile  # v3.0 Github release <Modified: See https://github.com/SickRage/SickRage/commit/059dd933b9da3a0f83c6cbb4f47c198e5a957fc6#diff-c1f4e968aa545d42d2e462672169da4a>
+# git+https://github.com/Toilal/rebulk.git@42d0a58af9d793334616a6582f2a83b0fae0dd5f#egg=rebulk
 requests==2.18.1
 requests-oauthlib==0.8.0
 #! rtorrent-python==0.2.9  # <Modified: See https://github.com/SickRage/SickRage/commits/master/lib/rtorrent>
 #! send2trash==1.3.0  # <Modified: See https://github.com/SickRage/SickRage/commit/9ad811432ab0ca3292410d29464ce2532361eb55>
 singledispatch==3.4.0.3
 six==1.10.0
-# sqlalchemy==ccc0c44c3a60fc4906e5e3b26cc6d2b7a69d33bf
+# git+https://github.com/zzzeek/sqlalchemy.git@ccc0c44c3a60fc4906e5e3b26cc6d2b7a69d33bf#egg=sqlalchemy
 stevedore==1.10.0
-# subliminal==7eb7a53fe6bcaf3e01a6b44c8366faf7c96f7f1b  # <Modified: Subscenter provider disabled until fixed upstream, https://github.com/SickRage/SickRage/pull/3825/files#diff-ab7eb9ba0a2d4c74c16795ff40f2bd62>
+#! git+https://github.com/Diaoul/subliminal.git@7eb7a53fe6bcaf3e01a6b44c8366faf7c96f7f1b#egg=subliminal  # <Modified: Subscenter provider disabled until fixed upstream, https://github.com/SickRage/SickRage/pull/3825/files#diff-ab7eb9ba0a2d4c74c16795ff40f2bd62>
 # synchronous-deluge  # <Custom: by Christian Dale>
 tmdbsimple==0.3.0  # [NOTE] Package naming is modified.
 tornado==4.5.1  # [NOTE] Contains a `routes.py` file, which is not a part of the original package
 tus.py==1.2.0
 #! tvdb_api==1.9  # <Heavily Modified> Deprecated API, will be disabled by October 1st, 2017
-# twilio==f91e1a9e6f4e0a60589b2b90cb66b89b879b9c3e
+# git+https://github.com/twilio/twilio-python.git@f91e1a9e6f4e0a60589b2b90cb66b89b879b9c3e#egg=twilio
 tzlocal==1.4
 Unidecode==0.04.20
 urllib3==1.21.1

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -36,7 +36,7 @@ markdown2==2.3.4
 MarkupSafe==1.0
 ndg-httpsclient==0.3.3
 oauthlib==2.0.2
-# pgi==0.0.11.1  # Can't verify, unable to install this using pip. Only being used by sickbeard.notifiers.libnotify as far as I can tell.
+git+https://github.com/pygobject/pgi.git@38f834902247a5851cb4c72ba018f160ae26d612#egg=pgi; platform_system!="Windows"
 #! pkg_resources.py  # Copied from setuptools and looks to be modified. Maybe we don't really need this? Used to load the egg files for pymediainfo and pytz.
 profilehooks==1.5
 putio.py==6.1.0

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,5 +1,5 @@
 #! adba==???  # <Modified + not on PYPI - https://github.com/lad1337/adba>
-# babelfish==0.5.5-dev  # we can use 0.5.5. The diff is that -dev includes get_files.py which isn't needed and doesn't even work anymore
+babelfish==0.5.5
 backports_abc==0.5
 backports.ssl-match-hostname==3.5.0.1
 beautifulsoup4==4.5.3
@@ -7,7 +7,7 @@ bencode==1.0  # Made vanilla with https://github.com/SickRage/SickRage/commit/8c
 cachecontrol==0.11.5
 # certgen.py==d52975cef3a36e18552aeb23de7c06aa73d76454  # Source: https://github.com/pyca/pyopenssl/blob/master/examples/certgen.py
 certifi==2017.4.17
-cfscrape==1.7.1
+cfscrape==1.7.1  # rq.filter: <1.8.0
 chardet==3.0.4
 configobj==4.6.0
 decorator==4.0.10
@@ -16,7 +16,7 @@ dogpile.core==0.4.1
 enum34==1.0.4
 # enzyme==9572bea606a6145dad153cd712653d6cf10ef18e
 fake-useragent==0.1.2  # [NOTE] there's a `ua.json` file that's used by sickbeard.common, should be moved to a better location.
-#! feedparser==f1dd1bb923ebfe6482fc2521c1f150b4032289ec  # <Modified: See https://github.com/SickRage/SickRage/pull/2957/commits/04fc020d315acd4e947a30a5b7653c507b91b5ac>
+git+https://github.com/kurtmckee/feedparser.git@f1dd1bb923ebfe6482fc2521c1f150b4032289ec#egg=feedparser
 # futures==43bfc41626208d78f4db1839e2808772defdfdca
 # guessit==a4fb2865d4b697397aa976388bbd0edf558a24fb
 # hachoir_core==708fdf64a982ba2e638aa59d94f143112066b8ce  # On Bitbucket
@@ -25,14 +25,14 @@ fake-useragent==0.1.2  # [NOTE] there's a `ua.json` file that's used by sickbear
 html5lib==0.999999999
 httplib2==0.9.2  # + tests folder from cf631a73e2f3f43897b65206127ced82382d35f5
 idna==2.5
-#! imdbpy==aa68c6c919eae91bbd5cebc49866a78ce67dc9ea  # <Modified: Only comments... See https://github.com/SickRage/SickRage/pull/3697>
+# IMDbPY==5.1.1 --no-deps --global-option="--without-sqlobject" --global-option="--without-sqlalchemy"  # doesn't work because --no-deps isn't supported in reqs file context
 # js2py==05e77f0d4ffe91ef418a93860e666962cfd193b8
 # jsonrpclib==e3a3cdedc9577b25b91274815b38ba7f3bc43c68
 # libgrowl  # <Custom: by Sick-Beard's midgetspy. Some of the code is from https://github.com/kfdm/gntp>
 # libtrakt  # <Custom> Just a small note - https://github.com/fuzeman/trakt.py is a great implementation of Trakt.tv's API, if needed
 lockfile==0.11.0
 Mako==1.0.6
-# markdown2==596d48b4279259561ca96329538c65de4c00edde
+markdown2==2.3.4
 MarkupSafe==1.0
 ndg-httpsclient==0.3.3
 oauthlib==2.0.2
@@ -41,11 +41,13 @@ oauthlib==2.0.2
 profilehooks==1.5
 putio.py==6.1.0
 pyasn1==0.1.7  # + LICENSE
-#! PyGithub==5ad69189ea527334a4501b73b6641a7757519e34  # <Modified: See https://github.com/SickRage/SickRage/pull/3185/files#diff-b83eae1ebdf7d9aac4aedd1568ca6c8a>
+PyGithub==1.34
+PyJWT==1.5.0
 pymediainfo==2.0  # as an .egg file, loaded by pkg_resources
 pynma==1.0
+PySocks==1.6.7
 # pysrt==47aaa592c3bc185cd2bc1d58d1451bf98be3c1ef
-# python-dateutil==d05b837d2b6ce2be8e6901ec2ccc4966cf0aae08
+python-dateutil==2.6.0
 #! python-fanart==1.4.0  # <Modified: API url was updated. No newer version>
 python-twitter==3.3
 pytz==2016.4  # as an .egg file, loaded by pkg_resources
@@ -55,10 +57,8 @@ requests==2.18.1
 requests-oauthlib==0.8.0
 #! rtorrent-python==0.2.9  # <Modified: See https://github.com/SickRage/SickRage/commits/master/lib/rtorrent>
 #! send2trash==1.3.0  # <Modified: See https://github.com/SickRage/SickRage/commit/9ad811432ab0ca3292410d29464ce2532361eb55>
-simplejson==2.0.9
 singledispatch==3.4.0.3
 six==1.10.0
-# SocksiPy=1.00  # (1) Not sure if it's even being used. (2) Unmaintained, and not on PyPI - https://sourceforge.net/projects/socksipy/files/socksipy/SocksiPy%201.00 (3) If it's still needed, there's httplib2.socks, requests[socks] and a new fork of the SF project @ https://github.com/Anorov/PySocks
 # sqlalchemy==ccc0c44c3a60fc4906e5e3b26cc6d2b7a69d33bf
 stevedore==1.10.0
 # subliminal==7eb7a53fe6bcaf3e01a6b44c8366faf7c96f7f1b  # <Modified: Subscenter provider disabled until fixed upstream, https://github.com/SickRage/SickRage/pull/3825/files#diff-ab7eb9ba0a2d4c74c16795ff40f2bd62>
@@ -68,9 +68,10 @@ tornado==4.5.1  # [NOTE] Contains a `routes.py` file, which is not a part of the
 tus.py==1.2.0
 #! tvdb_api==1.9  # <Heavily Modified> Deprecated API, will be disabled by October 1st, 2017
 # twilio==f91e1a9e6f4e0a60589b2b90cb66b89b879b9c3e
-# tzlocal==8e0a63ddbf50ff9e5b1d23b540cdc343efe1a4af
-unidecode==0.04.12
+tzlocal==1.4
+Unidecode==0.04.20
 urllib3==1.21.1
 validators==0.10
 webencodings==0.5.1
-# xmltodict==579a00520315e30681e0f0f81de645ce5680ed47
+win-inet-pton==1.0.1  # Required on Windows systems
+xmltodict==0.11.0

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -22,7 +22,7 @@ git+https://github.com/guessit-io/guessit.git@a4fb2865d4b697397aa976388bbd0edf55
 hg+https://bitbucket.org/haypo/hachoir@708fdf64a982ba2e638aa59d94f143112066b8ce#egg=hachoir-core&subdirectory=hachoir-core
 # hg+https://bitbucket.org/haypo/hachoir@708fdf64a982ba2e638aa59d94f143112066b8ce#egg=hachoir-metadata&subdirectory=hachoir-metadata  # Unable to install
 # hg+https://bitbucket.org/haypo/hachoir@708fdf64a982ba2e638aa59d94f143112066b8ce#egg=hachoir-parser&subdirectory=hachoir-parser  # Unable to install
-html5lib==0.999999999
+html5lib==1.0b10
 httplib2==0.9.2  # + tests folder from cf631a73e2f3f43897b65206127ced82382d35f5
 idna==2.5
 # IMDbPY==5.1.1 --no-deps --global-option="--without-sqlobject" --global-option="--without-sqlalchemy"  # doesn't work because --no-deps isn't supported in reqs file context

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -11,23 +11,23 @@ cfscrape==1.7.1  # rq.filter: <1.8.0
 chardet==3.0.4
 configobj==4.6.0
 decorator==4.0.10
-# git+https://bitbucket.org/zzzeek/dogpile.cache.git@229615be466d00c9c135a90d8965679ab3e4edaa#egg=dogpile.cache
+git+https://bitbucket.org/zzzeek/dogpile.cache.git@229615be466d00c9c135a90d8965679ab3e4edaa#egg=dogpile.cache
 dogpile.core==0.4.1
 enum34==1.0.4
-# git+https://github.com/Diaoul/enzyme.git@9572bea606a6145dad153cd712653d6cf10ef18e#egg=enzyme
+git+https://github.com/Diaoul/enzyme.git@9572bea606a6145dad153cd712653d6cf10ef18e#egg=enzyme
 fake-useragent==0.1.2  # [NOTE] there's a `ua.json` file that's used by sickbeard.common, should be moved to a better location.
 git+https://github.com/kurtmckee/feedparser.git@f1dd1bb923ebfe6482fc2521c1f150b4032289ec#egg=feedparser
-# git+https://github.com/agronholm/pythonfutures.git@43bfc41626208d78f4db1839e2808772defdfdca#egg=futures
-# git+https://github.com/guessit-io/guessit.git@a4fb2865d4b697397aa976388bbd0edf558a24fb#egg=guessit
-# hg+https://bitbucket.org/haypo/hachoir@708fdf64a982ba2e638aa59d94f143112066b8ce#egg=hachoir-core&subdirectory=hachoir-core
-# hg+https://bitbucket.org/haypo/hachoir@708fdf64a982ba2e638aa59d94f143112066b8ce#egg=hachoir-metadata&subdirectory=hachoir-metadata
-# hg+https://bitbucket.org/haypo/hachoir@708fdf64a982ba2e638aa59d94f143112066b8ce#egg=hachoir-parser&subdirectory=hachoir-parser
+git+https://github.com/agronholm/pythonfutures.git@43bfc41626208d78f4db1839e2808772defdfdca#egg=futures
+git+https://github.com/guessit-io/guessit.git@a4fb2865d4b697397aa976388bbd0edf558a24fb#egg=guessit
+hg+https://bitbucket.org/haypo/hachoir@708fdf64a982ba2e638aa59d94f143112066b8ce#egg=hachoir-core&subdirectory=hachoir-core
+# hg+https://bitbucket.org/haypo/hachoir@708fdf64a982ba2e638aa59d94f143112066b8ce#egg=hachoir-metadata&subdirectory=hachoir-metadata  # Unable to install
+# hg+https://bitbucket.org/haypo/hachoir@708fdf64a982ba2e638aa59d94f143112066b8ce#egg=hachoir-parser&subdirectory=hachoir-parser  # Unable to install
 html5lib==0.999999999
 httplib2==0.9.2  # + tests folder from cf631a73e2f3f43897b65206127ced82382d35f5
 idna==2.5
 # IMDbPY==5.1.1 --no-deps --global-option="--without-sqlobject" --global-option="--without-sqlalchemy"  # doesn't work because --no-deps isn't supported in reqs file context
-# git+https://github.com/PiotrDabkowski/Js2Py.git@05e77f0d4ffe91ef418a93860e666962cfd193b8#egg=js2py
-# git+https://github.com/joshmarshall/jsonrpclib.git@e3a3cdedc9577b25b91274815b38ba7f3bc43c68#egg=jsonrpclib
+git+https://github.com/PiotrDabkowski/Js2Py.git@05e77f0d4ffe91ef418a93860e666962cfd193b8#egg=js2py
+git+https://github.com/joshmarshall/jsonrpclib.git@e3a3cdedc9577b25b91274815b38ba7f3bc43c68#egg=jsonrpclib
 # libgrowl  # <Custom: by Sick-Beard's midgetspy. Some of the code is from https://github.com/kfdm/gntp>
 # libtrakt  # <Custom> Just a small note - https://github.com/fuzeman/trakt.py is a great implementation of Trakt.tv's API, if needed
 lockfile==0.11.0
@@ -46,20 +46,20 @@ PyJWT==1.5.0
 pymediainfo==2.0  # as an .egg file, loaded by pkg_resources
 pynma==1.0
 PySocks==1.6.7
-# git+https://github.com/byroot/pysrt.git@47aaa592c3bc185cd2bc1d58d1451bf98be3c1ef#egg=pysrt
+git+https://github.com/byroot/pysrt.git@47aaa592c3bc185cd2bc1d58d1451bf98be3c1ef#egg=pysrt
 python-dateutil==2.6.0
 #! python-fanart==1.4.0  # <Modified: API url was updated. No newer version>
 python-twitter==3.3
 pytz==2016.4  # as an .egg file, loaded by pkg_resources
 #! git+https://github.com/markokr/rarfile.git@3e54b222c8703eea64cd07102df7bb9408b582b3#egg=rarfile  # v3.0 Github release <Modified: See https://github.com/SickRage/SickRage/commit/059dd933b9da3a0f83c6cbb4f47c198e5a957fc6#diff-c1f4e968aa545d42d2e462672169da4a>
-# git+https://github.com/Toilal/rebulk.git@42d0a58af9d793334616a6582f2a83b0fae0dd5f#egg=rebulk
+git+https://github.com/Toilal/rebulk.git@42d0a58af9d793334616a6582f2a83b0fae0dd5f#egg=rebulk
 requests==2.18.1
 requests-oauthlib==0.8.0
 #! rtorrent-python==0.2.9  # <Modified: See https://github.com/SickRage/SickRage/commits/master/lib/rtorrent>
 #! send2trash==1.3.0  # <Modified: See https://github.com/SickRage/SickRage/commit/9ad811432ab0ca3292410d29464ce2532361eb55>
 singledispatch==3.4.0.3
 six==1.10.0
-# git+https://github.com/zzzeek/sqlalchemy.git@ccc0c44c3a60fc4906e5e3b26cc6d2b7a69d33bf#egg=sqlalchemy
+git+https://github.com/zzzeek/sqlalchemy.git@ccc0c44c3a60fc4906e5e3b26cc6d2b7a69d33bf#egg=sqlalchemy
 stevedore==1.10.0
 #! git+https://github.com/Diaoul/subliminal.git@7eb7a53fe6bcaf3e01a6b44c8366faf7c96f7f1b#egg=subliminal  # <Modified: Subscenter provider disabled until fixed upstream, https://github.com/SickRage/SickRage/pull/3825/files#diff-ab7eb9ba0a2d4c74c16795ff40f2bd62>
 # synchronous-deluge  # <Custom: by Christian Dale>
@@ -67,7 +67,7 @@ tmdbsimple==0.3.0  # [NOTE] Package naming is modified.
 tornado==4.5.1  # [NOTE] Contains a `routes.py` file, which is not a part of the original package
 tus.py==1.2.0
 #! tvdb_api==1.9  # <Heavily Modified> Deprecated API, will be disabled by October 1st, 2017
-# git+https://github.com/twilio/twilio-python.git@f91e1a9e6f4e0a60589b2b90cb66b89b879b9c3e#egg=twilio
+git+https://github.com/twilio/twilio-python.git@f91e1a9e6f4e0a60589b2b90cb66b89b879b9c3e#egg=twilio
 tzlocal==1.4
 Unidecode==0.04.20
 urllib3==1.21.1


### PR DESCRIPTION
**TL;DR** This doesn't affect any actual code. Safe to merge.

- Update the list to account for the changes made in #3877 
- Specify VCS sources for packages that are on a specific commit, and
- Enable VCS sources for some packages (mostly the unmodified ones)
- Pin `cfscrape` to <1.8.0 so it doesn't say "outdated" on requires.io
- Change `html5lib` version to 1.0b10 (new version style)
- Change `pgi` version to the actual commit hash


VCS sources won't work with setuptools (`setup.py`) in the current configuration,
but [there might be a possible solution](https://stackoverflow.com/a/18563923/7597273).
