### PR TITLE
XML headers now write to NFO

### DIFF
--- a/sickchill/providers/metadata/generic.py
+++ b/sickchill/providers/metadata/generic.py
@@ -256,7 +256,7 @@ class GenericMetadata(object):
                 # Make it purdy
                 helpers.indentXML(root)
 
-                showXML.write(nfo_file_path, encoding="UTF-8")
+                showXML.write(nfo_file_path, encoding="UTF-8", xml_declaration=True)
                 helpers.chmodAsParent(nfo_file_path)
 
                 return True
@@ -310,7 +310,7 @@ class GenericMetadata(object):
                 # Make it purdy
                 helpers.indentXML(root)
 
-                episodeXML.write(nfo_file_path, encoding="UTF-8")
+                episodeXML.write(nfo_file_path, encoding="UTF-8", xml_declaration=True)
                 helpers.chmodAsParent(nfo_file_path)
 
                 return True
@@ -407,7 +407,7 @@ class GenericMetadata(object):
             logger.debug("Writing show nfo file to " + nfo_file_path)
 
             nfo_file = open(nfo_file_path, "wb")
-            data.write(nfo_file, encoding="UTF-8")
+            data.write(nfo_file, encoding="UTF-8", xml_declaration=True)
             nfo_file.close()
             helpers.chmodAsParent(nfo_file_path)
         except IOError as error:
@@ -454,7 +454,7 @@ class GenericMetadata(object):
 
             logger.debug("Writing episode nfo file to " + nfo_file_path)
             nfo_file = open(nfo_file_path, "wb")
-            data.write(nfo_file, encoding="UTF-8")
+            data.write(nfo_file, encoding="UTF-8", xml_declaration=True)
             nfo_file.close()
             helpers.chmodAsParent(nfo_file_path)
         except IOError as error:


### PR DESCRIPTION
Fixes #8325 

Proposed changes in this pull request:
- Added xml.write parameter "xml_declaration=True", this ensures an XML header is written to NFO files.