### PR TITLE
Re-enable screen size from mediainfo

### DIFF
--- a/sickchill/helper/media_info.py
+++ b/sickchill/helper/media_info.py
@@ -95,8 +95,9 @@ def video_screen_size(filename):
         return None, None
 
     # Need to implement mediainfo another way, pymediainfo 2.0 causes segfaults
-    # for method in [_mediainfo_screen_size, _mkv_screen_size, _avi_screen_size]:
-    for method in [_mkv_screen_size, _avi_screen_size]:
+    # It's at pymedia 5 and this was never switched back
+    for method in [_mediainfo_screen_size, _mkv_screen_size, _avi_screen_size]:
+    # for method in [_mkv_screen_size, _avi_screen_size]:
 
         screen_size = method(filename)
         if screen_size != (None, None):


### PR DESCRIPTION
Fixes #3875

Proposed changes in this pull request:
- Re-enable mediainfo for getting video size now it's at pymediainfo 5.x

- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read [contribution guide](https://github.com/SickChill/SickChill/blob/master/.github/CONTRIBUTING.md)
