### PR TITLE
set better headers for static content / media

### DIFF
--- a/sickchill/views/index.py
+++ b/sickchill/views/index.py
@@ -247,7 +247,14 @@ class WebRoot(WebHandler):
             media = None
 
         if media:
+            abspath = media.get_static_media_path()
+            stat_result = os.stat(abspath)
+            modified = datetime.datetime.fromtimestamp(int(stat_result.st_mtime))
+
+            self.set_header(b'Last-Modified', modified)
             self.set_header(b'Content-Type', media.get_media_type())
+            self.set_header(b'Accept-Ranges', 'bytes')
+            self.set_header(b'Cache-Control', 'public, max-age=86400')
 
             return media.get_media()
 


### PR DESCRIPTION
set better headers for static content / media

https://github.com/tornadoweb/tornado/blob/8e9e75502ff910629663c4cdd7779d43ea2dd150/tornado/web.py#L2363

as in tornado/web.py methods

Fixes #

caching of images
Proposed changes in this pull request:
-
-
-

- [ ] PR is based on the DEVELOP branch
- [ ] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [ ] Read [contribution guide](https://github.com/SickChill/SickChill/blob/master/.github/CONTRIBUTING.md)
