### PR TITLE
Use `all` subcategory on YggTorrent, to catch anime and documentaries better

### DIFF
--- a/sickbeard/providers/yggtorrent.py
+++ b/sickbeard/providers/yggtorrent.py
@@ -142,13 +142,9 @@ class YggTorrentProvider(TorrentProvider):  # pylint: disable=too-many-instance-
                 try:
                     search_params = {
                         'category': "2145",
-                        'sub_category' : "2184",
                         'name': re.sub(r'[()]', '', search_string),
                         'do': 'search'
                     }
-
-                    if self.show and self.show.is_anime:
-                        search_params['sub_category'] = "2179"
 
                     data = self.get_url(self.urls['search'], params=search_params, returns='text')
                     if not data:

--- a/sickbeard/providers/yggtorrent.py
+++ b/sickbeard/providers/yggtorrent.py
@@ -141,7 +141,8 @@ class YggTorrentProvider(TorrentProvider):  # pylint: disable=too-many-instance-
 
                 try:
                     search_params = {
-                        'category': "2145",
+                        'category': '2145',
+                        'sub_category' : 'all',
                         'name': re.sub(r'[()]', '', search_string),
                         'do': 'search'
                     }


### PR DESCRIPTION
sub_category is useless and leads to incomplete search results

Fixes #5209

Proposed changes in this pull request:
- remove sub_category

- [x ] PR is based on the DEVELOP branch
- [ x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [ x] Read [contribution guide](https://github.com/SickChill/SickChill/blob/master/.github/CONTRIBUTING.md)
