### PR TITLE
Filter commits in grunt/exec/git_list_changes task

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -299,7 +299,7 @@ module.exports = function(grunt) {
                 }
             },
             'git_list_changes': {
-                cmd: function() { return 'git log --oneline --pretty=format:%s ' + grunt.config('last_tag') + '..HEAD'; },
+                cmd: function() { return 'git log --oneline --first-parent --pretty=format:%s ' + grunt.config('last_tag') + '..HEAD'; },
                 stdout: false,
                 callback: function(err, stdout) {
                     var commits = stdout.trim()


### PR DESCRIPTION
@miigotu 
This will fix the automated changes list generator for the publish task.
It will ignore the commits merged by **merge-commits**, but it will keep the actual merge commits.
## For example, the next version:
Unwanted commits marked with `-`, merge commits marked with `+`
[[Comparison on Github](https://github.com/SickRage/SickRage/compare/v2017.06.05-1...b5ae6efbe48c8150b4120b6ba4881024c049d6a3), but it's easier to see with a graphical git client..]
```diff
Fix qBittorrent (#3836)
Try and fix multiple desktop notifications (#3837)

[... skipping ...]

Re-apply isort (#3908)
Swap jshint with xo (+2 more small fixes) (#3916)
- fix base linting issues with core.js
- fix more core.js linting issues
- fix even more core.js linting issues
- CI: Stop if any of the tests fail
- CI: Try and fix AppVeyor
Switched to use sickbeard's TMDB API key. (#3920)
- Merge branch 'develop' into lint_corejs
- finish core.js linting
- Try out harmony branch for grunt-contrib-uglify
- CI: Fixes
- Review
- More lint
- Simplify filter_functions in shows list tablesorter
- Uglify using new plugin (need to do vender.min.js too)
- Uglify bower (maybe move this to a separate PR)
Docker support (#3901)
- switch click and change to on
- change $(this) to $(event.currentTarget)
- switch e to event, switch prop checked to native checked
- switch click and change to on (not core.js)
- More e to event
- Merge branch 'develop' into lint_corejs
- Update minified core
+ Merge pull request #3919 from SickRage/lint_corejs
- Merge branch 'develop' into lint_js-click-to-on
+ Merge pull request #3922 from SickRage/lint_js-click-to-on
- lint formwizard
- lint bookmarkscroll
- lint scrolltopcontrol
- Remove bower install from AppVeyor
core.js: Switch .checked on jQuery elements to .is('checked') (#3926)
- Fixes for formwizard.js
- Merge branch 'develop' into lint-js_libs
+ Merge pull request #3923 from SickRage/lint-js_libs
```
