### PR TITLE
Fix file.extension double dot

### DIFF
--- a/sickchill/oldbeard/postProcessor.py
+++ b/sickchill/oldbeard/postProcessor.py
@@ -1058,7 +1058,7 @@ class PostProcessor(object):
             old_path = Path(self.filename)
             orig_extension = old_path.suffix
             new_base_name = os.path.basename(proper_path)
-            new_filename = f"{new_base_name}.{orig_extension}"
+            new_filename = f"{new_base_name}{orig_extension}"
         else:
             # if we're not renaming then there's no new base name, we'll just use the existing name
             new_base_name = None

--- a/sickchill/oldbeard/processTV.py
+++ b/sickchill/oldbeard/processTV.py
@@ -311,7 +311,6 @@ def validate_dir(process_path, release_name, failed, result):
                 NameParser().parse(found_file, cache_result=False)
             except (InvalidNameException, InvalidShowException) as error:
                 logger.debug(f"Could not properly parse a show and episode from [{found_file}]: {str(error)}")
-                found_files.remove(found_file)
             else:
                 return True
 

--- a/sickchill/oldbeard/processTV.py
+++ b/sickchill/oldbeard/processTV.py
@@ -311,6 +311,7 @@ def validate_dir(process_path, release_name, failed, result):
                 NameParser().parse(found_file, cache_result=False)
             except (InvalidNameException, InvalidShowException) as error:
                 logger.debug(f"Could not properly parse a show and episode from [{found_file}]: {str(error)}")
+                found_files.remove(found_file)
             else:
                 return True
 


### PR DESCRIPTION
Fixes #8074 
Database getting `..` instead of `.` stored so rename and other extensions being corrupted.