### PR TITLE
 kodi.py: Add missing unquote_plus

### DIFF
--- a/sickchill/oldbeard/notifiers/kodi.py
+++ b/sickchill/oldbeard/notifiers/kodi.py
@@ -107,7 +107,7 @@ class Notifier(object):
                     logger.debug("Updating library in KODI for show " + show_name)
 
                     # let's try letting kodi filter the shows
-                    response = connection.VideoLibrary.GetTVShows(filter={"field": "title", "operator": "is", "value": show_name}, properties=["file"])
+                    response = connection.VideoLibrary.GetTVShows(filter={"field": "title", "operator": "is", "value": unquote_plus(show_name)}, properties=["file"])
                     if response and "result" in response and "tvshows" in response["result"]:
                         shows = response["result"]["tvshows"]
                     else:


### PR DESCRIPTION
Unquote_plus  was not called for showname sent to kodi. Kodi returns a not found response.

Fixes #6306

Proposed changes in this pull request:
- Unquote show_name when sending as json property
-
-

- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read [contribution guide](https://github.com/SickChill/SickChill/blob/master/.github/CONTRIBUTING.md)
