### PR TITLE
Added Amazon as search tag and fixed itunes tag - wrong pr

### DIFF
--- a/sickbeard/common.py
+++ b/sickbeard/common.py
@@ -33,17 +33,14 @@ import uuid
 from os import path
 
 from fake_useragent import settings as UA_SETTINGS, UserAgent
-
-
+# noinspection PyUnresolvedReferences
+from six.moves import reduce
 
 from sickbeard.numdict import NumDict
 from sickrage.helper import video_screen_size
 from sickrage.helper.encoding import ek
 from sickrage.recompiled import tags
 from sickrage.tagger.episode import EpisodeTags
-
-# noinspection PyUnresolvedReferences
-from six.moves import reduce
 
 gettext.install('messages', unicode=1, codeset='UTF-8', names=["ngettext"])
 

--- a/sickbeard/common.py
+++ b/sickbeard/common.py
@@ -33,14 +33,17 @@ import uuid
 from os import path
 
 from fake_useragent import settings as UA_SETTINGS, UserAgent
-# noinspection PyUnresolvedReferences
-from six.moves import reduce
+
+
 
 from sickbeard.numdict import NumDict
 from sickrage.helper import video_screen_size
 from sickrage.helper.encoding import ek
 from sickrage.recompiled import tags
 from sickrage.tagger.episode import EpisodeTags
+
+# noinspection PyUnresolvedReferences
+from six.moves import reduce
 
 gettext.install('messages', unicode=1, codeset='UTF-8', names=["ngettext"])
 
@@ -338,7 +341,7 @@ class Quality(object):
             if ep.avc and ep.bluray:
                 result = Quality.UHD_4K_BLURAY if not full_res else Quality.UHD_8K_BLURAY
             # WEB-DL
-            elif (ep.avc and ep.itunes) or ep.web:
+            elif ep.itunes or ep.amazon or ep.netflix or ep.web:
                 result = Quality.UHD_4K_WEBDL if not full_res else Quality.UHD_8K_WEBDL
             # HDTV
             elif ep.avc and ep.tv == 'hd':
@@ -352,7 +355,7 @@ class Quality(object):
                 if ep.avc and (ep.bluray or ep.hddvd):
                     result = Quality.FULLHDBLURAY if full_res else Quality.HDBLURAY
                 # WEB-DL
-                elif (ep.avc and ep.itunes) or ep.web:
+                elif ep.itunes or ep.amazon or ep.netflix or ep.web:
                     result = Quality.FULLHDWEBDL if full_res else Quality.HDWEBDL
                 # HDTV
                 elif ep.avc and ep.tv == 'hd':
@@ -381,6 +384,7 @@ class Quality(object):
         elif ep.tv:
             # SD TV/HD TV
             result = Quality.SDTV
+
 
         return Quality.UNKNOWN if result is None else result
 

--- a/sickrage/recompiled/tags.py
+++ b/sickrage/recompiled/tags.py
@@ -16,8 +16,9 @@ dvd = re.compile(r'(?P<hd>hd)?dvd(?P<rip>rip|mux)?', re.I)
 web = re.compile(r'(web(?P<type>rip|mux|hd|.?dl|\b))', re.I)
 bluray = re.compile(r'(blue?-?ray|b[rd](?:rip|mux))', re.I)
 sat = re.compile(r'(dsr|satrip)', re.I)
-itunes = re.compile(r'(itunes)', re.I)
+itunes = re.compile(r'itunes(hd|uhd)', re.I)
 netflix = re.compile(r'netflix(hd|uhd)', re.I)
+amazon = re.compile(r'amazon(hd|uhd)', re.I)
 
 # Codecs
 avc = re.compile(r'([xh].?26[45])', re.I)

--- a/sickrage/tagger/episode.py
+++ b/sickrage/tagger/episode.py
@@ -30,6 +30,7 @@ class EpisodeTags(object):
             'mpeg': tags.mpeg,
             'xvid': tags.xvid,
             'netflix': tags.netflix,
+            'amazon': tags.amazon,
         }
 
     def _get_match_obj(self, attr, regex=None, flags=0):
@@ -275,5 +276,15 @@ class EpisodeTags(object):
         :return: an empty string if not found
         """
         attr = 'netflix'
+        match = self._get_match_obj(attr)
+        return '' if not match else match.group()
+
+    @property
+    def amazon(self):
+        """
+        Amazon tage found in name
+        :return: an empty string if not found
+        """
+        attr = 'amazon'
         match = self._get_match_obj(attr)
         return '' if not match else match.group()


### PR DESCRIPTION
Fixes 
- added the amazon tag for releases
- changed itunes tag to itunes hd/uhd
- changed common.py so avc tag is not needed (avc = re.compile(r'([xh].?26[45])', re.I))

The main reason is that some releases were found with unknown quality.
In common.py you want to know if a release is WEBDL. Itunes/Amazon/Netflix can only be a WEBDL release, so there is no point to look for the codec. In some cases the AVC tag was not found and the result is unknown quality. 

On the other hand you could add 'AVC' to the avc tag but in the end it stays the same. The result will be webdl
