### PR TITLE
Show name helper full sanitize check

### DIFF
--- a/sickchill/oldbeard/show_name_helpers.py
+++ b/sickchill/oldbeard/show_name_helpers.py
@@ -109,9 +109,10 @@ def allPossibleShowNames(show, season=-1):
 
     showNames.append(show.name)
     if show.name.lower().strip() != helpers.full_sanitizeSceneName(show.name):
-        showNames.append(helpers.full_sanitizeSceneName(show.name))
-        logger.debug("append full sanitized show name to list: show_name_helpers")
-    
+        if helpers.full_sanitizeSceneName(show.name) not in showNames:
+            showNames.append(helpers.full_sanitizeSceneName(show.name))
+            logger.debug("SNH append full sanitized {} to list".format(helpers.full_sanitizeSceneName(show.name)))
+
     if not show.is_anime:
         newShowNames = []
         country_list = common.countryList

--- a/sickchill/oldbeard/show_name_helpers.py
+++ b/sickchill/oldbeard/show_name_helpers.py
@@ -5,6 +5,7 @@ import re
 import validators
 
 from sickchill import logger, settings
+from sickchill.oldbeard import helpers
 
 from . import common
 from .name_parser.parser import InvalidNameException, InvalidShowException, NameParser
@@ -107,7 +108,10 @@ def allPossibleShowNames(show, season=-1):
         showNames = get_scene_exceptions(show.indexerid, season=season)
 
     showNames.append(show.name)
-
+    if show.name.lower().strip() != helpers.full_sanitizeSceneName(show.name):
+        showNames.append(helpers.full_sanitizeSceneName(show.name))
+        logger.debug("append full sanitized show name to list: show_name_helpers")
+    
     if not show.is_anime:
         newShowNames = []
         country_list = common.countryList


### PR DESCRIPTION
Fixes #7190 
search for both with and without. 
Notes:
added a supplement to search for the full sanitized scene name if different from show name. Debug line is for testing.
I could not find where name_cache.py and it's build_name_cache added the full sanitized name to cache.db, my scene_name remains empty and never gets appended to and could not find where it is particularly referenced and drawings on elsewhere for scene exceptions.
If I've gone the wrong way or have missed something let me knwo.
