### PR TITLE
Handle magnet links in SkyTorrents RSS

### DIFF
--- a/COPYING.txt
+++ b/COPYING.txt
@@ -632,6 +632,7 @@ state the exclusion of warranty; and each file should have at least
 the "copyright" line and a pointer to where the full notice is found.
 
     The ultimate PVR application that downloads and manages your TV shows
+    Copyright (C) 2010 - Nic Wolfe
     Copyright (C) 2015 - Dustyn Gibson
 
     This program is free software: you can redistribute it and/or modify
@@ -652,6 +653,7 @@ Also add information on how to contact you by electronic and paper mail.
   If the program does terminal interaction, make it output a short
 notice like this when it starts in an interactive mode:
 
+    Sick Beard - Copyright (C) 2010 - Nic Wolfe
     SickRage -  Copyright (C) 2015 - Dustyn Gibson
     This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
     This is free software, and you are welcome to redistribute it

--- a/SickBeard.py
+++ b/SickBeard.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python2.7
 # -*- coding: utf-8 -*
-# Author: miigotu <miigotu@gmail.com>
+# Author: Nic Wolfe <nic@wolfeden.ca>
+# URL: http://code.google.com/p/sickbeard/
+#
+# Rewrite Author: miigotu <miigotu@gmail.com>
 # URL: https://sickrage.github.io
 #
 # This file is part of SickRage.

--- a/gui/slick/views/inc_home_showList.mako
+++ b/gui/slick/views/inc_home_showList.mako
@@ -23,6 +23,7 @@
                     <div class="show-image">
                         <img alt="" title="${loading_show.name}" class="show-image" style="border-bottom: 1px solid #111;" src="" data-src="${srRoot}/showPoster/?show=${loading_show.id | u}&amp;which=poster_thumb" />
                     </div>
+                    <div class="show-information">
                     <div class="progressbar hidden-print" style="position:relative;" data-show-id="${loading_show.id | u}" data-progress-percentage="0"></div>
                     <div class="show-title">${_('Loading')} (${loading_show.name})</div>
                     <div class="show-date">&nbsp;</div>
@@ -40,6 +41,7 @@
                                 </td>
                             </tr>
                         </table>
+                    </div>
                     </div>
                 </div>
             % endfor
@@ -103,6 +105,7 @@
                         <a href="${srRoot}/home/displayShow?show=${curShow.indexerid}"><img alt="" class="show-image" src="" data-src="${srRoot}/showPoster/?show=${curShow.indexerid}&amp;which=poster_thumb" /></a>
                     </div>
 
+                    <div class="show-information">
                     <div class="progressbar hidden-print" style="position:relative;" data-show-id="${curShow.indexerid}" data-progress-percentage="${progressbar_percent}"></div>
 
                     <div class="show-title">
@@ -153,6 +156,7 @@
                                 </td>
                             </tr>
                         </table>
+                    </div>
                     </div>
                 </div>
             % endfor

--- a/gui/slick/views/inc_home_showList.mako
+++ b/gui/slick/views/inc_home_showList.mako
@@ -23,7 +23,6 @@
                     <div class="show-image">
                         <img alt="" title="${loading_show.name}" class="show-image" style="border-bottom: 1px solid #111;" src="" data-src="${srRoot}/showPoster/?show=${loading_show.id | u}&amp;which=poster_thumb" />
                     </div>
-                    <div class="show-information">
                     <div class="progressbar hidden-print" style="position:relative;" data-show-id="${loading_show.id | u}" data-progress-percentage="0"></div>
                     <div class="show-title">${_('Loading')} (${loading_show.name})</div>
                     <div class="show-date">&nbsp;</div>
@@ -41,7 +40,6 @@
                                 </td>
                             </tr>
                         </table>
-                    </div>
                     </div>
                 </div>
             % endfor
@@ -105,7 +103,6 @@
                         <a href="${srRoot}/home/displayShow?show=${curShow.indexerid}"><img alt="" class="show-image" src="" data-src="${srRoot}/showPoster/?show=${curShow.indexerid}&amp;which=poster_thumb" /></a>
                     </div>
 
-                    <div class="show-information">
                     <div class="progressbar hidden-print" style="position:relative;" data-show-id="${curShow.indexerid}" data-progress-percentage="${progressbar_percent}"></div>
 
                     <div class="show-title">
@@ -156,7 +153,6 @@
                                 </td>
                             </tr>
                         </table>
-                    </div>
                     </div>
                 </div>
             % endfor

--- a/sickbeard/providers/skytorrents.py
+++ b/sickbeard/providers/skytorrents.py
@@ -114,7 +114,10 @@ class SkyTorrents(TorrentProvider):  # pylint: disable=too-many-instance-attribu
                                        'Title={title}'.format(cat=category, title=title), logger.ERROR)
 
                         size = convert_size(info.group('size')) or -1
-                        info_hash = download_url.rsplit('/', 2)[1]
+                        if download_url.startswith('magnet'):
+                            info_hash = download_url.split(':', 4)[3][:40]
+                        else:
+                            info_hash = download_url.rsplit('/', 2)[1]
 
                         item = {'title': title, 'link': download_url, 'size': size, 'seeders': seeders, 'leechers': leechers, 'hash': info_hash}
                         if mode != "RSS":


### PR DESCRIPTION
Fixes a recent error I got after activating SkyTorrents (which seems to have moved from http dowload_url to magnet link):
```
IndexError: list index out of range
info_hash = download_url.rsplit('/', 2)[1]
File "/home/deploy/SickRage/sickbeard/providers/skytorrents.py", line 117, in search
items_list += self.search(search_string, ep_obj=episode)
File "/home/deploy/SickRage/sickrage/providers/GenericProvider.py", line 154, in find_search_results
searchResults = curProvider.find_search_results(show, episodes, search_mode, manualSearch, downCurQuality)
File "/home/deploy/SickRage/sickbeard/search.py", line 480, in searchProviders
Traceback (most recent call last):
```
Proposed changes in this pull request:
- Handle magnet links in SkyTorrents RSS

- [X] PR is based on the DEVELOP branch
- [X] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [X] Read [contribution guide](https://github.com/SickRage/SickRage/blob/master/.github/CONTRIBUTING.md)
