### PR TITLE
another fix for str.format missing var name

### DIFF
--- a/sickchill/oldbeard/helpers.py
+++ b/sickchill/oldbeard/helpers.py
@@ -1011,12 +1011,12 @@ def set_up_anidb_connection():
     if not settings.ADBA_CONNECTION:
 
         def anidb_logger(msg):
-            return logger.debug(_("{msg}").format(msg))
+            return logger.debug(_("{msg}").format(msg=msg))
 
         try:
             settings.ADBA_CONNECTION = adba.Connection(keep_alive=True, log=anidb_logger)
         except Exception as error:
-            logger.warning(_("There was a problem attempting to connect to anidb. Error: {error}").format(error))
+            logger.warning(_("There was a problem attempting to connect to anidb. Error: {error}").format(error=error))
             return False
 
     try:


### PR DESCRIPTION
Proposed changes in this pull request:
- fix missing param name for str.format

- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read [contribution guide](https://github.com/SickChill/SickChill/blob/master/.github/CONTRIBUTING.md)
