### PR TITLE
Update yggtorrent.py to the new URL

### DIFF
--- a/sickbeard/providers/yggtorrent.py
+++ b/sickbeard/providers/yggtorrent.py
@@ -49,7 +49,7 @@ class YggTorrentProvider(TorrentProvider):  # pylint: disable=too-many-instance-
 
         # URLs
         self.custom_url = None
-        self.url = 'https://www.yggtorrent.is/'
+        self.url = 'https://yggtorrent.to/'
         self.urls = {
             'login': urljoin(self.url, 'user/login'),
             'search': urljoin(self.url, 'engine/search')


### PR DESCRIPTION
On 14/09/2018, yggtorrent changed is tld from 'is' to 'to' and become unreachable on yggtorrent.is
Also, there is an tls error when using the subdomain 'www'.

Proposed changes in this pull request:
- changed 'is' to 'to tld for yggtorrent as it changed
- removed 'www' in yggtorrent url as it failed with tls error

- [ V] PR is based on the DEVELOP branch
- [ V] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [V ] Read [contribution guide](https://github.com/SickRage/SickRage/blob/master/.github/CONTRIBUTING.md)
