### PR TITLE
Fix seeder/leecher count extraction for BTN

### DIFF
--- a/sickchill/oldbeard/providers/btn.py
+++ b/sickchill/oldbeard/providers/btn.py
@@ -241,6 +241,12 @@ class Provider(TorrentProvider):
         # use with caution!
         return self.search({"search": search_string})
 
+    def _get_seeders_and_leechers(self, item):
+        try:
+            return item.get("Seeders", -1), item.get("Leechers", -1)
+        except AttributeError:
+            return -1, -1
+
     def find_propers(self, search_date=None):
         results = []
 


### PR DESCRIPTION
- use the correct case for the `Seeders` and `Leechers` keys in BTN's item feeds

When the manual search is showing the seeder/leecher count, it
consistently shows them as -1; 

- [x] PR is based on the DEVELOP branch
- [X] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [X] Read [contribution guide](https://github.com/SickChill/SickChill/blob/master/.github/CONTRIBUTING.md)
