### PR TITLE
Bugfix/postprocess release group

### DIFF
--- a/sickchill/oldbeard/postProcessor.py
+++ b/sickchill/oldbeard/postProcessor.py
@@ -1012,6 +1012,9 @@ class PostProcessor(object):
                 # clean up any left over folders
                 if cur_ep.location:
                     helpers.delete_empty_folders(os.path.dirname(cur_ep.location), keep_dir=ep_obj.show._location)
+
+                # clean up download-related properties
+                cur_ep.cleanup_download_properties()
             except (OSError, IOError):
                 raise EpisodePostProcessingFailedException("Unable to delete the existing files")
 

--- a/sickchill/tv.py
+++ b/sickchill/tv.py
@@ -2456,8 +2456,14 @@ class TVEpisode(object):
         Clean the properties related with the current download.
         Use only when replacing with a new release or similar tasks.
         """
-        if hasattr(self, '_release_group'):
-            del self._release_group
+        self.file_size = 0
+        self.is_proper = False
+        self.location = ''
+        self.release_group = ''
+        self.release_name = ''
+        self._location = ''
+        self._release_group = ''
+
 
     def __getstate__(self):
         d = dict(self.__dict__)

--- a/sickchill/tv.py
+++ b/sickchill/tv.py
@@ -2451,6 +2451,14 @@ class TVEpisode(object):
             logger.warning("{0}: Failed to modify date of '{1}'".format
                            (self.show.indexerid, os.path.basename(self.location)))
 
+    def cleanup_download_properties(self):
+        """
+        Clean the properties related with the current download.
+        Use only when replacing with a new release or similar tasks.
+        """
+        if hasattr(self, '_release_group'):
+            del self._release_group
+
     def __getstate__(self):
         d = dict(self.__dict__)
         del d['lock']


### PR DESCRIPTION
Fixes #6822

Proposed changes in this pull request:
- When post-processing a file and the old file should be deleted, remove the properties related with old file (now just the release group is deleted, but probably more properties should be added to the cleanup process)

- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read [contribution guide](https://github.com/SickChill/SickChill/blob/master/.github/CONTRIBUTING.md)
