### PR TITLE
root dirs, trakt, addshow, bdecode

### DIFF
--- a/sickchill/oldbeard/clients/generic.py
+++ b/sickchill/oldbeard/clients/generic.py
@@ -161,7 +161,7 @@ class GenericClient(object):
                 raise
 
             try:
-                info = torrent_bdecode[b"info"]
+                info = torrent_bdecode["info"]
             except Exception:
                 logger.exception("Unable to find info field in torrent")
                 logger.info(f"Torrent bencoded data: {result.content!r}")

--- a/sickchill/oldbeard/traktChecker.py
+++ b/sickchill/oldbeard/traktChecker.py
@@ -21,7 +21,7 @@ class TraktChecker(object):
         self.collection_list = {}
         self.amActive = False
 
-    def run(self, force=False):
+    def run(self):
         self.amActive = True
 
         # add shows from trakt.tv watchlist
@@ -290,7 +290,7 @@ class TraktChecker(object):
             trakt_data = []
 
             for show in settings.showList or []:
-                if not self._is_in_show_watchlist(show.idxr.slug, str(show.indexerid), "0", "0"):
+                if not self._is_in_show_watchlist(show.idxr.slug, str(show.indexerid)):
                     logger.debug("Adding Show: Indexer {0} {1} - {2} to Watchlist".format(show.idxr.name, str(show.indexerid), show.name))
                     show_element = {"title": show.name, "year": show.startyear, "ids": {show.idxr.slug: show.indexerid}}
 

--- a/sickchill/oldbeard/traktChecker.py
+++ b/sickchill/oldbeard/traktChecker.py
@@ -21,7 +21,7 @@ class TraktChecker(object):
         self.collection_list = {}
         self.amActive = False
 
-    def run(self):
+    def run(self, force=False):
         self.amActive = True
 
         # add shows from trakt.tv watchlist

--- a/sickchill/views/manage/add_shows.py
+++ b/sickchill/views/manage/add_shows.py
@@ -239,7 +239,7 @@ class AddShows(Home):
         posts them to addNewShow
         """
 
-        trakt_list = self.get_argument("traktList", default="anticipated")
+        trakt_list = self.get_query_argument("traktList", default="anticipated").lower()
 
         trakt_options = {
             "anticipated": _("Most Anticipated Shows"),
@@ -253,8 +253,6 @@ class AddShows(Home):
         }
         if settings.TRAKT_ACCESS_TOKEN:
             trakt_options["recommended"] = _("Recommended Shows")
-
-        trakt_list = trakt_list.lower()
 
         t = PageTemplate(rh=self, filename="addShows_trendingShows.mako")
         return t.render(
@@ -457,7 +455,7 @@ class AddShows(Home):
         provided then it forwards back to newShow, if not it goes to /home.
         """
 
-        indexerLang = self.get_argument("indexerLang", default=settings.INDEXER_DEFAULT_LANGUAGE)
+        indexerLang = self.get_body_argument("indexerLang", default=settings.INDEXER_DEFAULT_LANGUAGE)
 
         # grab our list of other dirs if given
         other_shows = self.get_arguments("other_shows")

--- a/sickchill/views/server_settings.py
+++ b/sickchill/views/server_settings.py
@@ -70,7 +70,7 @@ class SCWebServer(threading.Thread):
         # video root
         if settings.ROOT_DIRS:
             root_dirs = settings.ROOT_DIRS.split("|")
-            self.video_root = root_dirs[int(root_dirs[0]) + 1]
+            self.video_root = root_dirs[int(root_dirs[0])]
         else:
             self.video_root = None
 


### PR DESCRIPTION
Fixes 

- rootDir reference numbering (must have come with the js) aligns with actual position of full list no longer needing +1, removes startup error if only one entry
- trakt interaction and data sharing
- addshow bunch of cleans and trakt link.
- torrent_bdecode b"info not found so change to "info"


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
	- Updated the `traktChecker` class to enhance the show tracking process without requiring a `force` update.
	- Improved show search and addition flow by streamlining parameter handling and variable naming.
	- Corrected video root directory assignment in server settings for accurate path configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->