### PR TITLE
Make update method call the correct updater

### DIFF
--- a/sickchill/update_manager/runner.py
+++ b/sickchill/update_manager/runner.py
@@ -301,7 +301,7 @@ class UpdateManager(object):
     def update(self):
         self.branch = settings.BRANCH
         if self.need_update():
-            return self.update()
+            return self.updater.update()
 
     def list_remote_branches(self):
         if self.updater:


### PR DESCRIPTION
Fixes (hopefully?) a bug with updating in the python3 develop branch: https://github.com/SickChill/SickChill/issues/6545#issuecomment-678416661