### PR TITLE
adba bugfix for compression handling

### DIFF
--- a/sickchill/adba/aniDBlink.py
+++ b/sickchill/adba/aniDBlink.py
@@ -85,12 +85,17 @@ class AniDBLink(threading.Thread):
             try:
                 for i in range(2):
                     try:
-                        tmp = data.decode('utf8')
+                        tmp = data
                         resp = None
-                        if tmp[:2] == '\x00\x00':
+                        if tmp[:2] == b'\x00\x00':
+                            self.log('Attempting inflation')
                             tmp = zlib.decompressobj().decompress(tmp[2:])
                             self.log("UnZip | %s" % repr(tmp))
+                        self.log('Decoding')
+                        tmp = tmp.decode('utf8')
+                        self.log('Parsing')
                         resp = ResponseResolver(tmp)
+                        self.log('Response success!')
                     except Exception:
                         self.log("ResponseResolver Error")
                         sys.excepthook(*sys.exc_info())


### PR DESCRIPTION
Fixes exception caused by UTF8 decoding attempt before decompression of long packets (>1400 bytes)

References #6835 

- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read [contribution guide](https://github.com/SickChill/SickChill/blob/master/.github/CONTRIBUTING.md)
