### PR TITLE
Fixing error when accessing html for torrent size

### DIFF
--- a/sickbeard/providers/magnetdl.py
+++ b/sickbeard/providers/magnetdl.py
@@ -96,7 +96,7 @@ class MagnetDLProvider(TorrentProvider):  # pylint: disable=too-many-instance-at
                             magnet = result.find("td", class_="m").find("a")['href']
                             seeders = try_int(result.find("td", class_="s").get_text(strip=True))
                             leechers = try_int(result.find("td", class_="l").get_text(strip=True))
-                            size = convert_size(result("td")[labels.index('Size')] or '') or -1
+                            size = convert_size(result("td")[labels.index('Size')].get_text(strip=True) or '') or -1
 
                             if not all([title, magnet]):
                                 continue


### PR DESCRIPTION
Fixes (no issue raised)

Proposed changes in this pull request:
- MagnetDL provider currently throws an error when calculating torrent size (and silently reports no torrent found), this fixes that bug.

- [x] PR is based on the DEVELOP branch
- [X] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [X] Read [contribution guide](https://github.com/SickChill/SickChill/blob/master/.github/CONTRIBUTING.md)
