### PR TITLE
Update subscenter domain to .info

### DIFF
--- a/sickrage/providers/subtitle/subscenter.py
+++ b/sickrage/providers/subtitle/subscenter.py
@@ -76,7 +76,7 @@ class SubsCenterSubtitle(Subtitle):
 class SubsCenterProvider(Provider):
     """SubsCenter Provider."""
     languages = {Language.fromalpha2(l) for l in ['he']}
-    server_url = 'http://www.subscenter.org/he/'
+    server_url = 'http://www.subscenter.info/he/'
 
     def __init__(self, username=None, password=None):
         if username is not None and password is None or username is None and password is not None:


### PR DESCRIPTION
Fixes subcenter subtitles provider
Provider domain was changed from '.org' to '.info'
