### PR TITLE
Temporary workaround to support RFC 4007 IPv6 Scoped Literal Addresses

### DIFF
--- a/sickchill/views/index.py
+++ b/sickchill/views/index.py
@@ -169,7 +169,8 @@ class BaseHandler(RequestHandler):
 
         else:
             # Local network
-            return helpers.is_ip_private(self.request.remote_ip)
+            # strip <scope id> / <zone id> (%value/if_name) from remote_ip IPv6 scoped literal IP Addresses (RFC 4007) until phihag/ipaddress is updated tracking cpython 3.9.
+            return helpers.is_ip_private(self.request.remote_ip.rsplit('%')[0])
 
     def get_user_locale(self):
         return sickbeard.GUI_LANG or None


### PR DESCRIPTION
Fixes #6199 

Proposed changes in this pull request:
- Strip <scope id> / <zone id> ('%value/if_name') from remote_ip IPv6 scoped literal IP Addresses (RFC 4007) until phihag/ipaddress is updated tracking cpython 3.9.

- [X] PR is based on the DEVELOP branch

- [X] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review

- [X] Read [contribution guide](https://github.com/SickChill/SickChill/blob/master/.github/CONTRIBUTING.md)
