### PR TITLE
Show information in poster view in seperate DIV

### DIFF
--- a/gui/slick/views/inc_home_showList.mako
+++ b/gui/slick/views/inc_home_showList.mako
@@ -23,6 +23,7 @@
                     <div class="show-image">
                         <img alt="" title="${loading_show.name}" class="show-image" style="border-bottom: 1px solid #111;" src="" data-src="${srRoot}/showPoster/?show=${loading_show.id | u}&amp;which=poster_thumb" />
                     </div>
+                    <div class="show-information">
                     <div class="progressbar hidden-print" style="position:relative;" data-show-id="${loading_show.id | u}" data-progress-percentage="0"></div>
                     <div class="show-title">${_('Loading')} (${loading_show.name})</div>
                     <div class="show-date">&nbsp;</div>
@@ -40,6 +41,7 @@
                                 </td>
                             </tr>
                         </table>
+                    </div>
                     </div>
                 </div>
             % endfor
@@ -103,6 +105,7 @@
                         <a href="${srRoot}/home/displayShow?show=${curShow.indexerid}"><img alt="" class="show-image" src="" data-src="${srRoot}/showPoster/?show=${curShow.indexerid}&amp;which=poster_thumb" /></a>
                     </div>
 
+                    <div class="show-information">
                     <div class="progressbar hidden-print" style="position:relative;" data-show-id="${curShow.indexerid}" data-progress-percentage="${progressbar_percent}"></div>
 
                     <div class="show-title">
@@ -153,6 +156,7 @@
                                 </td>
                             </tr>
                         </table>
+                    </div>
                     </div>
                 </div>
             % endfor


### PR DESCRIPTION
Added a new DIV to hold the show information.
This way custom CSS is more dynamic. And if original CSS is used, there is no harm.

See screenshots for goal...

![screenshot_4](https://user-images.githubusercontent.com/3872395/29836447-95c3f86a-8cf5-11e7-8b2c-7e61133cfcf7.png)
![screenshot_5](https://user-images.githubusercontent.com/3872395/29836448-95c563a8-8cf5-11e7-99a9-0d834a2aae4a.png)

