### PR TITLE
Fix fetch custom images when using authentication

### DIFF
--- a/sickchill/gui/slick/js/imageSelector.js
+++ b/sickchill/gui/slick/js/imageSelector.js
@@ -78,11 +78,12 @@
         const wrapUrl = new URL(scRoot + '/imageSelector/url_wrap/', location.href);
         if (thumbSrc) {
             wrapUrl.searchParams.append('url', thumbSrc);
-            image.attr('src', wrapUrl.href).attr('data-image', imageSrc);
+            image.attr('data-thumb', thumbSrc);
         } else {
             wrapUrl.searchParams.append('url', imageSrc);
-            image.attr('src', wrapUrl.href);
         }
+
+        image.attr('src', wrapUrl.href).attr('data-image', imageSrc);
 
         image.appendTo(imagesContainer);
     }
@@ -114,9 +115,10 @@
 
                 if (selectedImage.length > 0) {
                     const image = selectedImage.data('image');
-                    const thumb = selectedImage.attr('src');
+                    const thumb = selectedImage.data('thumb');
+                    const src = selectedImage.attr('src');
                     $('[name=' + imageType + ']').val((image ? image + '|' : '') + thumb);
-                    field.attr('src', thumb).addClass('modified');
+                    field.attr('src', src).addClass('modified');
                 }
 
                 $(this).dialog('close');

--- a/sickchill/gui/slick/views/displayShow.mako
+++ b/sickchill/gui/slick/views/displayShow.mako
@@ -11,7 +11,7 @@
     from sickchill.helper.common import pretty_file_size, try_int
 %>
 <%block name="metas">
-    <meta data-var="showBackgroundImage" data-content="${static_url(show.show_image_url('fanart', include_date=True), include_version=False)}">
+    <meta data-var="showBackgroundImage" data-content="${static_url(show.show_image_url('fanart'))}">
 </%block>
 <%block name="scripts">
     <script type="text/javascript" src="${static_url('js/lib/jquery.bookmarkscroll.js')}"></script>
@@ -111,8 +111,8 @@
             <div class="row">
                 <div class="col-md-12">
                     <div class="poster-container">
-                        <a href="${static_url(show.show_image_url('poster_thumb', include_date=True), include_version=False)}">
-                            <img src="${static_url(show.show_image_url('poster_thumb', include_date=True), include_version=False)}"
+                        <a href="${static_url(show.show_image_url('poster_thumb'))}">
+                            <img src="${static_url(show.show_image_url('poster_thumb'))}"
                                  class="tvshowImg" alt="${_('Poster for')} ${show.name}"
                             />
                         </a>
@@ -121,7 +121,7 @@
                     <div class="info-container">
                         <div class="row">
                             <div class="pull-right col-lg-4 col-md-4 hidden-sm hidden-xs">
-                                <img src="${static_url(show.show_image_url('banner', include_date=True), include_version=False)}"
+                                <img src="${static_url(show.show_image_url('banner'))}"
                                      style="max-height:50px;border:1px solid black;" class="pull-right">
                             </div>
                             <div class="pull-left col-lg-8 col-md-8 col-sm-12 col-xs-12">

--- a/sickchill/gui/slick/views/displayShow.mako
+++ b/sickchill/gui/slick/views/displayShow.mako
@@ -111,8 +111,8 @@
             <div class="row">
                 <div class="col-md-12">
                     <div class="poster-container">
-                        <a href="${static_url(show.show_image_url('poster', include_date=True), include_version=False)}">
-                            <img src="${static_url(show.show_image_url('poster', include_date=True), include_version=False)}"
+                        <a href="${static_url(show.show_image_url('poster_thumb', include_date=True), include_version=False)}">
+                            <img src="${static_url(show.show_image_url('poster_thumb', include_date=True), include_version=False)}"
                                  class="tvshowImg" alt="${_('Poster for')} ${show.name}"
                             />
                         </a>

--- a/sickchill/gui/slick/views/editShow.mako
+++ b/sickchill/gui/slick/views/editShow.mako
@@ -484,7 +484,7 @@
                                             <div class="col-md-12">
                                                 <div class="poster-container">
                                                     <input type="hidden" name="poster"/>
-                                                    <img src="${static_url(show.show_image_url('poster', include_date=True), include_version=False)}"
+                                                    <img src="${static_url(show.show_image_url('poster'))}"
                                                          data-image-type="poster"
                                                          class="custom-image tvshowImg" alt="${_('Poster for')} ${show.name}"
                                                     />
@@ -504,7 +504,7 @@
                                             <div class="col-md-12">
                                                 <div class="banner-container">
                                                     <input type="hidden" name="banner"/>
-                                                    <img src="${static_url(show.show_image_url('banner', include_date=True), include_version=False)}"
+                                                    <img src="${static_url(show.show_image_url('banner'))}"
                                                          data-image-type="banner"
                                                          class="custom-image banner" alt="${_('Banner for')} ${show.name}"
                                                     />
@@ -524,7 +524,7 @@
                                             <div class="col-md-12">
                                                 <div class="fanart-container">
                                                     <input type="hidden" name="fanart"/>
-                                                    <img src="${static_url(show.show_image_url('fanart', include_date=True), include_version=False)}"
+                                                    <img src="${static_url(show.show_image_url('fanart'))}"
                                                          data-image-type="fanart"
                                                          class="custom-image tvshowImg" alt="${_('Fanart for')} ${show.name}"
                                                     />

--- a/sickchill/gui/slick/views/inc_home_show_list.mako
+++ b/sickchill/gui/slick/views/inc_home_show_list.mako
@@ -55,13 +55,13 @@
                                 <div class="imgsmallposter ${settings.HOME_LAYOUT}">
                                     % if curLoadingShow.show:
                                         <a href="${scRoot}/home/displayShow?show=${loading_show.id}" title="${loading_show.name}">
-                                            <img src="${static_url("images/poster.png")}" data-src="${static_url(loading_show.show_image_url('poster_thumb', include_date=True), include_version=False)}"
+                                            <img src="${static_url("images/poster.png")}" data-src="${static_url(loading_show.show_image_url('poster_thumb'))}"
                                                  class="${settings.HOME_LAYOUT}" alt="${loading_show.name}"/>
                                         </a>
                                         <a href="${scRoot}/home/displayShow?show=${loading_show.id}" style="vertical-align: middle;">${loading_show.name}</a>
                                     % else:
                                         <span title="${loading_show.name}">
-                                        <img src="${static_url("images/poster.png")}" data-src="${static_url(loading_show.show_image_url('poster_thumb', include_date=True), include_version=False)}"
+                                        <img src="${static_url("images/poster.png")}" data-src="${static_url(loading_show.show_image_url('poster_thumb'))}"
                                              class="${settings.HOME_LAYOUT}" alt="${loading_show.name}"/>
                                         </span>
                                         <span style="vertical-align: middle;">${_('Loading...')} (${loading_show.name})</span>
@@ -75,7 +75,7 @@
                                     % if curLoadingShow.show:
                                         <a href="${scRoot}/home/displayShow?show=${loading_show.id}">
                                     % endif
-                                    <img src="${static_url("images/banner.png")}" data-src="${static_url(loading_show.show_image_url('banner', include_date=True), include_version=False)}"
+                                    <img src="${static_url("images/banner.png")}" data-src="${static_url(loading_show.show_image_url('banner'))}"
                                          class="${settings.HOME_LAYOUT}" alt="${loading_show.name}" title="${loading_show.name}"/>
                                     % if curLoadingShow.show:
                                         </a>
@@ -178,7 +178,7 @@
                             <td class="tvShow">
                                 <div class="imgsmallposter ${settings.HOME_LAYOUT}">
                                     <a href="${scRoot}/home/displayShow?show=${curShow.indexerid}" title="${curShow.name}">
-                                        <img src="${static_url("images/poster.png")}" data-src="${static_url(curShow.show_image_url('poster_thumb', include_date=True), include_version=False)}"
+                                        <img src="${static_url("images/poster.png")}" data-src="${static_url(curShow.show_image_url('poster_thumb'))}"
                                              class="${settings.HOME_LAYOUT}" alt="${curShow.indexerid}"/>
                                     </a>
                                     <a href="${scRoot}/home/displayShow?show=${curShow.indexerid}" style="vertical-align: middle;">${curShow.name}</a>
@@ -189,7 +189,7 @@
                                 <span style="display: none;">${curShow.name}</span>
                                 <div class="imgbanner ${settings.HOME_LAYOUT}">
                                     <a href="${scRoot}/home/displayShow?show=${curShow.indexerid}">
-                                        <img src="${static_url("images/banner.png")}" data-src="${static_url(curShow.show_image_url('banner', include_date=True), include_version=False)}"
+                                        <img src="${static_url("images/banner.png")}" data-src="${static_url(curShow.show_image_url('banner'))}"
                                              class="${settings.HOME_LAYOUT}" alt="${curShow.indexerid}" title="${curShow.name}"/>
                                     </a>
                                 </div>

--- a/sickchill/gui/slick/views/inc_home_show_list_poster.mako
+++ b/sickchill/gui/slick/views/inc_home_show_list_poster.mako
@@ -17,7 +17,7 @@
                  data-date="1" data-network="0" data-progress="0" data-progress-sort="0" data-status="Loading">
                 <div class="show-image">
                     <img alt="" title="${loading_show.name}" class="show-image" style="border-bottom: 1px solid #111;" src="${static_url("images/poster.png")}"
-                         data-src="${static_url(loading_show.show_image_url('poster_thumb', include_date=True), include_version=False)}" />
+                         data-src="${static_url(loading_show.show_image_url('poster_thumb'))}" />
                 </div>
                 <div class="show-information">
                     <div class="progressbar hidden-print" style="position:relative;" data-show-id="${loading_show.id}" data-progress-percentage="0"></div>
@@ -103,7 +103,7 @@
                  data-progress="${int(progressbar_percent)}" data-progress-sort="${progressbar_percent + (cur_total/1000000.0)}" data-status="${curShow.status}">
                 <div class="show-image">
                     <a href="${scRoot}/home/displayShow?show=${curShow.indexerid}">
-                        <img alt="" class="show-image" src="${static_url("images/poster.png")}" data-src="${static_url(curShow.show_image_url('poster_thumb', include_date=True), include_version=False)}" />
+                        <img alt="" class="show-image" src="${static_url("images/poster.png")}" data-src="${static_url(curShow.show_image_url('poster_thumb'))}" />
                     </a>
                 </div>
 

--- a/sickchill/gui/slick/views/schedule.mako
+++ b/sickchill/gui/slick/views/schedule.mako
@@ -171,7 +171,7 @@
                                         <a href="${scRoot}/home/displayShow?show=${cur_result['showid']}">
                                             <img alt="" class="bannerThumb"
                                                  src="${static_url("images/banner.png")}"
-                                                 data-src="${static_url(settings.IMAGE_CACHE.image_url(cur_result['showid'], 'banner_thumb', include_date=True))}"
+                                                 data-src="${static_url(settings.IMAGE_CACHE.image_url(cur_result['showid'], 'banner_thumb'))}"
                                             />
                                         </a>
                                     </td>
@@ -278,7 +278,7 @@
                                                     <div class="poster">
                                                         <a title="${cur_result['show_name']}" href="${scRoot}/home/displayShow?show=${cur_result['showid']}">
                                                             <img alt=""
-                                                                 src="${static_url(settings.IMAGE_CACHE.image_url(cur_result['showid'], 'poster_thumb', include_date=True))}"
+                                                                 src="${static_url(settings.IMAGE_CACHE.image_url(cur_result['showid'], 'poster_thumb'))}"
                                                             />
                                                         </a>
                                                     </div>
@@ -425,7 +425,7 @@
                                     <th ${('class="nobg"', 'rowspan="3"')[layout == 'poster']} valign="top">
                                         <a href="${scRoot}/home/displayShow?show=${cur_result['showid']}">
                                             <img alt="" class="${('posterThumb', 'bannerThumb')[layout == 'banner']}"
-                                                 src="${static_url(settings.IMAGE_CACHE.image_url(cur_result['showid'], (layout, 'poster_thumb')[layout == 'poster'], include_date=True))}"
+                                                 src="${static_url(settings.IMAGE_CACHE.image_url(cur_result['showid'], (layout, 'poster_thumb')[layout == 'poster']))}"
                                             />
                                         </a>
                                     </th>

--- a/sickchill/oldbeard/image_cache.py
+++ b/sickchill/oldbeard/image_cache.py
@@ -122,16 +122,10 @@ class ImageCache(object):
         logger.debug("Checking if file " + str(banner_thumb_path) + " exists")
         return os.path.isfile(banner_thumb_path)
 
-    def image_url(self, indexer_id, which, include_date=False):
+    def image_url(self, indexer_id, which):
         path = self.__getattribute__(which + "_path")(indexer_id)
         if os.path.isfile(path):
-            try:
-                image_path = 'cache' + path.split(settings.CACHE_DIR)[1].replace('\\', '/')
-                return f"{image_path}?updated={int(os.path.getctime(path))}" if include_date else image_path
-
-            except (AttributeError, ValueError, IndexError):
-                logger.info('Error with cache path, path={}, cache={}, split={}'.format(
-                    path, settings.CACHE_DIR, str(path.split(settings.CACHE_DIR))))
+            return 'cache' + path.split(settings.CACHE_DIR)[1].replace('\\', '/')
         return ('images/poster.png', 'images/banner.png')['banner' in which]
 
     BANNER = 1

--- a/sickchill/oldbeard/show_queue.py
+++ b/sickchill/oldbeard/show_queue.py
@@ -272,7 +272,7 @@ class QueueItemAdd(ShowQueueItem):
                         network_image_url=self.show.network_image_url, show_image_url=self.show.show_image_url, quality=self.show.quality)
         # noinspection PyUnresolvedReferences
         return info(id=0, name=self.show_name, sort_name=sortable_name(self.show_name), network=_('Loading'),
-                    network_image_url='images/network/nonetwork.png', show_image_url=lambda x, include_date=False: 'images/{}.png'.format(('poster', 'banner')['banner' in x]),
+                    network_image_url='images/network/nonetwork.png', show_image_url=lambda x: 'images/{}.png'.format(('poster', 'banner')['banner' in x]),
                     quality=0)
 
     def run(self):

--- a/sickchill/tv.py
+++ b/sickchill/tv.py
@@ -152,8 +152,8 @@ class TVShow(object):
     def network_image_url(self):
         return 'images/network/{0}.png'.format(unidecode(self.network or 'nonetwork').lower())
 
-    def show_image_url(self, which, include_date=False):
-        return settings.IMAGE_CACHE.image_url(self.indexerid, which, include_date)
+    def show_image_url(self, which):
+        return settings.IMAGE_CACHE.image_url(self.indexerid, which)
 
     def _getLocation(self):
         # no dir check needed if missing show dirs are created during post-processing

--- a/sickchill/views/server_settings.py
+++ b/sickchill/views/server_settings.py
@@ -35,9 +35,10 @@ class SickChillStaticFileHandler(StaticFileHandler):
         if not include_version:
             return url
 
-        custom_settings = settings
+        custom_settings = settings.copy()
         if 'cache/' in path:
             custom_settings['static_path'] = os.path.dirname(sickchill.settings.CACHE_DIR)
+
         version_hash = cls.get_version(custom_settings, path)
         if not version_hash:
             return url


### PR DESCRIPTION
Proposed changes in this pull request:
- Add thumb url to the hidden field, instead of the wrap_url
- Restore the use of thumbs on displayShow

- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read [contribution guide](https://github.com/SickChill/SickChill/blob/master/.github/CONTRIBUTING.md)
