### PR TITLE
fix() Hotfix to remove "Close" text on dialogs

### DIFF
--- a/sickchill/gui/slick/css/jquery-ui-custom.css
+++ b/sickchill/gui/slick/css/jquery-ui-custom.css
@@ -1,0 +1,10 @@
+
+/* to make room for the icon, a width needs to be set here
+ * @note Copied from jquery-ui@1.12.1
+ */
+.ui-button-icon-only {
+	width: 2em;
+	box-sizing: border-box;
+	text-indent: -9999px;
+	white-space: nowrap;
+}

--- a/sickchill/gui/slick/views/layouts/main.mako
+++ b/sickchill/gui/slick/views/layouts/main.mako
@@ -99,6 +99,7 @@
         <link rel="stylesheet" type="text/css" href="${static_url('css/style.css')}"/>
         <link rel="stylesheet" type="text/css" href="${static_url('css/print.css')}" />
         <link rel="stylesheet" type="text/css" href="${static_url('css/country-flags.css')}"/>
+        <link rel="stylesheet" type="text/css" href="${static_url('css/jquery-ui-custom.css')}" />
 
         % if settings.THEME_NAME != "light":
             <link rel="stylesheet" type="text/css" href="${static_url(urljoin('css/', '.'.join((settings.THEME_NAME, 'css'))))}" />


### PR DESCRIPTION
Fixes "close" text is visible on dialog on top-right button, it shouldn't

Proposed changes in this pull request:
- Hide the text as is done in latest jquery-ui CSS

- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read [contribution guide](https://github.com/SickChill/SickChill/blob/master/.github/CONTRIBUTING.md)
