### PR TITLE
Updating magnetdl.com to https, to bypass UK blocking page

### DIFF
--- a/sickchill/oldbeard/providers/magnetdl.py
+++ b/sickchill/oldbeard/providers/magnetdl.py
@@ -18,7 +18,7 @@ class Provider(TorrentProvider):
         self.minseed = 0
         self.minleech = 0
 
-        self.url = "http://www.magnetdl.com"
+        self.url = "https://www.magnetdl.com"
         self.urls = {"rss": urljoin(self.url, "download/tv/age/desc/")}
 
         self.custom_url = None


### PR DESCRIPTION
Fixes #

Proposed changes in this pull request:
- The magnetdl.com site has started having some http requests intercepted by a court ordered blocking page for UK based IPs. This change updates it to utilise https to prevent this impacting searches.

- [X] PR is based on the DEVELOP branch
- [X] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [X] Read [contribution guide](https://github.com/SickChill/SickChill/blob/master/.github/CONTRIBUTING.md)
