### PR TITLE
use tvdbId for emby show update instead of fs path

### DIFF
--- a/sickchill/oldbeard/notifiers/__init__.py
+++ b/sickchill/oldbeard/notifiers/__init__.py
@@ -1,6 +1,6 @@
 from sickchill import settings
 from sickchill.oldbeard import helpers
-from sickchill.oldbeard.notifiers import (
+from sickchill.oldbeard.notifiers import (  # twilio_notify,
     boxcar2,
     discord,
     emailnotify,
@@ -26,7 +26,6 @@ from sickchill.oldbeard.notifiers import (
     telegram,
     trakt,
     tweet,
-    # twilio_notify,
 )
 
 # home theater / nas

--- a/sickchill/oldbeard/notifiers/emby.py
+++ b/sickchill/oldbeard/notifiers/emby.py
@@ -68,9 +68,9 @@ class Notifier(object):
 
             try:
                 session = self.__make_session()
-                response = session.post(url,params=params)
+                response = session.post(url, params=params)
                 response.raise_for_status()
-                logger.debug("EMBY: HTTP response: {0}".format(response.status_code))
+                logger.debug("EMBY: HTTP status: {0}, response: {1}".format(response.status_code, response.text.replace("\n", "")))
                 return True
 
             except requests.exceptions.RequestException as error:

--- a/sickchill/oldbeard/notifiers/emby.py
+++ b/sickchill/oldbeard/notifiers/emby.py
@@ -60,16 +60,17 @@ class Notifier(object):
 
             params = {}
             if show:
-                params.update({"Updates": [{"Path": show.location, "UpdateType": "Created"}]})
-                url = urljoin(settings.EMBY_HOST, "emby/Library/Media/Updated")
+                params.update({"TvdbId": show.indexerid})
+                # Endpoint emby/Library/Series/Added is deprecated http://swagger.emby.media/?staticview=true#/LibraryService/postLibrarySeriesAdded
+                url = urljoin(settings.EMBY_HOST, "emby/Library/Series/Added")
             else:
                 url = urljoin(settings.EMBY_HOST, "emby/Library/Refresh")
 
             try:
                 session = self.__make_session()
-                response = session.post(url, json=params)
+                response = session.post(url,params=params)
                 response.raise_for_status()
-                logger.debug("EMBY: HTTP response: {0}".format(response.text.replace("\n", "")))
+                logger.debug("EMBY: HTTP response: {0}".format(response.status_code))
                 return True
 
             except requests.exceptions.RequestException as error:


### PR DESCRIPTION
Fixes #7007

Proposed changes in this pull request:
- Use endpoint /Library/Series/Added with TvdbId param for update notification on emby instead of /Library/Media/Updated

### Warning 
endpoint /Library/Series/Added is deprecated & we should be using /Library/Media/Updated 
http://swagger.emby.media/?staticview=true#/LibraryService/postLibrarySeriesAdded

- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read [contribution guide](https://github.com/SickChill/SickChill/blob/master/.github/CONTRIBUTING.md)
