### PR TITLE
chg: Fix case sensitivity supportedParams property for newznab

### DIFF
--- a/sickchill/oldbeard/providers/newnewznab.py
+++ b/sickchill/oldbeard/providers/newnewznab.py
@@ -121,7 +121,7 @@ class NewznabProvider(NZBProvider):
         elm = data.find("tv-search")
         self.use_tv_search = elm and elm.get("available") == "yes"
         if self.use_tv_search:
-            self.cap_tv_search = elm.get("supportedparams", "tvdbid,season,ep")
+            self.cap_tv_search = elm.get("supportedParams", "tvdbid,season,ep")
 
         self._caps = any([self.cap_tv_search])
 


### PR DESCRIPTION
Potentially fixes #8055

Proposed changes in this pull request:
- Update the `supportedparams` property for newznab provider to be the correct case sensitivty `supportedParams` following language change to XML in the BS4 processor

Unfortunately I am unable to test whether this resolves all issues as I do not have a configurable instance of SickChill, but it should be a step in the right direction.