### PR TITLE
hidden reversal

### DIFF
--- a/sickchill/gui/slick/views/config_postProcessing.mako
+++ b/sickchill/gui/slick/views/config_postProcessing.mako
@@ -186,7 +186,7 @@
                             </div>
                         </div>
 
-                        <div class="field-pair row" id="content_move_associated_files" ${hidden(settings.MOVE_ASSOCIATED_FILES)}>
+                        <div class="field-pair row" id="content_move_associated_files" ${selected(settings.MOVE_ASSOCIATED_FILES)}>
                             <div class="col-lg-3 col-md-3 col-sm-4 col-xs-12">
                                 <label class="component-title">${_('Rename .nfo file')}</label>
                             </div>
@@ -194,9 +194,6 @@
                                 <input type="checkbox" name="nfo_rename" id="nfo_rename" ${checked(settings.NFO_RENAME)}/>
                                 <label for="nfo_rename">${_('rename the original .nfo file to .nfo-orig to avoid conflicts?')}</label>
                             </div>
-                        </div>
-
-                        <div class="field-pair row">
                             <div class="col-lg-3 col-md-3 col-sm-4 col-xs-12">
                                 <label class="component-title">${_('Associated file extensions')}</label>
                             </div>

--- a/sickchill/gui/slick/views/config_providers.mako
+++ b/sickchill/gui/slick/views/config_providers.mako
@@ -197,7 +197,7 @@
                                 % endif
 
                                 % if hasattr(curNewznabProvider, 'enable_backlog'):
-                                    <div class="field-pair row${hidden(curNewznabProvider.supports_backlog)}">
+                                    <div class="field-pair row">
                                         <div class="col-lg-3 col-md-4 col-sm-5 col-xs-12">
                                             <label class="component-title">${_('Enable backlog searches')}</label>
                                         </div>
@@ -310,7 +310,7 @@
                                 % endif
 
                                 % if hasattr(curNzbProvider, 'enable_backlog'):
-                                    <div class="field-pair row${hidden(curNzbProvider.supports_backlog)}">
+                                    <div class="field-pair row">
                                         <div class="col-lg-3 col-md-4 col-sm-5 col-xs-12">
                                             <label class="component-title">${_('Enable backlog searches')}</label>
                                         </div>
@@ -669,7 +669,7 @@
                                 % endif
 
                                 % if hasattr(curTorrentProvider, 'enable_backlog'):
-                                    <div class="field-pair row${hidden(curTorrentProvider.supports_backlog)}">
+                                    <div class="field-pair row">
                                         <div class="col-lg-3 col-md-4 col-sm-5 col-xs-12">
                                             <label class="component-title">${_('Enable backlog searches')}</label>
                                         </div>

--- a/sickchill/gui/slick/views/config_providers.mako
+++ b/sickchill/gui/slick/views/config_providers.mako
@@ -658,7 +658,7 @@
                                             <input type="checkbox" name="${curTorrentProvider.get_id("_enable_daily")}"
                                                    id="${curTorrentProvider.get_id("_enable_daily")}"
                                                    ${checked(curTorrentProvider.daily_enabled)}
-                                                   ${disabled(not curTorrentProvider.can_daily)}
+                                                   ${disabled(curTorrentProvider.can_daily)}
                                             />
                                             <label for="${curTorrentProvider.get_id("_enable_daily")}">${_('enable provider to perform daily searches.')}</label>
                                             % if not curTorrentProvider.can_daily:

--- a/sickchill/gui/slick/views/editShow.mako
+++ b/sickchill/gui/slick/views/editShow.mako
@@ -247,7 +247,7 @@
                                         <span class="component-title">${_('Season folders')}</span>
                                     </div>
                                     <div class="col-lg-9 col-md-8 col-sm-7 col-xs-12 component-desc">
-                                        <input type="checkbox" id="season_folders" name="season_folders" title="season_folders" ${checked(show.season_folders or settings.NAMING_FORCE_FOLDERS)} ${disabled(settings.NAMING_FORCE_FOLDERS)} />
+                                        <input type="checkbox" id="season_folders" name="season_folders" title="season_folders" ${checked(show.season_folders or settings.NAMING_FORCE_FOLDERS)} ${disabled(not settings.NAMING_FORCE_FOLDERS)} />
                                         <label for="season_folders">${_('group episodes by season folder (uncheck to store in a single folder)')}</label>
                                     </div>
                                 </div>


### PR DESCRIPTION
Fixes the one `hidden` that needed to be a `selected` 
The only one found.
Also hooked the `Associated file extensions` list to be hidden if unselected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# Release Notes

- Refactor: Updated the Post Processing settings page to improve visibility of the option to move associated files based on user settings.
- Bug Fix: Adjusted the Providers settings page to correctly enable or disable a checkbox based on the provider's daily capabilities.
- Bug Fix: Modified the Edit Show page to correctly disable the 'Season Folders' checkbox based on the user's naming settings.

These changes enhance the user interface's intuitiveness by ensuring settings and options are displayed or hidden based on relevant conditions, improving overall user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->