### PR TITLE
Changed search order to 7 as 8 was the least seeders first. Probably …

### DIFF
--- a/sickbeard/providers/thepiratebay.py
+++ b/sickbeard/providers/thepiratebay.py
@@ -75,13 +75,13 @@ class ThePirateBayProvider(TorrentProvider):  # pylint: disable=too-many-instanc
         205 = SD, 208 = HD, 200 = All Videos
         https://pirateproxy.pl/s/?q=Game of Thrones&type=search&orderby=7&page=0&category=200
         """
-        # oder_by is 7 in browse for seeders, but 8 in search!
+
         search_params = {
             "q": "",
             "type": "search",
-            "orderby": 8,
-            "page": 0,
-            "category": 200
+            "orderby": 7,       # order by seeders: most first
+            "page": 0,          # first page of results
+            "category": 200     # All videos
         }
 
         # Units


### PR DESCRIPTION
Fixes #5425 

Proposed changes in this pull request:
- Fix for PirateBay search URL

- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read [contribution guide](https://github.com/SickChill/SickChill/blob/master/.github/CONTRIBUTING.md)
