### PR TITLE
PIDfile should not be created world-writable

### DIFF
--- a/SickBeard.py
+++ b/SickBeard.py
@@ -366,7 +366,7 @@ class SickChill(object):
             logger.log('Writing PID: {pid} to {filename}'.format(pid=pid, filename=self.pid_file))
 
             try:
-                with io.open(self.pid_file, 'w') as f_pid:
+                with os.fdopen(os.open(self.pid_file, os.O_CREAT | os.O_WRONLY, 0o644), 'w') as f_pid:
                     f_pid.write('{0}\n'.format(pid))
             except EnvironmentError as error:
                 logger.log_error_and_exit('Unable to write PID file: {filename} Error {error_num}: {error_message}'.format


### PR DESCRIPTION
Sickchill's pidfile is currently created with mode `0666`, as the umask is set to `0000`.
This small patch fixes that. The pidfile will now be created with mode `0644`.

Fixes #N/A

Proposed changes in this pull request:
- Create pidfile with appropriate permissions

- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read [contribution guide](https://github.com/SickChill/SickChill/blob/master/.github/CONTRIBUTING.md)
