### PR TITLE
Update Emby API notify

### DIFF
--- a/sickchill/oldbeard/notifiers/emby.py
+++ b/sickchill/oldbeard/notifiers/emby.py
@@ -59,23 +59,11 @@ class Notifier(object):
                 logger.debug('EMBY: No host specified, check your settings')
                 return False
 
-            params = {}
-            if show:
-                if show.indexer == 1:
-                    provider = 'tvdb'
-                elif show.indexer == 2:
-                    logger.warning('EMBY: TVRage Provider no longer valid')
-                    return False
-                else:
-                    logger.warning('EMBY: Provider unknown')
-                    return False
-                params.update({f'{provider}id': show.indexerid})
-
-            url = urljoin(settings.EMBY_HOST, 'emby/Library/Series/Updated')
+            url = urljoin(settings.EMBY_HOST, 'emby/Library/Refresh')
 
             try:
                 session = self.__make_session()
-                response = session.get(url, params=params)
+                response = session.post(url)
                 response.raise_for_status()
                 logger.debug('EMBY: HTTP response: {0}'.format(response.text.replace('\n', '')))
                 return True


### PR DESCRIPTION
Fixes #6816 

Proposed changes in this pull request:
- The Library/Series/Updated request used is depricated.
- Library/Refresh requests Emby do a library update which handles additions and deletions as well as updates.
- There is a potential replacement request with a different set of parameters (/Library/Media/Updated) which requires a path and a change type, however the Library/Refresh is suitably fast on my 8TB library.

- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read [contribution guide](https://github.com/SickChill/SickChill/blob/master/.github/CONTRIBUTING.md)
