### PR TITLE
Implementation suggestion for "Prefer words" (#5629)

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -55,10 +55,8 @@ install:
   - "python --version"
   - "python -c \"import struct; print(struct.calcsize('P') * 8)\""
 
-  # Upgrade to the latest version of pip to avoid it displaying warnings
-  # about it being out of date.
-  - "python -m pip install --disable-pip-version-check --user --upgrade pip"
-  - "python -m easy_install -U tox"
+  - pip install --disable-pip-version-check -U pip
+  - pip install --disable-pip-version-check "zipp<0.6.0" "tox"
 
   # Install node/npm
   - ps: Install-Product node $env:8

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -43,7 +43,7 @@ coverage:
 
     changes:                     # if there are any unexpected changes in coverage
       default:
-        enabled: yes             # must be yes|true to enable this status
+        enabled: no              # must be yes|true to enable this status
         branches: null           # -> see https://github.com/codecov/support/wiki/Filtering-Branches
         if_no_uploads: error
         if_not_found: success

--- a/gui/slick/views/config_search.mako
+++ b/gui/slick/views/config_search.mako
@@ -149,6 +149,25 @@
 
                             <div class="field-pair row">
                                 <div class="col-lg-3 col-md-4 col-sm-5 col-xs-12">
+                                    <label class="component-title">${_('Prefer words')}</label>
+                                </div>
+                                <div class="col-lg-9 col-md-8 col-sm-7 col-xs-12 component-desc">
+                                    <div class="row">
+                                        <div class="col-md-12">
+                                            <input type="text" name="prefer_words" value="${sickbeard.PREFER_WORDS}"
+                                                   id="prefer_words" class="form-control input-sm input350" autocapitalize="off"/>
+                                        </div>
+                                    </div>
+                                    <div class="row">
+                                        <div class="col-md-12">
+                                            <label for="prefer_words">${_('''search results with these words will be preferred in this order<br>separate words with a comma, e.g. "word1,word2,word3"''')}</label>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+
+                            <div class="field-pair row">
+                                <div class="col-lg-3 col-md-4 col-sm-5 col-xs-12">
                                     <label class="component-title">${_('Require words')}</label>
                                 </div>
                                 <div class="col-lg-9 col-md-8 col-sm-7 col-xs-12 component-desc">
@@ -165,6 +184,7 @@
                                     </div>
                                 </div>
                             </div>
+
                             <div class="field-pair row">
                                 <div class="col-lg-3 col-md-4 col-sm-5 col-xs-12">
                                     <label class="component-title">${_('Ignore language names in subbed results')}</label>

--- a/gui/slick/views/displayShow.mako
+++ b/gui/slick/views/displayShow.mako
@@ -223,6 +223,14 @@
                                                     <td>${show.rls_require_words}</td>
                                                 </tr>
                                             % endif
+
+                                            % if show.rls_prefer_words:
+                                                <tr>
+                                                    <td class="showLegend">${_('Prefered Words')}: </td>
+                                                    <td>${show.rls_prefer_words}</td>
+                                                </tr>
+                                            % endif
+
                                             % if show.rls_ignore_words:
                                                 <tr>
                                                     <td class="showLegend">${_('Ignored Words')}: </td>

--- a/gui/slick/views/editShow.mako
+++ b/gui/slick/views/editShow.mako
@@ -298,6 +298,34 @@
 
                                 <div class="field-pair row">
                                     <div class="col-lg-3 col-md-4 col-sm-5 col-xs-12">
+                                        <span class="component-title">${_('Prefered Words')}</span>
+                                    </div>
+                                    <div class="col-lg-9 col-md-8 col-sm-7 col-xs-12 component-desc">
+                                        <div class="row">
+                                            <div class="col-md-12">
+                                                <input type="text" id="rls_prefer_words" name="rls_prefer_words"
+                                                       value="${show.rls_prefer_words}" autocapitalize="off"
+                                                       class="form-control input-sm input350"/>
+                                                <br/>
+                                            </div>
+                                        </div>
+                                        <div class="row">
+                                            <div class="col-md-12">
+                                                <label for="rls_prefer_words">${_('comma-separated <i>e.g. "word1,word2,word3</i>"')}</label>
+                                            </div>
+                                        </div>
+                                        <div class="row">
+                                            <div class="col-md-12">
+                                                <label>${_('search results with these words will be prefered in this order.')}</label>
+                                                <label><b>${_('note')}:</b> ${_('this option overrides the globally prefered words!')}</label>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+
+
+                                <div class="field-pair row">
+                                    <div class="col-lg-3 col-md-4 col-sm-5 col-xs-12">
                                         <span class="component-title">${_('Required Words')}</span>
                                     </div>
                                     <div class="col-lg-9 col-md-8 col-sm-7 col-xs-12 component-desc">

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ setup(
         'flake8-coding',
         'isort'
     ],
-
+    python_requires='>=2.7, <3',
     classifiers=[
         'Development Status :: 3 - Alpha',
         'Intended Audience :: System Administrators',

--- a/sickbeard/__init__.py
+++ b/sickbeard/__init__.py
@@ -630,6 +630,7 @@ TRACKERS_LIST += "udp://glotorrents.pw:6969/announce,udp://tracker.openbittorren
 TRACKERS_LIST += "udp://9.rarbg.to:2710/announce"
 
 REQUIRE_WORDS = ""
+PREFER_WORDS = ""
 IGNORED_SUBS_LIST = "dk,fin,heb,kor,nor,nordic,pl,swe"
 SYNC_FILES = "!sync,lftp-pget-status,bts,!qb,!qB"
 
@@ -727,7 +728,7 @@ def initialize(consoleLogging=True):  # pylint: disable=too-many-locals, too-man
             NFO_RENAME, GUI_NAME, HOME_LAYOUT, HISTORY_LAYOUT, DISPLAY_SHOW_SPECIALS, COMING_EPS_LAYOUT, COMING_EPS_SORT, COMING_EPS_DISPLAY_PAUSED, \
             COMING_EPS_DISPLAY_SNATCHED, COMING_EPS_MISSED_RANGE, FUZZY_DATING, TRIM_ZERO, DATE_PRESET, TIME_PRESET, TIME_PRESET_W_SECONDS, THEME_NAME, \
             POSTER_SORTBY, POSTER_SORTDIR, HISTORY_LIMIT, CREATE_MISSING_SHOW_DIRS, ADD_SHOWS_WO_DIR, USE_FREE_SPACE_CHECK, METADATA_WDTV, METADATA_TIVO, \
-            METADATA_MEDE8ER, IGNORE_WORDS, TRACKERS_LIST, IGNORED_SUBS_LIST, REQUIRE_WORDS, CALENDAR_UNPROTECTED, CALENDAR_ICONS, NO_RESTART, USE_SUBTITLES,\
+            METADATA_MEDE8ER, IGNORE_WORDS, TRACKERS_LIST, IGNORED_SUBS_LIST, REQUIRE_WORDS, PREFER_WORDS, CALENDAR_UNPROTECTED, CALENDAR_ICONS, NO_RESTART, USE_SUBTITLES,\
             SUBTITLES_INCLUDE_SPECIALS, SUBTITLES_LANGUAGES, SUBTITLES_DIR, SUBTITLES_SERVICES_LIST, SUBTITLES_SERVICES_ENABLED, SUBTITLES_HISTORY, \
             SUBTITLES_FINDER_FREQUENCY, SUBTITLES_MULTI, SUBTITLES_KEEP_ONLY_WANTED, EMBEDDED_SUBTITLES_ALL, SUBTITLES_EXTRA_SCRIPTS, SUBTITLES_PERFECT_MATCH,\
             subtitlesFinderScheduler, SUBTITLES_HEARING_IMPAIRED, ADDIC7ED_USER, ADDIC7ED_PASS, ITASA_USER, ITASA_PASS, LEGENDASTV_USER, LEGENDASTV_PASS, \
@@ -1379,6 +1380,7 @@ def initialize(consoleLogging=True):  # pylint: disable=too-many-locals, too-man
         IGNORE_WORDS = check_setting_str(CFG, 'General', 'ignore_words', IGNORE_WORDS)
         TRACKERS_LIST = check_setting_str(CFG, 'General', 'trackers_list', TRACKERS_LIST)
         REQUIRE_WORDS = check_setting_str(CFG, 'General', 'require_words', REQUIRE_WORDS)
+        PREFER_WORDS = check_setting_str(CFG, 'General', 'prefer_words', PREFER_WORDS)
         IGNORED_SUBS_LIST = check_setting_str(CFG, 'General', 'ignored_subs_list', IGNORED_SUBS_LIST)
 
         CALENDAR_UNPROTECTED = check_setting_bool(CFG, 'General', 'calendar_unprotected')
@@ -1943,6 +1945,7 @@ def save_config():  # pylint: disable=too-many-statements, too-many-branches
             'ignore_words': IGNORE_WORDS,
             'trackers_list': TRACKERS_LIST,
             'require_words': REQUIRE_WORDS,
+            'prefer_words': PREFER_WORDS,
             'ignored_subs_list': IGNORED_SUBS_LIST,
             'calendar_unprotected': int(CALENDAR_UNPROTECTED),
             'calendar_icons': int(CALENDAR_ICONS),

--- a/sickbeard/browser.py
+++ b/sickbeard/browser.py
@@ -54,8 +54,7 @@ def getFileList(path, includeFiles, fileTypes):
     hide_list += ['.fseventd', '.spotlight', '.trashes', '.vol', 'cachedmessages', 'caches', 'trash']  # osx specific
     hide_list += ['.git']
 
-    file_list = []
-    dir_list = []
+    file_list, dir_list = [], []
     for filename in ek(os.listdir, path):
         if filename.lower() in hide_list:
             continue
@@ -109,16 +108,17 @@ def foldersAtPath(path, includeParent=False, includeFiles=False, fileTypes=None)
     :return: list of folders/files
     """
 
-    # walk up the tree until we find a valid path
-    while path and not ek(os.path.isdir, path):
+    # walk up the tree until we find a valid directory path
+    while path and not ek(os.path.isdir, path) and path != '/':
         if path == ek(os.path.dirname, path):
             path = ''
-            break
         else:
             path = ek(os.path.dirname, path)
 
     if path == '':
-        if os.name == 'nt':
+        if os.name != 'nt':
+            path = '/'
+        else:
             entries = [{'currentPath': 'Root'}]
             for letter in getWinDrives():
                 letter_path = letter + ':\\'
@@ -128,8 +128,6 @@ def foldersAtPath(path, includeParent=False, includeFiles=False, fileTypes=None)
                 entries.append({'name': name, 'path': r'\\{server}\{path}'.format(server=share['server'], path=share['path'])})
 
             return entries
-        else:
-            path = '/'
 
     # fix up the path and find the parent
     path = ek(os.path.abspath, ek(os.path.normpath, path))

--- a/sickbeard/databases/mainDB.py
+++ b/sickbeard/databases/mainDB.py
@@ -1156,9 +1156,17 @@ class UseSickChillMetadataForSubtitle(AlterTVShowsFieldTypes):
         self.add_column('tv_shows', 'sub_use_sr_metadata', "NUMERIC", "0")
 
 
-class ResetDBVersion(UseSickChillMetadataForSubtitle):
+class AddPreferWords(UseSickChillMetadataForSubtitle):
+    """ Adding column rls_prefer_words to tv_shows """
+
     def test(self):
-        return False
+        return self.has_column("tv_shows", "rls_prefer_words")
 
     def execute(self):
-        self.connection.action("UPDATE db_version SET db_version = ?, db_minor_version = ?", [MAX_DB_VERSION, 0])
+        backupDatabase(self.get_db_version())
+
+        logger.log("Adding column rls_prefer_words to tvshows")
+        if not self.has_column("tv_shows", "rls_prefer_words"):
+            self.add_column("tv_shows", "rls_prefer_words", "TEXT", "")
+
+        self.inc_minor_version()

--- a/sickbeard/databases/mainDB.py
+++ b/sickbeard/databases/mainDB.py
@@ -319,12 +319,12 @@ class InitialSchema(db.SchemaUpgrade):
     def execute(self):
         if not self.has_table("tv_shows") and not self.has_table("db_version"):
             queries = [
-                "CREATE TABLE db_version(db_version INTEGER);",
+                "CREATE TABLE db_version(db_version INTEGER, db_minor_version INTEGER);",
                 "CREATE TABLE history(action NUMERIC, date NUMERIC, showid NUMERIC, season NUMERIC, episode NUMERIC, quality NUMERIC, resource TEXT, provider TEXT, version NUMERIC DEFAULT -1);",
                 "CREATE TABLE imdb_info(indexer_id INTEGER PRIMARY KEY, imdb_id TEXT, title TEXT, year NUMERIC, akas TEXT, runtimes NUMERIC, genres TEXT, countries TEXT, country_codes TEXT, certificates TEXT, rating TEXT, votes INTEGER, last_update NUMERIC);",
                 "CREATE TABLE info(last_backlog NUMERIC, last_indexer NUMERIC, last_proper_search NUMERIC);",
                 "CREATE TABLE scene_numbering(indexer TEXT, indexer_id INTEGER, season INTEGER, episode INTEGER, scene_season INTEGER, scene_episode INTEGER, absolute_number NUMERIC, scene_absolute_number NUMERIC, PRIMARY KEY(indexer_id, season, episode));",
-                "CREATE TABLE tv_shows(show_id INTEGER PRIMARY KEY, indexer_id NUMERIC, indexer NUMERIC, show_name TEXT, location TEXT, network TEXT, genre TEXT, classification TEXT, runtime NUMERIC, quality NUMERIC, airs TEXT, status TEXT, flatten_folders NUMERIC, paused NUMERIC, startyear NUMERIC, air_by_date NUMERIC, lang TEXT, subtitles NUMERIC, notify_list TEXT, imdb_id TEXT, last_update_indexer NUMERIC, dvdorder NUMERIC, archive_firstmatch NUMERIC, rls_require_words TEXT, rls_ignore_words TEXT, sports NUMERIC, anime NUMERIC, scene NUMERIC, default_ep_status NUMERIC DEFAULT -1);",
+                "CREATE TABLE tv_shows(show_id INTEGER PRIMARY KEY, indexer_id NUMERIC, indexer NUMERIC, show_name TEXT, location TEXT, network TEXT, genre TEXT, classification TEXT, runtime NUMERIC, quality NUMERIC, airs TEXT, status TEXT, flatten_folders NUMERIC, paused NUMERIC, startyear NUMERIC, air_by_date NUMERIC, lang TEXT, subtitles NUMERIC, notify_list TEXT, imdb_id TEXT, last_update_indexer NUMERIC, dvdorder NUMERIC, archive_firstmatch NUMERIC, rls_require_words TEXT, rls_ignore_words TEXT, sports NUMERIC, anime NUMERIC, scene NUMERIC, default_ep_status NUMERIC DEFAULT -1, sub_use_sr_metadata NUMERIC DEFAULT 0);",
                 "CREATE TABLE tv_episodes(episode_id INTEGER PRIMARY KEY, showid NUMERIC, indexerid NUMERIC, indexer TEXT, name TEXT, season NUMERIC, episode NUMERIC, description TEXT, airdate NUMERIC, hasnfo NUMERIC, hastbn NUMERIC, status NUMERIC, location TEXT, file_size NUMERIC, release_name TEXT, subtitles TEXT, subtitles_searchcount NUMERIC, subtitles_lastsearch TIMESTAMP, is_proper NUMERIC, scene_season NUMERIC, scene_episode NUMERIC, absolute_number NUMERIC, scene_absolute_number NUMERIC, version NUMERIC DEFAULT -1, release_group TEXT);",
                 "CREATE TABLE blacklist (show_id INTEGER, range TEXT, keyword TEXT);",
                 "CREATE TABLE whitelist (show_id INTEGER, range TEXT, keyword TEXT);",
@@ -336,7 +336,7 @@ class InitialSchema(db.SchemaUpgrade):
                 "CREATE INDEX idx_sta_epi_sta_air ON tv_episodes(season, episode, status, airdate);",
                 "CREATE INDEX idx_status ON tv_episodes(status,season,episode,airdate);",
                 "CREATE INDEX idx_tv_episodes_showid_airdate ON tv_episodes(showid, airdate);",
-                "INSERT INTO db_version(db_version) VALUES (43);"
+                "INSERT INTO db_version(db_version, db_minor_version) VALUES (44, 3);"
             ]
             for query in queries:
                 self.connection.action(query)
@@ -1153,7 +1153,11 @@ class UseSickChillMetadataForSubtitle(AlterTVShowsFieldTypes):
 
     def execute(self):
         backupDatabase(self.get_db_version())
+
+        logger.log("Adding column sub_use_sr_metadata to tvshows")
         self.add_column('tv_shows', 'sub_use_sr_metadata', "NUMERIC", "0")
+        self.inc_minor_version()
+        logger.log('Updated to: {0:d}.{1:d}'.format(*self.connection.version))
 
 
 class AddPreferWords(UseSickChillMetadataForSubtitle):
@@ -1166,7 +1170,6 @@ class AddPreferWords(UseSickChillMetadataForSubtitle):
         backupDatabase(self.get_db_version())
 
         logger.log("Adding column rls_prefer_words to tvshows")
-        if not self.has_column("tv_shows", "rls_prefer_words"):
-            self.add_column("tv_shows", "rls_prefer_words", "TEXT", "")
-
+        self.add_column("tv_shows", "rls_prefer_words", "TEXT", "")
         self.inc_minor_version()
+        logger.log('Updated to: {0:d}.{1:d}'.format(*self.connection.version))

--- a/sickbeard/search.py
+++ b/sickbeard/search.py
@@ -198,6 +198,9 @@ def pickBestResult(results, show):  # pylint: disable=too-many-branches
 
     bestResult = None
 
+    # order the list so that prefered releases are at the top
+    results.sort(key=lambda ep: show_name_helpers.hasPreferedWords(ep.name, ep.show), reverse=True)
+
     # find the best result for the current episode
     for cur_result in results:
         if show and cur_result.show is not show:

--- a/sickbeard/showUpdater.py
+++ b/sickbeard/showUpdater.py
@@ -24,9 +24,9 @@
 from __future__ import unicode_literals
 
 import datetime
+import json
 import threading
 import time
-import json
 
 import sickbeard
 from sickbeard import db, helpers, logger, network_timezones, ui

--- a/sickbeard/show_name_helpers.py
+++ b/sickbeard/show_name_helpers.py
@@ -201,3 +201,40 @@ def determineReleaseName(dir_name=None, nzb_name=None):
         return folder
 
     return None
+
+
+def hasPreferedWords(name, show=None):
+    """Determine based on the full episode (file)name combined with the prefered words what the weight its preference should be"""
+
+    name = name.lower()
+
+    def clean_set(words):
+        weighted_words = []
+
+        words = words.lower().strip().split(',')
+        val = len(words)
+
+        for word in words:
+            weighted_words.append({"word": word, "weight": val})
+            val = val - 1
+
+        return weighted_words
+
+    prefer_words = []
+
+    ## Because we weigh values, we can not union global and show based values, so we don't do that
+    if sickbeard.PREFER_WORDS:
+        prefer_words = clean_set(sickbeard.PREFER_WORDS)
+    if show and show.rls_prefer_words:
+        prefer_words = clean_set(show.rls_prefer_words or '')
+
+    ## if nothing set, return position 0
+    if len(prefer_words) <= 0:
+        return 0
+
+    value = 0
+    for word_pair in prefer_words:
+        if word_pair['weight'] > value and word_pair['word'] in name:
+            value = word_pair['weight']
+
+    return value

--- a/sickbeard/tv.py
+++ b/sickbeard/tv.py
@@ -95,6 +95,7 @@ class TVShow(object):  # pylint: disable=too-many-instance-attributes, too-many-
         self._scene = 0
         self._rls_ignore_words = ""
         self._rls_require_words = ""
+        self._rls_prefer_words = ""
         self._default_ep_status = SKIPPED
         self.dirty = True
 
@@ -136,6 +137,7 @@ class TVShow(object):  # pylint: disable=too-many-instance-attributes, too-many-
     scene = property(lambda self: self._scene, dirty_setter("_scene"))
     rls_ignore_words = property(lambda self: self._rls_ignore_words, dirty_setter("_rls_ignore_words"))
     rls_require_words = property(lambda self: self._rls_require_words, dirty_setter("_rls_require_words"))
+    rls_prefer_words = property(lambda self: self._rls_prefer_words, dirty_setter("_rls_prefer_words"))
     default_ep_status = property(lambda self: self._default_ep_status, dirty_setter("_default_ep_status"))
     subtitles_sr_metadata = property(lambda self: self._subtitles_sr_metadata, dirty_setter("_subtitles_sr_metadata"))
 
@@ -794,6 +796,7 @@ class TVShow(object):  # pylint: disable=too-many-instance-attributes, too-many-
 
             self.rls_ignore_words = sql_results[0][b"rls_ignore_words"]
             self.rls_require_words = sql_results[0][b"rls_require_words"]
+            self.rls_prefer_words = sql_results[0][b"rls_prefer_words"]
 
             self.default_ep_status = int(sql_results[0][b"default_ep_status"] or SKIPPED)
 
@@ -1184,6 +1187,7 @@ class TVShow(object):  # pylint: disable=too-many-instance-attributes, too-many-
                         "last_update_indexer": self.last_update_indexer,
                         "rls_ignore_words": self.rls_ignore_words,
                         "rls_require_words": self.rls_require_words,
+                        "rls_prefer_words": self.rls_prefer_words,
                         "default_ep_status": self.default_ep_status,
                         "sub_use_sr_metadata": self.subtitles_sr_metadata}
 

--- a/sickchill/views/api/webapi.py
+++ b/sickchill/views/api/webapi.py
@@ -1996,6 +1996,11 @@ class CMDShow(ApiCall):
         else:
             show_dict["rls_require_words"] = []
 
+        if show_obj.rls_prefer_words:
+            show_dict["rls_prefer_words"] = show_obj.rls_prefer_words.split(", ")
+        else:
+            show_dict["rls_prefer_words"] = []
+
         if show_obj.rls_ignore_words:
             show_dict["rls_ignore_words"] = show_obj.rls_ignore_words.split(", ")
         else:

--- a/sickchill/views/config/search.py
+++ b/sickchill/views/config/search.py
@@ -65,7 +65,7 @@ class ConfigSearch(Config):
                    torrent_complete_dir_deluge=None, torrent_verify_cert=None,
                    torrent_seed_time=None, torrent_paused=None, torrent_high_bandwidth=None,
                    torrent_rpcurl=None, torrent_auth_type=None, ignore_words=None, trackers_list=None, require_words=None, ignored_subs_list=None,
-                   syno_dsm_host=None, syno_dsm_user=None, syno_dsm_pass=None, syno_dsm_path=None, quality_allow_hevc=False):
+                   syno_dsm_host=None, syno_dsm_user=None, syno_dsm_pass=None, syno_dsm_path=None, quality_allow_hevc=False, prefer_words=None):
 
         results = []
 
@@ -90,6 +90,7 @@ class ConfigSearch(Config):
         sickbeard.IGNORE_WORDS = ignore_words if ignore_words else ""
         sickbeard.TRACKERS_LIST = trackers_list if trackers_list else ""
         sickbeard.REQUIRE_WORDS = require_words if require_words else ""
+        sickbeard.PREFER_WORDS = prefer_words if prefer_words else ""
         sickbeard.IGNORED_SUBS_LIST = ignored_subs_list if ignored_subs_list else ""
 
         sickbeard.RANDOMIZE_PROVIDERS = config.checkbox_to_value(randomize_providers)

--- a/sickchill/views/home.py
+++ b/sickchill/views/home.py
@@ -946,7 +946,7 @@ class Home(WebRoot):
     def editShow(self, show=None, location=None, anyQualities=None, bestQualities=None,
                  exceptions_list=None, season_folders=None, paused=None, directCall=False,
                  air_by_date=None, sports=None, dvdorder=None, indexerLang=None,
-                 subtitles=None, subtitles_sr_metadata=None, rls_ignore_words=None, rls_require_words=None,
+                 subtitles=None, subtitles_sr_metadata=None, rls_ignore_words=None, rls_require_words=None, rls_prefer_words=None,
                  anime=None, blacklist=None, whitelist=None, scene=None,
                  defaultEpStatus=None, quality_preset=None):
 
@@ -1106,6 +1106,7 @@ class Home(WebRoot):
                 show_obj.dvdorder = dvdorder
                 show_obj.rls_ignore_words = rls_ignore_words.strip()
                 show_obj.rls_require_words = rls_require_words.strip()
+                show_obj.rls_prefer_words = rls_prefer_words.strip()
 
             if not isinstance(location, six.text_type):
                 location = ek(six.text_type, location, 'utf-8')

--- a/tests/prefer_words_tests.py
+++ b/tests/prefer_words_tests.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python2.7
+# coding=utf-8
+
+from __future__ import print_function, unicode_literals
+
+import unittest
+
+import sickbeard
+from sickbeard.show_name_helpers import hasPreferedWords
+
+
+class PreferWordFilterTest(unittest.TestCase):
+    def setUp(self):
+        sickbeard.PREFER_WORDS = 'atmos,7.1,5.1,ddp,dd'
+
+        # prefer words only works on names, so we don't need complete shows
+        self.results_names_only_source = [
+            'Archer.2009.S01E10.1080p.WEB.x264-MEMENTO',
+            'Archer.2009.S01E10.1080p.WEB.dd2.0.x264-MEMENTO',
+            'Archer.2009.S10E08.1080p.AMZN.WEB-DL.DDP5.1.H.264-NT',
+            'Archer.2009.S10E08.1080p.AMZN.WEB-DL.Atmos.DDP5.1.H.264-NT',
+            'Archer.2009.S10E08.1080p.AMZN.WEB-DL.Atmos.DDP7.1.H.264-NT',
+            'Archer.2009.S10E08.1080p.AMZN.WEB-DL.True-HD.DDP7.1.H.264-NT',
+            'Archer.2009.S10E08.1080p.AMZN.WEB-DL.DDP.H.264-NT',
+        ]
+
+    def test_prefer_words_determine_weight(self):
+        self.assertTrue(hasPreferedWords(self.results_names_only_source[0]) == 0)
+        self.assertTrue(hasPreferedWords(self.results_names_only_source[1]) == 1)
+        self.assertTrue(hasPreferedWords(self.results_names_only_source[2]) == 3)
+        self.assertTrue(hasPreferedWords(self.results_names_only_source[3]) == 5)
+        self.assertTrue(hasPreferedWords(self.results_names_only_source[4]) == 5)
+        self.assertTrue(hasPreferedWords(self.results_names_only_source[5]) == 4)
+        self.assertTrue(hasPreferedWords(self.results_names_only_source[6]) == 2)
+
+if __name__ == '__main__':
+    SUITE = unittest.TestLoader().loadTestsFromTestCase(PreferWordFilterTest)
+    unittest.TextTestRunner(verbosity=2).run(SUITE)


### PR DESCRIPTION
PR Is based my own wishes and needs for a "Prefer words" option as is discussed in #5629 

As much as possible I tried to follow current guidelines and general best-practices. I also tried to contact dev on IRC to get some pointers/suggestions on how to create more specific unit-tests to help.

Unfortunately I was not able to get any specific help, so I hope that by using this pull-request I can get some help for merging.

To layout the implemented changes:

- Added hasPreferedWords to show_name_helper
- hasPreferedWords goes through the fetched results and finds out if any of the prefered words are in the list
- If no prefered words exists, it does nothing
- If prefered words exists, it will return a sorted list with the most prefered item at the top
- Also has unit tests available which should capture any issues
- Implements a prefered words option in the settings
- Implements a DB migration (although Im not really sure I did it correct)

(be gentle and/or poke me on IRC, though time-zones may make this tricky)