### PR TITLE
Use certifi to enforce usage of the correct ca-certificates

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ beautifulsoup4
 beekeeper
 bencode.py
 CacheControl
+certifi
 #cfscrape
 chardet
 cloudscraper

--- a/sickchill/oldbeard/notifiers/telegram.py
+++ b/sickchill/oldbeard/notifiers/telegram.py
@@ -1,5 +1,6 @@
 # Author: Marvin Pinto <me@marvinp.ca>
 # Author: Dennis Lutter <lad1337@gmail.com>
+import certifi
 import urllib.parse
 import urllib.request
 
@@ -50,7 +51,7 @@ class Notifier(object):
 
         success = False
         try:
-            urllib.request.urlopen(req)
+            urllib.request.urlopen(req, cafile=certifi.where())
             message = 'Telegram message sent successfully.'
             success = True
         except IOError as e:


### PR DESCRIPTION
Fixes #

Proposed changes in this pull request:
- Use certifi to enforce the usage of correct ca-certicates bundles.
-
-

- [ ] PR is based on the DEVELOP branch
- [ ] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [ ] Read [contribution guide](https://github.com/SickChill/SickChill/blob/master/.github/CONTRIBUTING.md)
