### PR TITLE
is_ip_private() should handle IPv6 addresses

### DIFF
--- a/sickbeard/helpers.py
+++ b/sickbeard/helpers.py
@@ -28,6 +28,7 @@ import ctypes
 import datetime
 import hashlib
 import io
+import ipaddress
 import operator
 import os
 import platform
@@ -1713,12 +1714,7 @@ def tvdbid_from_remote_id(indexer_id, indexer):  # pylint:disable=too-many-retur
 
 
 def is_ip_private(ip):
-    priv_lo = re.compile(r"^(127\.\d{1,3}\.\d{1,3}\.\d{1,3}|::1)$")
-    priv_24 = re.compile(r"^10\.\d{1,3}\.\d{1,3}\.\d{1,3}$")
-    priv_20 = re.compile(r"^192\.168\.\d{1,3}.\d{1,3}$")
-    priv_16 = re.compile(r"^172.(1[6-9]|2[0-9]|3[0-1]).[0-9]{1,3}.[0-9]{1,3}$")
-    return priv_lo.match(ip) or priv_24.match(ip) or priv_20.match(ip) or priv_16.match(ip) or (ip == '0.0.0.0')
-
+    return ipaddress.ip_address(ip.decode()).is_private
 
 def recursive_listdir(path):
     for directory_path, directory_names, file_names in ek(os.walk, path, topdown=False):


### PR DESCRIPTION
Fixes #6029

Proposed changes in this pull request:
- Handle IPv6 addresses more completely in is_ip_private()

- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read [contribution guide](https://github.com/SickChill/SickChill/blob/master/.github/CONTRIBUTING.md)
