### PR TITLE
Fix scrollable content on ui-dialog (file dialog and image selector dialog)

### DIFF
--- a/sickchill/gui/slick/css/jquery-ui-custom.css
+++ b/sickchill/gui/slick/css/jquery-ui-custom.css
@@ -18,7 +18,5 @@
 
 .ui-dialog.ui-dialog-scrollable-by-child .ui-dialog-content .ui-dialog-scrollable-child {
   overflow: auto;
-  max-height: inherit;
-  height: inherit;
   padding-right: 0.5em;
 }

--- a/sickchill/gui/slick/js/browser.js
+++ b/sickchill/gui/slick/js/browser.js
@@ -88,8 +88,7 @@
             $('a', list).wrap('<li class="ui-state-default ui-corner-all">');
             fileBrowserDialog.dialog('option', 'dialogClass', 'browserDialog');
 
-            const scrollableHeight = fileBrowserDialog.height()
-                - inputContainer.outerHeight();
+            const scrollableHeight = fileBrowserDialog.height() - inputContainer.outerHeight();
 
             listContainer.height(scrollableHeight).css('maxHeight', scrollableHeight);
         });

--- a/sickchill/gui/slick/js/browser.js
+++ b/sickchill/gui/slick/js/browser.js
@@ -43,17 +43,19 @@
                 return i++ !== 0;
             });
 
+            const inputContainer = $('<div class="fileBrowserFieldContainer"></div>');
             $('<input type="text" class="form-control input-sm">').val(firstValue.currentPath).on('keypress', event_ => {
                 if (event_.which === 13) {
                     browse(event_.target.value, endpoint, includeFiles, fileTypes);
                 }
-            }).appendTo($('<div class="fileBrowserFieldContainer">').appendTo(fileBrowserDialog)).fileBrowser({
+            }).appendTo(inputContainer.appendTo(fileBrowserDialog)).fileBrowser({
                 showBrowseButton: false
             }).on('autocompleteselect', (event_, ui) => {
                 browse(ui.item.value, endpoint, includeFiles, fileTypes);
             });
 
-            list = $('<ul>').appendTo($('<div class="ui-dialog-scrollable-child">').appendTo(fileBrowserDialog));
+            const listContainer = $('<div class="ui-dialog-scrollable-child">');
+            list = $('<ul>').appendTo(listContainer.appendTo(fileBrowserDialog));
             $.each(data, (i, entry) => {
                 if (entry.isFile && fileTypes && (!entry.isAllowed || fileTypes.includes('images') && !entry.isImage)) { // eslint-disable-line no-mixed-operators
                     return true;
@@ -85,6 +87,11 @@
             });
             $('a', list).wrap('<li class="ui-state-default ui-corner-all">');
             fileBrowserDialog.dialog('option', 'dialogClass', 'browserDialog');
+
+            const scrollableHeight = fileBrowserDialog.height()
+                - inputContainer.outerHeight();
+
+            listContainer.height(scrollableHeight).css('maxHeight', scrollableHeight);
         });
     }
 

--- a/sickchill/gui/slick/js/imageSelector.js
+++ b/sickchill/gui/slick/js/imageSelector.js
@@ -61,9 +61,9 @@
             imageSelectorDialog.dialog('option', 'dialogClass', 'browserDialog');
         });
 
-        const scrollableHeight = imageSelectorDialog.outerHeight()
-            - imageSelectorDialog.find('.image-provider-container').outerHeight()
-            - 15;
+        const scrollableHeight = imageSelectorDialog.outerHeight() -
+            imageSelectorDialog.find('.image-provider-container').outerHeight() -
+            15;
 
         imagesContainer.height(scrollableHeight).css('maxHeight', scrollableHeight);
     }
@@ -133,8 +133,6 @@
         dropdown.val(dropdown.data('default'));
         imageSelectorDialog.children('.upload').hide();
         imageSelectorDialog.children('.error').hide();
-
-
 
         imageSelectorDialog.dialog('open');
         fetchImages();

--- a/sickchill/gui/slick/js/imageSelector.js
+++ b/sickchill/gui/slick/js/imageSelector.js
@@ -60,6 +60,12 @@
 
             imageSelectorDialog.dialog('option', 'dialogClass', 'browserDialog');
         });
+
+        const scrollableHeight = imageSelectorDialog.outerHeight()
+            - imageSelectorDialog.find('.image-provider-container').outerHeight()
+            - 15;
+
+        imagesContainer.height(scrollableHeight).css('maxHeight', scrollableHeight);
     }
 
     function createImage(imageSrc, thumbSrc) {
@@ -81,11 +87,11 @@
         image.appendTo(imagesContainer);
     }
 
-    $.fn.nImageSelector = function () {
+    $.fn.nImageSelector = function (imageSelectorElement) {
         const field = $(this);
         imageType = field.data('image-type');
 
-        imageSelectorDialog.dialog({
+        imageSelectorDialog = imageSelectorElement.dialog({
             dialogClass: 'image-selector-dialog',
             classes: {
                 'ui-dialog': 'ui-dialog-scrollable-by-child'
@@ -93,6 +99,7 @@
             title: _('Choose Image'),
             position: {my: 'center top', at: 'center top+60', of: window},
             minWidth: Math.min($(document).width() - 80, 650),
+            height: Math.min($(document).height() - 80, $(window).height() - 80),
             maxHeight: Math.min($(document).height() - 80, $(window).height() - 80),
             maxWidth: $(document).width() - 80,
             modal: true,
@@ -127,9 +134,10 @@
         imageSelectorDialog.children('.upload').hide();
         imageSelectorDialog.children('.error').hide();
 
-        fetchImages();
+
 
         imageSelectorDialog.dialog('open');
+        fetchImages();
 
         return false;
     };
@@ -137,11 +145,11 @@
     $.fn.imageSelector = function () {
         const $this = $(this);
 
-        imageSelectorDialog = $('.image-selector-dialog');
-        imagesContainer = imageSelectorDialog.children('.images');
+        const imageSelectorElement = $('.image-selector-dialog');
+        imagesContainer = imageSelectorElement.children('.images');
 
-        imageSelectorDialog.children('#images-provider').on('change', function () {
-            const uploadContainer = imageSelectorDialog.children('.upload');
+        imageSelectorElement.children('#images-provider').on('change', function () {
+            const uploadContainer = imageSelectorElement.children('.upload');
 
             if ($(this).children('option:selected').val() === '-1') {
                 imagesContainer.empty();
@@ -153,7 +161,7 @@
         });
 
         $('.upload #upload-image-input').on('change', function () {
-            imageSelectorDialog.children('.error').hide();
+            imageSelectorElement.children('.error').hide();
 
             if (this.files) {
                 const loadFunction = ev => {
@@ -162,8 +170,8 @@
                         if (SIZES_BY_TYPE[imageType].validate(img)) {
                             createImage(img.src);
                         } else {
-                            imageSelectorDialog.children('.error').text(SIZES_BY_TYPE[imageType].errorMsg);
-                            imageSelectorDialog.children('.error').show();
+                            imageSelectorElement.children('.error').text(SIZES_BY_TYPE[imageType].errorMsg);
+                            imageSelectorElement.children('.error').show();
                         }
                     });
                     img.src = ev.target.result;
@@ -178,7 +186,7 @@
         });
 
         $this.on('click', function () {
-            $(this).nImageSelector();
+            $(this).nImageSelector(imageSelectorElement);
             return false;
         });
 

--- a/sickchill/gui/slick/views/editShow.mako
+++ b/sickchill/gui/slick/views/editShow.mako
@@ -22,17 +22,18 @@
 
 <%block name="content">
     <div class="image-selector-dialog" style="display:none">
-        <select id="images-provider" name="provider" data-default="${show.indexer}">
-            <option value="-1">Upload</option>
-            <option value="${show_indexer.FANART}">Fanart</option>
-            <option value="${show_indexer.TMDB}">TMDB</option>
-            % for index, indexer in show_indexer:
-            <option value="${index}" ${('', 'selected="selected"')[show.indexer == index]}>
-                ${indexer.name}
-            </option>
-            % endfor
-        </select>
-
+        <div class="image-provider-container">
+            <select id="images-provider" name="provider" data-default="${show.indexer}">
+                <option value="-1">Upload</option>
+                <option value="${show_indexer.FANART}">Fanart</option>
+                <option value="${show_indexer.TMDB}">TMDB</option>
+                % for index, indexer in show_indexer:
+                <option value="${index}" ${('', 'selected="selected"')[show.indexer == index]}>
+                    ${indexer.name}
+                </option>
+                % endfor
+            </select>
+        </div>
         <div class="upload" hidden>
             <input type="file" id="upload-image-input" accept="image/*" multiple/>
         </div>


### PR DESCRIPTION
On the file browser dialog, if there are multiple file/folders to select, the latest is not shown and on image selector, the latest row of images is cut off.

Proposed changes in this pull request:
- Calculate the height & maxHeight.

- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read [contribution guide](https://github.com/SickChill/SickChill/blob/master/.github/CONTRIBUTING.md)
