### PR TITLE
change yggtorrent url

### DIFF
--- a/sickbeard/providers/yggtorrent.py
+++ b/sickbeard/providers/yggtorrent.py
@@ -48,7 +48,7 @@ class YggTorrentProvider(TorrentProvider):  # pylint: disable=too-many-instance-
         self.minleech = None
 
         # URLs
-        self.url = 'https://ww3.yggtorrent.is/'
+        self.url = 'https://ww4.yggtorrent.is/'
         self.urls = {
             'login': urljoin(self.url, 'user/login'),
             'search': urljoin(self.url, 'engine/search')


### PR DESCRIPTION
Or adapter for the code that it recovers the target https://yggtorrent.is

```
import requests
response = requests.get('https://yggtorrent.is')
print(response.url)
```
