### PR TITLE
Update of Yggtorrent url due to recent change

### DIFF
--- a/sickbeard/providers/yggtorrent.py
+++ b/sickbeard/providers/yggtorrent.py
@@ -49,7 +49,7 @@ class YggTorrentProvider(TorrentProvider):  # pylint: disable=too-many-instance-
 
         # URLs
         self.custom_url = None
-        self.url = 'https://www2.yggtorrent.gg/'
+        self.url = 'https://www.yggtorrent.ch/'
         self.urls = {
             'login': urljoin(self.url, 'user/login'),
             'search': urljoin(self.url, 'engine/search')


### PR DESCRIPTION
Fixes #
Correct Yggtorrent URL due to recent domain modifications.
Website is: https://www.yggtorrent.ch/

search URL is: https://www2.yggtorrent.ch/