### PR TITLE
fix login when rev proxy has auth basic

### DIFF
--- a/sickchill/views/index.py
+++ b/sickchill/views/index.py
@@ -154,6 +154,10 @@ class BaseHandler(RequestHandler):
                         if jwt.decode(self.request.cookies['CF_Authorization'], key=public_key, audience=sickbeard.CF_POLICY_AUD):
                             return True
 
+            # Logged into UI?
+            if self.get_secure_cookie('sickchill_user'):
+                return True
+
             # Basic Auth at a minimum
             auth_header = self.request.headers.get('Authorization')
             if auth_header and auth_header.startswith('Basic '):
@@ -163,8 +167,6 @@ class BaseHandler(RequestHandler):
                     return True
                 return False
 
-            # Logged into UI?
-            return self.get_secure_cookie('sickchill_user')
         else:
             # Local network
             return helpers.is_ip_private(self.request.remote_ip)


### PR DESCRIPTION
If the user has a reverse proxy with basic auth enabled & the login/password are different from those on SC the user can never login,
so we must check UI login before Authorization header.

Fixes #

Proposed changes in this pull request:
- check UI login before header

- [x] PR is based on the DEVELOP branch
- [X] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [X] Read [contribution guide](https://github.com/SickChill/SickChill/blob/master/.github/CONTRIBUTING.md)
