### PR TITLE
Fix broken unrar validation.

### DIFF
--- a/sickbeard/config.py
+++ b/sickbeard/config.py
@@ -182,7 +182,7 @@ def change_unrar_tool(unrar_tool, alt_unrar_tool):
     sickbeard.ALT_UNRAR_TOOL = rarfile.ALT_TOOL = alt_unrar_tool
 
     try:
-        rarfile.custom_check([rarfile.UNRAR_TOOL])
+        rarfile.custom_check([rarfile.UNRAR_TOOL], True)
         return True
     except (rarfile.RarCannotExec, rarfile.RarExecError, OSError, IOError):
         if sickbeard.UNPACK == 1:


### PR DESCRIPTION
In this commit https://github.com/SickChill/SickChill/commit/221a10cd4d81f3428335beaf7a105038654baea1 major refactoring was made to `rarlib` and since then app keeps disabling unpack option even if `unrar` is installed because when unrar is being run without args (as it is done while checking) it returns help which returns exit code `1` not `0` therefore we need to set `ignore_retcode=True` as it was before this commit.

Evidence:
```
root@cd8eb55b5a4f:/app/sickrage# which unrar
/usr/bin/unrar

root@cd8eb55b5a4f:/app/sickrage# unrar
unrar: Archive not specified
Try `unrar --help' or `unrar --usage' for more information.
root@cd8eb55b5a4f:/app/sickrage# echo $?
1
```

```
unrar --version
unrar 0.0.1
root@cd8eb55b5a4f:/app/sickrage# echo $?
0
```
