### PR TITLE
Do not assume that torrenttable div will be present and well formed.

### DIFF
--- a/sickbeard/providers/scenetime.py
+++ b/sickbeard/providers/scenetime.py
@@ -100,7 +100,11 @@ class SceneTimeProvider(TorrentProvider):  # pylint: disable=too-many-instance-a
                     continue
 
                 with BS4Parser(data, 'html5lib') as html:
-                    torrent_rows = html.find(id='torrenttable').findAll('tr')
+                    torrent_table = html.find(id='torrenttable')
+                    if torrent_table:
+                        torrent_rows = torrent_table.findAll('tr')
+                    else:
+                        torrent_rows = []
 
                     # Continue only if one Release is found
                     if len(torrent_rows) < 2:


### PR DESCRIPTION
It appears that when there are no search results the &lt;div
id="torrenttable"&gt; element may be missing or incomplete.  To avoid this
causing exceptions in the log, simply treat this as an empty result set.

Fixes #4784 

Proposed changes in this pull request:
- Treats a search result without a &lt;div="torrenttable"&gt; element as an empty result

- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read [contribution guide](https://github.com/SickRage/SickRage/blob/master/.github/CONTRIBUTING.md)
