### PR TITLE
Zero limit - provider float string

### DIFF
--- a/sickchill/gui/slick/views/config_notifications.mako
+++ b/sickchill/gui/slick/views/config_notifications.mako
@@ -2207,7 +2207,6 @@
 
                             <div class="row">
                                 <div class="col-md-12">
-
                                     <div class="testNotification" id="testJoin-result">${_('Click below to test your settings.')}</div>
                                 </div>
                             </div>
@@ -2249,7 +2248,7 @@
                             </div>
                         </div>
 
-                        <div id="content_use_gotify">
+                        <div id="content_use_gotify"> ${hidden(settings.USE_GOTIFY)}>
 
                             <div class="field-pair row">
                                 <div class="col-lg-3 col-md-4 col-sm-5 col-xs-12">

--- a/sickchill/gui/slick/views/config_notifications.mako
+++ b/sickchill/gui/slick/views/config_notifications.mako
@@ -2248,7 +2248,7 @@
                             </div>
                         </div>
 
-                        <div id="content_use_gotify"> ${hidden(settings.USE_GOTIFY)}>
+                        <div id="content_use_gotify" ${hidden(settings.USE_GOTIFY)}>
 
                             <div class="field-pair row">
                                 <div class="col-lg-3 col-md-4 col-sm-5 col-xs-12">

--- a/sickchill/helper/common.py
+++ b/sickchill/helper/common.py
@@ -389,6 +389,19 @@ def try_int(candidate, default_value=0):
         return default_value
 
 
+def try_float(candidate, default_value=0):
+    """
+    Try to convert ``candidate`` to int, or return the ``default_value``.
+    :param candidate: The value to convert to int
+    :param default_value: The value to return if the conversion fails
+    :return: ``candidate`` as int, or ``default_value`` if the conversion fails
+    """
+
+    try:
+        return float(candidate)
+    except (ValueError, TypeError):
+        return default_value
+
 def episode_num(season=None, episode=None, **kwargs):
     """
     Convert season and episode into string

--- a/sickchill/helper/common.py
+++ b/sickchill/helper/common.py
@@ -402,6 +402,7 @@ def try_float(candidate, default_value=0):
     except (ValueError, TypeError):
         return default_value
 
+
 def episode_num(season=None, episode=None, **kwargs):
     """
     Convert season and episode into string

--- a/sickchill/oldbeard/clients/download_station.py
+++ b/sickchill/oldbeard/clients/download_station.py
@@ -187,7 +187,7 @@ class Client(GenericClient):
         data["create_list"] = "false"
         data["destination"] = self._get_destination(result)
 
-        logger.debug(f"Posted as file with {data['api']} destination {data['destination']}")
+        logger.debug(f"Posted as url with {data['api']} destination {data['destination']}")
         self._request(method="post", data=data)
         return self._check_response(data)
 

--- a/sickchill/oldbeard/clients/qbittorrent.py
+++ b/sickchill/oldbeard/clients/qbittorrent.py
@@ -47,7 +47,8 @@ class Client(GenericClient):
             download_path=settings.TORRENT_PATH_INCOMPLETE or None,
             category=(settings.TORRENT_LABEL, settings.TORRENT_LABEL_ANIME)[result.show.is_anime] or settings.TORRENT_LABEL,
             is_paused=settings.TORRENT_PAUSED,
-            ratio_limit=(None, float(result.ratio))[float(result.ratio) > 0],
+            #ratio_limit=(None, float(result.ratio))[float(result.ratio) > 0],
+            ratio_limit=max(float(result.ratio or 0), 0) or None,
             seeding_time_limit=(None, 60 * int(settings.TORRENT_SEED_TIME))[int(settings.TORRENT_SEED_TIME) > 0],
             tags=("sickchill", "sickchill-anime")[result.show.is_anime],
         )

--- a/sickchill/oldbeard/clients/qbittorrent.py
+++ b/sickchill/oldbeard/clients/qbittorrent.py
@@ -48,7 +48,7 @@ class Client(GenericClient):
             category=(settings.TORRENT_LABEL, settings.TORRENT_LABEL_ANIME)[result.show.is_anime] or settings.TORRENT_LABEL,
             is_paused=settings.TORRENT_PAUSED,
             #ratio_limit=(None, float(result.ratio))[float(result.ratio) > 0],
-            ratio_limit=max(float(result.ratio or 0), 0) or None,
+            ratio_limit=max(float(result.ratio or 0), 0),
             seeding_time_limit=(None, 60 * int(settings.TORRENT_SEED_TIME))[int(settings.TORRENT_SEED_TIME) > 0],
             tags=("sickchill", "sickchill-anime")[result.show.is_anime],
         )

--- a/sickchill/oldbeard/clients/qbittorrent.py
+++ b/sickchill/oldbeard/clients/qbittorrent.py
@@ -47,7 +47,6 @@ class Client(GenericClient):
             download_path=settings.TORRENT_PATH_INCOMPLETE or None,
             category=(settings.TORRENT_LABEL, settings.TORRENT_LABEL_ANIME)[result.show.is_anime] or settings.TORRENT_LABEL,
             is_paused=settings.TORRENT_PAUSED,
-            #ratio_limit=(None, float(result.ratio))[float(result.ratio) > 0],
             ratio_limit=max(float(result.ratio or 0), 0),
             seeding_time_limit=(None, 60 * int(settings.TORRENT_SEED_TIME))[int(settings.TORRENT_SEED_TIME) > 0],
             tags=("sickchill", "sickchill-anime")[result.show.is_anime],

--- a/sickchill/oldbeard/nzbget.py
+++ b/sickchill/oldbeard/nzbget.py
@@ -75,11 +75,9 @@ def send_nzb(result: "SearchResult", proper=False) -> bool:
         dupe_key += f"-{curEp.season:02d}{curEp.episode:02d}"
 
     dupe_score = result.quality or 0
-    logger.debug(f"Testing: result.quality {result.quality}, dupe_score {dupe_score}, result.show.quality {result.show.quality}")
 
     if result.show.quality and dupe_score:
         allowed_qualities, preferred_qualities = Quality.splitQuality(result.show.quality)
-        logger.debug(f"Testing2: allowed_qualities {allowed_qualities}, preferred_qualities {preferred_qualities}")
         if result.quality == max(preferred_qualities, default=0):
             dupe_score *= 1000
         elif result.quality in preferred_qualities:

--- a/sickchill/oldbeard/nzbget.py
+++ b/sickchill/oldbeard/nzbget.py
@@ -75,10 +75,12 @@ def send_nzb(result: "SearchResult", proper=False) -> bool:
         dupe_key += f"-{curEp.season:02d}{curEp.episode:02d}"
 
     dupe_score = result.quality or 0
+    logger.debug(f"Testing: result.quality {result.quality}, dupe_score {dupe_score}, result.show.quality {result.show.quality}")
 
     if result.show.quality and dupe_score:
         allowed_qualities, preferred_qualities = Quality.splitQuality(result.show.quality)
-        if result.quality == max(preferred_qualities):
+        logger.debug(f"Testing2: allowed_qualities {allowed_qualities}, preferred_qualities {preferred_qualities}")
+        if result.quality == max(preferred_qualities, default=0):
             dupe_score *= 1000
         elif result.quality in preferred_qualities:
             dupe_score *= 800

--- a/sickchill/oldbeard/postProcessor.py
+++ b/sickchill/oldbeard/postProcessor.py
@@ -1221,7 +1221,7 @@ class PostProcessor(object):
         # If any notification fails, don't stop postProcessor
         try:
             # send notifications
-            notifiers.email_notifier.notify_postprocess(self.filename)
+            notifiers.email_notifier.notify_postprocess(f"{episode_object.pretty_name} - {new_quality_string}")
         except Exception:
             logger.info(_("Some notifications could not be sent. Finishing postProcessing..."))
 

--- a/sickchill/oldbeard/postProcessor.py
+++ b/sickchill/oldbeard/postProcessor.py
@@ -1191,7 +1191,7 @@ class PostProcessor(object):
         # If any notification fails, don't stop postProcessor
         try:
             # send notifications
-            notifiers.notify_download(self.filename)
+            notifiers.notify_download(f"{episode_object.pretty_name} - {new_quality_string}")
 
             # do the library update for KODI
             notifiers.kodi_notifier.update_library(episode_object.show.name)

--- a/sickchill/oldbeard/postProcessor.py
+++ b/sickchill/oldbeard/postProcessor.py
@@ -1191,7 +1191,7 @@ class PostProcessor(object):
         # If any notification fails, don't stop postProcessor
         try:
             # send notifications
-            notifiers.notify_download(episode_object.format_pattern("%SN - %Sx%0E - %EN - %QN"))
+            notifiers.notify_download(self.filename)
 
             # do the library update for KODI
             notifiers.kodi_notifier.update_library(episode_object.show.name)
@@ -1221,7 +1221,7 @@ class PostProcessor(object):
         # If any notification fails, don't stop postProcessor
         try:
             # send notifications
-            notifiers.email_notifier.notify_postprocess(episode_object._format_pattern("%SN - %Sx%0E - %EN - %QN"))
+            notifiers.email_notifier.notify_postprocess(self.filename)
         except Exception:
             logger.info(_("Some notifications could not be sent. Finishing postProcessing..."))
 

--- a/sickchill/oldbeard/providers/torrent9.py
+++ b/sickchill/oldbeard/providers/torrent9.py
@@ -8,7 +8,7 @@ from sickchill.providers.torrent.FrenchProvider import FrenchTorrentProvider
 
 class Provider(FrenchTorrentProvider):
     def __init__(self):
-        super().__init__("Torrent9", "https://ww1.torrent9.re")
+        super().__init__("Torrent9", "https://www.torrent9.rs")
 
     def search(self, search_strings, episode_object=None):
         results = []

--- a/sickchill/oldbeard/providers/torrent911.py
+++ b/sickchill/oldbeard/providers/torrent911.py
@@ -8,7 +8,7 @@ from sickchill.providers.torrent.FrenchProvider import FrenchTorrentProvider
 
 class Provider(FrenchTorrentProvider):
     def __init__(self):
-        super().__init__("Torrent911", "https://www.torrent911.tv")
+        super().__init__("Torrent911", "https://www.torrent911.ph")
 
     def search(self, search_strings, episode_object=None):
         results = []

--- a/sickchill/start.py
+++ b/sickchill/start.py
@@ -207,7 +207,7 @@ def initialize(console_logging: bool = True, debug: bool = False, dbdebug: bool 
         settings.ANON_REDIRECT = check_setting_str(settings.CFG, "General", "anon_redirect", settings.DEFAULT_ANON_REDIRECT)
         if settings.ANON_REDIRECT == "disabled" or not settings.ANON_REDIRECT.endswith("?"):
             settings.ANON_REDIRECT = ""
-        if settings.ANON_REDIRECT == "http://dereferer.org/?":
+        if settings.ANON_REDIRECT in ("http://dereferer.org/?", "https://anonym.to/?"):
             settings.ANON_REDIRECT = settings.DEFAULT_ANON_REDIRECT
 
         settings.PROXY_SETTING = check_setting_str(settings.CFG, "General", "proxy_setting")

--- a/sickchill/views/config/providers.py
+++ b/sickchill/views/config/providers.py
@@ -6,6 +6,7 @@ from tornado.web import addslash
 import sickchill.start
 from sickchill import settings
 from sickchill.helper import try_int
+from sickchill.helper.common import try_float
 from sickchill.oldbeard import config, ui
 from sickchill.oldbeard.providers.newznab import NewznabProvider
 from sickchill.oldbeard.providers.rsstorrent import TorrentRssProvider
@@ -14,7 +15,6 @@ from sickchill.views.common import PageTemplate
 from sickchill.views.routes import Route
 
 from . import Config
-from ...helper.common import try_float
 
 
 @Route("/config/providers(/?.*)", name="config:providers")

--- a/sickchill/views/config/providers.py
+++ b/sickchill/views/config/providers.py
@@ -14,6 +14,7 @@ from sickchill.views.common import PageTemplate
 from sickchill.views.routes import Route
 
 from . import Config
+from ...helper.common import try_float
 
 
 @Route("/config/providers(/?.*)", name="config:providers")
@@ -251,7 +252,7 @@ class ConfigProviders(Config):
             provider.check_set_option(self, "sorting", "seeders")
             provider.check_set_option(self, "search_mode", "episode")
 
-            provider.check_set_option(self, "ratio", 0, cast=lambda x: max(try_int(x), -1))
+            provider.check_set_option(self, "ratio", 0, cast=lambda x: max(try_float(x), -1))
 
         settings.NEWZNAB_DATA = "!!!".join([x.config_string() for x in settings.newznab_provider_list])
         settings.PROVIDER_ORDER = enabled_provider_list + disabled_provider_list

--- a/sickchill/views/config/providers.py
+++ b/sickchill/views/config/providers.py
@@ -251,7 +251,7 @@ class ConfigProviders(Config):
             provider.check_set_option(self, "sorting", "seeders")
             provider.check_set_option(self, "search_mode", "episode")
 
-            provider.check_set_option(self, "ratio", 0, cast=float)
+            provider.check_set_option(self, "ratio", 0, cast=lambda x: max(try_int(x), -1))
 
         settings.NEWZNAB_DATA = "!!!".join([x.config_string() for x in settings.newznab_provider_list])
         settings.PROVIDER_ORDER = enabled_provider_list + disabled_provider_list

--- a/sickchill/views/index.py
+++ b/sickchill/views/index.py
@@ -175,7 +175,7 @@ class WebHandler(BaseHandler):
 
             results = await self.async_call(method, len(sig.parameters))
 
-            self.finish(results)
+            await self.finish(results)
 
         except AttributeError:
             logger.debug('Failed doing webui request "{0}": {1}'.format(route, traceback.format_exc()))


### PR DESCRIPTION
Fixes when setting provider seed ratio to blank. Reverts to previous lamda string.

Not enough time to test whether this fixes qbt ratio and a couple of others.

Also a mako display error in notifications


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Enhancements**
  - Improved the handling of ratio settings for providers to ensure more accurate configuration.
  - Updated provider base URLs for better access and reliability.

- **Bug Fixes**
  - Fixed an issue with casting values to float, preventing potential errors during configuration.

- **Refactor**
  - Enhanced logging and comparison logic in NZB sending process to improve feedback and accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->