### PR TITLE
Fixes #3987, Allows for anime searching by absolute episode number in the backlog

### DIFF
--- a/sickbeard/providers/newznab.py
+++ b/sickbeard/providers/newznab.py
@@ -302,6 +302,8 @@ class NewznabProvider(NZBProvider):  # pylint: disable=too-many-instance-attribu
                         date_str = str(ep_obj.airdate)
                         search_params['season'] = date_str.partition('-')[0]
                         search_params['ep'] = date_str.partition('-')[2].replace('-', '/')
+                    elif ep_obj.show.is_anime:
+                        search_params['ep'] = ep_obj.absolute_number
                     else:
                         search_params['season'] = ep_obj.scene_season
                         search_params['ep'] = ep_obj.scene_episode


### PR DESCRIPTION
Fixes #3987 

Proposed changes in this pull request:
- If the episode being searched is marked as Anime, the absolute episode number is used for searching instead of the season/scene episode

- [X] PR is based on the DEVELOP branch
- [X] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [X] Read [contribution guide](https://github.com/SickRage/SickRage/blob/master/.github/CONTRIBUTING.md)
