### PR TITLE
Update tags.py

### DIFF
--- a/sickrage/recompiled/tags.py
+++ b/sickrage/recompiled/tags.py
@@ -21,7 +21,7 @@ netflix = re.compile(r'netflix(hd|uhd)?', re.I)
 amazon = re.compile(r'(amzn|amazon)(hd|uhd)?', re.I)
 
 # Codecs
-avc = re.compile(r'([xh].?26[45])', re.I)
+avc = re.compile(r'([xh].?26[45]|avc)', re.I)
 xvid = re.compile(r'(xvid|divx)', re.I)
 mpeg = re.compile(r'(mpeg-?2)', re.I)
 


### PR DESCRIPTION
add avc to the tag because
Call.the.Midwife.Christmas.Special.2015.Teil2.German.DD51.Synced.DL.1080p.iTunesHD.AVC-TVS 
would be unknown quality

Fixes #

Proposed changes in this pull request:
-
-
-

- [ ] PR is based on the DEVELOP branch
- [ ] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [ ] Read [contribution guide](https://github.com/SickRage/SickRage/blob/master/.github/CONTRIBUTING.md)
