### PR TITLE
YggTorrent url extension has changed

### DIFF
--- a/sickchill/oldbeard/providers/yggtorrent.py
+++ b/sickchill/oldbeard/providers/yggtorrent.py
@@ -27,7 +27,7 @@ class Provider(TorrentProvider):
 
         # URLs
         self.custom_url = None
-        self.url = 'https://www2.yggtorrent.se/'
+        self.url = 'https://www2.yggtorrent.si/'
         self.urls = {
             'login': urljoin(self.url, 'user/login'),
             'search': urljoin(self.url, 'engine/search')


### PR DESCRIPTION
Fixes the URL extension of YggTorrent

http://www2.yggtorrent.se is now unreachable, new url is http://www2.yggtorrent.si

Proposed changes in this pull request:
- Just change the URL extention for the YggTorrent provider : .se -> .si
