### PR TITLE
Add StartYear to detailed show info for api

### DIFF
--- a/sickchill/views/api/webapi.py
+++ b/sickchill/views/api/webapi.py
@@ -1948,6 +1948,7 @@ class CMDShow(ApiCall):
 
         show_dict["language"] = show_obj.lang
         show_dict["show_name"] = show_obj.name
+        show_dict["start_year"] = show_obj.startyear
         show_dict["paused"] = (0, 1)[show_obj.paused]
         show_dict["subtitles"] = (0, 1)[show_obj.subtitles]
         show_dict["air_by_date"] = (0, 1)[show_obj.air_by_date]


### PR DESCRIPTION
Fixes #

Proposed changes in this pull request:
- Add StartYear to detailed show info for api 

- [X] PR is based on the DEVELOP branch
- [X] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [X] Read [contribution guide](https://github.com/SickChill/SickChill/blob/master/.github/CONTRIBUTING.md)
