### PR TITLE
Hide passwords in plain html, for when SR is not password protected

### DIFF
--- a/gui/slick/views/config_anime.mako
+++ b/gui/slick/views/config_anime.mako
@@ -1,6 +1,7 @@
 <%inherit file="/layouts/config.mako"/>
 <%!
     import sickbeard
+    from sickbeard.filters import hide
     from sickbeard.helpers import anon_url
 %>
 
@@ -67,10 +68,10 @@
                                 <div class="col-lg-9 col-md-9 col-sm-8 col-xs-12 pull-right">
                                     <div class="row">
                                         <div class="col-md-12">
-                                            <input type="password" name="anidb_password" id="anidb_password"
-                                                   value="${sickbeard.ANIDB_PASSWORD}"
-                                                   class="form-control input-sm input350 pull-left" autocomplete="no"
-                                                   autocapitalize="off" title="Password"/>
+                                            <input
+                                                type="password" name="anidb_password" id="anidb_password" value="${sickbeard.ANIDB_PASSWORD|hide}"
+                                                class="form-control input-sm input350 pull-left" autocomplete="no" autocapitalize="off" title="Password"
+                                            />
                                         </div>
                                     </div>
                                     <div class="row">

--- a/gui/slick/views/config_general.mako
+++ b/gui/slick/views/config_general.mako
@@ -5,6 +5,7 @@
 
     import sickbeard
     from sickbeard.common import SKIPPED, ARCHIVED, IGNORED, statusStrings, cpu_presets
+    from sickbeard.filters import hide
     from sickbeard.sbdatetime import sbdatetime, date_presets, time_presets
     from sickbeard.helpers import anon_url, LOCALE_NAMES
 
@@ -702,7 +703,9 @@
                             <div class="col-lg-9 col-md-8 col-sm-7 col-xs-12 component-desc">
                                 <div class="row">
                                     <div class="col-md-12">
-                                        <input type="password" name="web_password" id="web_password" value="${sickbeard.WEB_PASSWORD}" class="form-control input-sm input300" autocomplete="no" autocapitalize="off"/>
+                                        <input
+                                            type="password" name="web_password" id="web_password" value="${sickbeard.WEB_PASSWORD|hide}"
+                                            class="form-control input-sm input300" autocomplete="no" autocapitalize="off"/>
                                     </div>
                                 </div>
                                 <div class="row">
@@ -1150,7 +1153,8 @@
                                 <div class="col-lg-9 col-md-8 col-sm-7 col-xs-12 component-desc">
                                     <div class="row">
                                         <div class="col-md-12">
-                                            <input type="password" name="git_password" id="git_password" value="${sickbeard.GIT_PASSWORD}" class="form-control input-sm input300" autocomplete="no" autocapitalize="off" />
+                                            <input type="password" name="git_password" id="git_password" value="${sickbeard.GIT_PASSWORD|hide}"
+                                                   class="form-control input-sm input300" autocomplete="no" autocapitalize="off" />
                                         </div>
                                     </div>
                                     <div class="row">
@@ -1170,7 +1174,10 @@
                                 <div class="col-lg-9 col-md-8 col-sm-7 col-xs-12 component-desc">
                                     <div class="row">
                                         <div class="col-md-12">
-                                            <input type="text" name="git_token" id="git_token" value="${sickbeard.GIT_TOKEN}" class="form-control input-sm input350" autocapitalize="off" autocomplete="no" />
+                                            <input
+                                                type="text" name="git_token" id="git_token" value="${sickbeard.GIT_TOKEN|hide}"
+                                                class="form-control input-sm input350" autocapitalize="off" autocomplete="no"
+                                            />
                                             % if not sickbeard.GIT_TOKEN:
                                                 <input class="btn btn-inline" type="button" id="create_access_token" value="${_('Generate Token')}">
                                             % else:

--- a/gui/slick/views/config_notifications.mako
+++ b/gui/slick/views/config_notifications.mako
@@ -1,7 +1,8 @@
 <%inherit file="/layouts/config.mako"/>
 <%!
-    import sickbeard
     import re
+    import sickbeard
+    from sickbeard.filters import hide
     from sickbeard.helpers import anon_url
 %>
 
@@ -159,7 +160,10 @@
                                 <div class="col-lg-9 col-md-8 col-sm-7 col-xs-12 component-desc">
                                     <div class="row">
                                         <div class="col-md-12">
-                                            <input type="password" name="kodi_password" id="kodi_password" value="${sickbeard.KODI_PASSWORD}" class="form-control input-sm input250" autocomplete="no" autocapitalize="off" />
+                                            <input
+                                                type="password" name="kodi_password" id="kodi_password" value="${sickbeard.KODI_PASSWORD|hide}"
+                                                class="form-control input-sm input250" autocomplete="no" autocapitalize="off"
+                                            />
                                         </div>
                                     </div>
                                     <div class="row">
@@ -264,7 +268,11 @@
                                 <div class="col-lg-9 col-md-8 col-sm-7 col-xs-12 component-desc">
                                     <div class="row">
                                         <div class="col-md-12">
-                                            <input type="password" name="plex_server_password" id="plex_server_password" value="${'*' * len(sickbeard.PLEX_SERVER_PASSWORD)}" class="form-control input-sm input250" autocomplete="no" autocapitalize="off" />
+                                            <input
+                                                type="password" name="plex_server_password" id="plex_server_password"
+                                                value="${sickbeard.PLEX_SERVER_PASSWORD|hide}" class="form-control input-sm input250"
+                                                autocomplete="no" autocapitalize="off"
+                                            />
                                         </div>
                                     </div>
                                     <div class="row">
@@ -431,7 +439,11 @@
                                 <div class="col-lg-9 col-md-8 col-sm-7 col-xs-12 component-desc">
                                     <div class="row">
                                         <div class="col-md-12">
-                                            <input type="password" name="plex_client_password" id="plex_client_password" value="${'*' * len(sickbeard.PLEX_CLIENT_PASSWORD)}" class="form-control input-sm input250" autocomplete="no" autocapitalize="off" />
+                                            <input
+                                                type="password" name="plex_client_password" id="plex_client_password"
+                                                value="${sickbeard.PLEX_CLIENT_PASSWORD|hide}" class="form-control input-sm input250"
+                                                autocomplete="no" autocapitalize="off"
+                                            />
                                         </div>
                                     </div>
                                     <div class="row">
@@ -1092,7 +1104,10 @@
                                 <div class="col-lg-9 col-md-8 col-sm-7 col-xs-12 component-desc">
                                     <div class="row">
                                         <div class="col-md-12">
-                                            <input type="password" name="growl_password" id="growl_password" value="${sickbeard.GROWL_PASSWORD}" class="form-control input-sm input250" autocomplete="no" autocapitalize="off" />
+                                            <input
+                                                type="password" name="growl_password" id="growl_password" value="${sickbeard.GROWL_PASSWORD|hide}"
+                                                class="form-control input-sm input250" autocomplete="no" autocapitalize="off"
+                                            />
                                         </div>
                                     </div>
                                     <div class="row">
@@ -3009,7 +3024,10 @@
                                 <div class="col-lg-9 col-md-8 col-sm-7 col-xs-12 component-desc">
                                     <div class="row">
                                         <div class="col-md-12">
-                                            <input type="password" name="email_password" id="email_password" value="${sickbeard.EMAIL_PASSWORD}" class="form-control input-sm input250" autocomplete="no" autocapitalize="off" />
+                                            <input
+                                                type="password" name="email_password" id="email_password" value="${sickbeard.EMAIL_PASSWORD|hide}"
+                                                class="form-control input-sm input250" autocomplete="no" autocapitalize="off"
+                                            />
                                         </div>
                                     </div>
                                     <div class="row">

--- a/gui/slick/views/config_providers.mako
+++ b/gui/slick/views/config_providers.mako
@@ -1,6 +1,7 @@
 <%inherit file="/layouts/config.mako"/>
 <%!
     import sickbeard
+    from sickbeard.filters import hide
     from sickbeard.helpers import anon_url
     from sickrage.providers.GenericProvider import GenericProvider
 %>
@@ -428,10 +429,11 @@
                                             <label class="component-title">${_('Password')}</label>
                                         </div>
                                         <div class="col-lg-9 col-md-8 col-sm-7 col-xs-12 component-desc">
-                                            <input type="password" name="${curTorrentProvider.get_id()}_password"
-                                                   id="${curTorrentProvider.get_id()}_password"
-                                                   value="${curTorrentProvider.password | h}" class="form-control input-sm input350"
-                                                   autocomplete="no" autocapitalize="off"/>
+                                            <input
+                                                type="password" name="${curTorrentProvider.get_id()}_password"
+                                                id="${curTorrentProvider.get_id()}_password" value="${curTorrentProvider.password|hide}"
+                                                class="form-control input-sm input350" autocomplete="no" autocapitalize="off"
+                                            />
                                         </div>
                                     </div>
                                 % endif
@@ -442,10 +444,10 @@
                                             <label class="component-title">${_('Passkey')}</label>
                                         </div>
                                         <div class="col-lg-9 col-md-8 col-sm-7 col-xs-12 component-desc">
-                                            <input type="text" name="${curTorrentProvider.get_id()}_passkey"
-                                                   id="${curTorrentProvider.get_id()}_passkey"
-                                                   value="${curTorrentProvider.passkey}" class="form-control input-sm input350"
-                                                   autocapitalize="off"/>
+                                            <input
+                                                type="text" name="${curTorrentProvider.get_id()}_passkey" id="${curTorrentProvider.get_id()}_passkey"
+                                                value="${curTorrentProvider.passkey|hide}" class="form-control input-sm input350" autocapitalize="off"
+                                            />
                                         </div>
                                     </div>
                                 % endif
@@ -484,10 +486,11 @@
                                             <label class="component-title">${_('Pin')}</label>
                                         </div>
                                         <div class="col-lg-9 col-md-8 col-sm-7 col-xs-12 component-desc">
-                                            <input type="password" name="${curTorrentProvider.get_id()}_pin"
-                                                   id="${curTorrentProvider.get_id()}_pin" value="${curTorrentProvider.pin}"
-                                                   class="form-control input-sm input100" autocomplete="no"
-                                                   autocapitalize="off"/>
+                                            <input
+                                                type="password" name="${curTorrentProvider.get_id()}_pin"
+                                                id="${curTorrentProvider.get_id()}_pin" value="${curTorrentProvider.pin|hide}"
+                                                class="form-control input-sm input100" autocomplete="no" autocapitalize="off"
+                                            />
                                         </div>
                                     </div>
                                 % endif
@@ -781,8 +784,9 @@
                                     <div class="col-lg-9 col-md-8 col-sm-7 col-xs-12 component-desc">
                                         <div class="row">
                                             <div class="col-md-12">
-                                                <input type="password" id="newznab_key"
-                                                       class="form-control input-sm input350" autocapitalize="off"/>
+                                                <input
+                                                    type="password" id="newznab_key" class="form-control input-sm input350" autocapitalize="off"
+                                                />
                                             </div>
                                         </div>
                                         <div class="row">

--- a/gui/slick/views/config_search.mako
+++ b/gui/slick/views/config_search.mako
@@ -2,6 +2,7 @@
 <%!
     import six
     import sickbeard
+    from sickbeard.filters import hide
 %>
 
 <%block name="tabs">
@@ -375,9 +376,10 @@
                                         <div class="col-lg-9 col-md-8 col-sm-7 col-xs-12 component-desc">
                                             <div class="row">
                                                 <div class="col-md-12">
-                                                    <input type="password" name="sab_password" id="sab_password"
-                                                           value="${sickbeard.SAB_PASSWORD}" class="form-control input-sm input200"
-                                                           autocomplete="no" autocapitalize="off"/>
+                                                    <input
+                                                        type="password" name="sab_password" id="sab_password" value="${sickbeard.SAB_PASSWORD|hide}"
+                                                        class="form-control input-sm input200" autocomplete="no" autocapitalize="off"
+                                                    />
                                                 </div>
                                             </div>
                                             <div class="row">
@@ -395,9 +397,10 @@
                                         <div class="col-lg-9 col-md-8 col-sm-7 col-xs-12 component-desc">
                                             <div class="row">
                                                 <div class="col-md-12">
-                                                    <input type="text" name="sab_apikey" id="sab_apikey"
-                                                           value="${sickbeard.SAB_APIKEY}" class="form-control input-sm input350"
-                                                           autocapitalize="off"/>
+                                                    <input
+                                                        type="password" name="sab_apikey" id="sab_apikey" value="${sickbeard.SAB_APIKEY|hide}"
+                                                        class="form-control input-sm input350" autocapitalize="off"
+                                                    />
                                                 </div>
                                             </div>
                                             <div class="row">
@@ -598,10 +601,10 @@
                                         <div class="col-lg-9 col-md-8 col-sm-7 col-xs-12 component-desc">
                                             <div class="row">
                                                 <div class="col-md-12">
-                                                    <input type="password" name="nzbget_password" id="nzbget_password"
-                                                           value="${sickbeard.NZBGET_PASSWORD}"
-                                                           class="form-control input-sm input200" autocomplete="no"
-                                                           autocapitalize="off"/>
+                                                    <input
+                                                        type="password" name="nzbget_password" id="nzbget_password" value="${sickbeard.NZBGET_PASSWORD|hide}"
+                                                        class="form-control input-sm input200" autocomplete="no" autocapitalize="off"
+                                                    />
                                                 </div>
                                             </div>
                                             <div class="row">
@@ -769,10 +772,10 @@
                                         <div class="col-lg-9 col-md-8 col-sm-7 col-xs-12 component-desc">
                                             <div class="row">
                                                 <div class="col-md-12">
-                                                    <input type="password" name="syno_dsm_pass" id="syno_dsm_pass"
-                                                           value="${sickbeard.SYNOLOGY_DSM_PASSWORD}"
-                                                           class="form-control input-sm input200" autocomplete="no"
-                                                           autocapitalize="off"/>
+                                                    <input
+                                                        type="password" name="syno_dsm_pass" id="syno_dsm_pass" value="${sickbeard.SYNOLOGY_DSM_PASSWORD|hide}"
+                                                        class="form-control input-sm input200" autocomplete="no" autocapitalize="off"
+                                                    />
                                                 </div>
                                             </div>
                                             <div class="row">
@@ -999,10 +1002,10 @@
                                         <div class="col-lg-9 col-md-8 col-sm-7 col-xs-12 component-desc">
                                             <div class="row">
                                                 <div class="col-md-12">
-                                                    <input type="password" name="torrent_password" id="torrent_password"
-                                                           value="${sickbeard.TORRENT_PASSWORD}"
-                                                           class="form-control input-sm input200" autocomplete="no"
-                                                           autocapitalize="off"/>
+                                                    <input
+                                                        type="password" name="torrent_password" id="torrent_password" value="${sickbeard.TORRENT_PASSWORD|hide}"
+                                                        class="form-control input-sm input200" autocomplete="no" autocapitalize="off"
+                                                    />
                                                 </div>
                                             </div>
                                             <div class="row">

--- a/gui/slick/views/config_subtitles.mako
+++ b/gui/slick/views/config_subtitles.mako
@@ -1,7 +1,8 @@
 <%inherit file="/layouts/config.mako"/>
 <%!
-    from sickbeard import subtitles
     import sickbeard
+    from sickbeard import subtitles
+    from sickbeard.filters import hide
     from sickbeard.helpers import anon_url
 %>
 
@@ -362,11 +363,11 @@
                                     </div>
                                     <div class="row">
                                         <div class="col-md-12">
-                                            <input type="password" name="${curService['name']}_pass"
-                                                   id="${curService['name']}_pass"
-                                                   value="${providerLoginDict[curService['name']]['pass']}"
-                                                   class="form-control input-sm input300" autocomplete="no"
-                                                   autocapitalize="off" title="Password"/>
+                                            <input
+                                                type="password" name="${curService['name']}_pass" id="${curService['name']}_pass"
+                                                value="${providerLoginDict[curService['name']]['pass']|hide}"
+                                                class="form-control input-sm input300" autocomplete="no" autocapitalize="off" title="Password"
+                                            />
                                         </div>
                                     </div>
                                 </div>

--- a/gui/slick/views/layouts/main.mako
+++ b/gui/slick/views/layouts/main.mako
@@ -3,6 +3,7 @@
     import datetime
     from requests.compat import urljoin
     import sickbeard
+    from sickbeard.filters import hide
     from sickrage.helper.common import pretty_file_size
     from sickrage.show.Show import Show
     from time import time

--- a/sickbeard/filters.py
+++ b/sickbeard/filters.py
@@ -1,0 +1,30 @@
+# coding=utf-8
+# Author: Dustyn Gibson (miigotu) <miigotu@gmail.com>
+# URL: https://sickrage.github.io
+# Git: https://github.com/SickRage/SickRage.git
+#
+# This file is part of SickRage.
+#
+# SickRage is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# SickRage is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty    of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+# pylint:disable=too-many-lines
+
+from __future__ import print_function, unicode_literals
+
+
+def hide(value):
+    return 'hidden_value' if value else ''
+
+
+def unhide(old, new):
+    return (new, old)[new == 'hidden_value'] or None

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -55,7 +55,8 @@ from tornado.routes import route
 from tornado.web import addslash, authenticated, HTTPError, RequestHandler
 
 import sickbeard
-from sickbeard import classes, clients, config, db, helpers, logger, naming, network_timezones, notifiers, sab, search_queue, subtitles as subtitle_module, ui
+from sickbeard import (classes, clients, config, db, filters, helpers, logger, naming, network_timezones, notifiers, sab, search_queue,
+                       subtitles as subtitle_module, ui)
 from sickbeard.blackandwhitelist import BlackAndWhiteList, short_group_names
 from sickbeard.browser import foldersAtPath
 from sickbeard.common import (cpu_presets, FAILED, IGNORED, NAMING_LIMITED_EXTEND_E_PREFIXED, Overview, Quality, SKIPPED, SNATCHED, statusStrings, UNAIRED,
@@ -297,20 +298,11 @@ class LoginHandler(BaseHandler):
             self.finish(t.render(title=_("Login"), header=_("Login"), topmenu="login"))
 
     def post(self, *args, **kwargs):
-
-        api_key = None
-
-        username = sickbeard.WEB_USERNAME
-        password = sickbeard.WEB_PASSWORD
-
-        if self.get_argument('username', '') == username and self.get_argument('password', '') == password:
-            api_key = sickbeard.API_KEY
-
         notifiers.notify_login(self.request.remote_ip)
 
-        if api_key:
-            remember_me = try_int(self.get_argument('remember_me', default=0), 0)
-            self.set_secure_cookie('sickrage_user', api_key, expires_days=30 if remember_me > 0 else None)
+        if self.get_argument('username', '') == sickbeard.WEB_USERNAME and self.get_argument('password', '') == sickbeard.WEB_PASSWORD:
+            remember_me = (None, 30)[try_int(self.get_argument('remember_me', default=0), 0) > 0]
+            self.set_secure_cookie('sickrage_user', sickbeard.API_KEY, expires_days=remember_me)
             logger.log('User logged into the SickRage web interface', logger.INFO)
         else:
             logger.log('User attempted a failed login to the SickRage web interface from IP: ' + self.request.remote_ip, logger.WARNING)
@@ -332,16 +324,10 @@ class KeyHandler(RequestHandler):
         super(KeyHandler, self).__init__(*args, **kwargs)
 
     def get(self, *args, **kwargs):
-        api_key = None
-
         try:
-            username = sickbeard.WEB_USERNAME
-            password = sickbeard.WEB_PASSWORD
-
-            if self.get_argument('u', '') == username and self.get_argument('p', '') == password:
-                api_key = sickbeard.API_KEY
-
-            self.finish({'success': bool(api_key), 'api_key': api_key})
+            if self.get_argument('u', '') != sickbeard.WEB_USERNAME or self.get_argument('p', '') != sickbeard.WEB_PASSWORD:
+                raise Exception
+            self.finish({'success': bool(sickbeard.API_KEY), 'api_key': sickbeard.API_KEY})
         except Exception:
             logger.log('Failed doing key request: {0}'.format((traceback.format_exc())), logger.ERROR)
             self.finish({'success': False, 'error': 'Failed returning results'})
@@ -851,9 +837,10 @@ class Home(WebRoot):
         # self.set_header(b'Cache-Control', 'max-age=0,no-cache,no-store')
 
         host = config.clean_url(host)
-
         connection, accesMsg = sab.getSabAccesMethod(host)
         if connection:
+            password = filters.unhide(sickbeard.SAB_PASSWORD, password)
+            apikey = filters.unhide(sickbeard.SAB_APIKEY, apikey)
             authed, authMsg = sab.testAuthentication(host, username, password, apikey)  # @UnusedVariable
             if authed:
                 return _("Success. Connected and authenticated")
@@ -863,22 +850,21 @@ class Home(WebRoot):
             return _("Unable to connect to host")
 
     def testDSM(self, host=None, username=None, password=None):
+        password = filters.unhide(sickbeard.SYNOLOGY_DSM_PASSWORD, password)
         return self.testTorrent('download_station', host, username, password)
 
     @staticmethod
     def testTorrent(torrent_method=None, host=None, username=None, password=None):
-
         host = config.clean_url(host)
-
         client = clients.getClientInstance(torrent_method)
-
+        password = filters.unhide(sickbeard.TORRENT_PASSWORD, password)
         result_, accesMsg = client(host, username, password).testAuthentication()
 
         return accesMsg
 
     @staticmethod
     def testFreeMobile(freemobile_id=None, freemobile_apikey=None):
-
+        freemobile_apikey = filters.unhide(sickbeard.FREEMOBILE_APIKEY, freemobile_apikey)
         result, message = notifiers.freemobile_notifier.test_notify(freemobile_id, freemobile_apikey)
         if result:
             return _("SMS sent successfully")
@@ -887,7 +873,7 @@ class Home(WebRoot):
 
     @staticmethod
     def testTelegram(telegram_id=None, telegram_apikey=None):
-
+        telegram_apikey = filters.unhide(sickbeard.TELEGRAM_APIKEY, telegram_apikey)
         result, message = notifiers.telegram_notifier.test_notify(telegram_id, telegram_apikey)
         if result:
             return _("Telegram notification succeeded. Check your Telegram clients to make sure it worked")
@@ -896,7 +882,7 @@ class Home(WebRoot):
 
     @staticmethod
     def testJoin(join_id=None, join_apikey=None):
-
+        join_apikey = filters.unhide(sickbeard.JOIN_APIKEY, join_apikey)
         result, message = notifiers.join_notifier.test_notify(join_id, join_apikey)
         if result:
             return _("join notification succeeded. Check your join clients to make sure it worked")
@@ -908,7 +894,7 @@ class Home(WebRoot):
         # self.set_header(b'Cache-Control', 'max-age=0,no-cache,no-store')
 
         host = config.clean_host(host, default_port=23053)
-
+        password = filters.unhide(sickbeard.GROWL_PASSWORD, password)
         result = notifiers.growl_notifier.test_notify(host, password)
 
         pw_append = _(" with password") + ": " + password if password else ''
@@ -1010,6 +996,7 @@ class Home(WebRoot):
 
         host = config.clean_hosts(host)
         finalResult = ''
+        password = filters.unhide(sickbeard.KODI_PASSWORD, password)
         for curHost in [x.strip() for x in host.split(",")]:
             curResult = notifiers.kodi_notifier.test_notify(unquote_plus(curHost), username, password)
             if len(curResult.split(":")) > 2 and 'OK' in curResult.split(":")[2]:
@@ -1023,8 +1010,7 @@ class Home(WebRoot):
     def testPHT(self, host=None, username=None, password=None):
         self.set_header(b'Cache-Control', 'max-age=0,no-cache,no-store')
 
-        if set('*') == set(password or '*'):
-            password = sickbeard.PLEX_CLIENT_PASSWORD
+        password = filters.unhide(sickbeard.PLEX_CLIENT_PASSWORD, password)
 
         finalResult = ''
         for curHost in [x.strip() for x in host.split(',')]:
@@ -1042,8 +1028,7 @@ class Home(WebRoot):
     def testPMS(self, host=None, username=None, password=None, plex_server_token=None):
         self.set_header(b'Cache-Control', 'max-age=0,no-cache,no-store')
 
-        if set('*') == set(password or '*'):
-            password = sickbeard.PLEX_SERVER_PASSWORD
+        password = filters.unhide(sickbeard.PLEX_SERVER_PASSWORD, password)
 
         finalResult = ''
 
@@ -1069,8 +1054,8 @@ class Home(WebRoot):
 
     @staticmethod
     def testEMBY(host=None, emby_apikey=None):
-
         host = config.clean_host(host)
+        emby_apikey = filters.unhide(sickbeard.EMBY_APIKEY, emby_apikey)
         result = notifiers.emby_notifier.test_notify(unquote_plus(host), emby_apikey)
         if result:
             return _("Test notice sent successfully to {emby_host}").format(emby_host=unquote_plus(host))
@@ -4059,8 +4044,8 @@ class ConfigGeneral(Config):
 
         sickbeard.GIT_AUTH_TYPE = int(git_auth_type)
         sickbeard.GIT_USERNAME = git_username
-        sickbeard.GIT_PASSWORD = git_password
-        sickbeard.GIT_TOKEN = git_token
+        sickbeard.GIT_PASSWORD = filters.unhide(sickbeard.GIT_PASSWORD, git_password)
+        sickbeard.GIT_TOKEN = filters.unhide(sickbeard.GIT_TOKEN, git_token)
 
         # noinspection PyPep8
         if (sickbeard.GIT_AUTH_TYPE, sickbeard.GIT_USERNAME, sickbeard.GIT_PASSWORD, sickbeard.GIT_TOKEN) != (git_auth_type, git_username, git_password, git_token):
@@ -4090,7 +4075,7 @@ class ConfigGeneral(Config):
         # sickbeard.WEB_LOG is set in config.change_log_dir()
         sickbeard.ENCRYPTION_VERSION = config.checkbox_to_value(encryption_version, value_on=2, value_off=0)
         sickbeard.WEB_USERNAME = web_username
-        sickbeard.WEB_PASSWORD = web_password
+        sickbeard.WEB_PASSWORD = filters.unhide(sickbeard.WEB_PASSWORD, web_password)
 
         sickbeard.FUZZY_DATING = config.checkbox_to_value(fuzzy_dating)
         sickbeard.TRIM_ZERO = config.checkbox_to_value(trim_zero)
@@ -4278,8 +4263,8 @@ class ConfigSearch(Config):
         sickbeard.DELETE_FAILED = config.checkbox_to_value(delete_failed)
 
         sickbeard.SAB_USERNAME = sab_username
-        sickbeard.SAB_PASSWORD = sab_password
-        sickbeard.SAB_APIKEY = sab_apikey.strip()
+        sickbeard.SAB_PASSWORD = filters.unhide(sickbeard.SAB_PASSWORD, sab_password)
+        sickbeard.SAB_APIKEY = filters.unhide(sickbeard.SAB_APIKEY, sab_apikey.strip())
         sickbeard.SAB_CATEGORY = sab_category
         sickbeard.SAB_CATEGORY_BACKLOG = sab_category_backlog
         sickbeard.SAB_CATEGORY_ANIME = sab_category_anime
@@ -4288,7 +4273,7 @@ class ConfigSearch(Config):
         sickbeard.SAB_FORCED = config.checkbox_to_value(sab_forced)
 
         sickbeard.NZBGET_USERNAME = nzbget_username
-        sickbeard.NZBGET_PASSWORD = nzbget_password
+        sickbeard.NZBGET_PASSWORD = filters.unhide(sickbeard.NZBGET_PASSWORD, nzbget_password)
         sickbeard.NZBGET_CATEGORY = nzbget_category
         sickbeard.NZBGET_CATEGORY_BACKLOG = nzbget_category_backlog
         sickbeard.NZBGET_CATEGORY_ANIME = nzbget_category_anime
@@ -4298,7 +4283,7 @@ class ConfigSearch(Config):
         sickbeard.NZBGET_PRIORITY = try_int(nzbget_priority, 100)
 
         sickbeard.TORRENT_USERNAME = torrent_username
-        sickbeard.TORRENT_PASSWORD = torrent_password
+        sickbeard.TORRENT_PASSWORD = filters.unhide(sickbeard.TORRENT_PASSWORD, torrent_password)
         sickbeard.TORRENT_LABEL = torrent_label
         sickbeard.TORRENT_LABEL_ANIME = torrent_label_anime
         sickbeard.TORRENT_VERIFY_CERT = config.checkbox_to_value(torrent_verify_cert)
@@ -4314,7 +4299,7 @@ class ConfigSearch(Config):
 
         sickbeard.SYNOLOGY_DSM_HOST = config.clean_url(syno_dsm_host)
         sickbeard.SYNOLOGY_DSM_USERNAME = syno_dsm_user
-        sickbeard.SYNOLOGY_DSM_PASSWORD = syno_dsm_pass
+        sickbeard.SYNOLOGY_DSM_PASSWORD = filters.unhide(sickbeard.SYNOLOGY_DSM_PASSWORD, syno_dsm_pass)
         sickbeard.SYNOLOGY_DSM_PATH = syno_dsm_path.rstrip('/\\')
 
         # This is a PITA, but lets merge the settings if they only set DSM up in one section to save them some time
@@ -4798,19 +4783,19 @@ class ConfigProviders(Config):
 
             if hasattr(curTorrentProvider, 'password'):
                 try:
-                    curTorrentProvider.password = str(kwargs[curTorrentProvider.get_id() + '_password']).strip()
+                    curTorrentProvider.password = filters.unhide(curTorrentProvider.password, str(kwargs[curTorrentProvider.get_id() + '_password']).strip())
                 except Exception:
                     curTorrentProvider.password = None
 
             if hasattr(curTorrentProvider, 'passkey'):
                 try:
-                    curTorrentProvider.passkey = str(kwargs[curTorrentProvider.get_id() + '_passkey']).strip()
+                    curTorrentProvider.passkey = filters.unhide(curTorrentProvider.passkey, str(kwargs[curTorrentProvider.get_id() + '_passkey']).strip())
                 except Exception:
                     curTorrentProvider.passkey = None
 
             if hasattr(curTorrentProvider, 'pin'):
                 try:
-                    curTorrentProvider.pin = str(kwargs[curTorrentProvider.get_id() + '_pin']).strip()
+                    curTorrentProvider.pin = filters.unhide(curTorrentProvider.pin, str(kwargs[curTorrentProvider.get_id() + '_pin']).strip())
                 except Exception:
                     curTorrentProvider.pin = None
 
@@ -5039,7 +5024,7 @@ class ConfigNotifications(Config):
         sickbeard.KODI_UPDATE_ONLYFIRST = config.checkbox_to_value(kodi_update_onlyfirst)
         sickbeard.KODI_HOST = config.clean_hosts(kodi_host)
         sickbeard.KODI_USERNAME = kodi_username
-        sickbeard.KODI_PASSWORD = kodi_password
+        sickbeard.KODI_PASSWORD = filters.unhide(sickbeard.KODI_PASSWORD, kodi_password)
 
         sickbeard.USE_PLEX_SERVER = config.checkbox_to_value(use_plex_server)
         sickbeard.PLEX_NOTIFY_ONSNATCH = config.checkbox_to_value(plex_notify_onsnatch)
@@ -5050,46 +5035,44 @@ class ConfigNotifications(Config):
         sickbeard.PLEX_SERVER_HOST = config.clean_hosts(plex_server_host)
         sickbeard.PLEX_SERVER_TOKEN = config.clean_host(plex_server_token)
         sickbeard.PLEX_SERVER_USERNAME = plex_server_username
-        if plex_server_password != '*' * len(sickbeard.PLEX_SERVER_PASSWORD):
-            sickbeard.PLEX_SERVER_PASSWORD = plex_server_password
+        sickbeard.PLEX_SERVER_PASSWORD = filters.unhide(sickbeard.PLEX_SERVER_PASSWORD, plex_server_password)
 
         sickbeard.USE_PLEX_CLIENT = config.checkbox_to_value(use_plex_client)
         sickbeard.PLEX_CLIENT_USERNAME = plex_client_username
-        if plex_client_password != '*' * len(sickbeard.PLEX_CLIENT_PASSWORD):
-            sickbeard.PLEX_CLIENT_PASSWORD = plex_client_password
+        sickbeard.PLEX_CLIENT_PASSWORD = filters.unhide(sickbeard.PLEX_CLIENT_PASSWORD, plex_client_password)
         sickbeard.PLEX_SERVER_HTTPS = config.checkbox_to_value(plex_server_https)
 
         sickbeard.USE_EMBY = config.checkbox_to_value(use_emby)
         sickbeard.EMBY_HOST = config.clean_host(emby_host)
-        sickbeard.EMBY_APIKEY = emby_apikey
+        sickbeard.EMBY_APIKEY = filters.unhide(sickbeard.EMBY_APIKEY, emby_apikey)
 
         sickbeard.USE_GROWL = config.checkbox_to_value(use_growl)
         sickbeard.GROWL_NOTIFY_ONSNATCH = config.checkbox_to_value(growl_notify_onsnatch)
         sickbeard.GROWL_NOTIFY_ONDOWNLOAD = config.checkbox_to_value(growl_notify_ondownload)
         sickbeard.GROWL_NOTIFY_ONSUBTITLEDOWNLOAD = config.checkbox_to_value(growl_notify_onsubtitledownload)
         sickbeard.GROWL_HOST = config.clean_host(growl_host, default_port=23053)
-        sickbeard.GROWL_PASSWORD = growl_password
+        sickbeard.GROWL_PASSWORD = filters.unhide(sickbeard.GROWL_PASSWORD, growl_password)
 
         sickbeard.USE_FREEMOBILE = config.checkbox_to_value(use_freemobile)
         sickbeard.FREEMOBILE_NOTIFY_ONSNATCH = config.checkbox_to_value(freemobile_notify_onsnatch)
         sickbeard.FREEMOBILE_NOTIFY_ONDOWNLOAD = config.checkbox_to_value(freemobile_notify_ondownload)
         sickbeard.FREEMOBILE_NOTIFY_ONSUBTITLEDOWNLOAD = config.checkbox_to_value(freemobile_notify_onsubtitledownload)
         sickbeard.FREEMOBILE_ID = freemobile_id
-        sickbeard.FREEMOBILE_APIKEY = freemobile_apikey
+        sickbeard.FREEMOBILE_APIKEY = filters.unhide(sickbeard.FREEMOBILE_APIKEY, freemobile_apikey)
 
         sickbeard.USE_TELEGRAM = config.checkbox_to_value(use_telegram)
         sickbeard.TELEGRAM_NOTIFY_ONSNATCH = config.checkbox_to_value(telegram_notify_onsnatch)
         sickbeard.TELEGRAM_NOTIFY_ONDOWNLOAD = config.checkbox_to_value(telegram_notify_ondownload)
         sickbeard.TELEGRAM_NOTIFY_ONSUBTITLEDOWNLOAD = config.checkbox_to_value(telegram_notify_onsubtitledownload)
         sickbeard.TELEGRAM_ID = telegram_id
-        sickbeard.TELEGRAM_APIKEY = telegram_apikey
+        sickbeard.TELEGRAM_APIKEY = filters.unhide(sickbeard.TELEGRAM_APIKEY, telegram_apikey)
 
         sickbeard.USE_JOIN = config.checkbox_to_value(use_join)
         sickbeard.JOIN_NOTIFY_ONSNATCH = config.checkbox_to_value(join_notify_onsnatch)
         sickbeard.JOIN_NOTIFY_ONDOWNLOAD = config.checkbox_to_value(join_notify_ondownload)
         sickbeard.JOIN_NOTIFY_ONSUBTITLEDOWNLOAD = config.checkbox_to_value(join_notify_onsubtitledownload)
         sickbeard.JOIN_ID = join_id
-        sickbeard.JOIN_APIKEY = join_apikey
+        sickbeard.JOIN_APIKEY = filters.unhide(sickbeard.JOIN_APIKEY, join_apikey)
 
         sickbeard.USE_PROWL = config.checkbox_to_value(use_prowl)
         sickbeard.PROWL_NOTIFY_ONSNATCH = config.checkbox_to_value(prowl_notify_onsnatch)
@@ -5139,7 +5122,7 @@ class ConfigNotifications(Config):
         sickbeard.PUSHOVER_NOTIFY_ONDOWNLOAD = config.checkbox_to_value(pushover_notify_ondownload)
         sickbeard.PUSHOVER_NOTIFY_ONSUBTITLEDOWNLOAD = config.checkbox_to_value(pushover_notify_onsubtitledownload)
         sickbeard.PUSHOVER_USERKEY = pushover_userkey
-        sickbeard.PUSHOVER_APIKEY = pushover_apikey
+        sickbeard.PUSHOVER_APIKEY = filters.unhide(sickbeard.PUSHOVER_APIKEY, pushover_apikey)
         sickbeard.PUSHOVER_DEVICE = pushover_device
         sickbeard.PUSHOVER_SOUND = pushover_sound
         sickbeard.PUSHOVER_PRIORITY = pushover_priority
@@ -5191,7 +5174,7 @@ class ConfigNotifications(Config):
         sickbeard.EMAIL_FROM = email_from
         sickbeard.EMAIL_TLS = config.checkbox_to_value(email_tls)
         sickbeard.EMAIL_USER = email_user
-        sickbeard.EMAIL_PASSWORD = email_password
+        sickbeard.EMAIL_PASSWORD = filters.unhide(sickbeard.EMAIL_PASSWORD, email_password)
         sickbeard.EMAIL_LIST = email_list
         sickbeard.EMAIL_SUBJECT = email_subject
 
@@ -5289,15 +5272,15 @@ class ConfigSubtitles(Config):
         sickbeard.SUBTITLES_SERVICES_ENABLED = subtitles_services_enabled
 
         sickbeard.ADDIC7ED_USER = addic7ed_user or ''
-        sickbeard.ADDIC7ED_PASS = addic7ed_pass or ''
+        sickbeard.ADDIC7ED_PASS = filters.unhide(sickbeard.ADDIC7ED_PASS, addic7ed_pass) or ''
         sickbeard.ITASA_USER = itasa_user or ''
-        sickbeard.ITASA_PASS = itasa_pass or ''
+        sickbeard.ITASA_PASS = filters.unhide(sickbeard.ITASA_PASS, itasa_pass) or ''
         sickbeard.LEGENDASTV_USER = legendastv_user or ''
-        sickbeard.LEGENDASTV_PASS = legendastv_pass or ''
+        sickbeard.LEGENDASTV_PASS = filters.unhide(sickbeard.LEGENDASTV_PASS, legendastv_pass) or ''
         sickbeard.OPENSUBTITLES_USER = opensubtitles_user or ''
-        sickbeard.OPENSUBTITLES_PASS = opensubtitles_pass or ''
+        sickbeard.OPENSUBTITLES_PASS = filters.unhide(sickbeard.OPENSUBTITLES_PASS, opensubtitles_pass) or ''
         sickbeard.SUBSCENTER_USER = subscenter_user or ''
-        sickbeard.SUBSCENTER_PASS = subscenter_pass or ''
+        sickbeard.SUBSCENTER_PASS = filters.unhide(sickbeard.SUBCENTER_PASS, subscenter_pass) or ''
 
         sickbeard.save_config()
         # Reset provider pool so next time we use the newest settings
@@ -5327,7 +5310,7 @@ class ConfigAnime(Config):
 
         sickbeard.USE_ANIDB = config.checkbox_to_value(use_anidb)
         sickbeard.ANIDB_USERNAME = anidb_username
-        sickbeard.ANIDB_PASSWORD = anidb_password
+        sickbeard.ANIDB_PASSWORD = filters.unhide(sickbeard.ANIDB_PASS, anidb_password)
         sickbeard.ANIDB_USE_MYLIST = config.checkbox_to_value(anidb_use_mylist)
         sickbeard.ANIME_SPLIT_HOME = config.checkbox_to_value(split_home)
         sickbeard.ANIME_SPLIT_HOME_IN_TABS = config.checkbox_to_value(split_home_in_tabs)


### PR DESCRIPTION
@mezdanak Partial fixes (the most immediately necessary changes)
Proposed changes in this pull request:
- Do not populate password fields with the values saved on the server when viewing the page
- XHTML escaping on passed GET/POST values.

- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read [contribution guide](https://github.com/SickRage/SickRage/blob/master/.github/CONTRIBUTING.md)
