### PR TITLE
set_header('Cache-Control') on images

### DIFF
--- a/sickchill/views/index.py
+++ b/sickchill/views/index.py
@@ -247,6 +247,7 @@ class WebRoot(WebHandler):
             media = None
 
         if media:
+            self.set_header(b'Cache-Control', 'public, max-age=86400')
             self.set_header(b'Content-Type', media.get_media_type())
 
             return media.get_media()


### PR DESCRIPTION
set_header('Cache-Control') to showPoster images so the browser caches them for 24h

Fixes #

Proposed changes in this pull request:
-
-
-

- [ ] PR is based on the DEVELOP branch
- [ ] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [ ] Read [contribution guide](https://github.com/SickChill/SickChill/blob/master/.github/CONTRIBUTING.md)
