### PR TITLE
 Use correct 404 messaging for API access failures

### DIFF
--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -185,7 +185,7 @@ class BaseHandler(RequestHandler):
             if sickbeard.WEB_ROOT and self.request.uri.startswith(sickbeard.WEB_ROOT):
                 url = url[len(sickbeard.WEB_ROOT) + 1:]
 
-            if url[:3] != 'api':
+            if url[:4] != '/api':
                 t = PageTemplate(rh=self, filename="404.mako")
                 return self.finish(t.render(title='404', header=_('Oops')))
             else:


### PR DESCRIPTION
SickRage presents the generic 404 page for API accesses with the wrong key.

Fixes #

Proposed changes in this pull request:
- include leading / in API url check


- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read [contribution guide](https://github.com/SickRage/SickRage/blob/master/.github/CONTRIBUTING.md)
