### PR TITLE
Stop HTML Escaping internal arguments

### DIFF
--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -277,11 +277,11 @@ class WebHandler(BaseHandler):
             kwargs = self.request.arguments
             for arg, value in six.iteritems(kwargs):
                 if len(value) == 1:
-                    kwargs[arg] = xhtml_escape(value[0])
+                    kwargs[arg] = value[0]
                 elif isinstance(value, six.string_types):
-                    kwargs[arg] = xhtml_escape(value)
+                    kwargs[arg] = value
                 elif isinstance(value, list):
-                    kwargs[arg] = [xhtml_escape(v) for v in value]
+                    kwargs[arg] = value
                 else:
                     raise Exception
 


### PR DESCRIPTION
Fixes #4445

Proposed changes in this pull request:
- Stop HTML Escaping internal arguments within async_call in webserve.py

- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read [contribution guide](https://github.com/SickRage/SickRage/blob/master/.github/CONTRIBUTING.md)
