### PR TITLE
Use HTTPS throughout the project

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -2,7 +2,7 @@ environment:
   global:
     # SDK v7.0 MSVC Express 2008's SetEnv.cmd script will fail if the
     # /E:ON and /V:ON options are not enabled in the batch script intepreter
-    # See: http://stackoverflow.com/a/13751649/163740
+    # See: https://stackoverflow.com/a/13751649/163740
     CMD_IN_ENV: "cmd /E:ON /V:ON /C .\\appveyor\\run_with_env.cmd"
 
   matrix:
@@ -43,7 +43,7 @@ install:
         Where-Object pullRequestId -eq $env:APPVEYOR_PULL_REQUEST_NUMBER)[0].buildNumber) { `
           throw "There are newer queued builds for this pull request, failing early." }
 
-  # Install Python (from the official .msi of http://python.org) and pip
+  # Install Python (from the official .msi of https://python.org) and pip
   - ps: if (-not(Test-Path($env:PYTHON))) { & appveyor\install.ps1 }
 
   # Prepend newly installed Python to the PATH of this build (this cannot be

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 ### Questions about SickRage?
 
-To get your questions answered, please ask on the [#sickrage-issues](http://webchat.freenode.net/?channels=sickrage-issues) IRC channel on irc.freenode.net
+To get your questions answered, please ask on the [#sickrage-issues](https://webchat.freenode.net/?channels=sickrage-issues) IRC channel on irc.freenode.net
 
 # Contributing to SickRage
 
@@ -19,7 +19,7 @@ The goal of this guide is to provide the best way to contribute to the official 
 
 If you think you've found a bug please [file it in the bug tracker](#how-to-report-bugs).
 
-Most of the SickRage development team can be found in the [#sickrage-issues](http://webchat.freenode.net/?channels=sickrage-issues) IRC channel on irc.freenode.net.
+Most of the SickRage development team can be found in the [#sickrage-issues](https://webchat.freenode.net/?channels=sickrage-issues) IRC channel on irc.freenode.net.
 
 
 ## How to Report Bugs
@@ -28,7 +28,7 @@ Most of the SickRage development team can be found in the [#sickrage-issues](htt
 
 Many bugs reported are actually issues with the user mis-understanding of how something works (there are a bit of moving parts to an ideal setup) and most of the time can be fixed by just changing some settings to fit the users needs.
 
-If you are new to SickRage, it is usually a much better idea to ask for help first in the [SickRage IRC channel](http://webchat.freenode.net/?channels=sickrage-issues). You will get much quicker support, and you will help avoid tying up the SickRage team with invalid bug reports.
+If you are new to SickRage, it is usually a much better idea to ask for help first in the [SickRage IRC channel](https://webchat.freenode.net/?channels=sickrage-issues). You will get much quicker support, and you will help avoid tying up the SickRage team with invalid bug reports.
 
 ### Try the latest version of SickRage
 
@@ -64,8 +64,8 @@ Please follow these guidelines before reporting a bug:
 
 
 ### Feature requests
-Please follow the bug guidelines above for feature requests, i.e. update to the latest version and search for existing requests on [FeatHub](http://feathub.com/SickRage/SickRage) before posting a new request..
-[![Feature Requests](https://cloud.githubusercontent.com/assets/390379/10127973/045b3a96-6560-11e5-9b20-31a2032956b2.png)](http://feathub.com/SickRage/SickRage)
+Please follow the bug guidelines above for feature requests, i.e. update to the latest version and search for existing requests on [FeatHub](https://feathub.com/SickRage/SickRage) before posting a new request..
+[![Feature Requests](https://cloud.githubusercontent.com/assets/390379/10127973/045b3a96-6560-11e5-9b20-31a2032956b2.png)](https://feathub.com/SickRage/SickRage)
 
 ### Pull requests
 
@@ -87,7 +87,7 @@ Please follow these guidelines before sending a pull request:
 
 Please follow this process; it's the best way to get your work included in the project:
 
-- [Fork](http://help.github.com/fork-a-repo/) the project, clone your fork,
+- [Fork](https://help.github.com/fork-a-repo/) the project, clone your fork,
    and configure the remotes:
 
 ```bash

--- a/COPYING.txt
+++ b/COPYING.txt
@@ -1,7 +1,7 @@
                     GNU GENERAL PUBLIC LICENSE
                        Version 3, 29 June 2007
 
- Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
  Everyone is permitted to copy and distribute verbatim copies
  of this license document, but changing it is not allowed.
 
@@ -646,7 +646,7 @@ the "copyright" line and a pointer to where the full notice is found.
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 Also add information on how to contact you by electronic and paper mail.
 
@@ -666,11 +666,11 @@ might be different; for a GUI interface, you would use an "about box".
   You should also get your employer (if you work as a programmer) or school,
 if any, to sign a "copyright disclaimer" for the program, if necessary.
 For more information on this, and how to apply and follow the GNU GPL, see
-<http://www.gnu.org/licenses/>.
+<https://www.gnu.org/licenses/>.
 
   The GNU General Public License does not permit incorporating your program
 into proprietary programs.  If your program is a subroutine library, you
 may consider it more useful to permit linking proprietary applications with
 the library.  If this is what you want to do, use the GNU Lesser General
 Public License instead of this License.  But first, please read
-<http://www.gnu.org/philosophy/why-not-lgpl.html>.
+<https://www.gnu.org/philosophy/why-not-lgpl.html>.

--- a/SickBeard.py
+++ b/SickBeard.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python2.7
 # -*- coding: utf-8 -*
 # Author: Nic Wolfe <nic@wolfeden.ca>
-# URL: http://code.google.com/p/sickbeard/
+# URL: https://code.google.com/p/sickbeard/
 #
 # Rewrite Author: miigotu <miigotu@gmail.com>
 # URL: https://sickrage.github.io
@@ -19,7 +19,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import print_function, unicode_literals
 
@@ -81,7 +81,7 @@ from sickrage.helper.argument_parser import SickRageArgumentParser
 from six.moves import reload_module
 
 
-# http://bugs.python.org/issue7980#msg221094
+# https://bugs.python.org/issue7980#msg221094
 THROWAWAY = datetime.datetime.strptime('20110101', '%Y%m%d')
 
 signal.signal(signal.SIGINT, sickbeard.sig_handler)

--- a/gui/slick/js/core.js
+++ b/gui/slick/js/core.js
@@ -1275,7 +1275,7 @@ var SICKRAGE = {
             $('#tv_download_dir').fileBrowser({title: _('Select TV Download Directory')});
             $('#unpack_dir').fileBrowser({title: _('Select Unpack Directory')});
 
-            // http://stackoverflow.com/questions/2219924/idiomatic-jquery-delayed-event-only-after-a-short-pause-in-typing-e-g-timew
+            // https://stackoverflow.com/questions/2219924/idiomatic-jquery-delayed-event-only-after-a-short-pause-in-typing-e-g-timew
             const typewatch = (function() {
                 let timer = 0;
                 return function(callback, ms) {

--- a/gui/slick/views/config.mako
+++ b/gui/slick/views/config.mako
@@ -179,8 +179,8 @@
                     <i class="icon16-config-web"></i>&nbsp;&nbsp;${_('Website')}:
                 </div>
                 <div class="col-lg-9 col-md-9 col-sm-9 col-xs-12">
-                    <a href="${anon_url('http://sickrage.github.io/')}" rel="noreferrer" onclick="window.open(this.href, '_blank'); return false;">
-                        http://sickrage.github.io/
+                    <a href="${anon_url('https://sickrage.github.io/')}" rel="noreferrer" onclick="window.open(this.href, '_blank'); return false;">
+                        https://sickrage.github.io/
                     </a>
                 </div>
             </div>

--- a/gui/slick/views/config_anime.mako
+++ b/gui/slick/views/config_anime.mako
@@ -18,7 +18,7 @@
                 <div class="col-lg-3 col-md-4 col-sm-4 col-xs-12">
                     <div class="component-group-desc">
                         <span class="icon-notifiers-anime" title="AniDB"></span>
-                        <h3><a href="${anon_url('http://anidb.info')}"
+                        <h3><a href="${anon_url('https://anidb.net')}"
                                onclick="window.open(this.href, '_blank'); return false;">AniDB</a></h3>
                         <p>${_('AniDB is non-profit database of anime information that is freely open to the public')}</p>
                     </div>

--- a/gui/slick/views/config_general.mako
+++ b/gui/slick/views/config_general.mako
@@ -921,7 +921,7 @@
                                 <div class="row">
                                     <div class="col-md-12">
                                         <b>${_('warning')}:</b>&nbsp;${_('passwords must only contain')}
-                                        <a target="_blank" href="${anon_url('http://en.wikipedia.org/wiki/ASCII#ASCII_printable_characters')}">${_('ASCII characters')}</a>
+                                        <a target="_blank" href="${anon_url('https://en.wikipedia.org/wiki/ASCII#ASCII_printable_characters')}">${_('ASCII characters')}</a>
                                     </div>
                                 </div>
                             </div>

--- a/gui/slick/views/config_notifications.mako
+++ b/gui/slick/views/config_notifications.mako
@@ -22,7 +22,7 @@
                 <div class="col-lg-3 col-md-4 col-sm-4 col-xs-12">
                     <div class="component-group-desc">
                         <span class="icon-notifiers-kodi" title="KODI"></span>
-                        <h3><a href="${anon_url('http://kodi.tv/')}" rel="noreferrer" onclick="window.open(this.href, '_blank'); return false;">KODI</a></h3>
+                        <h3><a href="${anon_url('https://kodi.tv/')}" rel="noreferrer" onclick="window.open(this.href, '_blank'); return false;">KODI</a></h3>
                         <p>${_('A free and open source cross-platform media center and home entertainment system software with a 10-foot user interface designed for the living-room TV.')}</p>
                     </div>
                 </div>
@@ -194,7 +194,7 @@
                 <div class="col-lg-3 col-md-4 col-sm-4 col-xs-12">
                     <div class="component-group-desc">
                         <span class="icon-notifiers-plex" title="Plex Media Server"></span>
-                        <h3><a href="${anon_url('http://www.plexapp.com/')}" rel="noreferrer" onclick="window.open(this.href, '_blank'); return false;">Plex Media Server</a></h3>
+                        <h3><a href="${anon_url('https://www.plex.tv')}" rel="noreferrer" onclick="window.open(this.href, '_blank'); return false;">Plex Media Server</a></h3>
                         <p>${_('Experience your media on a visually stunning, easy to use interface on your Mac connected to your TV. Your media library has never looked this good!')}</p>
                         <p class="plexinfo hide">${_('For sending notifications to Plex Home Theater (PHT) clients, use the KODI notifier with port <b>3005</b>.')}</p>
                     </div>
@@ -340,7 +340,7 @@
                 <div class="col-lg-3 col-md-4 col-sm-4 col-xs-12">
                     <div class="component-group-desc">
                         <span class="icon-notifiers-plexth" title="${_('Plex Home Theater')}"></span>
-                        <h3><a href="${anon_url('http://www.plexapp.com/')}" rel="noreferrer" onclick="window.open(this.href, '_blank'); return false;">Plex Home Theater</a></h3>
+                        <h3><a href="${anon_url('https://www.plex.tv')}" rel="noreferrer" onclick="window.open(this.href, '_blank'); return false;">Plex Home Theater</a></h3>
                     </div>
                 </div>
                 <div class="col-lg-9 col-md-8 col-sm-8 col-xs-12">
@@ -472,7 +472,7 @@
                 <div class="col-lg-3 col-md-4 col-sm-4 col-xs-12">
                     <div class="component-group-desc">
                         <span class="icon-notifiers-emby" title="${_('Emby')}"></span>
-                        <h3><a href="${anon_url('http://emby.media/')}" rel="noreferrer" onclick="window.open(this.href, '_blank'); return false;">Emby</a></h3>
+                        <h3><a href="${anon_url('https://emby.media/')}" rel="noreferrer" onclick="window.open(this.href, '_blank'); return false;">Emby</a></h3>
                         <p>${_('A home media server built using other popular open source technologies.')}</p>
                     </div>
                 </div>
@@ -800,7 +800,7 @@
                 <div class="col-lg-3 col-md-4 col-sm-4 col-xs-12">
                     <div class="component-group-desc">
                         <span class="icon-notifiers-syno1" title="${_('Synology')}"></span>
-                        <h3><a href="${anon_url('http://synology.com/')}" rel="noreferrer" onclick="window.open(this.href, '_blank'); return false;">Synology</a></h3>
+                        <h3><a href="${anon_url('https://synology.com/')}" rel="noreferrer" onclick="window.open(this.href, '_blank'); return false;">Synology</a></h3>
                         <p>${_('The Synology DiskStation NAS.')}</p>
                         <p>${_('Synology Indexer is the daemon running on the Synology NAS to build its media database.')}</p>
                     </div>
@@ -846,7 +846,7 @@
                 <div class="col-lg-3 col-md-4 col-sm-4 col-xs-12">
                     <div class="component-group-desc">
                         <span class="icon-notifiers-syno2" title="${_('Synology Indexer')}"></span>
-                        <h3><a href="${anon_url('http://synology.com/')}" rel="noreferrer" onclick="window.open(this.href, '_blank'); return false;">Synology Notifier</a></h3>
+                        <h3><a href="${anon_url('https://synology.com/')}" rel="noreferrer" onclick="window.open(this.href, '_blank'); return false;">Synology Notifier</a></h3>
                         <p>${_('Synology Notifier is the notification system of Synology DSM')}</p>
                     </div>
                 </div>
@@ -921,7 +921,7 @@
                 <div class="col-lg-3 col-md-4 col-sm-4 col-xs-12">
                     <div class="component-group-desc">
                         <span class="icon-notifiers-pytivo" title="${_('pyTivo')}"></span>
-                        <h3><a href="${anon_url('http://pytivo.sourceforge.net/wiki/index.php/PyTivo')}" rel="noreferrer" onclick="window.open(this.href, '_blank'); return false;">pyTivo</a></h3>
+                        <h3><a href="${anon_url('https://pytivo.sourceforge.net/wiki/index.php/PyTivo')}" rel="noreferrer" onclick="window.open(this.href, '_blank'); return false;">pyTivo</a></h3>
                         <p>${_('pyTivo is both an HMO and GoBack server. This notifier will load the completed downloads to your Tivo.')}</p>
                     </div>
                 </div>
@@ -1133,7 +1133,7 @@
                 <div class="col-lg-3 col-md-4 col-sm-4 col-xs-12">
                     <div class="component-group-desc">
                         <span class="icon-notifiers-prowl" title="${_('Prowl')}"></span>
-                        <h3><a href="${anon_url('http://www.prowlapp.com/')}" rel="noreferrer" onclick="window.open(this.href, '_blank'); return false;">Prowl</a></h3>
+                        <h3><a href="${anon_url('https://www.prowlapp.com/')}" rel="noreferrer" onclick="window.open(this.href, '_blank'); return false;">Prowl</a></h3>
                         <p>${_('A Growl client for iOS.')}</p>
                     </div>
                 </div>
@@ -1286,7 +1286,7 @@
                 <div class="col-lg-3 col-md-4 col-sm-4 col-xs-12">
                     <div class="component-group-desc">
                         <span class="icon-notifiers-libnotify" title="${_('Libnotify')}"></span>
-                        <h3><a href="${anon_url('http://library.gnome.org/devel/libnotify/')}" rel="noreferrer" onclick="window.open(this.href, '_blank'); return false;">Libnotify</a></h3>
+                        <h3><a href="${anon_url('https://library.gnome.org/devel/libnotify/')}" rel="noreferrer" onclick="window.open(this.href, '_blank'); return false;">Libnotify</a></h3>
                         <p>${_('The standard desktop notification API for Linux/*nix systems.  This notifier will only function if the pynotify module is installed (Ubuntu/Debian package <a href="apt:python-notify">python-notify</a>).')}</p>
                     </div>
                 </div>
@@ -1649,7 +1649,7 @@
                 <div class="col-lg-3 col-md-4 col-sm-4 col-xs-12">
                     <div class="component-group-desc">
                         <span class="icon-notifiers-nma" alt="" title="${_('NMA')}"></span>
-                        <h3><a href="${anon_url('http://www.notifymyandroid.com/')}" rel="noreferrer" onclick="window.open(this.href, '_blank'); return false;">${_('Notify My Android')}</a></h3>
+                        <h3><a href="${anon_url('https://www.notifymyandroid.com/')}" rel="noreferrer" onclick="window.open(this.href, '_blank'); return false;">${_('Notify My Android')}</a></h3>
                         <p>${_('Notify My Android is a Prowl-like Android App and API that offers an easy way to send notifications from your application directly to your Android device.')}</p>
                     </div>
                 </div>
@@ -2219,7 +2219,7 @@
                 <div class="col-lg-3 col-md-4 col-sm-4 col-xs-12">
                     <div class="component-group-desc">
                         <span class="icon-notifiers-join" title="${_('Join')}"></span>
-                        <h3><a href="${anon_url('http://joaoapps.com/join/')}" rel="noreferrer" onclick="window.open(this.href, '_blank'); return false;">${_('Join')}</a></h3>
+                        <h3><a href="${anon_url('https://joaoapps.com/join/')}" rel="noreferrer" onclick="window.open(this.href, '_blank'); return false;">${_('Join')}</a></h3>
                         <p>${_('Join all of your devices together!')}</p>
                     </div>
                 </div>
@@ -2331,7 +2331,7 @@
                 <div class="col-lg-3 col-md-4 col-sm-4 col-xs-12">
                     <div class="component-group-desc">
                         <span class="icon-notifiers-twilio" title="${_('Twilio')}"></span>
-                        <h3><a href="${anon_url('http://www.twilio.com/')}" rel="noreferrer" onclick="window.open(this.href, '_blank'); return false;">Twilio</a></h3>
+                        <h3><a href="${anon_url('https://www.twilio.com/')}" rel="noreferrer" onclick="window.open(this.href, '_blank'); return false;">Twilio</a></h3>
                         <p>${_('Twilio is a webservice API that allows you to communicate directly with a mobile number. This notifier will send a text directly to your mobile device.')}</p>
                     </div>
                 </div>
@@ -2483,7 +2483,7 @@
                 <div class="col-lg-3 col-md-4 col-sm-4 col-xs-12">
                     <div class="component-group-desc">
                         <span class="icon-notifiers-twitter" title="${_('Twitter')}"></span>
-                        <h3><a href="${anon_url('http://www.twitter.com/')}" rel="noreferrer" onclick="window.open(this.href, '_blank'); return false;">Twitter</a></h3>
+                        <h3><a href="${anon_url('https://www.twitter.com/')}" rel="noreferrer" onclick="window.open(this.href, '_blank'); return false;">Twitter</a></h3>
                         <p>${_('A social networking and microblogging service, enabling its users to send and read other users\' messages called tweets.')}</p>
                     </div>
                 </div>
@@ -2623,7 +2623,7 @@
                 <div class="col-lg-3 col-md-4 col-sm-4 col-xs-12">
                     <div class="component-group-desc">
                         <span class="icon-notifiers-trakt" title="${_('Trakt')}"></span>
-                        <h3><a href="${anon_url('http://trakt.tv/')}" rel="noreferrer" onclick="window.open(this.href, '_blank'); return false;">Trakt</a></h3>
+                        <h3><a href="${anon_url('https://trakt.tv/')}" rel="noreferrer" onclick="window.open(this.href, '_blank'); return false;">Trakt</a></h3>
                         <p>${_('Trakt helps keep a record of what TV shows and movies you are watching. Based on your favorites, Trakt recommends additional shows and movies you\'ll enjoy!')}</p>
                     </div>
                 </div>
@@ -2872,7 +2872,7 @@
                 <div class="col-lg-3 col-md-4 col-sm-4 col-xs-12">
                     <div class="component-group-desc">
                         <span class="icon-notifiers-email" title="${_('Email')}"></span>
-                        <h3><a href="${anon_url('http://en.wikipedia.org/wiki/Comparison_of_webmail_providers')}" rel="noreferrer" onclick="window.open(this.href, '_blank'); return false;">Email</a></h3>
+                        <h3><a href="${anon_url('https://en.wikipedia.org/wiki/Comparison_of_webmail_providers')}" rel="noreferrer" onclick="window.open(this.href, '_blank'); return false;">Email</a></h3>
                         <p>${_('Allows configuration of email notifications on a per show basis.')}</p>
                     </div>
                 </div>
@@ -3118,7 +3118,7 @@
                 <div class="col-lg-3 col-md-4 col-sm-4 col-xs-12">
                     <div class="component-group-desc">
                         <span class="icon-notifiers-slack" title="${_('Slack')}"></span>
-                        <h3><a href="${anon_url('http://www.slack.com/')}" rel="noreferrer" onclick="window.open(this.href, '_blank'); return false;">Slack</a></h3>
+                        <h3><a href="${anon_url('https://www.slack.com/')}" rel="noreferrer" onclick="window.open(this.href, '_blank'); return false;">Slack</a></h3>
                         <p>${_('Slack brings all your communication together in one place. It\'s real-time messaging, archiving and search for modern teams.')}</p>
                     </div>
                 </div>

--- a/gui/slick/views/displayShow.mako
+++ b/gui/slick/views/displayShow.mako
@@ -139,7 +139,7 @@
                                 % endif
                                         ${show.imdb_info['runtimes']} ${_('minutes')}
                             </span>
-                                    <a href="${anon_url('http://www.imdb.com/title/', _show.imdbid)}" rel="noreferrer" onclick="window.open(this.href, '_blank'); return false;" title="http://www.imdb.com/title/${show.imdbid}"><span class="displayshow-icon-imdb" /></a>
+                                    <a href="${anon_url('https://www.imdb.com/title/', _show.imdbid)}" rel="noreferrer" onclick="window.open(this.href, '_blank'); return false;" title="https://www.imdb.com/title/${show.imdbid}"><span class="displayshow-icon-imdb" /></a>
                                 % endif
                                 <a href="${anon_url(sickbeard.indexerApi(_show.indexer).config['show_url'], _show.indexerid)}" onclick="window.open(this.href, '_blank'); return false;" title="${sickbeard.indexerApi(show.indexer).config["show_url"] + str(show.indexerid)}"><img alt="${sickbeard.indexerApi(show.indexer).name}" src="${static_url('images/indexers/' + sickbeard.indexerApi(show.indexer).config["icon"])}" style="margin-top: -1px; vertical-align:middle;"/></a>
                                 % if xem_numbering or xem_absolute_numbering:
@@ -151,11 +151,11 @@
                                 <ul class="tags">
                                     % if show.genre and not show.imdb_info.get('genres'):
                                         % for genre in show.genre[1:-1].split('|'):
-                                            <a href="${anon_url('http://trakt.tv/shows/popular/?genres=', genre.lower())}" target="_blank" title="${_('View other popular {genre} shows on trakt.tv.').format(genre=_(genre))}"><li>${_(genre)}</li></a>
+                                            <a href="${anon_url('https://trakt.tv/shows/popular/?genres=', genre.lower())}" target="_blank" title="${_('View other popular {genre} shows on trakt.tv.').format(genre=_(genre))}"><li>${_(genre)}</li></a>
                                         % endfor
                                     % elif show.imdb_info.get('genres'):
                                         % for imdbgenre in show.imdb_info['genres'].replace('Sci-Fi','Science-Fiction').split('|'):
-                                            <a href="${anon_url('http://www.imdb.com/search/title?count=100&title_type=tv_series&genres=', imdbgenre.lower())}" target="_blank" title="${_('View other popular {imdbgenre} shows on IMDB.').format(imdbgenre=_(imdbgenre))}"><li>${_(imdbgenre)}</li></a>
+                                            <a href="${anon_url('https://www.imdb.com/search/title?count=100&title_type=tv_series&genres=', imdbgenre.lower())}" target="_blank" title="${_('View other popular {imdbgenre} shows on IMDB.').format(imdbgenre=_(imdbgenre))}"><li>${_(imdbgenre)}</li></a>
                                         % endfor
                                     % endif
                                 </ul>

--- a/gui/slick/views/schedule.mako
+++ b/gui/slick/views/schedule.mako
@@ -189,9 +189,9 @@
                                     </td>
                                     <td align="center" style="vertical-align: middle;">
                                         % if cur_result[b'imdb_id']:
-                                            <a href="${anon_url('http://www.imdb.com/title/', cur_result[b'imdb_id'])}" rel="noreferrer"
+                                            <a href="${anon_url('https://www.imdb.com/title/', cur_result[b'imdb_id'])}" rel="noreferrer"
                                                onclick="window.open(this.href, '_blank'); return false"
-                                               title="http://www.imdb.com/title/${cur_result[b'imdb_id']}">
+                                               title="https://www.imdb.com/title/${cur_result[b'imdb_id']}">
                                                 <span class="displayshow-icon-imdb"></span>
                                             </a>
                                         % endif
@@ -428,8 +428,8 @@
 
                                         <span class="tvshowTitleIcons">
                                             % if cur_result[b'imdb_id']:
-                                                <a href="${anon_url('http://www.imdb.com/title/', cur_result[b'imdb_id'])}" rel="noreferrer"
-                                                   onclick="window.open(this.href, '_blank'); return false" title="http://www.imdb.com/title/${cur_result[b'imdb_id']}">
+                                                <a href="${anon_url('https://www.imdb.com/title/', cur_result[b'imdb_id'])}" rel="noreferrer"
+                                                   onclick="window.open(this.href, '_blank'); return false" title="https://www.imdb.com/title/${cur_result[b'imdb_id']}">
                                                     <span class="displayshow-icon-imdb"></span>
                                                 </a>
                                             % endif

--- a/gui/slick/views/trendingShows.mako
+++ b/gui/slick/views/trendingShows.mako
@@ -17,7 +17,7 @@
             </div>
         % else:
             % for cur_show in trending_shows:
-                <% show_url = 'http://www.trakt.tv/shows/%s' % cur_show['show']['ids']['slug'] %>
+                <% show_url = 'https://www.trakt.tv/shows/%s' % cur_show['show']['ids']['slug'] %>
 
                 <div class="trakt_show" data-name="${cur_show['show']['title']}"
                      data-rating="${cur_show['show']['rating']}" data-votes="${cur_show['show']['votes']}">

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-SickRage [![Build Status](https://travis-ci.org/SickRage/SickRage.svg?branch=master)](https://travis-ci.org/SickRage/SickRage) [![Build status](https://ci.appveyor.com/api/projects/status/s8bb0iqroecnhya2/branch/master?svg=true)](https://ci.appveyor.com/project/miigotu/sickrage/branch/master) [![Average time to resolve an issue](http://isitmaintained.com/badge/resolution/SickRage/SickRage.svg)](http://isitmaintained.com/project/SickRage/SickRage "Average time to resolve an issue") [![Percentage of issues still open](http://isitmaintained.com/badge/open/SickRage/SickRage.svg)](http://isitmaintained.com/project/SickRage/SickRage "Percentage of issues still open") [![Coverage Status](https://codecov.io/gh/SickRage/SickRage/branch/master/graph/badge.svg)](https://codecov.io/gh/SickRage/SickRage) [![XO code style](https://img.shields.io/badge/code_style-XO-5ed9c7.svg)](https://github.com/sindresorhus/xo) [![Donate](https://img.shields.io/badge/donations-appreciated-green.svg)](https://github.com/SickRage/SickRage/wiki/Donations)
+SickRage [![Build Status](https://travis-ci.org/SickRage/SickRage.svg?branch=master)](https://travis-ci.org/SickRage/SickRage) [![Build status](https://ci.appveyor.com/api/projects/status/s8bb0iqroecnhya2/branch/master?svg=true)](https://ci.appveyor.com/project/miigotu/sickrage/branch/master) [![Average time to resolve an issue](https://isitmaintained.com/badge/resolution/SickRage/SickRage.svg)](https://isitmaintained.com/project/SickRage/SickRage "Average time to resolve an issue") [![Percentage of issues still open](https://isitmaintained.com/badge/open/SickRage/SickRage.svg)](https://isitmaintained.com/project/SickRage/SickRage "Percentage of issues still open") [![Coverage Status](https://codecov.io/gh/SickRage/SickRage/branch/master/graph/badge.svg)](https://codecov.io/gh/SickRage/SickRage) [![XO code style](https://img.shields.io/badge/code_style-XO-5ed9c7.svg)](https://github.com/sindresorhus/xo) [![Donate](https://img.shields.io/badge/donations-appreciated-green.svg)](https://github.com/SickRage/SickRage/wiki/Donations)
 ====================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================================
 Automatic Video Library Manager for TV Shows. It watches for new episodes of your favorite shows, and when they are posted it does its magic.
 
@@ -23,13 +23,13 @@ Automatic Video Library Manager for TV Shows. It watches for new episodes of you
  - Supports Anime shows
 
 #### Screenshots
-- [Desktop (Full-HD)](http://imgur.com/a/4fpBk)
-- [Mobile](http://imgur.com/a/WPyG6)
+- [Desktop (Full-HD)](https://imgur.com/a/4fpBk)
+- [Mobile](https://imgur.com/a/WPyG6)
 
 #### Dependencies
  To run SickRage from source you will need Python 2.7.10
 
-#### [![Feature Requests](https://cloud.githubusercontent.com/assets/390379/10127973/045b3a96-6560-11e5-9b20-31a2032956b2.png)](http://feathub.com/SickRage/SickRage)
+#### [![Feature Requests](https://cloud.githubusercontent.com/assets/390379/10127973/045b3a96-6560-11e5-9b20-31a2032956b2.png)](https://feathub.com/SickRage/SickRage)
 
 ##### [SickRage Issue Tracker](https://github.com/SickRage/SickRage/issues)
 
@@ -49,7 +49,7 @@ A full list can be found here: [Link](https://github.com/SickRage/SickRage/wiki/
 ![image](https://rarbg.com/favicon.ico)[RARBG](https://rarbg.to)
 ![image](https://torrentproject.se/favicon.ico)[TorrentProject](https://torrentproject.se/about)
 ![image](https://thepiratebay.se/favicon.ico)[ThePirateBay](https://thepiratebay.se/)
-![image](http://kat.cr/favicon.ico)[KickAssTorrents](https://kat.cr)
+![image](https://kat.cr/favicon.ico)[KickAssTorrents](https://kat.cr)
 ![image](https://nzb.cat/favicon.ico)[NZB.cat](https://nzb.cat/)
 ![image](https://nzbgeek.info/favicon.ico)[NZBGeek](https://nzbgeek.info)
 ![image](https://raw.githubusercontent.com/SickRage/SickRage/master/gui/slick/images/providers/dognzb.png)[DOGnzb](dognzb.cr)

--- a/sickbeard/__init__.py
+++ b/sickbeard/__init__.py
@@ -152,8 +152,8 @@ GIT_TOKEN = None
 GIT_PATH = None
 DEVELOPER = False
 
-NEWS_URL = 'http://sickrage.github.io/sickrage-news/news.md'
-LOGO_URL = 'http://sickrage.github.io/images/ico/favicon-64.png'
+NEWS_URL = 'https://sickrage.github.io/sickrage-news/news.md'
+LOGO_URL = 'https://sickrage.github.io/images/ico/favicon-64.png'
 
 NEWS_LAST_READ = None
 NEWS_LATEST = None

--- a/sickbeard/__init__.py
+++ b/sickbeard/__init__.py
@@ -15,7 +15,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 # pylint: disable=too-many-lines
 
 from __future__ import print_function, unicode_literals

--- a/sickbeard/auto_postprocessor.py
+++ b/sickbeard/auto_postprocessor.py
@@ -15,7 +15,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import unicode_literals
 

--- a/sickbeard/blackandwhitelist.py
+++ b/sickbeard/blackandwhitelist.py
@@ -16,7 +16,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import print_function, unicode_literals
 

--- a/sickbeard/browser.py
+++ b/sickbeard/browser.py
@@ -16,7 +16,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import unicode_literals
 
@@ -31,7 +31,7 @@ from sickbeard import logger
 from sickrage.helper.encoding import ek
 
 
-# adapted from http://stackoverflow.com/questions/827371/is-there-a-way-to-list-all-the-available-drive-letters-in-python/827490
+# adapted from https://stackoverflow.com/questions/827371/is-there-a-way-to-list-all-the-available-drive-letters-in-python/827490
 def getWinDrives():
     """ Return list of detected drives """
     assert os.name == 'nt'

--- a/sickbeard/bs4_parser.py
+++ b/sickbeard/bs4_parser.py
@@ -16,7 +16,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import unicode_literals
 

--- a/sickbeard/classes.py
+++ b/sickbeard/classes.py
@@ -16,7 +16,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import print_function, unicode_literals
 

--- a/sickbeard/clients/__init__.py
+++ b/sickbeard/clients/__init__.py
@@ -15,7 +15,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import unicode_literals
 

--- a/sickbeard/clients/deluge_client.py
+++ b/sickbeard/clients/deluge_client.py
@@ -15,7 +15,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import print_function, unicode_literals
 

--- a/sickbeard/clients/download_station_client.py
+++ b/sickbeard/clients/download_station_client.py
@@ -14,9 +14,9 @@
 # GNU General Public License for more details
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 #
-# Uses the Synology Download Station API: http://download.synology.com/download/Document/DeveloperGuide/Synology_Download_Station_Web_API.pdf
+# Uses the Synology Download Station API: https://download.synology.com/download/Document/DeveloperGuide/Synology_Download_Station_Web_API.pdf
 
 from __future__ import unicode_literals
 

--- a/sickbeard/clients/generic.py
+++ b/sickbeard/clients/generic.py
@@ -15,7 +15,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import unicode_literals
 

--- a/sickbeard/clients/mlnet_client.py
+++ b/sickbeard/clients/mlnet_client.py
@@ -16,7 +16,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import unicode_literals
 

--- a/sickbeard/clients/putio_client.py
+++ b/sickbeard/clients/putio_client.py
@@ -15,7 +15,7 @@
 #  GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage.  If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage.  If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import unicode_literals
 

--- a/sickbeard/clients/qbittorrent_client.py
+++ b/sickbeard/clients/qbittorrent_client.py
@@ -16,7 +16,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import unicode_literals
 

--- a/sickbeard/clients/rtorrent_client.py
+++ b/sickbeard/clients/rtorrent_client.py
@@ -16,7 +16,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 
 # pylint: disable=line-too-long

--- a/sickbeard/clients/transmission_client.py
+++ b/sickbeard/clients/transmission_client.py
@@ -16,7 +16,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import unicode_literals
 

--- a/sickbeard/clients/utorrent_client.py
+++ b/sickbeard/clients/utorrent_client.py
@@ -15,7 +15,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import unicode_literals
 

--- a/sickbeard/common.py
+++ b/sickbeard/common.py
@@ -16,7 +16,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 """
 Common interface for Quality and Status

--- a/sickbeard/config.py
+++ b/sickbeard/config.py
@@ -160,7 +160,7 @@ def change_unrar_tool(unrar_tool, alt_unrar_tool):
                 unrar_zip = ek(os.path.join, sickbeard.PROG_DIR, 'unrar_win.zip')  # file download
 
                 if (helpers.download_file(
-                    "http://sickrage.github.io/unrar/unrar_win.zip", filename=unrar_zip, session=helpers.make_session()
+                    "https://sickrage.github.io/unrar/unrar_win.zip", filename=unrar_zip, session=helpers.make_session()
                 ) and helpers.extractZip(archive=unrar_zip, targetDir=unrar_store)):
                     try:
                         ek(os.remove, unrar_zip)

--- a/sickbeard/config.py
+++ b/sickbeard/config.py
@@ -16,7 +16,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import print_function, unicode_literals
 
@@ -37,7 +37,7 @@ from sickrage.helper.encoding import ek
 
 # Address poor support for scgi over unix domain sockets
 # this is not nicely handled by python currently
-# http://bugs.python.org/issue23636
+# https://bugs.python.org/issue23636
 parse.uses_netloc.append('scgi')
 
 naming_ep_type = ("%(seasonnumber)dx%(episodenumber)02d",

--- a/sickbeard/dailysearcher.py
+++ b/sickbeard/dailysearcher.py
@@ -16,7 +16,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import print_function, unicode_literals
 

--- a/sickbeard/databases/__init__.py
+++ b/sickbeard/databases/__init__.py
@@ -15,7 +15,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 from __future__ import unicode_literals
 
 __all__ = ["mainDB", "cache", "failed"]

--- a/sickbeard/databases/cache_db.py
+++ b/sickbeard/databases/cache_db.py
@@ -16,7 +16,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import unicode_literals
 

--- a/sickbeard/databases/failed_db.py
+++ b/sickbeard/databases/failed_db.py
@@ -16,7 +16,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import unicode_literals
 

--- a/sickbeard/databases/mainDB.py
+++ b/sickbeard/databases/mainDB.py
@@ -16,7 +16,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 # pylint: disable=line-too-long
 
 from __future__ import print_function, unicode_literals

--- a/sickbeard/db.py
+++ b/sickbeard/db.py
@@ -16,7 +16,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import print_function, unicode_literals
 

--- a/sickbeard/failed_history.py
+++ b/sickbeard/failed_history.py
@@ -16,7 +16,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import print_function, unicode_literals
 

--- a/sickbeard/generic_queue.py
+++ b/sickbeard/generic_queue.py
@@ -16,7 +16,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import print_function, unicode_literals
 

--- a/sickbeard/helpers.py
+++ b/sickbeard/helpers.py
@@ -16,7 +16,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 # pylint:disable=too-many-lines
 
 from __future__ import print_function, unicode_literals
@@ -1863,7 +1863,7 @@ def add_site_message(message, tag=None, level='danger'):
         to_add = dict(level=level, tag=tag, message=message)
 
         if tag:  # prevent duplicate messages of the same type
-            # http://www.goodmami.org/2013/01/30/Getting-only-the-first-match-in-a-list-comprehension.html
+            # https://www.goodmami.org/2013/01/30/Getting-only-the-first-match-in-a-list-comprehension.html
             existing = next((x for x, msg in six.iteritems(sickbeard.SITE_MESSAGES) if msg.get('tag') == tag), None)
             if existing:
                 sickbeard.SITE_MESSAGES[existing] = to_add

--- a/sickbeard/helpers.py
+++ b/sickbeard/helpers.py
@@ -1783,7 +1783,7 @@ def tvdbid_from_remote_id(indexer_id, indexer):  # pylint:disable=too-many-retur
     session = make_session()
     tvdb_id = ''
     if indexer == 'IMDB':
-        url = "http://www.thetvdb.com/api/GetSeriesByRemoteID.php?imdbid={0}".format(indexer_id)
+        url = "https://www.thetvdb.com/api/GetSeriesByRemoteID.php?imdbid={0}".format(indexer_id)
         data = getURL(url, session=session, returns='content')
         if data is None:
             return tvdb_id
@@ -1797,7 +1797,7 @@ def tvdbid_from_remote_id(indexer_id, indexer):  # pylint:disable=too-many-retur
 
         return tvdb_id
     elif indexer == 'ZAP2IT':
-        url = "http://www.thetvdb.com/api/GetSeriesByRemoteID.php?zap2it={0}".format(indexer_id)
+        url = "https://www.thetvdb.com/api/GetSeriesByRemoteID.php?zap2it={0}".format(indexer_id)
         data = getURL(url, session=session, returns='content')
         if data is None:
             return tvdb_id
@@ -1811,7 +1811,7 @@ def tvdbid_from_remote_id(indexer_id, indexer):  # pylint:disable=too-many-retur
 
         return tvdb_id
     elif indexer == 'TVMAZE':
-        url = "http://api.tvmaze.com/shows/{0}".format(indexer_id)
+        url = "https://api.tvmaze.com/shows/{0}".format(indexer_id)
         data = getURL(url, session=session, returns='json')
         if data is None:
             return tvdb_id

--- a/sickbeard/history.py
+++ b/sickbeard/history.py
@@ -16,7 +16,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import unicode_literals
 

--- a/sickbeard/image_cache.py
+++ b/sickbeard/image_cache.py
@@ -16,7 +16,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import print_function, unicode_literals
 

--- a/sickbeard/imdbPopular.py
+++ b/sickbeard/imdbPopular.py
@@ -18,8 +18,7 @@ class imdbPopular(object):
     def __init__(self):
         """Gets a list of most popular TV series from imdb"""
 
-        # Use akas.imdb.com, just like the imdb lib.
-        self.url = 'http://akas.imdb.com/search/title'
+        self.url = 'https://www.imdb.com/search/title'
 
         self.params = {
             'at': 0,
@@ -35,7 +34,7 @@ class imdbPopular(object):
 
         popular_shows = []
 
-        data = helpers.getURL(self.url, session=self.session, params=self.params, headers={'Referer': 'http://akas.imdb.com/'}, returns='text')
+        data = helpers.getURL(self.url, session=self.session, params=self.params, headers={'Referer': 'https://www.imdb.com/'}, returns='text')
         if not data:
             return None
 
@@ -59,7 +58,7 @@ class imdbPopular(object):
                     a_tag = header.find("a")
                     if a_tag:
                         show['name'] = a_tag.get_text(strip=True)
-                        show['imdb_url'] = "http://www.imdb.com" + a_tag["href"]
+                        show['imdb_url'] = "https://www.imdb.com" + a_tag["href"]
                         show['year'] = header.find("span", {"class": "lister-item-year"}).contents[0].split(" ")[0][1:].strip("-")
 
                 imdb_rating = row.find("div", {"class": "ratings-imdb-rating"})

--- a/sickbeard/indexers/__init__.py
+++ b/sickbeard/indexers/__init__.py
@@ -16,7 +16,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import unicode_literals
 

--- a/sickbeard/indexers/indexer_api.py
+++ b/sickbeard/indexers/indexer_api.py
@@ -16,7 +16,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import unicode_literals
 

--- a/sickbeard/indexers/indexer_config.py
+++ b/sickbeard/indexers/indexer_config.py
@@ -36,9 +36,9 @@ indexerConfig = {
         'trakt_id': 'tvdb_id',
         'xem_origin': 'tvdb',
         'icon': 'thetvdb16.png',
-        'scene_loc': 'http://sickrage.github.io/scene_exceptions/scene_exceptions.json',
-        'show_url': 'http://thetvdb.com/?tab=series&id=',
-        'base_url': 'http://thetvdb.com/api/%(apikey)s/series/'
+        'scene_loc': 'https://sickrage.github.io/scene_exceptions/scene_exceptions.json',
+        'show_url': 'https://thetvdb.com/?tab=series&id=',
+        'base_url': 'https://thetvdb.com/api/%(apikey)s/series/'
     }
 }
 

--- a/sickbeard/indexers/indexer_exceptions.py
+++ b/sickbeard/indexers/indexer_exceptions.py
@@ -15,7 +15,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 """Custom exceptions used or raised by indexer_api"""
 

--- a/sickbeard/logger.py
+++ b/sickbeard/logger.py
@@ -235,7 +235,7 @@ class Logger(object):  # pylint: disable=too-many-instance-attributes
             r'error \[SSL: SSLV3_ALERT_HANDSHAKE_FAILURE\] sslv3 alert handshake failure \(_ssl\.c:\d+\)',
         ]
         for ssl_error in ssl_errors:
-            check = re.sub(ssl_error, 'See: http://git.io/vuU5V', message)
+            check = re.sub(ssl_error, 'See: https://git.io/vuU5V', message)
             if check != message:
                 message = check
                 level = WARNING

--- a/sickbeard/logger.py
+++ b/sickbeard/logger.py
@@ -16,7 +16,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 """
 Custom Logger for SickRage

--- a/sickbeard/metadata/__init__.py
+++ b/sickbeard/metadata/__init__.py
@@ -16,7 +16,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import unicode_literals
 

--- a/sickbeard/metadata/generic.py
+++ b/sickbeard/metadata/generic.py
@@ -16,7 +16,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import print_function, unicode_literals
 

--- a/sickbeard/metadata/helpers.py
+++ b/sickbeard/metadata/helpers.py
@@ -16,7 +16,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import print_function, unicode_literals
 

--- a/sickbeard/metadata/kodi.py
+++ b/sickbeard/metadata/kodi.py
@@ -16,7 +16,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import unicode_literals
 

--- a/sickbeard/metadata/kodi_12plus.py
+++ b/sickbeard/metadata/kodi_12plus.py
@@ -15,7 +15,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import print_function, unicode_literals
 

--- a/sickbeard/metadata/mede8er.py
+++ b/sickbeard/metadata/mede8er.py
@@ -16,7 +16,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import print_function, unicode_literals
 

--- a/sickbeard/metadata/mediabrowser.py
+++ b/sickbeard/metadata/mediabrowser.py
@@ -16,7 +16,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import print_function, unicode_literals
 

--- a/sickbeard/metadata/ps3.py
+++ b/sickbeard/metadata/ps3.py
@@ -16,7 +16,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import unicode_literals
 

--- a/sickbeard/metadata/tivo.py
+++ b/sickbeard/metadata/tivo.py
@@ -17,7 +17,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import print_function, unicode_literals
 
@@ -154,7 +154,7 @@ class TIVOMetadata(generic.GenericMetadata):
 
         ep_obj: a TVEpisode instance to create the metadata file for.
 
-        Lookup the show in http://thetvdb.com/ using the python library:
+        Lookup the show in https://thetvdb.com/ using the python library:
 
         https://github.com/dbr/indexer_api/
 
@@ -162,7 +162,7 @@ class TIVOMetadata(generic.GenericMetadata):
 
         The key values for the tivo metadata file are from:
 
-        http://pytivo.sourceforge.net/wiki/index.php/Metadata
+        https://pytivo.sourceforge.net/wiki/index.php/Metadata
         """
 
         data = ""

--- a/sickbeard/metadata/wdtv.py
+++ b/sickbeard/metadata/wdtv.py
@@ -16,7 +16,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import print_function, unicode_literals
 

--- a/sickbeard/name_cache.py
+++ b/sickbeard/name_cache.py
@@ -16,7 +16,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 from __future__ import unicode_literals
 
 import threading

--- a/sickbeard/name_parser/parser.py
+++ b/sickbeard/name_parser/parser.py
@@ -15,7 +15,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import print_function, unicode_literals
 

--- a/sickbeard/name_parser/regexes.py
+++ b/sickbeard/name_parser/regexes.py
@@ -15,7 +15,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 # all regexes are case insensitive
 

--- a/sickbeard/naming.py
+++ b/sickbeard/naming.py
@@ -16,7 +16,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import unicode_literals
 

--- a/sickbeard/network_timezones.py
+++ b/sickbeard/network_timezones.py
@@ -45,7 +45,7 @@ missing_network_timezones = set()
 def update_network_dict():
     """Update timezone information from SR repositories"""
 
-    url = 'http://sickrage.github.io/sb_network_timezones/network_timezones.txt'
+    url = 'https://sickrage.github.io/sb_network_timezones/network_timezones.txt'
     data = helpers.getURL(url, session=helpers.make_session(), returns='text')
     if not data:
         logger.log('Updating network timezones failed, this can happen from time to time. URL: {0}'.format(url), logger.WARNING)

--- a/sickbeard/network_timezones.py
+++ b/sickbeard/network_timezones.py
@@ -16,7 +16,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import print_function, unicode_literals
 

--- a/sickbeard/notifiers/__init__.py
+++ b/sickbeard/notifiers/__init__.py
@@ -16,7 +16,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import print_function, unicode_literals
 

--- a/sickbeard/notifiers/boxcar2.py
+++ b/sickbeard/notifiers/boxcar2.py
@@ -18,7 +18,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import unicode_literals
 

--- a/sickbeard/notifiers/discord.py
+++ b/sickbeard/notifiers/discord.py
@@ -15,7 +15,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 from __future__ import unicode_literals
 
 import json

--- a/sickbeard/notifiers/emailnotify.py
+++ b/sickbeard/notifiers/emailnotify.py
@@ -19,7 +19,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 #
 ##############################################################################
 

--- a/sickbeard/notifiers/emby.py
+++ b/sickbeard/notifiers/emby.py
@@ -16,7 +16,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import print_function, unicode_literals
 

--- a/sickbeard/notifiers/freemobile.py
+++ b/sickbeard/notifiers/freemobile.py
@@ -18,7 +18,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import print_function, unicode_literals
 

--- a/sickbeard/notifiers/growl.py
+++ b/sickbeard/notifiers/growl.py
@@ -16,7 +16,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import print_function, unicode_literals
 

--- a/sickbeard/notifiers/join.py
+++ b/sickbeard/notifiers/join.py
@@ -15,7 +15,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import unicode_literals
 
@@ -31,7 +31,7 @@ class Notifier(object):
     """
     Use Join to send notifications
 
-    http://joaoapps.com/join/
+    https://joaoapps.com/join/
     """
     def test_notify(self, id=None, apikey=None):
         """

--- a/sickbeard/notifiers/kodi.py
+++ b/sickbeard/notifiers/kodi.py
@@ -16,7 +16,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import print_function, unicode_literals
 

--- a/sickbeard/notifiers/libnotify.py
+++ b/sickbeard/notifiers/libnotify.py
@@ -16,7 +16,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import print_function, unicode_literals
 

--- a/sickbeard/notifiers/nmj.py
+++ b/sickbeard/notifiers/nmj.py
@@ -16,7 +16,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import print_function, unicode_literals
 

--- a/sickbeard/notifiers/nmjv2.py
+++ b/sickbeard/notifiers/nmjv2.py
@@ -17,7 +17,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import print_function, unicode_literals
 

--- a/sickbeard/notifiers/plex.py
+++ b/sickbeard/notifiers/plex.py
@@ -16,7 +16,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import print_function, unicode_literals
 

--- a/sickbeard/notifiers/prowl.py
+++ b/sickbeard/notifiers/prowl.py
@@ -16,7 +16,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 #
 ##############################################################################
 

--- a/sickbeard/notifiers/pushalot.py
+++ b/sickbeard/notifiers/pushalot.py
@@ -17,7 +17,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import unicode_literals
 

--- a/sickbeard/notifiers/pushbullet.py
+++ b/sickbeard/notifiers/pushbullet.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*
-# Author: Pedro Correia (http://github.com/pedrocorreia/)
+# Author: Pedro Correia (https://github.com/pedrocorreia/)
 # Based on pushalot.py by Nic Wolfe <nic@wolfeden.ca>
 # URL: https://sickrage.github.io
 #
@@ -16,7 +16,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import unicode_literals
 

--- a/sickbeard/notifiers/pushover.py
+++ b/sickbeard/notifiers/pushover.py
@@ -17,7 +17,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import print_function, unicode_literals
 

--- a/sickbeard/notifiers/pytivo.py
+++ b/sickbeard/notifiers/pytivo.py
@@ -16,7 +16,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import print_function, unicode_literals
 

--- a/sickbeard/notifiers/slack.py
+++ b/sickbeard/notifiers/slack.py
@@ -15,7 +15,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 from __future__ import unicode_literals
 
 import json

--- a/sickbeard/notifiers/synoindex.py
+++ b/sickbeard/notifiers/synoindex.py
@@ -16,7 +16,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import print_function, unicode_literals
 

--- a/sickbeard/notifiers/synologynotifier.py
+++ b/sickbeard/notifiers/synologynotifier.py
@@ -15,7 +15,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import print_function, unicode_literals
 

--- a/sickbeard/notifiers/telegram.py
+++ b/sickbeard/notifiers/telegram.py
@@ -17,7 +17,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import unicode_literals
 

--- a/sickbeard/notifiers/trakt.py
+++ b/sickbeard/notifiers/trakt.py
@@ -16,7 +16,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import print_function, unicode_literals
 

--- a/sickbeard/notifiers/tweet.py
+++ b/sickbeard/notifiers/tweet.py
@@ -16,7 +16,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import print_function, unicode_literals
 

--- a/sickbeard/notifiers/twilio_notify.py
+++ b/sickbeard/notifiers/twilio_notify.py
@@ -16,7 +16,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import print_function, unicode_literals
 

--- a/sickbeard/nzbSplitter.py
+++ b/sickbeard/nzbSplitter.py
@@ -16,7 +16,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 # pylint: disable=line-too-long
 

--- a/sickbeard/nzbget.py
+++ b/sickbeard/nzbget.py
@@ -16,7 +16,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import unicode_literals
 

--- a/sickbeard/postProcessor.py
+++ b/sickbeard/postProcessor.py
@@ -16,7 +16,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 # pylint: disable=too-many-lines
 
 from __future__ import print_function, unicode_literals

--- a/sickbeard/post_processing_queue.py
+++ b/sickbeard/post_processing_queue.py
@@ -15,7 +15,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import print_function, unicode_literals
 

--- a/sickbeard/processTV.py
+++ b/sickbeard/processTV.py
@@ -16,7 +16,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import print_function, unicode_literals
 

--- a/sickbeard/properFinder.py
+++ b/sickbeard/properFinder.py
@@ -16,7 +16,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import print_function, unicode_literals
 

--- a/sickbeard/providers/__init__.py
+++ b/sickbeard/providers/__init__.py
@@ -16,7 +16,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import unicode_literals
 

--- a/sickbeard/providers/abnormal.py
+++ b/sickbeard/providers/abnormal.py
@@ -16,7 +16,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import unicode_literals
 

--- a/sickbeard/providers/alpharatio.py
+++ b/sickbeard/providers/alpharatio.py
@@ -47,7 +47,7 @@ class AlphaRatioProvider(TorrentProvider):  # pylint: disable=too-many-instance-
         self.minleech = None
 
         # URLs
-        self.url = "http://alpharatio.cc"
+        self.url = "https://alpharatio.cc"
         self.urls = {
             "login": urljoin(self.url, "login.php"),
             "search": urljoin(self.url, "torrents.php"),

--- a/sickbeard/providers/alpharatio.py
+++ b/sickbeard/providers/alpharatio.py
@@ -16,7 +16,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import unicode_literals
 

--- a/sickbeard/providers/archetorrent.py
+++ b/sickbeard/providers/archetorrent.py
@@ -17,7 +17,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import unicode_literals
 

--- a/sickbeard/providers/binsearch.py
+++ b/sickbeard/providers/binsearch.py
@@ -16,7 +16,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import unicode_literals
 

--- a/sickbeard/providers/bitcannon.py
+++ b/sickbeard/providers/bitcannon.py
@@ -16,7 +16,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import unicode_literals
 

--- a/sickbeard/providers/btn.py
+++ b/sickbeard/providers/btn.py
@@ -16,7 +16,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import print_function, unicode_literals
 

--- a/sickbeard/providers/btn.py
+++ b/sickbeard/providers/btn.py
@@ -49,8 +49,8 @@ class BTNProvider(TorrentProvider):
 
         self.cache = BTNCache(self, min_time=15)  # Only poll BTN every 15 minutes max
 
-        self.urls = {'base_url': 'http://api.broadcasthe.net',
-                     'website': 'http://broadcasthe.net/', }
+        self.urls = {'base_url': 'https://api.broadcasthe.net',
+                     'website': 'https://broadcasthe.net/', }
 
         self.url = self.urls['website']
 

--- a/sickbeard/providers/cpasbien.py
+++ b/sickbeard/providers/cpasbien.py
@@ -16,7 +16,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import print_function, unicode_literals
 

--- a/sickbeard/providers/danishbits.py
+++ b/sickbeard/providers/danishbits.py
@@ -16,7 +16,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import print_function, unicode_literals
 

--- a/sickbeard/providers/elitetorrent.py
+++ b/sickbeard/providers/elitetorrent.py
@@ -16,7 +16,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import print_function, unicode_literals
 

--- a/sickbeard/providers/filelist.py
+++ b/sickbeard/providers/filelist.py
@@ -15,7 +15,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import unicode_literals
 

--- a/sickbeard/providers/filelist.py
+++ b/sickbeard/providers/filelist.py
@@ -46,7 +46,7 @@ class FileListProvider(TorrentProvider):  # pylint: disable=too-many-instance-at
         self.minleech = None
 
         # URLs
-        self.url = "http://filelist.ro"
+        self.url = "https://filelist.ro"
         self.urls = {
             "login": urljoin(self.url, "takelogin.php"),
             "search": urljoin(self.url, "browse.php"),

--- a/sickbeard/providers/gftracker.py
+++ b/sickbeard/providers/gftracker.py
@@ -16,7 +16,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import print_function, unicode_literals
 

--- a/sickbeard/providers/hd4free.py
+++ b/sickbeard/providers/hd4free.py
@@ -16,7 +16,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import print_function, unicode_literals
 

--- a/sickbeard/providers/hdbits.py
+++ b/sickbeard/providers/hdbits.py
@@ -15,7 +15,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import print_function, unicode_literals
 

--- a/sickbeard/providers/hdspace.py
+++ b/sickbeard/providers/hdspace.py
@@ -17,7 +17,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import print_function, unicode_literals
 

--- a/sickbeard/providers/hdtorrents.py
+++ b/sickbeard/providers/hdtorrents.py
@@ -16,7 +16,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import print_function, unicode_literals
 

--- a/sickbeard/providers/horriblesubs.py
+++ b/sickbeard/providers/horriblesubs.py
@@ -16,7 +16,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import print_function, unicode_literals
 

--- a/sickbeard/providers/hounddawgs.py
+++ b/sickbeard/providers/hounddawgs.py
@@ -16,7 +16,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import print_function, unicode_literals
 

--- a/sickbeard/providers/ilcorsaronero.py
+++ b/sickbeard/providers/ilcorsaronero.py
@@ -15,7 +15,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import unicode_literals
 

--- a/sickbeard/providers/immortalseed.py
+++ b/sickbeard/providers/immortalseed.py
@@ -16,7 +16,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import print_function, unicode_literals
 

--- a/sickbeard/providers/iptorrents.py
+++ b/sickbeard/providers/iptorrents.py
@@ -16,7 +16,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import print_function, unicode_literals
 

--- a/sickbeard/providers/kat.py
+++ b/sickbeard/providers/kat.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 # Author: Dustyn Gibson <miigotu@gmail.com>
-# URL: http://sickrage.github.io
+# URL: https://sickrage.github.io
 #
 # This file is part of SickRage.
 #
@@ -15,7 +15,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import unicode_literals
 

--- a/sickbeard/providers/limetorrents.py
+++ b/sickbeard/providers/limetorrents.py
@@ -16,7 +16,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import print_function, unicode_literals
 

--- a/sickbeard/providers/morethantv.py
+++ b/sickbeard/providers/morethantv.py
@@ -16,7 +16,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import print_function, unicode_literals
 

--- a/sickbeard/providers/ncore.py
+++ b/sickbeard/providers/ncore.py
@@ -10,7 +10,7 @@
 # SickRage is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or$
 # PARTICULAR PURPOSE. See the GNU General Public License for more details.
 #
-# You should have received a copy of the GNU General Public License along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# You should have received a copy of the GNU General Public License along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import print_function, unicode_literals
 

--- a/sickbeard/providers/nebulance.py
+++ b/sickbeard/providers/nebulance.py
@@ -15,7 +15,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import print_function, unicode_literals
 

--- a/sickbeard/providers/newpct.py
+++ b/sickbeard/providers/newpct.py
@@ -16,7 +16,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import print_function, unicode_literals
 

--- a/sickbeard/providers/newznab.py
+++ b/sickbeard/providers/newznab.py
@@ -16,7 +16,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import unicode_literals
 

--- a/sickbeard/providers/norbits.py
+++ b/sickbeard/providers/norbits.py
@@ -16,7 +16,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import unicode_literals
 

--- a/sickbeard/providers/nyaa.py
+++ b/sickbeard/providers/nyaa.py
@@ -16,7 +16,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import print_function, unicode_literals
 

--- a/sickbeard/providers/omgwtfnzbs.py
+++ b/sickbeard/providers/omgwtfnzbs.py
@@ -16,7 +16,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import unicode_literals
 

--- a/sickbeard/providers/pretome.py
+++ b/sickbeard/providers/pretome.py
@@ -16,7 +16,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import print_function, unicode_literals
 

--- a/sickbeard/providers/rarbg.py
+++ b/sickbeard/providers/rarbg.py
@@ -47,7 +47,7 @@ class RarbgProvider(TorrentProvider):  # pylint: disable=too-many-instance-attri
 
         # Spec: https://torrentapi.org/apidocs_v2.txt
         self.url = "https://rarbg.com"
-        self.urls = {"api": "http://torrentapi.org/pubapi_v2.php"}
+        self.urls = {"api": "https://torrentapi.org/pubapi_v2.php"}
 
         self.proper_strings = ["{{PROPER|REPACK}}"]
 

--- a/sickbeard/providers/rarbg.py
+++ b/sickbeard/providers/rarbg.py
@@ -16,7 +16,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import unicode_literals
 

--- a/sickbeard/providers/rsstorrent.py
+++ b/sickbeard/providers/rsstorrent.py
@@ -16,7 +16,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import unicode_literals
 

--- a/sickbeard/providers/scc.py
+++ b/sickbeard/providers/scc.py
@@ -16,7 +16,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import print_function, unicode_literals
 

--- a/sickbeard/providers/scenetime.py
+++ b/sickbeard/providers/scenetime.py
@@ -16,7 +16,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import print_function, unicode_literals
 

--- a/sickbeard/providers/shazbat.py
+++ b/sickbeard/providers/shazbat.py
@@ -16,7 +16,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import unicode_literals
 

--- a/sickbeard/providers/shazbat.py
+++ b/sickbeard/providers/shazbat.py
@@ -40,7 +40,7 @@ class ShazbatProvider(TorrentProvider):
 
         self.cache = ShazbatCache(self, min_time=20)
 
-        self.url = 'http://www.shazbat.tv'
+        self.url = 'https://www.shazbat.tv'
         self.urls = {
             'login': urljoin(self.url, 'login'),
             'rss_recent': urljoin(self.url, 'rss/recent'),

--- a/sickbeard/providers/skytorrents.py
+++ b/sickbeard/providers/skytorrents.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 # Author: Dustyn Gibson <miigotu@gmail.com>
-# URL: http://sickrage.github.io
+# URL: https://sickrage.github.io
 #
 # This file is part of SickRage.
 #
@@ -15,7 +15,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import unicode_literals
 

--- a/sickbeard/providers/speedcd.py
+++ b/sickbeard/providers/speedcd.py
@@ -16,7 +16,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import print_function, unicode_literals
 
@@ -92,7 +92,7 @@ class SpeedCDProvider(TorrentProvider):  # pylint: disable=too-many-instance-att
         if not self.login():
             return results
 
-        # http://speed.cd/browse.php?c49=1&c50=1&c52=1&c41=1&c55=1&c2=1&c30=1&freeleech=on&search=arrow&d=on
+        # https://speed.cd/browse.php?c49=1&c50=1&c52=1&c41=1&c55=1&c2=1&c30=1&freeleech=on&search=arrow&d=on
         # Search Params
         search_params = {
             'c30': 1,  # Anime

--- a/sickbeard/providers/thepiratebay.py
+++ b/sickbeard/providers/thepiratebay.py
@@ -16,7 +16,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import unicode_literals
 

--- a/sickbeard/providers/tntvillage.py
+++ b/sickbeard/providers/tntvillage.py
@@ -16,7 +16,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import print_function, unicode_literals
 

--- a/sickbeard/providers/tokyotoshokan.py
+++ b/sickbeard/providers/tokyotoshokan.py
@@ -16,7 +16,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import print_function, unicode_literals
 

--- a/sickbeard/providers/tokyotoshokan.py
+++ b/sickbeard/providers/tokyotoshokan.py
@@ -41,7 +41,7 @@ class TokyoToshokanProvider(TorrentProvider):  # pylint: disable=too-many-instan
         self.minseed = None
         self.minleech = None
 
-        self.url = 'http://tokyotosho.info/'
+        self.url = 'https://tokyotosho.info/'
         self.urls = {
             'search': self.url + 'search.php',
             'rss': self.url + 'rss.php'

--- a/sickbeard/providers/torrent9.py
+++ b/sickbeard/providers/torrent9.py
@@ -16,7 +16,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import print_function, unicode_literals
 

--- a/sickbeard/providers/torrentbytes.py
+++ b/sickbeard/providers/torrentbytes.py
@@ -16,7 +16,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import unicode_literals
 

--- a/sickbeard/providers/torrentday.py
+++ b/sickbeard/providers/torrentday.py
@@ -16,7 +16,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import unicode_literals
 

--- a/sickbeard/providers/torrentleech.py
+++ b/sickbeard/providers/torrentleech.py
@@ -16,7 +16,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import unicode_literals
 

--- a/sickbeard/providers/torrentproject.py
+++ b/sickbeard/providers/torrentproject.py
@@ -16,7 +16,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import print_function, unicode_literals
 

--- a/sickbeard/providers/torrentz.py
+++ b/sickbeard/providers/torrentz.py
@@ -16,7 +16,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import print_function, unicode_literals
 

--- a/sickbeard/providers/tvchaosuk.py
+++ b/sickbeard/providers/tvchaosuk.py
@@ -15,7 +15,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import print_function, unicode_literals
 

--- a/sickbeard/providers/xthor.py
+++ b/sickbeard/providers/xthor.py
@@ -16,7 +16,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import print_function, unicode_literals
 

--- a/sickbeard/providers/yggtorrent.py
+++ b/sickbeard/providers/yggtorrent.py
@@ -17,7 +17,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import unicode_literals
 

--- a/sickbeard/sab.py
+++ b/sickbeard/sab.py
@@ -16,7 +16,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import unicode_literals
 

--- a/sickbeard/sbdatetime.py
+++ b/sickbeard/sbdatetime.py
@@ -16,7 +16,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import unicode_literals
 

--- a/sickbeard/scene_exceptions.py
+++ b/sickbeard/scene_exceptions.py
@@ -16,7 +16,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import print_function, unicode_literals
 

--- a/sickbeard/scene_numbering.py
+++ b/sickbeard/scene_numbering.py
@@ -16,7 +16,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 #
 # Created on Sep 20, 2012
 # @author: Dermot Buckley <dermot@buckley.ie>

--- a/sickbeard/scheduler.py
+++ b/sickbeard/scheduler.py
@@ -16,7 +16,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import print_function, unicode_literals
 

--- a/sickbeard/search.py
+++ b/sickbeard/search.py
@@ -16,7 +16,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import print_function, unicode_literals
 

--- a/sickbeard/searchBacklog.py
+++ b/sickbeard/searchBacklog.py
@@ -15,7 +15,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import print_function, unicode_literals
 

--- a/sickbeard/search_queue.py
+++ b/sickbeard/search_queue.py
@@ -15,7 +15,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import print_function, unicode_literals
 

--- a/sickbeard/showUpdater.py
+++ b/sickbeard/showUpdater.py
@@ -15,7 +15,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import unicode_literals
 

--- a/sickbeard/showUpdater.py
+++ b/sickbeard/showUpdater.py
@@ -61,7 +61,7 @@ class ShowUpdater(object):  # pylint: disable=too-few-public-methods
 
         network_timezones.update_network_dict()
 
-        url = 'http://thetvdb.com/api/Updates.php?type=series&time={0}'.format(last_update)
+        url = 'https://thetvdb.com/api/Updates.php?type=series&time={0}'.format(last_update)
         data = helpers.getURL(url, session=self.session, returns='text', hooks={'response': self.request_hook})
         if not data:
             logger.log('Could not get the recently updated show data from {0}. Retrying later. Url was: {1}'.format(sickbeard.indexerApi(INDEXER_TVDB).name, url))

--- a/sickbeard/show_name_helpers.py
+++ b/sickbeard/show_name_helpers.py
@@ -15,7 +15,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import print_function, unicode_literals
 

--- a/sickbeard/show_queue.py
+++ b/sickbeard/show_queue.py
@@ -15,7 +15,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import unicode_literals
 

--- a/sickbeard/subtitles.py
+++ b/sickbeard/subtitles.py
@@ -17,7 +17,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import print_function, unicode_literals
 

--- a/sickbeard/subtitles.py
+++ b/sickbeard/subtitles.py
@@ -59,14 +59,14 @@ subliminal.region.configure('dogpile.cache.memory')
 
 PROVIDER_URLS = {
     'addic7ed': 'http://www.addic7ed.com',
-    'itasa': 'http://www.italiansubs.net/',
+    'itasa': 'https://www.italiansubs.net/',
     'legendastv': 'http://www.legendas.tv',
     'napiprojekt': 'http://www.napiprojekt.pl',
-    'opensubtitles': 'http://www.opensubtitles.org',
-    'podnapisi': 'http://www.podnapisi.net',
+    'opensubtitles': 'https://www.opensubtitles.org',
+    'podnapisi': 'https://www.podnapisi.net',
     'subscenter': 'http://www.subscenter.info',
     'thesubdb': 'http://www.thesubdb.com',
-    'wizdom': 'http://wizdom.xyz',
+    'wizdom': 'https://wizdom.xyz',
     'tvsubtitles': 'http://www.tvsubtitles.net'
 }
 
@@ -126,7 +126,7 @@ class SubtitleProviderPool(object):  # pylint: disable=too-few-public-methods
 
 def sorted_service_list():
     new_list = []
-    lmgtfy = 'http://lmgtfy.com/?q=%s'
+    lmgtfy = 'https://lmgtfy.com/?q=%s'
 
     current_index = 0
     for current_service in sickbeard.SUBTITLES_SERVICES_LIST:

--- a/sickbeard/traktChecker.py
+++ b/sickbeard/traktChecker.py
@@ -15,7 +15,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import print_function, unicode_literals
 

--- a/sickbeard/tv.py
+++ b/sickbeard/tv.py
@@ -15,7 +15,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 # pylint: disable=too-many-lines
 
 from __future__ import unicode_literals

--- a/sickbeard/tvcache.py
+++ b/sickbeard/tvcache.py
@@ -15,7 +15,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import print_function, unicode_literals
 

--- a/sickbeard/ui.py
+++ b/sickbeard/ui.py
@@ -15,7 +15,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import unicode_literals
 

--- a/sickbeard/versionChecker.py
+++ b/sickbeard/versionChecker.py
@@ -211,7 +211,7 @@ class CheckVersion(object):
             cur_hash = str(self.updater.get_newest_commit_hash())
             assert len(cur_hash) == 40, "Commit hash wrong length: {0} hash: {1}".format(len(cur_hash), cur_hash)
 
-            check_url = "http://cdn.rawgit.com/{0}/{1}/{2}/sickbeard/databases/mainDB.py".format(sickbeard.GIT_ORG, sickbeard.GIT_REPO, cur_hash)
+            check_url = "https://cdn.rawgit.com/{0}/{1}/{2}/sickbeard/databases/mainDB.py".format(sickbeard.GIT_ORG, sickbeard.GIT_REPO, cur_hash)
             response = helpers.getURL(check_url, session=self.session, returns='text')
             assert response, "Empty response from {0}".format(check_url)
 
@@ -559,7 +559,7 @@ class GitUpdateManager(UpdateManager):
 
         elif self._num_commits_behind > 0:
 
-            base_url = 'http://github.com/' + sickbeard.GIT_ORG + '/' + sickbeard.GIT_REPO
+            base_url = 'https://github.com/' + sickbeard.GIT_ORG + '/' + sickbeard.GIT_REPO
             if self._newest_commit_hash:
                 url = base_url + '/compare/' + self._cur_commit_hash + '...' + self._newest_commit_hash
             else:
@@ -763,7 +763,7 @@ class SourceUpdateManager(UpdateManager):
                             '&mdash; <a href="{update_url}">Update Now</a>').format(update_url=self.get_update_url())
 
         elif self._num_commits_behind > 0:
-            base_url = 'http://github.com/' + sickbeard.GIT_ORG + '/' + sickbeard.GIT_REPO
+            base_url = 'https://github.com/' + sickbeard.GIT_ORG + '/' + sickbeard.GIT_REPO
             if self._newest_commit_hash:
                 url = base_url + '/compare/' + self._cur_commit_hash + '...' + self._newest_commit_hash
             else:
@@ -786,7 +786,7 @@ class SourceUpdateManager(UpdateManager):
         Downloads the latest source tarball from github and installs it over the existing version.
         """
 
-        tar_download_url = 'http://github.com/' + sickbeard.GIT_ORG + '/' + sickbeard.GIT_REPO + '/tarball/' + self.branch
+        tar_download_url = 'https://github.com/' + sickbeard.GIT_ORG + '/' + sickbeard.GIT_REPO + '/tarball/' + self.branch
 
         try:
             # prepare the update dir

--- a/sickbeard/versionChecker.py
+++ b/sickbeard/versionChecker.py
@@ -15,7 +15,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import print_function, unicode_literals
 

--- a/sickbeard/webapi.py
+++ b/sickbeard/webapi.py
@@ -16,7 +16,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 # TODO: break this up into separate files
 # pylint: disable=line-too-long,too-many-lines,abstract-method

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -15,7 +15,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 # pylint: disable=abstract-method,too-many-lines, R
 
 from __future__ import print_function, unicode_literals
@@ -512,7 +512,7 @@ class CalendarHandler(BaseHandler):
 
     # Raw iCalendar implementation by Pedro Jose Pereira Vieito (@pvieito).
     #
-    # iCalendar (iCal) - Standard RFC 5545 <http://tools.ietf.org/html/rfc5546>
+    # iCalendar (iCal) - Standard RFC 5545 <https://tools.ietf.org/html/rfc5546>
     # Works with iCloud, Google Calendar and Outlook.
     def calendar(self):
         """ Provides a subscribeable URL for iCal subscriptions
@@ -4564,7 +4564,7 @@ class ConfigProviders(Config):
         """
         Retrieves a list of possible categories with category id's
         Using the default url/api?cat
-        http://yournewznaburl.com/api?t=caps&apikey=yourapikey
+        https://yournewznaburl.com/api?t=caps&apikey=yourapikey
         """
         error = ""
         success = False

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -2456,11 +2456,11 @@ class HomeChangeLog(Home):
 
     def index(self, *args_, **kwargs_):
         try:
-            changes = helpers.getURL('http://sickrage.github.io/sickrage-news/CHANGES.md', session=helpers.make_session(), returns='text')
+            changes = helpers.getURL('https://sickrage.github.io/sickrage-news/CHANGES.md', session=helpers.make_session(), returns='text')
         except Exception:
             logger.log('Could not load changes from repo, giving a link!', logger.DEBUG)
             changes = _('Could not load changes from the repo. [Click here for CHANGES.md]({changes_url})').format(
-                changes_url='http://sickrage.github.io/sickrage-news/CHANGES.md'
+                changes_url='https://sickrage.github.io/sickrage-news/CHANGES.md'
             )
 
         t = PageTemplate(rh=self, filename="markdown.mako")

--- a/sickrage/helper/common.py
+++ b/sickrage/helper/common.py
@@ -15,7 +15,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 """
 Common helper functions

--- a/sickrage/helper/encoding.py
+++ b/sickrage/helper/encoding.py
@@ -16,7 +16,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import unicode_literals
 

--- a/sickrage/helper/exceptions.py
+++ b/sickrage/helper/exceptions.py
@@ -15,7 +15,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import print_function, unicode_literals
 

--- a/sickrage/helper/media_info.py
+++ b/sickrage/helper/media_info.py
@@ -16,7 +16,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import print_function, unicode_literals
 

--- a/sickrage/helper/quality.py
+++ b/sickrage/helper/quality.py
@@ -15,7 +15,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import unicode_literals
 

--- a/sickrage/media/GenericMedia.py
+++ b/sickrage/media/GenericMedia.py
@@ -15,7 +15,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import unicode_literals
 

--- a/sickrage/media/ShowBanner.py
+++ b/sickrage/media/ShowBanner.py
@@ -15,7 +15,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import unicode_literals
 

--- a/sickrage/media/ShowFanArt.py
+++ b/sickrage/media/ShowFanArt.py
@@ -15,7 +15,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import unicode_literals
 

--- a/sickrage/media/ShowNetworkLogo.py
+++ b/sickrage/media/ShowNetworkLogo.py
@@ -15,7 +15,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import unicode_literals
 

--- a/sickrage/media/ShowPoster.py
+++ b/sickrage/media/ShowPoster.py
@@ -15,7 +15,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import unicode_literals
 

--- a/sickrage/providers/GenericProvider.py
+++ b/sickrage/providers/GenericProvider.py
@@ -53,11 +53,11 @@ class GenericProvider(object):  # pylint: disable=too-many-instance-attributes
         self.anime_only = False
         self.bt_cache_urls = [
             #'http://torcache.net/torrent/{torrent_hash}.torrent',
-            'http://torrentproject.se/torrent/{torrent_hash}.torrent',
-            'http://thetorrent.org/torrent/{torrent_hash}.torrent',
-            'http://btdig.com/torrent/{torrent_hash}.torrent',
+            'https://torrentproject.se/torrent/{torrent_hash}.torrent',
+            'https://thetorrent.org/torrent/{torrent_hash}.torrent',
+            'https://btdig.com/torrent/{torrent_hash}.torrent',
             # 'http://torrage.com/torrent/{torrent_hash}.torrent',
-            'http://itorrents.org/torrent/{torrent_hash}.torrent',
+            'https://itorrents.org/torrent/{torrent_hash}.torrent',
         ]
         self.cache = TVCache(self)
         self.enable_backlog = False

--- a/sickrage/providers/GenericProvider.py
+++ b/sickrage/providers/GenericProvider.py
@@ -15,7 +15,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import print_function, unicode_literals
 

--- a/sickrage/providers/nzb/NZBProvider.py
+++ b/sickrage/providers/nzb/NZBProvider.py
@@ -15,7 +15,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import print_function, unicode_literals
 

--- a/sickrage/providers/subtitle/wizdom.py
+++ b/sickrage/providers/subtitle/wizdom.py
@@ -105,7 +105,7 @@ class WizdomProvider(Provider):
         category = 'movie' if is_movie else 'tv'
         title = title.replace('\'', '')
         # get TMDB ID first
-        r = self.session.get('http://api.tmdb.org/3/search/{}?api_key={}&query={}{}&language=en'.format(
+        r = self.session.get('https://api.tmdb.org/3/search/{}?api_key={}&query={}{}&language=en'.format(
             category, sickbeard.TMDB_API_KEY, title, '' if not year else '&year={}'.format(year)))
         r.raise_for_status()
         tmdb_results = r.json().get('results')
@@ -113,7 +113,7 @@ class WizdomProvider(Provider):
             tmdb_id = tmdb_results[0].get('id')
             if tmdb_id:
                 # get actual IMDB ID from TMDB
-                r = self.session.get('http://api.tmdb.org/3/{}/{}{}?api_key={}&language=en'.format(
+                r = self.session.get('https://api.tmdb.org/3/{}/{}{}?api_key={}&language=en'.format(
                     category, tmdb_id, '' if is_movie else '/external_ids', sickbeard.TMDB_API_KEY))
                 r.raise_for_status()
                 return str(r.json().get('imdb_id', '')) or None
@@ -128,8 +128,8 @@ class WizdomProvider(Provider):
 
         # search
         logger.debug('Using IMDB ID %r', imdb_id)
-        url = 'http://json.{}/{}.json'.format(self.server_url, imdb_id)
-        page_link = 'http://{}/#/{}/{}'.format(self.server_url, 'movies' if is_movie else 'series', imdb_id)
+        url = 'https://json.{}/{}.json'.format(self.server_url, imdb_id)
+        page_link = 'https://{}/#/{}/{}'.format(self.server_url, 'movies' if is_movie else 'series', imdb_id)
 
         # get the list of subtitles
         logger.debug('Getting the list of subtitles')
@@ -186,7 +186,7 @@ class WizdomProvider(Provider):
 
     def download_subtitle(self, subtitle):
         # download
-        url = 'http://zip.{}/{}.zip'.format(self.server_url, subtitle.subtitle_id)
+        url = 'https://zip.{}/{}.zip'.format(self.server_url, subtitle.subtitle_id)
         r = self.session.get(url, headers={'Referer': subtitle.page_link}, timeout=10)
         r.raise_for_status()
 

--- a/sickrage/providers/torrent/TorrentProvider.py
+++ b/sickrage/providers/torrent/TorrentProvider.py
@@ -15,7 +15,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import unicode_literals
 

--- a/sickrage/show/ComingEpisodes.py
+++ b/sickrage/show/ComingEpisodes.py
@@ -15,7 +15,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import unicode_literals
 

--- a/sickrage/show/History.py
+++ b/sickrage/show/History.py
@@ -15,7 +15,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import unicode_literals
 

--- a/sickrage/show/Show.py
+++ b/sickrage/show/Show.py
@@ -15,7 +15,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import unicode_literals
 

--- a/sickrage/show/recommendations/anidb.py
+++ b/sickrage/show/recommendations/anidb.py
@@ -27,7 +27,7 @@ class AnidbPopular(object):
                      rating=str(show.ratings['temporary']['rating']), votes=str(try_int(show.ratings['temporary']['count'], 0)), image_href=show.url)
 
                 # Check cache or get and save image
-                recommended_show.cache_image("http://img7.anidb.net/pics/anime/{0}".format(show.image_path))
+                recommended_show.cache_image("https://img7.anidb.net/pics/anime/{0}".format(show.image_path))
 
                 result.append(recommended_show)
             except Exception:

--- a/sickrage/show/recommendations/imdb.py
+++ b/sickrage/show/recommendations/imdb.py
@@ -18,8 +18,7 @@ class imdbPopular(object):
     def __init__(self):
         """Gets a list of most popular TV series from imdb"""
 
-        # Use akas.imdb.com, just like the imdb lib.
-        self.url = 'http://akas.imdb.com/search/title'
+        self.url = 'https://www.imdb.com/search/title'
 
         self.params = {
             'at': 0,
@@ -35,7 +34,7 @@ class imdbPopular(object):
 
         popular_shows = []
 
-        data = helpers.getURL(self.url, session=self.session, params=self.params, headers={'Referer': 'http://akas.imdb.com/'}, returns='text')
+        data = helpers.getURL(self.url, session=self.session, params=self.params, headers={'Referer': 'https://www.imdb.com/'}, returns='text')
         if not data:
             return None
 
@@ -58,7 +57,7 @@ class imdbPopular(object):
 
             if td:
                 show['name'] = td.find("a").contents[0]
-                show['imdb_url'] = "http://akas.imdb.com" + td.find("a")["href"]
+                show['imdb_url'] = "https://www.imdb.com" + td.find("a")["href"]
                 show['imdb_tt'] = show['imdb_url'][-10:][0:9]
                 show['year'] = td.find("span", {"class": "year_type"}).contents[0].split(" ")[0][1:]
 

--- a/sickrage/show/recommendations/recommended.py
+++ b/sickrage/show/recommendations/recommended.py
@@ -15,7 +15,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 """
 Recommend shows based on lists from indexers

--- a/sickrage/system/Restart.py
+++ b/sickrage/system/Restart.py
@@ -15,7 +15,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import unicode_literals
 

--- a/sickrage/system/Shutdown.py
+++ b/sickrage/system/Shutdown.py
@@ -15,7 +15,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import unicode_literals
 

--- a/tests/db_tests.py
+++ b/tests/db_tests.py
@@ -15,7 +15,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 """
 Test show database functionality.

--- a/tests/helpers_tests.py
+++ b/tests/helpers_tests.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python2.7
 # coding=utf-8
 # Author: Dustyn Gibson <miigotu@gmail.com>
-# URL: http://github.com/SickRage/SickRage
+# URL: https://github.com/SickRage/SickRage
 #
 # This file is part of SickRage.
 #
@@ -16,7 +16,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 """
 Test sickbeard.helpers

--- a/tests/issue_submitter_tests.py
+++ b/tests/issue_submitter_tests.py
@@ -15,7 +15,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 """
 Test exception logging

--- a/tests/notifier_tests.py
+++ b/tests/notifier_tests.py
@@ -14,7 +14,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 #
 ##############################################################################
 

--- a/tests/post_processor_queue_tests.py
+++ b/tests/post_processor_queue_tests.py
@@ -15,7 +15,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 """
 Test the post processor queue

--- a/tests/pp_tests.py
+++ b/tests/pp_tests.py
@@ -15,7 +15,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 """
 Test post processing

--- a/tests/search_tests.py
+++ b/tests/search_tests.py
@@ -16,7 +16,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 # pylint: disable=line-too-long
 

--- a/tests/sickrage_tests/__init__.py
+++ b/tests/sickrage_tests/__init__.py
@@ -15,7 +15,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 """
 Tests for SickRage

--- a/tests/sickrage_tests/helper/common_tests.py
+++ b/tests/sickrage_tests/helper/common_tests.py
@@ -15,7 +15,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 # pylint: disable=line-too-long
 

--- a/tests/sickrage_tests/helper/quality_tests.py
+++ b/tests/sickrage_tests/helper/quality_tests.py
@@ -15,7 +15,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 """
 Test qualities

--- a/tests/sickrage_tests/media/generic_media_tests.py
+++ b/tests/sickrage_tests/media/generic_media_tests.py
@@ -15,7 +15,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 """
 Test GenericMedia

--- a/tests/sickrage_tests/media/show_banner_tests.py
+++ b/tests/sickrage_tests/media/show_banner_tests.py
@@ -15,7 +15,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 """
 Test ShowBanner

--- a/tests/sickrage_tests/media/show_fan_art_tests.py
+++ b/tests/sickrage_tests/media/show_fan_art_tests.py
@@ -15,7 +15,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 """
 Test ShowFanArt

--- a/tests/sickrage_tests/media/show_network_logo_tests.py
+++ b/tests/sickrage_tests/media/show_network_logo_tests.py
@@ -15,7 +15,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 """
 Test ShowNetworkLogo

--- a/tests/sickrage_tests/media/show_poster_tests.py
+++ b/tests/sickrage_tests/media/show_poster_tests.py
@@ -15,7 +15,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 """
 Test ShowPoster

--- a/tests/sickrage_tests/providers/generic_provider_tests.py
+++ b/tests/sickrage_tests/providers/generic_provider_tests.py
@@ -15,7 +15,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 """
 Test GenericProvider

--- a/tests/sickrage_tests/providers/nzb_provider_tests.py
+++ b/tests/sickrage_tests/providers/nzb_provider_tests.py
@@ -15,7 +15,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 """
 Test NZBProvider

--- a/tests/sickrage_tests/providers/torrent/cassettes/rarbg.yaml
+++ b/tests/sickrage_tests/providers/torrent/cassettes/rarbg.yaml
@@ -8,7 +8,7 @@ interactions:
       User-Agent: [!!python/unicode 'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:21.0)
           Gecko/20100101 Firefox/21.0']
     method: GET
-    uri: http://torrentapi.org/pubapi_v2.php?get_token=get_token&app_id=sickrage2&format=json
+    uri: https://torrentapi.org/pubapi_v2.php?get_token=get_token&app_id=sickrage2&format=json
   response:
     body:
       string: !!binary |
@@ -34,7 +34,7 @@ interactions:
       User-Agent: [!!python/unicode 'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:21.0)
           Gecko/20100101 Firefox/21.0']
     method: GET
-    uri: http://torrentapi.org/pubapi_v2.php?sort=seeders&min_leechers=0&min_seeders=0&app_id=sickrage2&search_string=Game+of+Thrones+S05E08&ranked=0&category=tv&format=json_extended&token=7teph5nai2&limit=100&mode=search
+    uri: https://torrentapi.org/pubapi_v2.php?sort=seeders&min_leechers=0&min_seeders=0&app_id=sickrage2&search_string=Game+of+Thrones+S05E08&ranked=0&category=tv&format=json_extended&token=7teph5nai2&limit=100&mode=search
   response:
     body:
       string: !!binary |
@@ -79,7 +79,7 @@ interactions:
       User-Agent: [!!python/unicode 'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:21.0)
           Gecko/20100101 Firefox/21.0']
     method: GET
-    uri: http://torrentapi.org/pubapi_v2.php?category=tv&sort=last&min_leechers=0&ranked=0&limit=100&token=7teph5nai2&min_seeders=0&format=json_extended&app_id=sickrage2&mode=list
+    uri: https://torrentapi.org/pubapi_v2.php?category=tv&sort=last&min_leechers=0&ranked=0&limit=100&token=7teph5nai2&min_seeders=0&format=json_extended&app_id=sickrage2&mode=list
   response:
     body:
       string: !!binary |
@@ -265,7 +265,7 @@ interactions:
       User-Agent: [!!python/unicode 'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:21.0)
           Gecko/20100101 Firefox/21.0']
     method: GET
-    uri: http://torrentapi.org/pubapi_v2.php?sort=seeders&min_leechers=0&min_seeders=0&app_id=sickrage2&search_string=Game+of+Thrones+S05&ranked=0&category=tv&format=json_extended&token=7teph5nai2&limit=100&mode=search
+    uri: https://torrentapi.org/pubapi_v2.php?sort=seeders&min_leechers=0&min_seeders=0&app_id=sickrage2&search_string=Game+of+Thrones+S05&ranked=0&category=tv&format=json_extended&token=7teph5nai2&limit=100&mode=search
   response:
     body:
       string: !!binary |

--- a/tests/sickrage_tests/providers/torrent/parsing_tests.py
+++ b/tests/sickrage_tests/providers/torrent/parsing_tests.py
@@ -15,7 +15,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 """
 Test Provider Result Parsing

--- a/tests/sickrage_tests/providers/torrent_provider_tests.py
+++ b/tests/sickrage_tests/providers/torrent_provider_tests.py
@@ -15,7 +15,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 """
 Test TorrentProvider

--- a/tests/sickrage_tests/show/coming_episodes_tests.py
+++ b/tests/sickrage_tests/show/coming_episodes_tests.py
@@ -15,7 +15,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 """
 Test coming episodes

--- a/tests/sickrage_tests/show/history_tests.py
+++ b/tests/sickrage_tests/show/history_tests.py
@@ -15,7 +15,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 """
 Test history

--- a/tests/sickrage_tests/show/show_tests.py
+++ b/tests/sickrage_tests/show/show_tests.py
@@ -15,7 +15,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 """
 Test shows

--- a/tests/sickrage_tests/system/restart_tests.py
+++ b/tests/sickrage_tests/system/restart_tests.py
@@ -15,7 +15,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 """
 Test restart

--- a/tests/sickrage_tests/system/shutdown_tests.py
+++ b/tests/sickrage_tests/system/shutdown_tests.py
@@ -15,7 +15,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 """
 Test shutdown

--- a/tests/snatch_tests.py
+++ b/tests/snatch_tests.py
@@ -15,7 +15,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 # pylint: disable=line-too-long
 

--- a/tests/ssl_sni_tests.py
+++ b/tests/ssl_sni_tests.py
@@ -1,6 +1,6 @@
 # coding=UTF-8
 # Author: Dustyn Gibson <miigotu@gmail.com>
-# URL: http://github.come/SickRage/SickRage
+# URL: https://github.come/SickRage/SickRage
 #
 # This file is part of SickRage.
 #
@@ -15,7 +15,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 # pylint: disable=line-too-long
 

--- a/tests/test_lib.py
+++ b/tests/test_lib.py
@@ -16,7 +16,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 # pylint: disable=line-too-long
 

--- a/tests/torrent_tests.py
+++ b/tests/torrent_tests.py
@@ -15,7 +15,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 """
 Test torrents

--- a/tests/tv_tests.py
+++ b/tests/tv_tests.py
@@ -15,7 +15,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 """
 Test tv

--- a/tests/xem_tests.py
+++ b/tests/xem_tests.py
@@ -15,7 +15,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# along with SickRage. If not, see <https://www.gnu.org/licenses/>.
 
 """
 Test XEM


### PR DESCRIPTION
Proposed changes in this pull request:
- Uses HTTPS to access SR resources (changelog, news, unrar, timezones etc)
- Uses HTTPS in providers and helper code (eg thetvdb, IMDB, github, etc)
  - Updates URLs for IMDB search to match where the old URL redirected to
- Link to 3rd party sites (notifiers etc) with HTTPS where available
- Changes references in text files, README, comments, file headers etc to use HTTPS where available.

All HTTPS URLs have been tested to ensure they work; various URLs have been left as HTTP as the corresponding site doesn't yet support HTTPS.  Overall, this helps improve security to reduce the possibility of requests being modified in flight.

### Checklist 
- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read [contribution guide](https://github.com/SickRage/SickRage/blob/master/.github/CONTRIBUTING.md)
