### PR TITLE
Page Sub Save Button not saving configuration

### DIFF
--- a/sickchill/gui/slick/views/config_search.mako
+++ b/sickchill/gui/slick/views/config_search.mako
@@ -914,7 +914,7 @@
                                     <div class="col-md-12">
                                         <input class="btn test-button" type="button" value="Test SABnzbd" id="testSABnzbd"/>
                                         <input type="button" value="Test DSM" id="testDSM" class="btn test-button"/>
-                                        <input type="submit" class="btn config_submitter" value="${_('Save Changes')}"/>
+                                        <input type="submit" class="btn config_submitter" value="${_('Save Changes')}" />
                                     </div>
                                 </div>
 
@@ -1003,7 +1003,7 @@
                                     </div>
                                     <div class="row">
                                         <div class="col-md-12">
-                                            <input type="submit" class="btn config_submitter" value="${_('Save Changes')}"/>
+                                            <input type="submit" class="btn config_submitter" value="${_('Save Changes')}" />
                                         </div>
                                     </div>
                                 </div>
@@ -1270,7 +1270,7 @@
                                     <div class="row">
                                         <div class="col-md-12">
                                             <input class="btn test-button" type="button" value="${_('Test Connection')}" id="test_torrent"/>
-                                            <input type="submit" class="btn config_submitter" value="${_('Save Changes')}"/>
+                                            <input type="submit" class="btn config_submitter" value="${_('Save Changes')}" />
                                         </div>
                                     </div>
 

--- a/sickchill/gui/slick/views/editShow.mako
+++ b/sickchill/gui/slick/views/editShow.mako
@@ -540,7 +540,7 @@
                     <br/>
                     <div class="row">
                         <div class="col-lg-2 col-md-2 col-sm-2 col-xs-12">
-                            <input type="submit" id="submit" class="btn pull-left config_submitter button" value="${_('Save Changes')}"/>
+                            <input type="submit" id="submit" class="btn pull-left config_submitter button" value="${_('Save Changes')}" />
                         </div>
                     </div>
 

--- a/sickchill/gui/slick/views/layouts/config.mako
+++ b/sickchill/gui/slick/views/layouts/config.mako
@@ -38,7 +38,7 @@
             <div class="row">
                 <%block name="saveButton">
                     <div class="col-lg-2 col-md-2 col-sm-2 col-xs-12">
-                        <input type="button" onclick="$('#configForm').submit()" class="btn pull-left config_submitter button" value="${_('Save Changes')}"/>
+                        <input type="button" onclick="$('#configForm').submit()" class="btn pull-left config_submitter button" value="${_('Save Changes')}" />
                     </div>
                 </%block>
                 <div class="col-lg-10 col-md-10 col-sm-10 col-xs-12 pull-right">

--- a/sickchill/settings.py
+++ b/sickchill/settings.py
@@ -563,7 +563,8 @@ movie_list: "MovieList" = None
 
 
 def get_backlog_cycle_time():
-    cycletime = DAILYSEARCH_FREQUENCY * 2 + 7
+    # backlog timer multiple of daily frequency and ensure multiple per mako 'step="60"'
+    cycletime = ((DAILYSEARCH_FREQUENCY * 2) // 60) * 60
     return max([cycletime, 720])
 
 


### PR DESCRIPTION
Fix the multiplier that calculates the Backlog search minimum value which becomes a variable once daily search is greater than 357 minutes. If not a 60 mult then this can be an issue as if you try to `Save Changes` on the other tab there is no error visible.

Also consistent space before \ with other inner `Save Changes` buttons