### PR TITLE
Fix issue #4675 (Filelist provider not working)

### DIFF
--- a/sickbeard/providers/filelist.py
+++ b/sickbeard/providers/filelist.py
@@ -46,7 +46,7 @@ class FileListProvider(TorrentProvider):  # pylint: disable=too-many-instance-at
         self.minleech = None
 
         # URLs
-        self.url = "http://filelist.ro"
+        self.url = "https://filelist.ro"
         self.urls = {
             "login": urljoin(self.url, "takelogin.php"),
             "search": urljoin(self.url, "browse.php"),


### PR DESCRIPTION
Fixes #
Fixes #4675 

Proposed changes in this pull request:
 - Provider filelist uses https.

- [X] PR is based on the DEVELOP branch
- [X] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [X] Read [contribution guide](https://github.com/SickRage/SickRage/blob/master/.github/CONTRIBUTING.md)
