### PR TITLE
yggtorrent site change

### DIFF
--- a/sickchill/oldbeard/providers/yggtorrent.py
+++ b/sickchill/oldbeard/providers/yggtorrent.py
@@ -26,7 +26,7 @@ class Provider(TorrentProvider):
 
         # URLs
         self.custom_url = None
-        self.url = "https://www2.yggtorrent.si/"
+        self.url = "https://www.yggtorrent.nz/"
         self.urls = {"login": urljoin(self.url, "user/login"), "search": urljoin(self.url, "engine/search")}
 
         # Proper Strings


### PR DESCRIPTION
https://www2.yggtorrent.si/ changed to https://www.yggtorrent.nz/

request by @Sango in discord.
Site checks out.
