### PR TITLE
update deluged TLS version to 1.2

### DIFF
--- a/lib/synchronousdeluge/transfer.py
+++ b/lib/synchronousdeluge/transfer.py
@@ -19,7 +19,7 @@ class DelugeTransfer(object):
             self.disconnect()
 
         self.sock = socket.create_connection(hostport)
-        self.conn = ssl.wrap_socket(self.sock, None, None, False, ssl.CERT_NONE, ssl.PROTOCOL_TLSv1)
+        self.conn = ssl.wrap_socket(self.sock, None, None, False, ssl.CERT_NONE, ssl.PROTOCOL_TLSv1_2)
         self.connected = True
 
     def disconnect(self):


### PR DESCRIPTION
Fixes #5535
Hello guys, i'm actually using SickChill with a deluge client and after updating my Debian to Buster SickChill could no longer authenticate to the deluge daemon, so i investigated the issue and fixed it,  i propose to integrate the fix to the main repository, if you want. :D 

Proposed changes in this pull request:

- updating Tls version used to connect to deluge daemon to TLS1.2 because deluged 1.3.15 do not support older

- [x] PR is based on the DEVELOP branch
- [X] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [X] Read [contribution guide](https://github.com/SickChill/SickChill/blob/master/.github/CONTRIBUTING.md)
