### PR TITLE
Fix addshow with exact match

### DIFF
--- a/sickchill/gui/slick/views/addShows_newShow.mako
+++ b/sickchill/gui/slick/views/addShows_newShow.mako
@@ -49,7 +49,7 @@
                                                            class="form-control"
                                                     />
                                                     <span class="input-group-addon">
-                                                        <input type="checkbox" id="exact-match" name="exact-match">
+                                                        <input type="checkbox" id="exact-match">
                                                     </span>
                                                 </div>
                                             </div>

--- a/sickchill/views/manage/add_shows.py
+++ b/sickchill/views/manage/add_shows.py
@@ -95,7 +95,7 @@ class AddShows(Home):
                 }
             )
 
-        if exact:
+        if exact in [True, "1"]:
             logger.debug(_("Filtering and sorting out excess results because exact match was checked"))
             final_results = [item for item in final_results if search_term.lower() in item[4].lower()]
             final_results.sort(key=itemgetter(4))

--- a/sickchill/views/manage/add_shows.py
+++ b/sickchill/views/manage/add_shows.py
@@ -545,7 +545,6 @@ class AddShows(Home):
         blacklist=None,
         whitelist=None,
         defaultStatusAfter=None,
-        exact_match=None
     ):
         """
         Receive tvdb id, dir, and other options and create a show from them. If extra show dirs are


### PR DESCRIPTION
Fixes #7312

Proposed changes in this pull request:
- remove exact-match input field attribute name so that it's not sent when submitting the addshow form
- check if exact-match is either True or "1" when filtering in the search method

- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read [contribution guide](https://github.com/SickChill/SickChill/blob/master/.github/CONTRIBUTING.md)
