### PR TITLE
Move verbose regex above scene_date_format to fix #4839

### DIFF
--- a/sickbeard/name_parser/regexes.py
+++ b/sickbeard/name_parser/regexes.py
@@ -93,6 +93,16 @@ normal_regexes = [
      ((?<![. _-])(?<!WEB)                          # Make sure this is really the release group
      -(?P<release_group>[^ -]+([. _-]\[.*\])?))?)?$              # Group
      '''),
+    ('verbose',
+     # Show Name Season 1 Episode 2 Ep Name
+     r'''
+     ^(?P<series_name>.+?)[. _-]+                # Show Name and separator
+     (season|series)[. _-]+                      # season and separator
+     (?P<season_num>\d+)[. _-]+                  # 1
+     episode[. _-]+                              # episode and separator
+     (?P<ep_num>\d+)[. _-]+                      # 02 and separator
+     (?P<extra_info>.+)$                         # Source_Quality_Etc-
+     '''),
     ('scene_date_format',
      # Show.Name.2010.11.23.Source.Quality.Etc-Group
      # Show Name - 2010-11-23 - Ep Name
@@ -130,16 +140,6 @@ normal_regexes = [
      (?!264)                                                            # don't count x264
      (?P<season_num>\d{1,2})                                            # 1
      (?P<ep_num>\d{2})$                                                 # 02
-     '''),
-    ('verbose',
-     # Show Name Season 1 Episode 2 Ep Name
-     r'''
-     ^(?P<series_name>.+?)[. _-]+                # Show Name and separator
-     (season|series)[. _-]+                      # season and separator
-     (?P<season_num>\d+)[. _-]+                  # 1
-     episode[. _-]+                              # episode and separator
-     (?P<ep_num>\d+)[. _-]+                      # 02 and separator
-     (?P<extra_info>.+)$                         # Source_Quality_Etc-
      '''),
     ('season_only',
      # Show.Name.S01.Source.Quality.Etc-Group


### PR DESCRIPTION
Fixes #4839 

Proposed changes in this pull request:
- Move verbose regex above scene_date_format in regexes.py to fix #4839 

- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read [contribution guide](https://github.com/SickRage/SickRage/blob/master/.github/CONTRIBUTING.md)
