### PR TITLE
Rename folder check

### DIFF
--- a/sickchill/views/home.py
+++ b/sickchill/views/home.py
@@ -1629,9 +1629,8 @@ class Home(WebRoot):
         if not show_obj:
             return self._genericMessage(_("Error"), _("Show not in show list"))
 
-        try:
-            show_obj.location
-        except ShowDirectoryNotFoundException:
+        if not os.path.isdir(show_obj.location):
+            logger.warning(_("Can't rename episodes '{show}' directory is missing.").format(show=show_obj.show_name))
             return self._genericMessage(_("Error"), _("Can't rename episodes when the show dir is missing."))
 
         if not eps:

--- a/sickchill/views/home.py
+++ b/sickchill/views/home.py
@@ -1604,9 +1604,8 @@ class Home(WebRoot):
         if not show_obj:
             return self._genericMessage(_("Error"), _("Show not in show list"))
 
-        try:
-            show_obj.location()
-        except ShowDirectoryNotFoundException:
+        if not os.path.isdir(show_obj.location):
+            logger.warning(_("Can't rename episodes '{show}' directory is missing.").format(show=show_obj.show_name))
             return self._genericMessage(_("Error"), _("Can't rename episodes when the show dir is missing."))
 
         show_obj.get_all_episodes(has_location=True)

--- a/sickchill/views/home.py
+++ b/sickchill/views/home.py
@@ -1604,9 +1604,10 @@ class Home(WebRoot):
         if not show_obj:
             return self._genericMessage(_("Error"), _("Show not in show list"))
 
-        if not os.path.isdir(show_obj.location):
-            logger.warning(_("Can't rename episodes '{show}' directory is missing.").format(show=show_obj.show_name))
-            return self._genericMessage(_("Error"), _("Can't rename episodes when the show dir is missing."))
+        try:
+            show_obj.location
+        except ShowDirectoryNotFoundException:
+            return
 
         show_obj.get_all_episodes(has_location=True)
         t = PageTemplate(rh=self, filename="testRename.mako")
@@ -1629,9 +1630,10 @@ class Home(WebRoot):
         if not show_obj:
             return self._genericMessage(_("Error"), _("Show not in show list"))
 
-        if not os.path.isdir(show_obj.location):
-            logger.warning(_("Can't rename episodes '{show}' directory is missing.").format(show=show_obj.show_name))
-            return self._genericMessage(_("Error"), _("Can't rename episodes when the show dir is missing."))
+        try:
+            show_obj.location
+        except ShowDirectoryNotFoundException:
+            return
 
         if not eps:
             return self.redirect("/home/displayShow?show=" + show)

--- a/sickchill/views/home.py
+++ b/sickchill/views/home.py
@@ -1607,7 +1607,7 @@ class Home(WebRoot):
         try:
             show_obj.location
         except ShowDirectoryNotFoundException:
-            return
+            return self._genericMessage(_("Error"), _("Can't rename episodes when the show dir is missing."))
 
         show_obj.get_all_episodes(has_location=True)
         t = PageTemplate(rh=self, filename="testRename.mako")
@@ -1633,7 +1633,7 @@ class Home(WebRoot):
         try:
             show_obj.location
         except ShowDirectoryNotFoundException:
-            return
+            return self._genericMessage(_("Error"), _("Can't rename episodes when the show dir is missing."))
 
         if not eps:
             return self.redirect("/home/displayShow?show=" + show)


### PR DESCRIPTION
Fixes #8720

rework the request for location and add warning message for missing directory

TypeError no longer an issue with this change. (ai comment)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling for missing show directories, ensuring users are informed about the inability to rename episodes under such circumstances.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->