### PR TITLE
Fix #5244: add new Torrent9 indexer file prefix 'Torrent9.PH ---> '

### DIFF
--- a/sickbeard/helpers.py
+++ b/sickbeard/helpers.py
@@ -192,7 +192,8 @@ def remove_non_release_groups(name):
         r'^\[ www\.TorrentDay\.com \] - ': 'searchre',
         r'\[NO-RAR\] - \[ www\.torrentday\.com \]$': 'searchre',
         r'^www\.Torrenting\.com\.-\.': 'searchre',
-        r'-Scrambled$': 'searchre'
+        r'-Scrambled$': 'searchre',
+        r'^Torrent9\.PH ---> ': 'searchre'
     }
 
     _name = name


### PR DESCRIPTION
Fixes #5244

Proposed changes in this pull request:
- support new format of release group adopted by Torrent9 indexer so that post-processing is not confused

with a file like 'Torrent9.PH ---> myshow.avi' post processing seeks for 'torrent9 ph > myshow' which is unknown obviously

