### PR TITLE
useful discord notifications

### DIFF
--- a/sickbeard/notifications_queue.py
+++ b/sickbeard/notifications_queue.py
@@ -115,7 +115,6 @@ class DiscordTask(generic_queue.QueueItem):
                 # 'url':
                 'icon_url': sickbeard.DISCORD_AVATAR_URL
             },
-            'title': 'SickChill',
             'fields': []
         }
 


### PR DESCRIPTION
Fixes #6464 

Proposed changes in this pull request:
- Removes title from discord notification. See issue for old and new format. Removing title has the following format below.
- This keeps the SickChill name and logo. Title is limited to 256 chars so fitting any decent information would cause more issues so keeping notifications in the fields makes sense.

Home Screen
![discord-not](https://i.imgur.com/5QXJwjo.jpg)
App View
![discord-not-multi](https://i.imgur.com/uxr4Mvm.jpg)


- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read [contribution guide](https://github.com/SickChill/SickChill/blob/master/.github/CONTRIBUTING.md)
