### PR TITLE
Fix broken Emby API Library updates

### DIFF
--- a/sickchill/oldbeard/notifiers/emby.py
+++ b/sickchill/oldbeard/notifiers/emby.py
@@ -61,21 +61,19 @@ class Notifier(object):
 
             params = {}
             if show:
-                if show.indexer == 1:
-                    provider = 'tvdb'
-                elif show.indexer == 2:
-                    logger.warning('EMBY: TVRage Provider no longer valid')
-                    return False
-                else:
-                    logger.warning('EMBY: Provider unknown')
-                    return False
-                params.update({f'{provider}id': show.indexerid})
-
-            url = urljoin(settings.EMBY_HOST, 'emby/Library/Series/Updated')
+                params.update({
+                    'Updates': [{
+                        'Path': show.location,
+                        'UpdateType': "Created"
+                    }]
+                })
+                url = urljoin(settings.EMBY_HOST, 'emby/Library/Media/Updated')
+            else:
+                url = urljoin(settings.EMBY_HOST, 'emby/Library/Refresh')
 
             try:
                 session = self.__make_session()
-                response = session.get(url, params=params)
+                response = session.post(url, json=params)
                 response.raise_for_status()
                 logger.debug('EMBY: HTTP response: {0}'.format(response.text.replace('\n', '')))
                 return True


### PR DESCRIPTION
Fixes #6816

Proposed changes in this pull request:
- Use the new /Library/Media/Updated instead of the deprecated and broken /Library/Series/Updated
- Fall back to /Library/Refresh (slower) if no show is specified
- This is an alternative to PR #6839 to avoid updating entire library on single-file updates

Ref http://swagger.emby.media/?staticview=true#/LibraryService/postLibraryMediaUpdated

- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read [contribution guide](https://github.com/SickChill/SickChill/blob/master/.github/CONTRIBUTING.md)
