### PR TITLE
Upgrade cfscrape to version 1.9.7

### DIFF
--- a/lib/cfscrape/__init__.py
+++ b/lib/cfscrape/__init__.py
@@ -12,7 +12,7 @@ try:
 except ImportError:
     from urllib.parse import urlparse
 
-__version__ = "1.9.6"
+__version__ = "1.9.7"
 
 DEFAULT_USER_AGENTS = [
     "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.181 Safari/537.36",
@@ -85,6 +85,7 @@ class CloudflareScraper(Session):
         try:
             params["jschl_vc"] = re.search(r'name="jschl_vc" value="(\w+)"', body).group(1)
             params["pass"] = re.search(r'name="pass" value="(.+?)"', body).group(1)
+            params["s"] = re.search(r'name="s"\svalue="(?P<s_value>[^"]+)', body).group('s_value')
         except Exception as e:
             # Something is wrong with the page.
             # This may indicate Cloudflare has changed their anti-bot


### PR DESCRIPTION
Branch: https://github.com/Anorov/cloudflare-scrape/commit/f35c463a60d175f0252b1e0c8e14a284e9d4daa5

I ran into issues with iptorrents and the current version of cloudflare-scrape
Upgraded to the latest version and the issue went away.

Quote of error:
```
2019-04-05 11:27:12 INFO SEARCHQUEUE-BACKLOG-331980 :: [IPTorrents] :: No NZB/Torrent providers found or enabled in the sickchill config for backlog searches. Please check your settings.
AA AttributeError: 'exceptions.ValueError' object has no attribute 'request'
AA if requests_exception.request:
AA File "/app/sickrage/sickbeard/helpers.py", line 1570, in handle_requests_exception
AA handle_requests_exception(error)
AA File "/app/sickrage/sickbeard/helpers.py", line 1465, in getURL
AA return getURL(url, post_data, params, self.headers, timeout, self.session, **kwargs)
AA File "/app/sickrage/sickchill/providers/GenericProvider.py", line 372, in get_url
AA self.get_url(login_url, returns='text')
AA File "/app/sickrage/sickbeard/providers/iptorrents.py", line 83, in login
AA if not self.login():
AA File "/app/sickrage/sickbeard/providers/iptorrents.py", line 108, in search
AA items_list += self.search(search_string, ep_obj=episode)
AA File "/app/sickrage/sickchill/providers/GenericProvider.py", line 170, in find_search_results
AA searchResults = curProvider.find_search_results(show, episodes, search_mode, manualSearch, downCurQuality)
AA File "/app/sickrage/sickbeard/search.py", line 474, in searchProviders
AA Traceback (most recent call last):
2019-04-05 11:27:12 ERROR SEARCHQUEUE-BACKLOG-331980 :: [IPTorrents] :: [f7a113a] Exception while searching IPTorrents. Error: AttributeError("'exceptions.ValueError' object has no attribute 'request'",)
AA Please read https://github.com/Anorov/cloudflare-scrape#updates, then file a bug report at https://github.com/Anorov/cloudflare-scrape/issues."
AA ValueError: Error parsing Cloudflare IUAM Javascript challenge. Cloudflare may have changed their technique, or there may be a bug in the script.
AA raise requests_exception
AA File "/app/sickrage/sickbeard/helpers.py", line 1526, in handle_requests_exception
AA Traceback (most recent call last):
AA Please read https://github.com/Anorov/cloudflare-scrape#updates, then file a bug report at https://github.com/Anorov/cloudflare-scrape/issues." ()
2019-04-05 11:27:12 ERROR SEARCHQUEUE-BACKLOG-331980 :: [IPTorrents] :: [f7a113a] Request failed: Error parsing Cloudflare IUAM Javascript challenge. Cloudflare may have changed their technique, or there may be a bug in the script.
```

Proposed changes in this pull request:
- Upgraded cfscrape to 1.9.7

- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read [contribution guide](https://github.com/SickChill/SickChill/blob/master/.github/CONTRIBUTING.md)
