### PR TITLE
Fix #7305 : wrong selector used for testRename season checkBox

### DIFF
--- a/sickchill/gui/slick/js/testRename.js
+++ b/sickchill/gui/slick/js/testRename.js
@@ -13,7 +13,7 @@ $(document).ready(() => {
 
     $('.seasonCheck').on('click', function () {
         const seasCheck = this.checked;
-        const seasNo = $(seasCheck).attr('id');
+        const seasNo = $(this).attr('id');
 
         $('.epCheck:visible').each(function () {
             const epParts = $(this).attr('id').split('x');


### PR DESCRIPTION
Fixes #7305

Proposed changes in this pull request:
- use correct selector to get season number for testRename checkboxes


---------
- [ x ] PR is based on the DEVELOP branch
- [ x ] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [ x ] Read [contribution guide](https://github.com/SickChill/SickChill/blob/master/.github/CONTRIBUTING.md)
