### PR TITLE
Change perms and add volume so docker --user foo:bar works

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,9 @@ RUN chmod -R 777 /app/sickchill $HOME/.cache
 
 RUN . $HOME/.cargo/env && poetry install --no-root --no-interaction --no-ansi
 
+RUN chmod -R a+w /app/sickchill/.venv
+VOLUME /app/sickchill/.venv
+
 CMD poetry run python3 /app/sickchill/SickChill.py --nolaunch --datadir=/data --port 8081
 EXPOSE 8081
 


### PR DESCRIPTION
Fixes #7688 

Proposed changes in this pull request:
- Made /app/sickchill/.venv writable by all in Docker image after poetry did its install.
- Made /app/sickchill/.venv a volume after making writable so container may write there
-

Caveats:  
- Did not test poetry upgrade behavior.  
- Cannot use the pip cache 
Command result: WARNING: The directory '/.cache/pip' or its parent directory is not owned or is not writable by the current user. The cache has been disabled. Check the permissions and owner of that directory. If executing pip with sudo, you should use sudo's -H flag.


- [ x ] PR is based on the DEVELOP branch
- [ x ] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [ x ] Read [contribution guide](https://github.com/SickChill/SickChill/blob/master/.github/CONTRIBUTING.md)
