### PR TITLE
Schedule View - add banner to list

### DIFF
--- a/gui/slick/views/schedule.mako
+++ b/gui/slick/views/schedule.mako
@@ -106,6 +106,7 @@
                                 <th>${_('Airdate')} (${('local', 'network')[sickbeard.TIMEZONE_DISPLAY == 'network']})</th>
                                 <th>${_('Ends')}</th>
                                 <th>${_('Show')}</th>
+			        <th>${_('Banner')}</th>
                                 <th>${_('Next Ep')}</th>
                                 <th>${_('Next Ep Name')}</th>
                                 <th>${_('Network')}</th>
@@ -166,6 +167,11 @@
                                             <span class="pause">[paused]</span>
                                         % endif
                                     </td>
+			            <td class="banner">
+					<a href="${srRoot}/home/displayShow?show=${cur_result[b'showid']}">
+						<img alt="" class="bannerThumb" src="${srRoot}/showPoster/?show=${cur_result[b'showid']}&amp;which=banner" />
+					</a>
+				    </td>
                                     <td nowrap="nowrap" align="center">
                                         ${'S%02iE%02i' % (int(cur_result[b'season']), int(cur_result[b'episode']))}
                                     </td>

--- a/gui/slick/views/schedule.mako
+++ b/gui/slick/views/schedule.mako
@@ -106,7 +106,7 @@
                                 <th>${_('Airdate')} (${('local', 'network')[sickbeard.TIMEZONE_DISPLAY == 'network']})</th>
                                 <th>${_('Ends')}</th>
                                 <th>${_('Show')}</th>
-			        <th>${_('Banner')}</th>
+                                <th>${_('Banner')}</th>
                                 <th>${_('Next Ep')}</th>
                                 <th>${_('Next Ep Name')}</th>
                                 <th>${_('Network')}</th>
@@ -167,11 +167,11 @@
                                             <span class="pause">[paused]</span>
                                         % endif
                                     </td>
-			            <td class="banner">
-					<a href="${srRoot}/home/displayShow?show=${cur_result[b'showid']}">
-						<img alt="" class="bannerThumb" src="${srRoot}/showPoster/?show=${cur_result[b'showid']}&amp;which=banner" />
-					</a>
-				    </td>
+                                    <td class="banner">
+                                        <a href="${srRoot}/home/displayShow?show=${cur_result[b'showid']}">
+                                            <img alt="" class="bannerThumb" src="${srRoot}/showPoster/?show=${cur_result[b'showid']}&amp;which=banner" />
+                                        </a>
+                                    </td>
                                     <td nowrap="nowrap" align="center">
                                         ${'S%02iE%02i' % (int(cur_result[b'season']), int(cur_result[b'episode']))}
                                     </td>


### PR DESCRIPTION
Adds banner element to the list view. I like seeing the banner image to visually show me what show I'm looking at, but the banner view is too large. I like the combination of the compact list view, while allowing me the option to include the banner. 

Proposed changes in this pull request:
- added the banner TH element and column selector on line 109
- adding the banner TD element in lines 170-174

- [✔] PR is based on the DEVELOP branch
- [✔] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [✔] Read [contribution guide](https://github.com/SickChill/SickChill/blob/master/.github/CONTRIBUTING.md)
