### PR TITLE
Reduce image size using docker multistage builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,5 @@
-FROM python:3.9-slim
+FROM python:3.9-slim as build
 
-LABEL org.opencontainers.image.source="https://github.com/sickchill/sickchill"
-LABEL maintainer="miigotu@gmail.com"
 ENV PYTHONIOENCODING="UTF-8"
 ENV PIP_FIND_LINKS=https://wheel-index.linuxserver.io/ubuntu/
 ENV POETRY_INSTALLER_PARALLEL=false
@@ -16,7 +14,6 @@ ENV POETRY_VIRTUALENVS_IN_PROJECT=true
 # -v /etc/localtime:/etc/localtime:ro
 # -p 8080:8081 sickchill/sickchill
 
-VOLUME /data /downloads /tv
 RUN mkdir -p /app/sickchill /var/run/sickchill $HOME/.cache/pip
 RUN chmod -R 777 /app/sickchill $HOME/.cache
 WORKDIR /app/sickchill
@@ -36,9 +33,32 @@ COPY . /app/sickchill
 RUN chmod -R 777 /app/sickchill $HOME/.cache
 
 RUN . $HOME/.cargo/env && poetry install --no-root --no-interaction --no-ansi
+# And again
+RUN chmod -R 777 /app/sickchill $HOME/.cache
 
-CMD poetry run python3 /app/sickchill/SickChill.py --nolaunch --datadir=/data --port 8081
+FROM python:3.9-slim
 EXPOSE 8081
+CMD PIP_NO_CACHE_DIR=true poetry run python3 /app/sickchill/SickChill.py --nolaunch --datadir=/data --port 8081
+# TODO see if works without git
+LABEL org.opencontainers.image.source="https://github.com/sickchill/sickchill"
+LABEL maintainer="miigotu@gmail.com"
+ENV PYTHONIOENCODING="UTF-8"
+RUN sed -i -e's/ main/ main contrib non-free/gm' /etc/apt/sources.list\
+    && apt-get update -qq && apt-get install -yq\
+    curl\
+    git\
+    libxml2\
+    libxslt1.1\
+    libffi7\
+    libssl1.1\
+    mediainfo\
+    unrar\
+    && apt-get clean -yqq && rm -rf /var/lib/apt/lists/*\
+    && pip3 install --no-cache-dir --upgrade --prefer-binary poetry\
+    && (umask 0 && mkdir /data /downloads /tv)
+VOLUME /data /downloads /tv
+COPY --from=build /app/sickchill /app/sickchill
+WORKDIR /app/sickchill
 
 HEALTHCHECK --interval=5m --timeout=3s \
   CMD curl -f http://localhost:8081/ || curl -f https://localhost:8081/ || exit 1

--- a/contrib/docker/Dockerfile-slim-git
+++ b/contrib/docker/Dockerfile-slim-git
@@ -1,7 +1,5 @@
-FROM python:3.9-slim
+FROM python:3.9-slim as build
 
-LABEL org.opencontainers.image.source="https://github.com/sickchill/sickchill"
-LABEL maintainer="miigotu@gmail.com"
 ENV PYTHONIOENCODING="UTF-8"
 ENV PIP_FIND_LINKS=https://wheel-index.linuxserver.io/ubuntu/
 ENV POETRY_INSTALLER_PARALLEL=false
@@ -16,7 +14,6 @@ ENV POETRY_VIRTUALENVS_IN_PROJECT=true
 # -v /etc/localtime:/etc/localtime:ro
 # -p 8080:8081 sickchill/sickchill
 
-VOLUME /data /downloads /tv
 RUN mkdir -p /app/sickchill /var/run/sickchill $HOME/.cache/pip
 RUN chmod -R 777 /app/sickchill $HOME/.cache
 WORKDIR /app/sickchill
@@ -36,9 +33,32 @@ COPY . /app/sickchill
 RUN chmod -R 777 /app/sickchill $HOME/.cache
 
 RUN . $HOME/.cargo/env && poetry install --no-root --no-interaction --no-ansi
+# And again
+RUN chmod -R 777 /app/sickchill $HOME/.cache
 
-CMD poetry run python3 /app/sickchill/SickChill.py --nolaunch --datadir=/data --port 8081
+FROM python:3.9-slim
 EXPOSE 8081
+CMD PIP_NO_CACHE_DIR=true poetry run python3 /app/sickchill/SickChill.py --nolaunch --datadir=/data --port 8081
+# TODO see if works without git
+LABEL org.opencontainers.image.source="https://github.com/sickchill/sickchill"
+LABEL maintainer="miigotu@gmail.com"
+ENV PYTHONIOENCODING="UTF-8"
+RUN sed -i -e's/ main/ main contrib non-free/gm' /etc/apt/sources.list\
+    && apt-get update -qq && apt-get install -yq\
+    curl\
+    git\
+    libxml2\
+    libxslt1.1\
+    libffi7\
+    libssl1.1\
+    mediainfo\
+    unrar\
+    && apt-get clean -yqq && rm -rf /var/lib/apt/lists/*\
+    && pip3 install --no-cache-dir --upgrade --prefer-binary poetry\
+    && (umask 0 && mkdir /data /downloads /tv)
+VOLUME /data /downloads /tv
+COPY --from=build /app/sickchill /app/sickchill
+WORKDIR /app/sickchill
 
 HEALTHCHECK --interval=5m --timeout=3s \
   CMD curl -f http://localhost:8081/ || curl -f https://localhost:8081/ || exit 1

--- a/contrib/docker/Dockerfile.slim-pip
+++ b/contrib/docker/Dockerfile.slim-pip
@@ -1,0 +1,47 @@
+ARG SICKCHILL_VERSION=2021.11.10
+
+FROM python:3.9-slim as build
+ENV OLDPATH=$PATH
+RUN python -m venv /app/sickchill/.venv
+ENV VIRTUAL_ENV=/app/sickchill/.venv
+ENV PATH=$VIRTUAL_ENV/bin:$OLDPATH
+ARG SICKCHILL_VERSION
+RUN pip install --no-cache-dir --upgrade sickchill==${SICKCHILL_VERSION}
+
+FROM python:3.9-slim
+
+LABEL org.opencontainers.image.source="https://github.com/sickchill/sickchill"
+LABEL maintainer="miigotu@gmail.com"
+ENV PYTHONIOENCODING="UTF-8"
+
+# docker run -dit --user 1000:1000 --name sickchill --restart=always \
+# -v ShowPath:/ShowPath \
+# -v DownloadPath:/DownloadPath \
+# -v /docker/sickchill/data:/data \
+# -v /docker/sickchill/cache/gui:/app/sickchill/sickchill/gui/slick/cache \
+# -v /etc/localtime:/etc/localtime:ro
+# -p 8080:8081 sickchill/sickchill
+
+ENV VIRTUAL_ENV=/app/sickchill/.venv
+ENV PATH=$VIRTUAL_ENV/bin:$PATH
+CMD [ "SickChill", "--nolaunch", "--datadir=/data", "--port", "8081"]
+EXPOSE 8081
+HEALTHCHECK --interval=5m --timeout=3s \
+  CMD curl -f http://localhost:8081/ || curl -f https://localhost:8081/ || exit 1
+# hadolint ignore=DL3008,DL3015
+RUN sed -i -e's/ main/ main contrib non-free/gm' /etc/apt/sources.list\
+    && (umask 0; mkdir -p /data /downloads /tv)\
+    && apt-get update -qq && apt-get install -yq\
+      libxml2\
+      libxslt1.1\
+      libffi7\
+      libssl1.1\
+      libmediainfo0v5\
+      mediainfo\
+      unrar\
+      curl\
+    && apt-get clean -yqq && rm -rf /var/lib/apt/lists/*
+VOLUME /data /downloads /tv
+
+COPY --from=build /app/sickchill /app/sickchill
+


### PR DESCRIPTION
Fixes #

I noticed the docker image included build-essential and rust.
Using a multi-stage build image size is reduced to 0.77GB from 1.93GB

Proposed changes in this pull request:
- Separate build requirements from run requirements
- Create /data /downloads /tv directories with 0777 perms before declaring them as volumes

- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read [contribution guide](https://github.com/SickChill/SickChill/blob/master/.github/CONTRIBUTING.md)
