### PR TITLE
Fix delete rar contents and archive_regex

### DIFF
--- a/sickbeard/config.py
+++ b/sickbeard/config.py
@@ -182,7 +182,7 @@ def change_unrar_tool(unrar_tool, alt_unrar_tool):
     sickbeard.ALT_UNRAR_TOOL = rarfile.ALT_TOOL = alt_unrar_tool
 
     try:
-        rarfile.custom_check([rarfile.UNRAR_TOOL])
+        rarfile.custom_check([rarfile.UNRAR_TOOL], True)
         return True
     except (rarfile.RarCannotExec, rarfile.RarExecError, OSError, IOError):
         if sickbeard.UNPACK == 1:

--- a/sickbeard/helpers.py
+++ b/sickbeard/helpers.py
@@ -249,7 +249,7 @@ def is_rar_file(filename):
     :param filename: Filename to check
     :return: True if this is RAR/Part file, False if not
     """
-    archive_regex = r'(?P<file>^(?P<base>(?:(?!\.part\d+\.rar$).)*)\.(?:(?:part0*1\.)?rar)$)'
+    archive_regex = r'(?P<file>^(?P<base>(?:(?!\.part\d+\.rar$).)*)\.(?:(?:part0*1\.)?rar|r\d+)$)'
     ret = re.search(archive_regex, filename) is not None
     try:
         if ret and ek(os.path.exists, filename) and ek(os.path.isfile, filename):

--- a/sickbeard/processTV.py
+++ b/sickbeard/processTV.py
@@ -239,8 +239,23 @@ def process_dir(process_path, release_name=None, process_method=None, force=Fals
 
         # Delete rar file only if the extracted dir was successfully processed
         if mode == 'auto' and method_fallback == 'move' or mode == 'manual' and delete_on:
-            this_rar = [rar_file for rar_file in rar_files if os.path.basename(directory_from_rar) == rar_file.rpartition('.')[0]]
-            delete_files(current_directory, this_rar, result) # Deletes only if result.result == True
+            try:
+                #The directory_from_rar includes the subfolder that is extracted. We want to cut this from the path string since we want to
+                #delete the rar files in the parent folder.
+                rar_path = str(directory_from_rar).split(os.path.basename(directory_from_rar))[0]
+                result.output += log_helper('Deleting rar files in path: ' + str(rar_path), logger.DEBUG)
+                #Iterate through parent folder and if_rar_file is true add it to the list
+                rar_files = [x for x in os.listdir(rar_path) if helpers.is_rar_file(ek(os.path.join, rar_path, x))]
+                this_rar = [rar_file for rar_file in rar_files if os.path.basename(directory_from_rar) == rar_file.rpartition('.')[0]]
+                result.output += log_helper('Deleting the files: ' + str(this_rar), logger.DEBUG)
+                if any('.rar' in x for x in rar_files):
+                    result.result = True
+                else:
+                    result.result = False
+                delete_files(rar_path, this_rar, result) # Deletes only if result.result == True
+            except:
+                result.output += log_helper("Could not delete rar files.", logger.DEBUG)
+
 
     result.output += log_helper(("Processing Failed", "Successfully processed")[result.aggresult], (logger.WARNING, logger.INFO)[result.aggresult])
     if result.missed_files:


### PR DESCRIPTION
Fixes #

Proposed changes in this pull request:
- Fixes rar deletion. The old code would look at the subpath where the rar would extract to. Had to change the logic to look at the parent directory. Also many torrents would not return the proper result for some odd reason. This checks if a rar file exists in the folder we want to Delete. Tested  very thoroughly and works without issues.
- Fixes regex for detecting rars. Most of the multipart rars filetypes uploaded these days are formatted as so (file.rar, file.r01, file.r02, file.r03 etc..)

- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read [contribution guide](https://github.com/SickChill/SickChill/blob/master/.github/CONTRIBUTING.md)
