### PR TITLE
Update tox `py27-flake8` test-env

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -69,7 +69,7 @@ install:
 test_script:
   - xo
   - ps: if ($LastExitCode -ne 0) { $host.SetShouldExit($LastExitCode) } # Stop if the previous test failed
-  - tox -v --recreate
+  - tox -v --recreate -e "py27-windows"
 
 before_test:
   - echo Starting Tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ install:
   - pip install --upgrade babel mako crowdin-cli-py
 
 script:
-  - xo && tox -v --recreate
+  - xo && tox -v --recreate -e "py27-{flake8,linux}"
 
 cache:
   directories:

--- a/tox.ini
+++ b/tox.ini
@@ -41,9 +41,7 @@ commands =
     - codecov -e APPVEYOR_REPO_BRANCH PYTHON_ARCH
 
 [testenv:py27-flake8]
-platform = linux
 envdir = {toxworkdir}/flake8
-passenv = CI TRAVIS TRAVIS_*
 setenv = PATH = {toxinidir}/lib;{env:PATH:}
 deps =
     flake8-coding


### PR DESCRIPTION
Update tox so the `py27-flake8` test-env can be used on all platforms.
Update CI configurations accordingly.

It seems BinSearch just pulled their RSS support.
https://www.binsearch.info/rss.php?max=50&g=alt.binaries.hdtv
> RSS feeds no longer available. Sorry, but we got tired of badly written clients DoS'ing our service