### PR TITLE
Fix Delete RAR contents issue

### DIFF
--- a/sickbeard/__init__.py
+++ b/sickbeard/__init__.py
@@ -35,16 +35,8 @@ import requests
 from configobj import ConfigObj
 from tornado.locale import load_gettext_translations
 
-try:
-    import pytz  # pylint: disable=unused-import
-except ImportError:
-    pytz = None
-    from pkg_resources import require
-    require('pytz')
-
-
-from sickbeard import (auto_postprocessor, dailysearcher, db, helpers, logger, metadata, naming, post_processing_queue, properFinder, providers, scheduler,
-                       search_queue, searchBacklog, show_queue, showUpdater, subtitles, traktChecker, versionChecker)
+from sickbeard import (auto_postprocessor, dailysearcher, db, helpers, logger, metadata, naming, post_processing_queue, properFinder, providers,
+                       scene_exceptions, scheduler, search_queue, searchBacklog, show_queue, showUpdater, subtitles, traktChecker, versionChecker)
 from sickbeard.common import ARCHIVED, IGNORED, MULTI_EP_STRINGS, SD, SKIPPED, WANTED
 from sickbeard.config import check_section, check_setting_bool, check_setting_float, check_setting_int, check_setting_str, ConfigMigrator
 from sickbeard.databases import cache_db, failed_db, mainDB
@@ -58,7 +50,15 @@ from sickchill.helper.encoding import ek
 from sickchill.helper.exceptions import ex
 from sickchill.system.Shutdown import Shutdown
 
-from sickbeard import scene_exceptions
+try:
+    import pytz  # pylint: disable=unused-import
+except ImportError:
+    pytz = None
+    from pkg_resources import require
+    require('pytz')
+
+
+
 
 gettext.install('messages', unicode=1, codeset='UTF-8', names=["ngettext"])
 

--- a/sickbeard/helpers.py
+++ b/sickbeard/helpers.py
@@ -249,7 +249,7 @@ def is_rar_file(filename):
     :param filename: Filename to check
     :return: True if this is RAR/Part file, False if not
     """
-    archive_regex = r'(?P<file>^(?P<base>(?:(?!\.part\d+\.rar$).)*)\.(?:(?:part0*1\.)?rar)$)'
+    archive_regex = r'(?P<file>^(?P<base>(?:(?!\.part\d+\.rar$).)*)\.(?:(?:part0*1\.)?rar|r\d+)$)'
     ret = re.search(archive_regex, filename) is not None
     try:
         if ret and ek(os.path.exists, filename) and ek(os.path.isfile, filename):


### PR DESCRIPTION
Fixes #

Proposed changes in this pull request:
- Fixes rar deletion. The old code would look at the subpath where the rar would extract to. Had to change the logic to look at the parent directory. Also many torrents would not return the proper result for some odd reason. This checks if a rar file exists in the folder we want to Delete. Tested very thoroughly and works without issues.

- Fixes regex for detecting rars. Most of the multipart rars filetypes uploaded these days on torrents are formatted as so (file.rar, file.r01, file.r02, file.r03 etc..) Old versions of winrar use the part1.rar, part2.rar style.


- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read [contribution guide](https://github.com/SickChill/SickChill/blob/master/.github/CONTRIBUTING.md)
