### PR TITLE
Changed "Download Finished" Notification String

### DIFF
--- a/sickbeard/common.py
+++ b/sickbeard/common.py
@@ -77,7 +77,7 @@ NOTIFY_LOGIN_TEXT = 7
 notifyStrings = NumDict({
     # pylint: disable=undefined-variable
     NOTIFY_SNATCH: _("Started Download"),
-    NOTIFY_DOWNLOAD: _("Download Finished"),
+    NOTIFY_DOWNLOAD: _("Finished Download"),
     NOTIFY_SUBTITLE_DOWNLOAD: _("Subtitle Download Finished"),
     NOTIFY_GIT_UPDATE: _("SickRage Updated"),
     NOTIFY_GIT_UPDATE_TEXT: _("SickRage Updated To Commit#: "),


### PR DESCRIPTION
Changed the 'Download Finished' notification string to match the 'Started Download' - therefore they both start with the status ["Started"/"Finished"] and allow for easier identification when scrolling through the list of notifications in whichever channel the user has chosen.

Fixes #

Proposed changes in this pull request:
-
-
-

- [ ] PR is based on the DEVELOP branch
- [ ] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [ ] Read [contribution guide](https://github.com/SickRage/SickRage/blob/master/.github/CONTRIBUTING.md)
