### PR TITLE
fix: xthor.to move to xthor.tk

### DIFF
--- a/sickbeard/providers/xthor.py
+++ b/sickbeard/providers/xthor.py
@@ -31,8 +31,8 @@ class XThorProvider(TorrentProvider):
 
         TorrentProvider.__init__(self, 'XThor')
 
-        self.url = 'https://xthor.to'
-        self.urls = {'search': 'https://api.xthor.to'}
+        self.url = 'https://xthor.tk'
+        self.urls = {'search': 'https://api.xthor.tk'}
 
         self.freeleech = None
         self.api_key = None


### PR DESCRIPTION
Proposed changes in this pull request:
- xthor change their domain from xthor.to to xthor.tk. Since this decision, the server behind xthor.to answer error to request and so the provider don't work anymore. By updating the FQDN, everything working fine.

- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read [contribution guide](https://github.com/SickChill/SickChill/blob/master/.github/CONTRIBUTING.md)

This is another PR for the Xthor FQDN update, but I hope that respecting the contribution rules will help.
Like :
- https://github.com/SickChill/SickChill/pull/5659
- https://github.com/SickChill/SickChill/pull/5662

![IMG_0987](https://user-images.githubusercontent.com/2594317/67679153-bdff3b80-f988-11e9-9d5c-09590ea1f7d5.PNG)