### PR TITLE
Better quaity detection for AMZN and Amazon, Itunes, and Netflix releases

### DIFF
--- a/sickbeard/common.py
+++ b/sickbeard/common.py
@@ -338,7 +338,7 @@ class Quality(object):
             if ep.avc and ep.bluray:
                 result = Quality.UHD_4K_BLURAY if not full_res else Quality.UHD_8K_BLURAY
             # WEB-DL
-            elif (ep.avc and ep.itunes) or ep.web:
+            elif ep.itunes or ep.amazon or ep.netflix or ep.web:
                 result = Quality.UHD_4K_WEBDL if not full_res else Quality.UHD_8K_WEBDL
             # HDTV
             elif ep.avc and ep.tv == 'hd':
@@ -352,7 +352,7 @@ class Quality(object):
                 if ep.avc and (ep.bluray or ep.hddvd):
                     result = Quality.FULLHDBLURAY if full_res else Quality.HDBLURAY
                 # WEB-DL
-                elif (ep.avc and ep.itunes) or ep.web:
+                elif ep.itunes or ep.amazon or ep.netflix or ep.web:
                     result = Quality.FULLHDWEBDL if full_res else Quality.HDWEBDL
                 # HDTV
                 elif ep.avc and ep.tv == 'hd':
@@ -381,6 +381,7 @@ class Quality(object):
         elif ep.tv:
             # SD TV/HD TV
             result = Quality.SDTV
+
 
         return Quality.UNKNOWN if result is None else result
 

--- a/sickbeard/common.py
+++ b/sickbeard/common.py
@@ -332,31 +332,31 @@ class Quality(object):
             return Quality.UNKNOWN if result is None else result
 
         # Is it UHD?
-        if ep.vres in [2160, 4320] and ep.scan == 'p':
+        if ep.vres in {2160, 4320} and ep.scan == 'p':
             # BluRay
             full_res = (ep.vres == 4320)
             if ep.avc and ep.bluray:
-                result = Quality.UHD_4K_BLURAY if not full_res else Quality.UHD_8K_BLURAY
+                result = (Quality.UHD_4K_BLURAY, Quality.UHD_8K_BLURAY)[full_res]
             # WEB-DL
-            elif ep.itunes or ep.amazon or ep.netflix or ep.web:
-                result = Quality.UHD_4K_WEBDL if not full_res else Quality.UHD_8K_WEBDL
+            elif (ep.avc and (ep.itunes or ep.amazon or ep.netflix)) or ep.web:
+                result = (Quality.UHD_4K_WEBDL, Quality.UHD_8K_WEBDL)[full_res]
             # HDTV
             elif ep.avc and ep.tv == 'hd':
-                result = Quality.UHD_4K_TV if not full_res else Quality.UHD_8K_TV
+                result = (Quality.UHD_4K_TV, Quality.UHD_8K_TV)[full_res]
 
         # Is it HD?
-        elif ep.vres in [1080, 720]:
+        elif ep.vres in {1080, 720}:
             if ep.scan == 'p':
                 # BluRay
                 full_res = (ep.vres == 1080)
                 if ep.avc and (ep.bluray or ep.hddvd):
-                    result = Quality.FULLHDBLURAY if full_res else Quality.HDBLURAY
+                    result = (Quality.HDBLURAY, Quality.FULLHDBLURAY)[full_res]
                 # WEB-DL
-                elif ep.itunes or ep.amazon or ep.netflix or ep.web:
-                    result = Quality.FULLHDWEBDL if full_res else Quality.HDWEBDL
+                elif (ep.avc and (ep.itunes or ep.amazon or ep.netflix)) or ep.web:
+                    result = (Quality.HDWEBDL, Quality.FULLHDWEBDL)[full_res]
                 # HDTV
                 elif ep.avc and ep.tv == 'hd':
-                    result = Quality.FULLHDTV if full_res else Quality.HDTV #1080 HDTV h264
+                    result = (Quality.HDTV, Quality.FULLHDTV)[full_res]  # 1080 HDTV h264
                 # MPEG2 encoded
                 elif all([ep.vres == 1080, ep.tv == 'hd', ep.mpeg]):
                     result = Quality.RAWHDTV
@@ -364,6 +364,8 @@ class Quality(object):
                     result = Quality.RAWHDTV
             elif (ep.res == '1080i') and ep.tv == 'hd' and (ep.mpeg or (ep.raw and ep.avc_non_free)):
                 result = Quality.RAWHDTV
+        elif not ep.vres and ep.netflix or ep.amazon or ep.itunes:
+            result = Quality.HDWEBDL
         elif ep.hrws:
             result = Quality.HDTV
 
@@ -381,7 +383,6 @@ class Quality(object):
         elif ep.tv:
             # SD TV/HD TV
             result = Quality.SDTV
-
 
         return Quality.UNKNOWN if result is None else result
 

--- a/sickrage/recompiled/tags.py
+++ b/sickrage/recompiled/tags.py
@@ -16,9 +16,9 @@ dvd = re.compile(r'(?P<hd>hd)?dvd(?P<rip>rip|mux)?', re.I)
 web = re.compile(r'(web(?P<type>rip|mux|hd|.?dl|\b))', re.I)
 bluray = re.compile(r'(blue?-?ray|b[rd](?:rip|mux))', re.I)
 sat = re.compile(r'(dsr|satrip)', re.I)
-itunes = re.compile(r'itunes(hd|uhd)', re.I)
-netflix = re.compile(r'netflix(hd|uhd)', re.I)
-amazon = re.compile(r'amazon(hd|uhd)', re.I)
+itunes = re.compile(r'itunes(hd|uhd)?', re.I)
+netflix = re.compile(r'netflix(hd|uhd)?', re.I)
+amazon = re.compile(r'(amzn|amazon)(hd|uhd)?', re.I)
 
 # Codecs
 avc = re.compile(r'([xh].?26[45])', re.I)

--- a/sickrage/recompiled/tags.py
+++ b/sickrage/recompiled/tags.py
@@ -16,8 +16,9 @@ dvd = re.compile(r'(?P<hd>hd)?dvd(?P<rip>rip|mux)?', re.I)
 web = re.compile(r'(web(?P<type>rip|mux|hd|.?dl|\b))', re.I)
 bluray = re.compile(r'(blue?-?ray|b[rd](?:rip|mux))', re.I)
 sat = re.compile(r'(dsr|satrip)', re.I)
-itunes = re.compile(r'(itunes)', re.I)
+itunes = re.compile(r'itunes(hd|uhd)', re.I)
 netflix = re.compile(r'netflix(hd|uhd)', re.I)
+amazon = re.compile(r'amazon(hd|uhd)', re.I)
 
 # Codecs
 avc = re.compile(r'([xh].?26[45])', re.I)

--- a/sickrage/tagger/episode.py
+++ b/sickrage/tagger/episode.py
@@ -30,6 +30,7 @@ class EpisodeTags(object):
             'mpeg': tags.mpeg,
             'xvid': tags.xvid,
             'netflix': tags.netflix,
+            'amazon': tags.amazon,
         }
 
     def _get_match_obj(self, attr, regex=None, flags=0):
@@ -275,5 +276,15 @@ class EpisodeTags(object):
         :return: an empty string if not found
         """
         attr = 'netflix'
+        match = self._get_match_obj(attr)
+        return '' if not match else match.group()
+
+    @property
+    def amazon(self):
+        """
+        Amazon tage found in name
+        :return: an empty string if not found
+        """
+        attr = 'amazon'
         match = self._get_match_obj(attr)
         return '' if not match else match.group()

--- a/tests/common_tests.py
+++ b/tests/common_tests.py
@@ -98,7 +98,13 @@ class QualityStringTests(unittest.TestCase):
             "Test Show S01E02 720p WEB-DL AAC2 0 H 264-GROUP",
             "Test_Show.S01E02_720p_WEB-DL_AAC2.0_H264-GROUP",
             "Test.Show.S01E02.720p.WEB-DL.AAC2.0.H264-GROUP",
-            "Test.Show.S01E02.720p.iTunes.Rip.H264.AAC-GROUP"
+            "Test.Show.S01E02.720p.iTunes.Rip.H264.AAC-GROUP",
+            "Test.Show.S01E02.Show.Name.AMZN.WEB-DL.x264",
+            "Test.Show.S01E02.Show.Name.Amazon.WEB-DL.x264",
+            "Test.Show.S01E02.Show.Name.Itunes.WEB-DL.x264",
+            "Test.Show.S01E02.Show.Name.720p.AMZN.WEB-DL.x264",
+            "Test.Show.S01E02.Show.Name.720p.Amazon.WEB-DL.x264",
+            "Test.Show.S01E02.Show.Name.720p.Itunes.WEB-DL.x264"
         ],
         'full_hd_web_dl': [
             "Test.Show.S01E02.1080p.WEB-DL-GROUP",
@@ -107,7 +113,11 @@ class QualityStringTests(unittest.TestCase):
             "Test.Show.S01E02.WEBRip.1080p.H264.AAC.2.0-GROUP",
             "Test.Show.S01E02.1080p.iTunes.H.264.AAC-GROUP",
             "Test Show S01E02 1080p iTunes H 264 AAC-GROUP",
-            "Test_Show_S01E02_1080p_iTunes_H_264_AAC-GROUP"
+            "Test_Show_S01E02_1080p_iTunes_H_264_AAC-GROUP",
+            "Test.Show.S01E02.Show.Name.1080p.AMZN.WEB-DL.x264",
+            "Test.Show.S01E02.Show.Name.1080p.Amazon.WEB-DL.x264",
+            "Test.Show.S01E02.Show.Name.1080p.ItunesHD.WEB-DL.x264"
+
         ],
         'hd_bluray': [
             "Test.Show.S01E02.720p.BluRay.x264-GROUP",


### PR DESCRIPTION
Fixes #4439 

Proposed changes in this pull request:
- Adds better quaity detection for AMZN and Amazon, Itunes, and Netflix
- Sets lowest quality for those services to HDWEBDL (This might need to change)

- [x] PR is basted on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read [contribution guide](https://github.com/SickRage/SickRage/blob/master/.github/CONTRIBUTING.md)
