### PR TITLE
revert some rabbitai damage

### DIFF
--- a/sickchill/gui/slick/views/history.mako
+++ b/sickchill/gui/slick/views/history.mako
@@ -22,9 +22,15 @@
                 <label>
                     <span>${_('Limit')}:</span>
                     <select name="history_limit" id="history_limit" class="form-control form-control-inline input-sm" title="Limit">
-                        % for val in [10, 25, 50, 100, 250, 500, 750, 1000, 0]:
-                            <option value="${val}}" ${selected(limit == val)}>${(0, _(All))[val == 0]}</option>
-                        % endfor
+                        <option value="10" ${('', 'selected="selected"')[limit == 10]}>10</option>
+                        <option value="25" ${('', 'selected="selected"')[limit == 25]}>25</option>
+                        <option value="50" ${('', 'selected="selected"')[limit == 50]}>50</option>
+                        <option value="100" ${('', 'selected="selected"')[limit == 100]}>100</option>
+                        <option value="250" ${('', 'selected="selected"')[limit == 250]}>250</option>
+                        <option value="500" ${('', 'selected="selected"')[limit == 500]}>500</option>
+                        <option value="750" ${('', 'selected="selected"')[limit == 750]}>750</option>
+                        <option value="1000" ${('', 'selected="selected"')[limit == 1000]}>1000</option>
+                        <option value="0" ${('', 'selected="selected"')[limit == 0  ]}>All</option>
                     </select>
                     &nbsp
                 </label>

--- a/sickchill/gui/slick/views/history.mako
+++ b/sickchill/gui/slick/views/history.mako
@@ -22,15 +22,9 @@
                 <label>
                     <span>${_('Limit')}:</span>
                     <select name="history_limit" id="history_limit" class="form-control form-control-inline input-sm" title="Limit">
-                        <option value="10" ${('', 'selected="selected"')[limit == 10]}>10</option>
-                        <option value="25" ${('', 'selected="selected"')[limit == 25]}>25</option>
-                        <option value="50" ${('', 'selected="selected"')[limit == 50]}>50</option>
-                        <option value="100" ${('', 'selected="selected"')[limit == 100]}>100</option>
-                        <option value="250" ${('', 'selected="selected"')[limit == 250]}>250</option>
-                        <option value="500" ${('', 'selected="selected"')[limit == 500]}>500</option>
-                        <option value="750" ${('', 'selected="selected"')[limit == 750]}>750</option>
-                        <option value="1000" ${('', 'selected="selected"')[limit == 1000]}>1000</option>
-                        <option value="0" ${('', 'selected="selected"')[limit == 0  ]}>All</option>
+                        % for val in [10, 25, 50, 100, 250, 500, 750, 1000, 0]:
+                            <option value="${val}}" ${selected(limit == val)}>${(val, _("All"))[val == 0]}</option>
+                        % endfor
                     </select>
                     &nbsp
                 </label>

--- a/sickchill/gui/slick/views/inc_qualityChooser.mako
+++ b/sickchill/gui/slick/views/inc_qualityChooser.mako
@@ -35,7 +35,7 @@ selected = None
                     <% anyQualityList = [x for x in Quality.qualityStrings if x > Quality.NONE] %>
                     <select id="anyQualities" name="anyQualities" multiple="multiple" size="${len(anyQualityList)}" class="form-control form-control-inline input-sm" title="anyQualities">
                         % for curQuality in sorted(anyQualityList):
-                            <option value="${curQuality}" ${('', 'selected="selected"')[curQuality in anyQualities]}>${Quality.qualityStrings[curQuality]}</option>
+                            <option value="${curQuality}" ${selected(curQuality in anyQualities)}>${Quality.qualityStrings[curQuality]}</option>
                         % endfor
                     </select>
                 </div>
@@ -45,7 +45,7 @@ selected = None
                     <% bestQualityList = [x for x in Quality.qualityStrings if Quality.SDTV <= x < Quality.UNKNOWN] %>
                     <select id="bestQualities" name="bestQualities" multiple="multiple" size="${len(bestQualityList)}" class="form-control form-control-inline input-sm" title="bestQualities">
                         % for curQuality in sorted(bestQualityList):
-                            <option value="${curQuality}" ${('', 'selected="selected"')[curQuality in bestQualities]}>${Quality.qualityStrings[curQuality]}</option>
+                            <option value="${curQuality}" ${selected(curQuality in bestQualities)}>${Quality.qualityStrings[curQuality]}</option>
                         % endfor
                     </select>
                 </div>

--- a/sickchill/gui/slick/views/inc_qualityChooser.mako
+++ b/sickchill/gui/slick/views/inc_qualityChooser.mako
@@ -19,7 +19,7 @@ selected = None
         <select id="qualityPreset" name="quality_preset" class="form-control input-sm input100" title="qualityPreset">
             <option value="0">Custom</option>
             % for curPreset in qualityPresets:
-                <option value="${curPreset}" ${selected(curPreset == overall_quality)} ${('', 'style="padding-left: 15px;"')[qualityPresetStrings[curPreset].endswith("0p")]}>${qualityPresetStrings[curPreset]}</option>
+                <option value="${curPreset}" ${('', 'selected="selected"')[curPreset == overall_quality]} ${('', 'style="padding-left: 15px;"')[qualityPresetStrings[curPreset].endswith("0p")]}>${qualityPresetStrings[curPreset]}</option>
             % endfor
         </select>
     </div>
@@ -35,7 +35,7 @@ selected = None
                     <% anyQualityList = [x for x in Quality.qualityStrings if x > Quality.NONE] %>
                     <select id="anyQualities" name="anyQualities" multiple="multiple" size="${len(anyQualityList)}" class="form-control form-control-inline input-sm" title="anyQualities">
                         % for curQuality in sorted(anyQualityList):
-                            <option value="${curQuality}" ${selected(curQuality in anyQualities)}>${Quality.qualityStrings[curQuality]}</option>
+                            <option value="${curQuality}" ${('', 'selected="selected"')[curQuality in anyQualities]}>${Quality.qualityStrings[curQuality]}</option>
                         % endfor
                     </select>
                 </div>
@@ -45,7 +45,7 @@ selected = None
                     <% bestQualityList = [x for x in Quality.qualityStrings if Quality.SDTV <= x < Quality.UNKNOWN] %>
                     <select id="bestQualities" name="bestQualities" multiple="multiple" size="${len(bestQualityList)}" class="form-control form-control-inline input-sm" title="bestQualities">
                         % for curQuality in sorted(bestQualityList):
-                            <option value="${curQuality}" ${selected(curQuality in bestQualities)}>${Quality.qualityStrings[curQuality]}</option>
+                            <option value="${curQuality}" ${('', 'selected="selected"')[curQuality in bestQualities]}>${Quality.qualityStrings[curQuality]}</option>
                         % endfor
                     </select>
                 </div>

--- a/sickchill/gui/slick/views/inc_qualityChooser.mako
+++ b/sickchill/gui/slick/views/inc_qualityChooser.mako
@@ -19,7 +19,7 @@ selected = None
         <select id="qualityPreset" name="quality_preset" class="form-control input-sm input100" title="qualityPreset">
             <option value="0">Custom</option>
             % for curPreset in qualityPresets:
-                <option value="${curPreset}" ${('', 'selected="selected"')[curPreset == overall_quality]} ${('', 'style="padding-left: 15px;"')[qualityPresetStrings[curPreset].endswith("0p")]}>${qualityPresetStrings[curPreset]}</option>
+                <option value="${curPreset}" ${selected(curPreset == overall_quality)} ${('', 'style="padding-left: 15px;"')[qualityPresetStrings[curPreset].endswith("0p")]}>${qualityPresetStrings[curPreset]}</option>
             % endfor
         </select>
     </div>


### PR DESCRIPTION
revert history and inc_qualityChooser mako files so they once again work.
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

### Summary by CodeRabbit

- Refactor: Simplified the dropdown menu in the history view, making it easier to navigate and understand.
- Bug Fix: Corrected a syntax error in the history view, ensuring the correct display of dropdown options.
- New Feature: Enhanced the quality chooser view with automatic selection of user-specific options, improving user experience by reflecting their previous choices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->