### PR TITLE
Optimize docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+# .git especially
+.*
+
+# Editor stuff
+**/*~
+**/.*.sw*
+
+tests
+
+Dockerfile
+docker-compose.yaml
+*.txt
+*.md
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ COPY --chown=sickrage:sickrage . /app/sickrage
 
 USER sickrage
 
-RUN echo -e "[General]\nauto_update = 1" > /config/config.ini
+RUN echo -e "[General]\nauto_update = 0" > /config/config.ini
 
 VOLUME ["/config","/data"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,14 +16,13 @@ RUN mkdir /var/run/sickrage/ && \
     mkdir /data/ && \
     chown sickrage. /data
 
-ADD . /app/sickrage
-RUN chown -R sickrage. /app/sickrage
+COPY --chown=sickrage:sickrage . /app/sickrage
+
+USER sickrage
 
 RUN echo -e "[General]\nauto_update = 1" > /config/config.ini
 
 VOLUME ["/config","/data"]
-
-USER sickrage
 
 WORKDIR /app/sickrage/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN addgroup -g ${PGID} sickrage && \
 RUN \
     apk add --no-cache git && \
     git config --global advice.detachedHead false && \
-    git clone --quiet https://github.com/SickRage/SickRage/ --branch $SICKRAGE_VERSION --single-branch --depth=1 /app/sickrage && \
+    git clone --quiet https://github.com/SickRage/SickRage/ --branch "${SICKRAGE_VERSION:-master}" --single-branch --depth=1 /app/sickrage && \
     apk del --no-cache git
 
 RUN mkdir /var/run/sickrage/ && \
@@ -24,9 +24,9 @@ RUN mkdir /var/run/sickrage/ && \
     mkdir /data/ && \
     chown sickrage. /data
 
-RUN echo '[General]' > /config/config.ini; if [ "$SICKRAGE_VERSION" = "master" ]; then echo 'auto_update = 1' >> /config/config.ini ; else echo 'auto_update = 0' >> /config/config.ini ; fi
+RUN echo '[General]' > /config/config.ini; if [ "${SICKRAGE_VERSION:-master}" = "master" ]; then echo 'auto_update = 1' >> /config/config.ini ; else echo 'auto_update = 0' >> /config/config.ini ; fi
 
-RUN if [ "$SICKRAGE_VERSION" = "master" ]; then chown -R sickrage. /app/sickrage/ ; fi
+RUN if [ "${SICKRAGE_VERSION:-master}" = "master" ]; then chown -R sickrage. /app/sickrage/ ; fi
 
 VOLUME ["/config","/data"]
 
@@ -37,3 +37,4 @@ WORKDIR /app/sickrage/
 CMD /usr/local/bin/python SickBeard.py -q --nolaunch --pidfile=${PID_FILE} --config=${CONF_DIR}/config.ini --datadir=${DATA_DIR} ${EXTRA_DAEMON_OPTS}
 
 EXPOSE 8081
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,5 @@
 FROM python:2.7.13-alpine
 
-ARG SICKRAGE_VERSION
-
 ENV PID_FILE /var/run/sickrage/sickrage.pid
 ENV DATA_DIR /data
 ENV CONF_DIR /config/
@@ -11,12 +9,6 @@ ENV PGID 1000
 RUN addgroup -g ${PGID} sickrage && \
     adduser -u ${PUID} -D -S -G sickrage sickrage
 
-RUN \
-    apk add --no-cache git && \
-    git config --global advice.detachedHead false && \
-    git clone --quiet https://github.com/SickRage/SickRage/ --branch "${SICKRAGE_VERSION:-master}" --single-branch --depth=1 /app/sickrage && \
-    apk del --no-cache git
-
 RUN mkdir /var/run/sickrage/ && \
     chown sickrage. /var/run/sickrage/ && \
     mkdir /config/ && \
@@ -24,9 +16,10 @@ RUN mkdir /var/run/sickrage/ && \
     mkdir /data/ && \
     chown sickrage. /data
 
-RUN echo '[General]' > /config/config.ini; if [ "${SICKRAGE_VERSION:-master}" = "master" ]; then echo 'auto_update = 1' >> /config/config.ini ; else echo 'auto_update = 0' >> /config/config.ini ; fi
+ADD . /app/sickrage
+RUN chown -R sickrage. /app/sickrage
 
-RUN if [ "${SICKRAGE_VERSION:-master}" = "master" ]; then chown -R sickrage. /app/sickrage/ ; fi
+RUN echo -e "[General]\nauto_update = 1" > /config/config.ini
 
 VOLUME ["/config","/data"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,14 +8,14 @@ ENV CONF_DIR /config/
 ENV PUID 1000
 ENV PGID 1000
 
-RUN apk update && \
-    apk add git
-
 RUN addgroup -g ${PGID} sickrage && \
     adduser -u ${PUID} -D -S -G sickrage sickrage
 
-RUN git config --global advice.detachedHead false && \
-    git clone --quiet https://github.com/SickRage/SickRage/ --branch $SICKRAGE_VERSION --single-branch --depth=1 /app/sickrage
+RUN \
+    apk add --no-cache git && \
+    git config --global advice.detachedHead false && \
+    git clone --quiet https://github.com/SickRage/SickRage/ --branch $SICKRAGE_VERSION --single-branch --depth=1 /app/sickrage && \
+    apk del --no-cache git
 
 RUN mkdir /var/run/sickrage/ && \
     chown sickrage. /var/run/sickrage/ && \


### PR DESCRIPTION
Did not submit issue beforehand

Proposed changes in this pull request:
- Reduce Docker image size (current image on Dockerhub is 273MB compressed; this builds to 155MB uncompressed on my machine; other popular images right now are 219-257MB uncompressed, so that would make this the smallest)
- Use Docker best practices - notably, build from working copy

- [X] PR is based on the DEVELOP branch
- [X] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [X] Read [contribution guide](https://github.com/SickRage/SickRage/blob/master/.github/CONTRIBUTING.md)

I kept my commits logically separated so the logic can be followed.  If you want to squash them I'll squash them.