### PR TITLE
Update stale.yml

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -12,6 +12,9 @@ exemptLabels:
   - Pinned
   - Security
   - "[Status] Maybe Later"
+  - "Feature Request"
+  - "In Progress"
+  - "Enhancement"
 
 # Set to true to ignore issues in a project (defaults to false)
 exemptProjects: false


### PR DESCRIPTION
Fixes #5256

@WebSpider I'm not sure all of them need to be exempted, because if the bot tags it stale and nobody responds within 7 days it must not be a very important request I think?