### PR TITLE
Feature 577, Flag to hide or display series with no defined episodes

### DIFF
--- a/gui/slick/views/inc_home_menu.mako
+++ b/gui/slick/views/inc_home_menu.mako
@@ -61,6 +61,11 @@
                     <span class="show-option">${_('Poster Size')}:</span>
                     <div style="width: 100px; display: inline-block; margin-left: 7px;" id="posterSizeSlider"></div>
                 </label>
+            % else:
+                <label>
+                    <span class="show-option">Unaired: </span>
+                    <input type="checkbox" name="display_unaired" id="display_unaired" ${('', 'checked="checked"')[bool(sickbeard.DISPLAY_UNAIRED)]} onclick="location.href='${srRoot}/toggleUnaired/'"/>
+                </label>
             % endif
         </div>
     </div>

--- a/gui/slick/views/inc_home_showList.mako
+++ b/gui/slick/views/inc_home_showList.mako
@@ -275,6 +275,10 @@
 
                             show_size = show_stat[curShow.indexerid]['show_size']
 
+                        if (not cur_total) or (cur_total == 0):
+                            if sickbeard.DISPLAY_UNAIRED is False:
+                                continue
+
                         download_stat = str(cur_downloaded)
                         download_stat_tip = _('Downloaded') + ": " + str(cur_downloaded)
 

--- a/sickbeard/__init__.py
+++ b/sickbeard/__init__.py
@@ -214,6 +214,7 @@ SORT_ARTICLE = False
 DEBUG = False
 DBDEBUG = False
 DISPLAY_ALL_SEASONS = True
+DISPLAY_UNAIRED = True
 DEFAULT_PAGE = 'home'
 
 
@@ -708,7 +709,7 @@ def initialize(consoleLogging=True):  # pylint: disable=too-many-locals, too-man
             AUTOPOSTPROCESSOR_FREQUENCY, SHOWUPDATE_HOUR, \
             ANIME_DEFAULT, NAMING_ANIME, ANIMESUPPORT, USE_ANIDB, ANIDB_USERNAME, ANIDB_PASSWORD, ANIDB_USE_MYLIST, \
             ANIME_SPLIT_HOME, ANIME_SPLIT_HOME_IN_TABS, SCENE_DEFAULT, DOWNLOAD_URL, BACKLOG_DAYS, GIT_AUTH_TYPE, GIT_USERNAME, GIT_PASSWORD, GIT_TOKEN, \
-            DEVELOPER, DISPLAY_ALL_SEASONS, SSL_VERIFY, NEWS_LAST_READ, NEWS_LATEST, SOCKET_TIMEOUT, \
+            DEVELOPER, DISPLAY_ALL_SEASONS, DISPLAY_UNAIRED, SSL_VERIFY, NEWS_LAST_READ, NEWS_LATEST, SOCKET_TIMEOUT, \
             SYNOLOGY_DSM_HOST, SYNOLOGY_DSM_USERNAME, SYNOLOGY_DSM_PASSWORD, SYNOLOGY_DSM_PATH, GUI_LANG, SICKRAGE_BACKGROUND, SICKRAGE_BACKGROUND_PATH, \
             FANART_BACKGROUND, FANART_BACKGROUND_OPACITY, CUSTOM_CSS, CUSTOM_CSS_PATH, USE_SLACK, SLACK_NOTIFY_SNATCH, SLACK_NOTIFY_DOWNLOAD, SLACK_WEBHOOK, \
             USE_DISCORD, DISCORD_NOTIFY_SNATCH, DISCORD_NOTIFY_DOWNLOAD, DISCORD_WEBHOOK
@@ -1379,6 +1380,7 @@ def initialize(consoleLogging=True):  # pylint: disable=too-many-locals, too-man
         POSTER_SORTBY = check_setting_str(CFG, 'GUI', 'poster_sortby', 'name')
         POSTER_SORTDIR = check_setting_int(CFG, 'GUI', 'poster_sortdir', 1, min_val=0, max_val=1)
         DISPLAY_ALL_SEASONS = check_setting_bool(CFG, 'General', 'display_all_seasons', True)
+        DISPLAY_UNAIRED = check_setting_bool(CFG, 'General', 'display_unaired', True)
 
         if check_section(CFG, 'Shares'):
             WINDOWS_SHARES.update(CFG['Shares'])
@@ -2000,6 +2002,7 @@ def save_config():  # pylint: disable=too-many-statements, too-many-branches
             'no_restart': int(NO_RESTART),
             'developer': int(DEVELOPER),
             'display_all_seasons': int(DISPLAY_ALL_SEASONS),
+            'display_unaired': int(DISPLAY_UNAIRED),
             'news_last_read': NEWS_LAST_READ,
         },
 

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -417,6 +417,10 @@ class WebRoot(WebHandler):
         # Don't redirect to default page so user can see new layout
         return self.redirect("/home/")
 
+    def toggleUnaired(self):
+        sickbeard.DISPLAY_UNAIRED = not sickbeard.DISPLAY_UNAIRED
+        return self.redirect("/home/")
+
     @staticmethod
     def setPosterSortBy(sort):
 
@@ -3977,7 +3981,7 @@ class ConfigGeneral(Config):
             indexer_timeout=None, download_url=None, rootDir=None, theme_name=None, default_page=None, fanart_background=None, fanart_background_opacity=None,
             sickrage_background=None, sickrage_background_path=None, custom_css=None, custom_css_path=None,
             git_reset=None, git_auth_type=0, git_username=None, git_password=None, git_token=None,
-            display_all_seasons=None, gui_language=None, ignore_broken_symlinks=None):
+            display_all_seasons=None, display_unaired=None, gui_language=None, ignore_broken_symlinks=None):
 
         results = []
 
@@ -4042,6 +4046,7 @@ class ConfigGeneral(Config):
         sickbeard.COMING_EPS_MISSED_RANGE = config.min_max(coming_eps_missed_range, 7, 0, 42810)
 
         sickbeard.DISPLAY_ALL_SEASONS = config.checkbox_to_value(display_all_seasons)
+        sickbeard.DISPLAY_UNAIRED = config.checkbox_to_value(display_unaired)
         sickbeard.NOTIFY_ON_LOGIN = config.checkbox_to_value(notify_on_login)
         sickbeard.WEB_PORT = try_int(web_port)
         sickbeard.WEB_IPV6 = config.checkbox_to_value(web_ipv6)


### PR DESCRIPTION
Feature #577
Fixes nothing

Proposed changes in this pull request:
- Add flag whether to display or hide series with no defined episodes (i.e. Unaired)
- Add GUI element on Show List page to toggle flag on and off

NOTE:  I am new to git and github.  I believe I've followed steps properly, as you've described them, but please confirm.  Contact me through feature 577 on feathub at https://feathub.com/SickRage/SickRage/+577 or just go ahead and add it to SickRage...thanks.

- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read [contribution guide](https://github.com/SickRage/SickRage/blob/master/.github/CONTRIBUTING.md)
