### PR TITLE
Download station

### DIFF
--- a/sickchill/oldbeard/clients/download_station.py
+++ b/sickchill/oldbeard/clients/download_station.py
@@ -184,7 +184,7 @@ class Client(GenericClient):
         data['create_list'] = "false"
         data["destination"] = self._get_destination(result)
 
-        logger.info("Posted as url with {} destination {}".format(data['api'], data['destination']))
+        logger.info("Posted as url with {} destination \"{}\"".format(data['api'], data['destination']))
         self._request(method="post", data=data)
         return self._check_response(data)
 

--- a/sickchill/oldbeard/clients/download_station.py
+++ b/sickchill/oldbeard/clients/download_station.py
@@ -184,7 +184,7 @@ class Client(GenericClient):
         data['create_list'] = "false"
         data["destination"] = self._get_destination(result)
 
-        logger.info("Posted as url to {}".format(data['api']))
+        logger.info("Posted as url with {} destination {}".format(data['api'], data['destination']))
         self._request(method="post", data=data)
         return self._check_response(data)
 
@@ -205,7 +205,7 @@ class Client(GenericClient):
         data['create_list'] = "false"
         data["destination"] = f'"{self._get_destination(result)}"'
 
-        logger.info("Posted as file to {}".format(data['api']))
+        logger.info("Posted as file with {} destination {}".format(data['api'], data['destination']))
         self._request(method="post", data=data, files=files)
         return self._check_response(data)
 

--- a/sickchill/oldbeard/clients/download_station.py
+++ b/sickchill/oldbeard/clients/download_station.py
@@ -184,7 +184,7 @@ class Client(GenericClient):
         data['create_list'] = "false"
         data["destination"] = self._get_destination(result)
 
-        logger.info("Posted as url to {}".format(data['api']))
+        logger.info("Post uri %s", data)
         self._request(method="post", data=data)
         return self._check_response(data)
 
@@ -205,7 +205,7 @@ class Client(GenericClient):
         data['create_list'] = "false"
         data["destination"] = f'"{self._get_destination(result)}"'
 
-        logger.info("Posted as file to {}".format(data['api']))
+        logger.info("Post file %s", data)
         self._request(method="post", data=data, files=files)
         return self._check_response(data)
 

--- a/sickchill/oldbeard/clients/download_station.py
+++ b/sickchill/oldbeard/clients/download_station.py
@@ -198,7 +198,7 @@ class Client(GenericClient):
         data = self._task_post_data
 
         result_type = result.resultType.replace("data", "")
-        files = {result_type: (result.name + "." + result_type, result.content)}
+        files = {result_type: ('.'.join(result.name, result_type), result.content)}
 
         data["type"] = '"file"'
         data["file"] = f'["{result_type}"]'

--- a/sickchill/oldbeard/clients/download_station.py
+++ b/sickchill/oldbeard/clients/download_station.py
@@ -198,7 +198,7 @@ class Client(GenericClient):
         data = self._task_post_data
 
         result_type = result.resultType.replace("data", "")
-        files = {result_type: ('.'.join(result.name, result_type), result.content)}
+        files = {result_type: ('.'.join([result.name, result_type]), result.content)}
 
         data["type"] = '"file"'
         data["file"] = f'["{result_type}"]'

--- a/sickchill/oldbeard/clients/download_station.py
+++ b/sickchill/oldbeard/clients/download_station.py
@@ -184,7 +184,7 @@ class Client(GenericClient):
         data['create_list'] = "false"
         data["destination"] = self._get_destination(result)
 
-        logger.info("Post uri %s", data)
+        logger.info("Posted as url to {}".format(data['api']))
         self._request(method="post", data=data)
         return self._check_response(data)
 
@@ -205,7 +205,7 @@ class Client(GenericClient):
         data['create_list'] = "false"
         data["destination"] = f'"{self._get_destination(result)}"'
 
-        logger.info("Post file %s", data)
+        logger.info("Posted as file to {}".format(data['api']))
         self._request(method="post", data=data, files=files)
         return self._check_response(data)
 


### PR DESCRIPTION
Add code to get default_destination from Downloadstation since API change.
This pushes the default destination back into the Search Settings>Torrent Search>Downloaded files location if it's found as blank.

Fixes #7062 #7101

Proposed changes in this pull request:
-

- [x] PR is based on the DEVELOP branch
