### PR TITLE
Enable 32-bit ARM v7

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -210,7 +210,7 @@ jobs:
         context: .
         # disable 32 bit arm builds for now, just get a working image out. 
         # platforms: linux/amd64,linux/arm64,linux/arm/v6,linux/arm/v7
-        platforms: linux/amd64,linux/arm64
+        platforms: linux/amd64,linux/arm64,linux/arm/v7
         push: ${{ github.event_name != 'pull_request' && !env.ACT }}
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
This will let me pull the image on my Raspberry Pi

Proposed changes in this pull request:
- enable arm/v7 in the docker build

- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read [contribution guide](https://github.com/SickChill/SickChill/blob/master/.github/CONTRIBUTING.md)
