### PR TITLE
Update speedcd.py

### DIFF
--- a/sickbeard/providers/speedcd.py
+++ b/sickbeard/providers/speedcd.py
@@ -21,6 +21,7 @@
 from __future__ import print_function, unicode_literals
 
 import re
+import string
 
 from requests.compat import urljoin
 from requests.utils import dict_from_cookiejar
@@ -129,7 +130,7 @@ class SpeedCDProvider(TorrentProvider):  # pylint: disable=too-many-instance-att
                     logger.log("Search string: {0}".format
                                (search_string.decode("utf-8")), logger.DEBUG)
 
-                search_params['search'] = search_string
+                search_params['search'] = search_string.translate(None, string.punctuation)
 
                 data = self.get_url(self.urls['search'], params=search_params, returns='text')
                 if not data:


### PR DESCRIPTION
This fixes #4775 

It looks like no results have any punctuation in the titles such as full stops or apostrophes (at least in my testing, others may know better and I will rethink this). This was throwing off the search query a bit. I have this fix running on my local install of SickRage and is providing results as expected.