### PR TITLE
Add notification after postprocessin (SickChill#4348)

### DIFF
--- a/gui/slick/views/config_notifications.mako
+++ b/gui/slick/views/config_notifications.mako
@@ -2811,6 +2811,16 @@
 
                             <div class="field-pair row">
                                 <div class="col-lg-3 col-md-4 col-sm-5 col-xs-12">
+                                    <label class="component-title">${_('Notify on postprocess')}</label>
+                                </div>
+                                <div class="col-lg-9 col-md-8 col-sm-7 col-xs-12 component-desc">
+                                    <input type="checkbox" name="email_notify_onpostprocess" id="email_notify_onpostprocess" ${('', 'checked="checked"')[bool(sickbeard.EMAIL_NOTIFY_ONPOSTPROCESS)]}/>
+                                    <label for="email_notify_onpostprocess">${_('send a notification when a postprocessing finishes?')}</label>
+                                </div>
+                            </div>
+
+                            <div class="field-pair row">
+                                <div class="col-lg-3 col-md-4 col-sm-5 col-xs-12">
                                     <label class="component-title">${_('Notify on subtitle download')}</label>
                                 </div>
                                 <div class="col-lg-9 col-md-8 col-sm-7 col-xs-12 component-desc">

--- a/sickbeard/__init__.py
+++ b/sickbeard/__init__.py
@@ -464,6 +464,7 @@ PUSHOVER_PRIORITY = 0
 USE_LIBNOTIFY = False
 LIBNOTIFY_NOTIFY_ONSNATCH = False
 LIBNOTIFY_NOTIFY_ONDOWNLOAD = False
+LIBNOTIFY_NOTIFY_ONPOSTPROCESS = False
 LIBNOTIFY_NOTIFY_ONSUBTITLEDOWNLOAD = False
 
 USE_NMJ = False
@@ -557,6 +558,7 @@ PUSHBULLET_CHANNEL = None
 USE_EMAIL = False
 EMAIL_NOTIFY_ONSNATCH = False
 EMAIL_NOTIFY_ONDOWNLOAD = False
+EMAIL_NOTIFY_ONPOSTPROCESS = False
 EMAIL_NOTIFY_ONSUBTITLEDOWNLOAD = False
 EMAIL_HOST = None
 EMAIL_PORT = 25
@@ -703,7 +705,7 @@ def initialize(consoleLogging=True):  # pylint: disable=too-many-locals, too-man
             USE_LIBNOTIFY, LIBNOTIFY_NOTIFY_ONSNATCH, LIBNOTIFY_NOTIFY_ONDOWNLOAD, LIBNOTIFY_NOTIFY_ONSUBTITLEDOWNLOAD, USE_NMJ, NMJ_HOST, NMJ_DATABASE, \
             NMJ_MOUNT, USE_NMJv2, NMJv2_HOST, NMJv2_DATABASE, NMJv2_DBLOC, USE_SYNOINDEX, USE_SYNOLOGYNOTIFIER, SYNOLOGYNOTIFIER_NOTIFY_ONSNATCH, \
             SYNOLOGYNOTIFIER_NOTIFY_ONDOWNLOAD, SYNOLOGYNOTIFIER_NOTIFY_ONSUBTITLEDOWNLOAD, USE_EMAIL, EMAIL_HOST, EMAIL_PORT, EMAIL_TLS, EMAIL_USER, \
-            EMAIL_PASSWORD, EMAIL_FROM, EMAIL_NOTIFY_ONSNATCH, EMAIL_NOTIFY_ONDOWNLOAD, EMAIL_NOTIFY_ONSUBTITLEDOWNLOAD, EMAIL_LIST, EMAIL_SUBJECT, \
+            EMAIL_PASSWORD, EMAIL_FROM, EMAIL_NOTIFY_ONSNATCH, EMAIL_NOTIFY_ONDOWNLOAD, EMAIL_NOTIFY_ONPOSTPROCESS, EMAIL_NOTIFY_ONSUBTITLEDOWNLOAD, EMAIL_LIST, EMAIL_SUBJECT, \
             USE_LISTVIEW, METADATA_KODI, METADATA_KODI_12PLUS, METADATA_MEDIABROWSER, METADATA_PS3, metadata_provider_dict, NEWZBIN, NEWZBIN_USERNAME, \
             NEWZBIN_PASSWORD, GIT_PATH, MOVE_ASSOCIATED_FILES, DELETE_NON_ASSOCIATED_FILES, SYNC_FILES, POSTPONE_IF_SYNC_FILES, dailySearchScheduler, \
             NFO_RENAME, GUI_NAME, HOME_LAYOUT, HISTORY_LAYOUT, DISPLAY_SHOW_SPECIALS, COMING_EPS_LAYOUT, COMING_EPS_SORT, COMING_EPS_DISPLAY_PAUSED, \
@@ -1294,6 +1296,7 @@ def initialize(consoleLogging=True):  # pylint: disable=too-many-locals, too-man
         USE_EMAIL = check_setting_bool(CFG, 'Email', 'use_email')
         EMAIL_NOTIFY_ONSNATCH = check_setting_bool(CFG, 'Email', 'email_notify_onsnatch')
         EMAIL_NOTIFY_ONDOWNLOAD = check_setting_bool(CFG, 'Email', 'email_notify_ondownload')
+        EMAIL_NOTIFY_ONPOSTPROCESS = check_setting_bool(CFG, 'Email', 'email_notify_onpostprocess')
         EMAIL_NOTIFY_ONSUBTITLEDOWNLOAD = check_setting_bool(CFG, 'Email', 'email_notify_onsubtitledownload')
         EMAIL_HOST = check_setting_str(CFG, 'Email', 'email_host')
         EMAIL_PORT = check_setting_int(CFG, 'Email', 'email_port', 25, min_val=21, max_val=65535)
@@ -2217,6 +2220,7 @@ def save_config():  # pylint: disable=too-many-statements, too-many-branches
             'use_email': int(USE_EMAIL),
             'email_notify_onsnatch': int(EMAIL_NOTIFY_ONSNATCH),
             'email_notify_ondownload': int(EMAIL_NOTIFY_ONDOWNLOAD),
+            'email_notify_onpostprocess': int(EMAIL_NOTIFY_ONPOSTPROCESS),
             'email_notify_onsubtitledownload': int(EMAIL_NOTIFY_ONSUBTITLEDOWNLOAD),
             'email_host': EMAIL_HOST,
             'email_port': int(EMAIL_PORT),

--- a/sickbeard/common.py
+++ b/sickbeard/common.py
@@ -73,6 +73,7 @@ NOTIFY_GIT_UPDATE = 4
 NOTIFY_GIT_UPDATE_TEXT = 5
 NOTIFY_LOGIN = 6
 NOTIFY_LOGIN_TEXT = 7
+NOTIFY_POSTPROCESS = 8
 
 notifyStrings = NumDict({
     # pylint: disable=undefined-variable
@@ -82,7 +83,8 @@ notifyStrings = NumDict({
     NOTIFY_GIT_UPDATE: _("SickChill Updated"),
     NOTIFY_GIT_UPDATE_TEXT: _("SickChill Updated To Commit#: "),
     NOTIFY_LOGIN: _("SickChill new login"),
-    NOTIFY_LOGIN_TEXT: _("New login from IP: {0}. http://geomaplookup.net/?ip={0}")
+    NOTIFY_LOGIN_TEXT: _("New login from IP: {0}. http://geomaplookup.net/?ip={0}"),
+    NOTIFY_POSTPROCESS: _("Finished Post Processing")
 })
 
 # Episode statuses

--- a/sickbeard/notifiers/__init__.py
+++ b/sickbeard/notifiers/__init__.py
@@ -85,6 +85,11 @@ def notify_download(ep_name):
         n.notify_download(ep_name)
 
 
+def notify_postprocess(ep_name):
+    for n in notifiers:
+        n.notify_postprocess(ep_name)
+
+
 def notify_subtitle_download(ep_name, lang):
     for n in notifiers:
         n.notify_subtitle_download(ep_name, lang)

--- a/sickbeard/postProcessor.py
+++ b/sickbeard/postProcessor.py
@@ -1243,4 +1243,11 @@ class PostProcessor(object):  # pylint: disable=too-many-instance-attributes
 
         self._run_extra_scripts(ep_obj)
 
+        # If any notification fails, don't stop postProcessor
+        try:
+            # send notifications
+            notifiers.email_notifier.notify_postprocess(ep_obj._format_pattern('%SN - %Sx%0E - %EN - %QN'))  # pylint: disable=protected-access
+        except Exception:
+            logger.log("Some notifications could not be sent. Finishing postProcessing...")
+
         return True

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -4896,7 +4896,7 @@ class ConfigNotifications(Config):
             use_pushbullet=None, pushbullet_notify_onsnatch=None, pushbullet_notify_ondownload=None,
             pushbullet_notify_onsubtitledownload=None, pushbullet_api=None, pushbullet_device=None,
             pushbullet_device_list=None, pushbullet_channel_list=None, pushbullet_channel=None,
-            use_email=None, email_notify_onsnatch=None, email_notify_ondownload=None,
+            use_email=None, email_notify_onsnatch=None, email_notify_ondownload=None, email_notify_onpostprocess=None,
             email_notify_onsubtitledownload=None, email_host=None, email_port=25, email_from=None,
             email_tls=None, email_user=None, email_password=None, email_list=None, email_subject=None, email_show_list=None,
             email_show=None, use_slack=False, slack_notify_snatch=None, slack_notify_download=None, slack_notify_subtitledownload=None, slack_webhook=None,
@@ -5060,6 +5060,7 @@ class ConfigNotifications(Config):
         sickbeard.USE_EMAIL = config.checkbox_to_value(use_email)
         sickbeard.EMAIL_NOTIFY_ONSNATCH = config.checkbox_to_value(email_notify_onsnatch)
         sickbeard.EMAIL_NOTIFY_ONDOWNLOAD = config.checkbox_to_value(email_notify_ondownload)
+        sickbeard.EMAIL_NOTIFY_ONPOSTPROCESS = config.checkbox_to_value(email_notify_onpostprocess)
         sickbeard.EMAIL_NOTIFY_ONSUBTITLEDOWNLOAD = config.checkbox_to_value(email_notify_onsubtitledownload)
         sickbeard.EMAIL_HOST = config.clean_host(email_host)
         sickbeard.EMAIL_PORT = try_int(email_port, 25)


### PR DESCRIPTION
Add the ability to send email notification at the end of postprocessing (SickChill#4348), useful when postprocessing is slow (ie. reencode)

Fixes #

Proposed changes in this pull request:
-
-
-

- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read [contribution guide](https://github.com/SickChill/SickChill/blob/master/.github/CONTRIBUTING.md)
