### PR TITLE
Update Scenetime provider after api change

### DIFF
--- a/sickbeard/providers/scenetime.py
+++ b/sickbeard/providers/scenetime.py
@@ -46,7 +46,7 @@ class SceneTimeProvider(TorrentProvider):  # pylint: disable=too-many-instance-a
         self.urls = {'base_url': 'https://www.scenetime.com',
                      'login': 'https://www.scenetime.com/takelogin.php',
                      'detail': 'https://www.scenetime.com/details.php?id=%s',
-                     'apisearch': 'https://www.scenetime.com/browse_API.php',
+                     'apisearch': 'https://www.scenetime.com/browse.php',
                      'download': 'https://www.scenetime.com/download.php/%s/%s'}
 
         self.url = self.urls['base_url']
@@ -100,7 +100,7 @@ class SceneTimeProvider(TorrentProvider):  # pylint: disable=too-many-instance-a
                     continue
 
                 with BS4Parser(data, 'html5lib') as html:
-                    torrent_rows = html.findAll('tr')
+                    torrent_rows = html.find(id='torrenttable').findAll('tr')
 
                     # Continue only if one Release is found
                     if len(torrent_rows) < 2:


### PR DESCRIPTION
The browse_API.php endpoint is no longer available, and the browse.php
page has a slightly different format.

Fixes #4755 

Proposed changes in this pull request:
- switches to use browse.php page
- only looks for torrent rows within the &lt;div id="torrenttable"&gt; element rather than the entire page

- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read [contribution guide](https://github.com/SickRage/SickRage/blob/master/.github/CONTRIBUTING.md)
