### PR TITLE
[yggtorrent] Use requests module to guess subdomain. Suggested in PR#…

### DIFF
--- a/sickbeard/providers/yggtorrent.py
+++ b/sickbeard/providers/yggtorrent.py
@@ -22,8 +22,8 @@
 from __future__ import unicode_literals
 
 import re
-import requests
 
+import requests
 from requests.compat import urljoin
 from requests.utils import dict_from_cookiejar
 

--- a/sickbeard/providers/yggtorrent.py
+++ b/sickbeard/providers/yggtorrent.py
@@ -22,6 +22,7 @@
 from __future__ import unicode_literals
 
 import re
+import requests
 
 from requests.compat import urljoin
 from requests.utils import dict_from_cookiejar
@@ -48,7 +49,7 @@ class YggTorrentProvider(TorrentProvider):  # pylint: disable=too-many-instance-
         self.minleech = None
 
         # URLs
-        self.url = 'https://ww3.yggtorrent.is/'
+        self.url = requests.get('https://yggtorrent.is').url
         self.urls = {
             'login': urljoin(self.url, 'user/login'),
             'search': urljoin(self.url, 'engine/search')


### PR DESCRIPTION
…4914

Fixes PR #4914

Proposed changes in this pull request:
- Usage of requests to guess the right yggtorrent.is subdomain (which change often)

- [X] PR is based on the DEVELOP branch
- [X] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [X] Read [contribution guide](https://github.com/SickRage/SickRage/blob/master/.github/CONTRIBUTING.md)
