### PR TITLE
Fix ygg url

### DIFF
--- a/sickbeard/providers/yggtorrent.py
+++ b/sickbeard/providers/yggtorrent.py
@@ -48,7 +48,7 @@ class YggTorrentProvider(TorrentProvider):  # pylint: disable=too-many-instance-
         self.minleech = None
 
         # URLs
-        self.url = 'https://ww3.yggtorrent.is/'
+        self.url = 'https://www6.yggtorrent.to/'
         self.urls = {
             'login': urljoin(self.url, 'user/login'),
             'search': urljoin(self.url, 'engine/search')
@@ -113,7 +113,7 @@ class YggTorrentProvider(TorrentProvider):  # pylint: disable=too-many-instance-
                 try:
                     search_params = {
                         'category': "2145",
-                        'sub_category' : "2184",
+                        'sub_category' : "all",
                         'name': re.sub(r'[()]', '', search_string),
                         'do': 'search'
                     }


### PR DESCRIPTION
Fixes #

Proposed changes in this pull request:
- Fix YGG url
- Replace the "2184" sub category to "all" because anime are not set in the good category in ygg, so they never match...

- [X] PR is based on the DEVELOP branch
- [X] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [X] Read [contribution guide](https://github.com/SickChill/SickChill/blob/master/.github/CONTRIBUTING.md)
