### PR TITLE
Fix failure to parse TPB results

### DIFF
--- a/sickchill/oldbeard/providers/thepiratebay.py
+++ b/sickchill/oldbeard/providers/thepiratebay.py
@@ -151,7 +151,8 @@ class Provider(TorrentProvider):
                                 logger.debug("Found result: {0} with {1} seeders and {2} leechers".format(title, seeders, leechers))
 
                             items.append(item)
-                        except Exception:
+                        except Exception as e:
+                            logger.debug("Unable to process torrent: {0}".format(str(e)))
                             continue
 
             # For each search mode sort all the items by seeders if available

--- a/sickchill/oldbeard/providers/thepiratebay.py
+++ b/sickchill/oldbeard/providers/thepiratebay.py
@@ -118,8 +118,8 @@ class Provider(TorrentProvider):
                             if not all([title, info_hash]):
                                 continue
 
-                            seeders = result["seeders"]
-                            leechers = result["leechers"]
+                            seeders = int(result["seeders"])
+                            leechers = int(result["leechers"])
 
                             # Filter unseeded torrent
                             if seeders < self.minseed or leechers < self.minleech:

--- a/sickchill/oldbeard/providers/thepiratebay.py
+++ b/sickchill/oldbeard/providers/thepiratebay.py
@@ -1,5 +1,6 @@
 import datetime
 import time
+import traceback
 from urllib.parse import urljoin
 
 import js2py
@@ -118,8 +119,8 @@ class Provider(TorrentProvider):
                             if not all([title, info_hash]):
                                 continue
 
-                            seeders = int(result["seeders"])
-                            leechers = int(result["leechers"])
+                            seeders = try_int(result["seeders"])
+                            leechers = try_int(result["leechers"])
 
                             # Filter unseeded torrent
                             if seeders < self.minseed or leechers < self.minleech:
@@ -151,8 +152,9 @@ class Provider(TorrentProvider):
                                 logger.debug("Found result: {0} with {1} seeders and {2} leechers".format(title, seeders, leechers))
 
                             items.append(item)
-                        except Exception as e:
-                            logger.debug("Unable to process torrent: {0}".format(str(e)))
+                        except Exception as error:
+                            logger.debug(f"Unable to process torrent on {self.name}: {error}")
+                            logger.debug(traceback.format_exc())
                             continue
 
             # For each search mode sort all the items by seeders if available


### PR DESCRIPTION
Fixes SC being unable to move any episode from "wanted" to "snatched" when only TPB is using a search provider, using thepiratebay.org. 
This was due to the JSON response from the API where `seeders` and `leechers` are encoded as strings instead of numbers. This caused an exception that discarded every result.
Debugging this was made more difficult by the lack of logging when a parse failure occurs.

Proposed changes in this pull request:
- Parse `seeders` and `leechers` fields with `int()` (it still works if e.g. TPB clones send ints)
- Log exception in try/catch

- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read [contribution guide](https://github.com/SickChill/SickChill/blob/master/.github/CONTRIBUTING.md)
