### PR TITLE
fix: only set up logging in frontend when running flask server directly

### DIFF
--- a/frontend/app.py
+++ b/frontend/app.py
@@ -11,19 +11,6 @@ from .config import blueprint as config_blueprint
 from .movies import blueprint as movies_blueprint
 from .shows import blueprint as shows_blueprint
 
-dictConfig(
-    {
-        "version": 1,
-        "formatters": {
-            "default": {
-                "format": "[%(asctime)s] %(levelname)s in %(module)s: %(message)s",
-            }
-        },
-        "handlers": {"wsgi": {"class": "logging.StreamHandler", "stream": "ext://flask.logging.wsgi_errors_stream", "formatter": "default"}},
-        "root": {"level": "DEBUG", "handlers": ["wsgi"]},
-    }
-)
-
 
 class FlaskServer(threading.Thread):
     """Flask application class to set up the sickchill flask webserver interface"""
@@ -79,3 +66,18 @@ class DevelopmentConfig(BaseConfig):
 
     DEBUG = True
     TESTING = True
+
+
+if __name__ == "__main__":
+    dictConfig(
+    {
+        "version": 1,
+        "formatters": {
+            "default": {
+                "format": "[%(asctime)s] %(levelname)s in %(module)s: %(message)s",
+            }
+        },
+        "handlers": {"wsgi": {"class": "logging.StreamHandler", "stream": "ext://flask.logging.wsgi_errors_stream", "formatter": "default"}},
+        "root": {"level": "DEBUG", "handlers": ["wsgi"]},
+    }
+    )


### PR DESCRIPTION
Fixes #

Proposed changes in this pull request:
-
-
-

- [ ] PR is based on the DEVELOP branch
- [ ] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [ ] Read [contribution guide](https://github.com/SickChill/SickChill/blob/master/.github/CONTRIBUTING.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved the logging configuration to only apply when the file is executed directly, enhancing code efficiency.
- **Style**
	- Cleaned up the code by removing unused imports and reorganizing the imports section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->