### PR TITLE
Update provider url: iptorrent

### DIFF
--- a/sickbeard/providers/iptorrents.py
+++ b/sickbeard/providers/iptorrents.py
@@ -49,9 +49,9 @@ class IPTorrentsProvider(TorrentProvider):  # pylint: disable=too-many-instance-
 
         self.cache = tvcache.TVCache(self, min_time=10)  # Only poll IPTorrents every 10 minutes max
 
-        self.urls = {'base_url': 'https://iptorrents.eu',
-                     'login': 'https://iptorrents.eu/take_login.php',
-                     'search': 'https://iptorrents.eu/t?%s%s&q=%s&qf=#torrents'}
+        self.urls = {'base_url': 'https://iptorrents.com',
+                     'login': 'https://iptorrents.com/take_login.php',
+                     'search': 'https://iptorrents.com/t?%s%s&q=%s&qf=#torrents'}
 
         self.url = self.urls['base_url']
 


### PR DESCRIPTION
I find that provider/iptorrent's url of `.eu` causes issues as sometimes it isn't available or doesn't respond well enough for SickChill. The result is improper data gets passed down as seen in the error below.

The fix I continue to implement is to simply change `.eu` to `.com`.

If using `.com` is an issue for other reasons I'd be curious about those other reasons.

Fixes #
```
2019-05-16 17:38:10 INFO     SEARCHQUEUE-BACKLOG-341663 :: [IPTorrents] :: Performing episode search for Titans (2018)
2019-05-16 17:38:10 ERROR    SEARCHQUEUE-BACKLOG-341663 :: [IPTorrents] :: [175df89] Exception while searching IPTorrents. Error: TypeError('tuple indices must be integers, not str',)
Traceback (most recent call last):
  File "/volume1/@appstore/sickbeard-custom/var/SickBeard/sickbeard/search.py", line 474, in searchProviders
    searchResults = curProvider.find_search_results(show, episodes, search_mode, manualSearch, downCurQuality)
  File "/volume1/@appstore/sickbeard-custom/var/SickBeard/sickchill/providers/GenericProvider.py", line 170, in find_search_results
    items_list += self.search(search_string, ep_obj=episode)
  File "/volume1/@appstore/sickbeard-custom/var/SickBeard/sickbeard/providers/iptorrents.py", line 108, in search
    if not self.login():
  File "/volume1/@appstore/sickbeard-custom/var/SickBeard/sickbeard/providers/iptorrents.py", line 83, in login
    self.get_url(login_url, returns='text')
  File "/volume1/@appstore/sickbeard-custom/var/SickBeard/sickchill/providers/GenericProvider.py", line 372, in get_url
    return getURL(url, post_data, params, self.headers, timeout, self.session, **kwargs)
  File "/volume1/@appstore/sickbeard-custom/var/SickBeard/sickbeard/helpers.py", line 1465, in getURL
    handle_requests_exception(error)
  File "/volume1/@appstore/sickbeard-custom/var/SickBeard/sickbeard/helpers.py", line 1578, in handle_requests_exception
    logger.log(default.format(error, type(error.__class__.__name__)), get_level(error))
  File "/volume1/@appstore/sickbeard-custom/var/SickBeard/sickbeard/helpers.py", line 1522, in get_level
    return (logger.ERROR, logger.WARNING)[exception.message and 's,t,o,p,b,r,e,a,k,i,n,g,f' in exception.message]
TypeError: tuple indices must be integers, not str
```

Proposed changes in this pull request:
- Update iptorrent URL to .com (from .eu)


- [ ] PR is based on the DEVELOP branch
- [ ] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [ ] Read [contribution guide](https://github.com/SickChill/SickChill/blob/master/.github/CONTRIBUTING.md)
