### PR TITLE
Init_Helpers clean warning line from pip string list

### DIFF
--- a/sickchill/init_helpers.py
+++ b/sickchill/init_helpers.py
@@ -2,6 +2,7 @@ import argparse
 import gettext
 import logging
 import os
+import re
 import site
 import subprocess
 import sys
@@ -182,7 +183,9 @@ def get_os_id():
 
 def pip_install(packages: Union[List[str], str]) -> bool:
     if not isinstance(packages, list):
-        packages = packages.splitlines()
+        # clean out Warning line in list (dirty clean)
+        packages = re.sub(r'Warning.*', "", packages)
+        packages = packages.strip().splitlines()
 
     cmd = [
         sys.executable,


### PR DESCRIPTION
Add re, regex and strip code at 186-188 to init_helpers to remove the warning line from list sent from poetry in the string of packages which enables the install of required packages during update.

I think this is a dirty way to remove the `Warning: The lock file is not up to date with the latest changes in pyproject.toml. You may be getting outdated dependencies. Run update to update them.` which is the first line of the cmd / packages string which pip process to install the updated or new packages.
This is hacky as it doesn't resolve where the warning comes from or how it gets in the string, it just removes it from the string so that other packages can be successfully processed. Therefore SC can run.