### PR TITLE
fix() Queue table td fix on try/except

### DIFF
--- a/sickchill/gui/slick/views/status.mako
+++ b/sickchill/gui/slick/views/status.mako
@@ -191,19 +191,23 @@
             % if BLSinProgress:
                 <td>${_('True')}</td>
             % else:
+                <td>
                 % try:
-                    <td>${service.action.amActive}</td>
+                    ${service.action.amActive}
                 % except Exception:
-                    <td>${_('N/A')}</td>
+                    ${_('N/A')}
                 % endtry
+                </td>
             % endif
         % else:
             <td>${service.enable}</td>
+            <td>
              % try:
-                <td>${service.action.amActive}</td>
+                ${service.action.amActive}
             % except Exception:
-                <td>${_('N/A')}</td>
+                ${_('N/A')}
             % endtry
+            </td>
         % endif
         % if service.start_time:
             <td align="right">${service.start_time}</td>
@@ -229,20 +233,21 @@
 
 <%def name="show_queue_row(item)">
     <tr>
+        <td>
         % try:
-            <td>${item.show.indexerid}</td>
+            ${item.show.indexerid}
         % except Exception:
-            <td></td>
         % endtry
+        </td>
+        <td>
         % try:
-            <td>${item.show.name}</td>
+            ${item.show.name}
         % except Exception:
             % if item.action_id == ShowQueueActions.ADD:
-                <td>${item.showDir}</td>
-            % else:
-                <td></td>
+                ${item.showDir}
             % endif
         % endtry
+        </td>
         <td>${item.inProgress}</td>
         % if item.priority == 10:
             <td>${_('LOW')}</td>


### PR DESCRIPTION
On try/except block, when a exception occurs, the `<td>` insde try block is printed as the fail is in the evaluated code, and then the `<td>`/`</td>` is also added, so the table is displayed with extra columns

![bad_colums_status](https://user-images.githubusercontent.com/1042532/90332350-4e604880-dfbc-11ea-96eb-1c256460cdc4.png)

Proposed changes in this pull request:
- Move the td tags outside try/except block


- [ ] PR is based on the DEVELOP branch
- [ ] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [ ] Read [contribution guide](https://github.com/SickChill/SickChill/blob/master/.github/CONTRIBUTING.md)
