### PR TITLE
Don't use torrent cache services as they don't work

### DIFF
--- a/sickrage/providers/GenericProvider.py
+++ b/sickrage/providers/GenericProvider.py
@@ -87,7 +87,7 @@ class GenericProvider(object):  # pylint: disable=too-many-instance-attributes
         if not self.login():
             return False
 
-        urls, filename = self._make_url(result, true)
+        urls, filename = self._make_url(result, True)
 
         for url in urls:
             if 'NO_DOWNLOAD_NAME' in url:

--- a/sickrage/providers/GenericProvider.py
+++ b/sickrage/providers/GenericProvider.py
@@ -87,11 +87,18 @@ class GenericProvider(object):  # pylint: disable=too-many-instance-attributes
         if not self.login():
             return False
 
-        urls, filename = self._make_url(result)
+        urls, filename = self._make_url(result, true)
 
         for url in urls:
             if 'NO_DOWNLOAD_NAME' in url:
                 continue
+
+            if url.startswith('magnet'):
+                text_file = open(filename, "w")
+                text_file.write("%s" % url)
+                text_file.close()
+                logger.log('Saved result to {0}'.format(filename), logger.INFO)
+                return True
 
             if url.startswith('http'):
                 self.headers.update({
@@ -488,13 +495,16 @@ class GenericProvider(object):  # pylint: disable=too-many-instance-attributes
             logger.log('Unable to extract torrent hash or name from magnet: {0}'.format(magnet), logger.ERROR)
             return ''
 
-    def _make_url(self, result):
+    def _make_url(self, result, force_magnet):
         if not result:
             return '', ''
 
         filename = ''
         urls = [result.url]
         if result.url.startswith('magnet'):
+            if force_magnet:
+                filename = ek(join, self._get_storage_dir(), sanitize_filename(result.name) + '.magnet')
+                return urls, filename
             torrent_hash = self.hash_from_magnet(result.url)
             if not torrent_hash:
                 return urls, filename


### PR DESCRIPTION
Currently when using blackhole for torrents, magnet links are "converted" to torrent files using webservices for torrent caching. But this doesn't work.

I'm not very familiar with python and i'd like some pointers on how to achieve the following:

make a checkbox in blackhole config to enable the changes i did (the optional flag `force_magnet`) so magnets are stored in a text file with .magnet extension.