### PR TITLE
feat: Slack Icon options

### DIFF
--- a/gui/slick/views/config_notifications.mako
+++ b/gui/slick/views/config_notifications.mako
@@ -3091,15 +3091,6 @@
                                 </div>
                             </div>
 
-                            <div class="field-pair row">
-                                <div class="col-lg-3 col-md-4 col-sm-5 col-xs-12">
-                                    <label for="slack_icon_url" class="component-title">${_('Slack Icon Url')}</label>
-                                </div>
-                                <div class="col-lg-9 col-md-8 col-sm-7 col-xs-12 component-desc">
-                                    <input type="text" name="slack_icon_url" id="slack_icon_url" value="${sickbeard.SLACK_ICON_URL}" class="form-control input-sm input350" autocapitalize="off" />
-                                </div>
-                            </div>
-
                             <div class="row">
                                 <div class="col-md-12">
                                     <div class="testNotification" id="testSlack-result">${_('Click below to test.')}</div>

--- a/gui/slick/views/config_notifications.mako
+++ b/gui/slick/views/config_notifications.mako
@@ -3082,6 +3082,24 @@
                                 </div>
                             </div>
 
+                            <div class="field-pair row">
+                                <div class="col-lg-3 col-md-4 col-sm-5 col-xs-12">
+                                    <label for="slack_icon_emoji" class="component-title">${_('Slack Icon Emoji')}</label>
+                                </div>
+                                <div class="col-lg-9 col-md-8 col-sm-7 col-xs-12 component-desc">
+                                    <input type="text" name="slack_icon_emoji" id="slack_icon_emoji" value="${sickbeard.SLACK_ICON_EMOJI}" class="form-control input-sm input350" autocapitalize="off" />
+                                </div>
+                            </div>
+
+                            <div class="field-pair row">
+                                <div class="col-lg-3 col-md-4 col-sm-5 col-xs-12">
+                                    <label for="slack_icon_url" class="component-title">${_('Slack Icon Url')}</label>
+                                </div>
+                                <div class="col-lg-9 col-md-8 col-sm-7 col-xs-12 component-desc">
+                                    <input type="text" name="slack_icon_url" id="slack_icon_url" value="${sickbeard.SLACK_ICON_URL}" class="form-control input-sm input350" autocapitalize="off" />
+                                </div>
+                            </div>
+
                             <div class="row">
                                 <div class="col-md-12">
                                     <div class="testNotification" id="testSlack-result">${_('Click below to test.')}</div>

--- a/sickbeard/__init__.py
+++ b/sickbeard/__init__.py
@@ -498,7 +498,6 @@ SLACK_NOTIFY_DOWNLOAD = None
 SLACK_NOTIFY_SUBTITLEDOWNLOAD = None
 SLACK_WEBHOOK = None
 SLACK_ICON_EMOJI = None
-SLACK_ICON_URL = None
 
 USE_DISCORD = False
 DISCORD_NOTIFY_SNATCH = None
@@ -721,7 +720,7 @@ def initialize(consoleLogging=True):  # pylint: disable=too-many-locals, too-man
             DOWNLOAD_URL, BACKLOG_DAYS, GIT_AUTH_TYPE, GIT_USERNAME, GIT_PASSWORD, GIT_TOKEN, DEVELOPER, DISPLAY_ALL_SEASONS, SSL_VERIFY, NEWS_LAST_READ, \
             NEWS_LATEST, SOCKET_TIMEOUT, SYNOLOGY_DSM_HOST, SYNOLOGY_DSM_USERNAME, SYNOLOGY_DSM_PASSWORD, SYNOLOGY_DSM_PATH, GUI_LANG, SICKCHILL_BACKGROUND, \
             SICKCHILL_BACKGROUND_PATH, FANART_BACKGROUND, FANART_BACKGROUND_OPACITY, CUSTOM_CSS, CUSTOM_CSS_PATH, USE_SLACK, SLACK_NOTIFY_SNATCH, \
-            SLACK_NOTIFY_DOWNLOAD, SLACK_NOTIFY_SUBTITLEDOWNLOAD, SLACK_WEBHOOK, SLACK_ICON_EMOJI, SLACK_ICON_URL, USE_DISCORD, DISCORD_NOTIFY_SNATCH, DISCORD_NOTIFY_DOWNLOAD, DISCORD_WEBHOOK
+            SLACK_NOTIFY_DOWNLOAD, SLACK_NOTIFY_SUBTITLEDOWNLOAD, SLACK_WEBHOOK, SLACK_ICON_EMOJI, USE_DISCORD, DISCORD_NOTIFY_SNATCH, DISCORD_NOTIFY_DOWNLOAD, DISCORD_WEBHOOK
 
         if __INITIALIZED__:
             return False
@@ -1239,7 +1238,6 @@ def initialize(consoleLogging=True):  # pylint: disable=too-many-locals, too-man
         SLACK_NOTIFY_SUBTITLEDOWNLOAD = check_setting_bool(CFG, 'Slack', 'slack_notify_subtitledownload')
         SLACK_WEBHOOK = check_setting_str(CFG, 'Slack', 'slack_webhook')
         SLACK_ICON_EMOJI = check_setting_str(CFG, 'Slack', 'slack_icon_emoji')
-        SLACK_ICON_URL = check_setting_str(CFG, 'Slack', 'slack_icon_url')
 
         USE_DISCORD = check_setting_bool(CFG, 'Discord', 'use_discord')
         DISCORD_NOTIFY_SNATCH = check_setting_bool(CFG, 'Discord', 'discord_notify_snatch')
@@ -2151,8 +2149,7 @@ def save_config():  # pylint: disable=too-many-statements, too-many-branches
             'slack_notify_download': int(SLACK_NOTIFY_DOWNLOAD),
             'slack_notify_subtitledownload': int(SLACK_NOTIFY_SUBTITLEDOWNLOAD),
             'slack_webhook': SLACK_WEBHOOK,
-            'slack_icon_emoji': SLACK_ICON_EMOJI,
-            'slack_icon_url': SLACK_ICON_URL
+            'slack_icon_emoji': SLACK_ICON_EMOJI
         },
 
         'Discord': {

--- a/sickbeard/__init__.py
+++ b/sickbeard/__init__.py
@@ -497,6 +497,8 @@ SLACK_NOTIFY_SNATCH = None
 SLACK_NOTIFY_DOWNLOAD = None
 SLACK_NOTIFY_SUBTITLEDOWNLOAD = None
 SLACK_WEBHOOK = None
+SLACK_ICON_EMOJI = None
+SLACK_ICON_URL = None
 
 USE_DISCORD = False
 DISCORD_NOTIFY_SNATCH = None
@@ -719,7 +721,7 @@ def initialize(consoleLogging=True):  # pylint: disable=too-many-locals, too-man
             DOWNLOAD_URL, BACKLOG_DAYS, GIT_AUTH_TYPE, GIT_USERNAME, GIT_PASSWORD, GIT_TOKEN, DEVELOPER, DISPLAY_ALL_SEASONS, SSL_VERIFY, NEWS_LAST_READ, \
             NEWS_LATEST, SOCKET_TIMEOUT, SYNOLOGY_DSM_HOST, SYNOLOGY_DSM_USERNAME, SYNOLOGY_DSM_PASSWORD, SYNOLOGY_DSM_PATH, GUI_LANG, SICKCHILL_BACKGROUND, \
             SICKCHILL_BACKGROUND_PATH, FANART_BACKGROUND, FANART_BACKGROUND_OPACITY, CUSTOM_CSS, CUSTOM_CSS_PATH, USE_SLACK, SLACK_NOTIFY_SNATCH, \
-            SLACK_NOTIFY_DOWNLOAD, SLACK_NOTIFY_SUBTITLEDOWNLOAD, SLACK_WEBHOOK, USE_DISCORD, DISCORD_NOTIFY_SNATCH, DISCORD_NOTIFY_DOWNLOAD, DISCORD_WEBHOOK
+            SLACK_NOTIFY_DOWNLOAD, SLACK_NOTIFY_SUBTITLEDOWNLOAD, SLACK_WEBHOOK, SLACK_ICON_EMOJI, SLACK_ICON_URL, USE_DISCORD, DISCORD_NOTIFY_SNATCH, DISCORD_NOTIFY_DOWNLOAD, DISCORD_WEBHOOK
 
         if __INITIALIZED__:
             return False
@@ -1236,6 +1238,8 @@ def initialize(consoleLogging=True):  # pylint: disable=too-many-locals, too-man
         SLACK_NOTIFY_DOWNLOAD = check_setting_bool(CFG, 'Slack', 'slack_notify_download')
         SLACK_NOTIFY_SUBTITLEDOWNLOAD = check_setting_bool(CFG, 'Slack', 'slack_notify_subtitledownload')
         SLACK_WEBHOOK = check_setting_str(CFG, 'Slack', 'slack_webhook')
+        SLACK_ICON_EMOJI = check_setting_str(CFG, 'Slack', 'slack_icon_emoji')
+        SLACK_ICON_URL = check_setting_str(CFG, 'Slack', 'slack_icon_url')
 
         USE_DISCORD = check_setting_bool(CFG, 'Discord', 'use_discord')
         DISCORD_NOTIFY_SNATCH = check_setting_bool(CFG, 'Discord', 'discord_notify_snatch')
@@ -2146,7 +2150,9 @@ def save_config():  # pylint: disable=too-many-statements, too-many-branches
             'slack_notify_snatch': int(SLACK_NOTIFY_SNATCH),
             'slack_notify_download': int(SLACK_NOTIFY_DOWNLOAD),
             'slack_notify_subtitledownload': int(SLACK_NOTIFY_SUBTITLEDOWNLOAD),
-            'slack_webhook': SLACK_WEBHOOK
+            'slack_webhook': SLACK_WEBHOOK,
+            'slack_icon_emoji': SLACK_ICON_EMOJI,
+            'slack_icon_url': SLACK_ICON_URL
         },
 
         'Discord': {

--- a/sickbeard/notifiers/slack.py
+++ b/sickbeard/notifiers/slack.py
@@ -61,6 +61,8 @@ class Notifier(object):
 
     def _send_slack(self, message=None):
         slack_webhook = self.SLACK_WEBHOOK_URL + sickbeard.SLACK_WEBHOOK.replace(self.SLACK_WEBHOOK_URL, '')
+        slack_icon_emoji = sickbeard.SLACK_ICON_EMOJI
+        slack_icon_url = sickbeard.SLACK_ICON_URL
 
         logger.log("Sending slack message: " + message, logger.INFO)
         logger.log("Sending slack message  to url: " + slack_webhook, logger.INFO)
@@ -70,7 +72,7 @@ class Notifier(object):
 
         headers = {b"Content-Type": b"application/json"}
         try:
-            r = requests.post(slack_webhook, data=json.dumps(dict(text=message, username="SickChillBot")), headers=headers)
+            r = requests.post(slack_webhook, data=json.dumps(dict(text=message, username="SickChillBot", icon_emoji=slack_icon_emoji, icon_url=slack_icon_url)), headers=headers)
             r.raise_for_status()
         except Exception as e:
             logger.log("Error Sending Slack message: " + ex(e), logger.ERROR)

--- a/sickbeard/notifiers/slack.py
+++ b/sickbeard/notifiers/slack.py
@@ -31,6 +31,7 @@ from sickchill.helper.exceptions import ex
 class Notifier(object):
 
     SLACK_WEBHOOK_URL = 'https://hooks.slack.com/services/'
+    SLACK_ICON_URL = 'https://github.com/SickChill/SickChill/raw/master/gui/slick/images/sickchill-sc.png'
 
     def notify_snatch(self, ep_name):
         if sickbeard.SLACK_NOTIFY_SNATCH:
@@ -62,7 +63,6 @@ class Notifier(object):
     def _send_slack(self, message=None):
         slack_webhook = self.SLACK_WEBHOOK_URL + sickbeard.SLACK_WEBHOOK.replace(self.SLACK_WEBHOOK_URL, '')
         slack_icon_emoji = sickbeard.SLACK_ICON_EMOJI
-        slack_icon_url = sickbeard.SLACK_ICON_URL
 
         logger.log("Sending slack message: " + message, logger.INFO)
         logger.log("Sending slack message  to url: " + slack_webhook, logger.INFO)
@@ -72,7 +72,7 @@ class Notifier(object):
 
         headers = {b"Content-Type": b"application/json"}
         try:
-            r = requests.post(slack_webhook, data=json.dumps(dict(text=message, username="SickChillBot", icon_emoji=slack_icon_emoji, icon_url=slack_icon_url)), headers=headers)
+            r = requests.post(slack_webhook, data=json.dumps(dict(text=message, username="SickChillBot", icon_emoji=slack_icon_emoji, icon_url=self.SLACK_ICON_URL)), headers=headers)
             r.raise_for_status()
         except Exception as e:
             logger.log("Error Sending Slack message: " + ex(e), logger.ERROR)

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -4899,7 +4899,7 @@ class ConfigNotifications(Config):
             use_email=None, email_notify_onsnatch=None, email_notify_ondownload=None,
             email_notify_onsubtitledownload=None, email_host=None, email_port=25, email_from=None,
             email_tls=None, email_user=None, email_password=None, email_list=None, email_subject=None, email_show_list=None,
-            email_show=None, use_slack=False, slack_notify_snatch=None, slack_notify_download=None, slack_notify_subtitledownload=None, slack_webhook=None,
+            email_show=None, use_slack=False, slack_notify_snatch=None, slack_notify_download=None, slack_notify_subtitledownload=None, slack_webhook=None, slack_icon_emoji=None, slack_icon_url=None,
             use_discord=False, discord_notify_snatch=None, discord_notify_download=None, discord_webhook=None, discord_name=None,
             discord_avatar_url=None, discord_tts=False):
 
@@ -4994,6 +4994,8 @@ class ConfigNotifications(Config):
         sickbeard.SLACK_NOTIFY_DOWNLOAD = config.checkbox_to_value(slack_notify_download)
         sickbeard.SLACK_NOTIFY_SUBTITLEDOWNLOAD = config.checkbox_to_value(slack_notify_subtitledownload)
         sickbeard.SLACK_WEBHOOK = slack_webhook
+        sickbeard.SLACK_ICON_EMOJI = slack_icon_emoji
+        sickbeard.SLACK_ICON_URL = slack_icon_url
 
         sickbeard.USE_DISCORD = config.checkbox_to_value(use_discord)
         sickbeard.DISCORD_NOTIFY_SNATCH = config.checkbox_to_value(discord_notify_snatch)

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -4899,7 +4899,7 @@ class ConfigNotifications(Config):
             use_email=None, email_notify_onsnatch=None, email_notify_ondownload=None,
             email_notify_onsubtitledownload=None, email_host=None, email_port=25, email_from=None,
             email_tls=None, email_user=None, email_password=None, email_list=None, email_subject=None, email_show_list=None,
-            email_show=None, use_slack=False, slack_notify_snatch=None, slack_notify_download=None, slack_notify_subtitledownload=None, slack_webhook=None, slack_icon_emoji=None, slack_icon_url=None,
+            email_show=None, use_slack=False, slack_notify_snatch=None, slack_notify_download=None, slack_notify_subtitledownload=None, slack_webhook=None, slack_icon_emoji=None,
             use_discord=False, discord_notify_snatch=None, discord_notify_download=None, discord_webhook=None, discord_name=None,
             discord_avatar_url=None, discord_tts=False):
 
@@ -4995,7 +4995,6 @@ class ConfigNotifications(Config):
         sickbeard.SLACK_NOTIFY_SUBTITLEDOWNLOAD = config.checkbox_to_value(slack_notify_subtitledownload)
         sickbeard.SLACK_WEBHOOK = slack_webhook
         sickbeard.SLACK_ICON_EMOJI = slack_icon_emoji
-        sickbeard.SLACK_ICON_URL = slack_icon_url
 
         sickbeard.USE_DISCORD = config.checkbox_to_value(use_discord)
         sickbeard.DISCORD_NOTIFY_SNATCH = config.checkbox_to_value(discord_notify_snatch)


### PR DESCRIPTION
**Slack Config**
![slack config](https://user-images.githubusercontent.com/6699589/57266248-ce210880-7040-11e9-9f33-0327e65b3839.png)

**Slack Test Message**
<img width="318" alt="test message" src="https://user-images.githubusercontent.com/6699589/57266236-c6616400-7040-11e9-9579-be86531c1fdb.png">

Proposed changes in this pull request:
- Default SC png as the icon for slack messages
- Allows custom emoji icons for slack notifications
Reference: https://api.slack.com/custom-integrations/incoming-webhooks

- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read [contribution guide](https://github.com/SickChill/SickChill/blob/master/.github/CONTRIBUTING.md)
