### PR TITLE
Prevent deleting a folder if other shows use the folder as a root dir…

### DIFF
--- a/sickbeard/tv.py
+++ b/sickbeard/tv.py
@@ -1006,13 +1006,16 @@ class TVShow(object):  # pylint: disable=too-many-instance-attributes, too-many-
                     except Exception as error:
                         logger.log('Unable to change permissions of {0}: {1}'.format(self._location, error), logger.WARNING)
 
-                if sickbeard.TRASH_REMOVE_SHOW:
-                    send2trash(self.location)
+                if {d for d in sickbeard.ROOT_DIRS if self.location in d}:
+                    logger.log('Cannot delete the show files from disk, because this location is the root dir for other shows!')
                 else:
-                    ek(shutil.rmtree, self.location)
+                    if sickbeard.TRASH_REMOVE_SHOW:
+                        send2trash(self.location)
+                    else:
+                        ek(shutil.rmtree, self.location)
 
-                logger.log('{0} show folder {1}'.format
-                           (('Deleted', 'Trashed')[sickbeard.TRASH_REMOVE_SHOW], self._location))
+                    logger.log('{0} show folder {1}'.format
+                               (('Deleted', 'Trashed')[sickbeard.TRASH_REMOVE_SHOW], self._location))
 
             except ShowDirectoryNotFoundException:
                 logger.log("Show folder does not exist, no need to {0} {1}".format(action, self._location), logger.WARNING)


### PR DESCRIPTION
…. Temporary workaround as this should use sql to check and also remove episodes by location. #4441

Signed-off-by: miigotu <miigotu@gmail.com>

Fixes #

Proposed changes in this pull request:
-
-
-

- [ ] PR is based on the DEVELOP branch
- [ ] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [ ] Read [contribution guide](https://github.com/SickRage/SickRage/blob/master/.github/CONTRIBUTING.md)
