### PR TITLE
Fix nzb splitting

### DIFF
--- a/sickchill/oldbeard/helpers.py
+++ b/sickchill/oldbeard/helpers.py
@@ -1192,6 +1192,7 @@ def request_defaults(kwargs):
 def getURL(
     url,
     post_data=None,
+    files=None,
     params=None,
     headers=None,
     timeout=30,
@@ -1240,9 +1241,10 @@ def getURL(
             return json_result["response"]
 
         response = session.request(
-            "POST" if post_data else "GET",
+            "POST" if post_data or files else "GET",
             url,
             data=post_data or {},
+            files=files or {},
             params=params or {},
             timeout=timeout,
             allow_redirects=allow_redirects,

--- a/sickchill/oldbeard/nzbSplitter.py
+++ b/sickchill/oldbeard/nzbSplitter.py
@@ -108,8 +108,8 @@ def strip_xmlns(element, xmlns):
     :param xmlns: xml namespace to be removed
     :return: processed element
     """
-    for e in element.iter():
-        e.tag = e.tag.replace("{" + xmlns + "}", "")
+    for subelement in element.iter():
+        subelement.tag = subelement.tag.replace("{" + xmlns + "}", "")
 
     return element
 

--- a/sickchill/oldbeard/nzbSplitter.py
+++ b/sickchill/oldbeard/nzbSplitter.py
@@ -108,9 +108,8 @@ def strip_xmlns(element, xmlns):
     :param xmlns: xml namespace to be removed
     :return: processed element
     """
-    element.tag = element.tag.replace("{" + xmlns + "}", "")
-    for cur_child in element.getchildren():
-        strip_xmlns(cur_child, xmlns)
+    for e in element.iter():
+        e.tag = e.tag.replace("{" + xmlns + "}", "")
 
     return element
 
@@ -167,7 +166,7 @@ def split_result(obj):
 
         want_ep = True
         for ep_num in parsed_obj.episode_numbers:
-            if not obj.extraInfo[0].wantEpisode(season, ep_num, obj.quality):
+            if not obj.show.wantEpisode(season, ep_num, obj.quality):
                 logger.debug("Ignoring result: " + new_nzb)
                 want_ep = False
                 break
@@ -175,7 +174,7 @@ def split_result(obj):
             continue
 
         # get all the associated episode objects
-        ep_obj_list = [obj.extraInfo[0].getEpisode(season, ep) for ep in parsed_obj.episode_numbers]
+        ep_obj_list = [obj.show.getEpisode(season, ep) for ep in parsed_obj.episode_numbers]
 
         # make a result
         cur_obj = classes.NZBDataSearchResult(ep_obj_list)

--- a/sickchill/oldbeard/sab.py
+++ b/sickchill/oldbeard/sab.py
@@ -49,7 +49,7 @@ def sendNZB(nzb):  # pylint:disable=too-many-return-statements, too-many-branche
     elif nzb.resultType == "nzbdata":
         params["mode"] = "addfile"
         multiPartParams = {"nzbfile": (nzb.name + ".nzb", nzb.extraInfo[0])}
-        jdata = helpers.getURL(url, params=params, file=multiPartParams, session=session, returns="json", verify=False)
+        jdata = helpers.getURL(url, params=params, files=multiPartParams, session=session, returns="json", verify=False)
 
     if not jdata:
         logger.info("Error connecting to sab, no data returned")

--- a/sickchill/providers/GenericProvider.py
+++ b/sickchill/providers/GenericProvider.py
@@ -213,8 +213,7 @@ class GenericProvider(object):
                             [
                                 ep
                                 for ep in episodes
-                                if (ep.season, ep.scene_season)[ep.show.is_scene] == (parse_result.season_number, parse_result.scene_season)[ep.show.is_scene]
-                                and (ep.episode, ep.scene_episode)[ep.show.is_scene] in parse_result.episode_numbers
+                                if ep.season == parse_result.season_number and ep.episode in parse_result.episode_numbers
                             ],
                         ]
                     ) and not all(
@@ -345,7 +344,7 @@ class GenericProvider(object):
 
     def get_url(self, url, post_data=None, params=None, timeout=30, **kwargs):
         kwargs["hooks"] = {"response": self.get_url_hook}
-        return getURL(url, post_data, params, self.headers, timeout, self.session, **kwargs)
+        return getURL(url, post_data=post_data, params=params, headers=self.headers, timeout=timeout, session=self.session, **kwargs)
 
     def image_name(self):
         return self.get_id() + ".png"


### PR DESCRIPTION
Fixes # 8365

Proposed changes in this pull request:
- Fix splitting NZB to grab individual episodes out of season packs

- [X] PR is based on the DEVELOP branch
- [X] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [X] Read [contribution guide](https://github.com/SickChill/SickChill/blob/master/.github/CONTRIBUTING.md)

This code does not look like it's been touched in some time, and there were a few issues preventing splitting a season pack's NZB into individual files for downloading. The initial error (in #8365) is fixed in nzbSplitter but there were then issues getting the split NZB files actually sent to (in my case) sabnzbd because of issues with getURL() and how it was being called; these fixes are in the other files here.

After these changes, things worked correctly for me.

Thanks for SickChill - it's a wonderful project, and I'd be happy to be able to give back to it!