### PR TITLE
emby update fix

### DIFF
--- a/sickchill/gui/slick/views/config_notifications.mako
+++ b/sickchill/gui/slick/views/config_notifications.mako
@@ -526,7 +526,16 @@
                                     <label for="emby_apikey" class="component-title">${_('Emby API Key')}</label>
                                 </div>
                                 <div class="col-lg-9 col-md-8 col-sm-7 col-xs-12 component-desc">
-                                    <input type="text" name="emby_apikey" id="emby_apikey" value="${settings.EMBY_APIKEY}" class="form-control input-sm input250" autocapitalize="off" />
+                                    <div class="row">
+                                        <div class="col-md-12">
+                                            <input type="text" name="emby_apikey" id="emby_apikey" value="${settings.EMBY_APIKEY}" class="form-control input-sm input250" autocapitalize="off" />
+                                        </div>
+                                    </div>
+                                    <div class="row">
+                                        <div class="col-md-12">
+                                            <label for="emby_apikey">${_('Generated from Emby > Settings > Advanced > API keys')}</label>
+                                        </div>
+                                    </div>
                                 </div>
                             </div>
 

--- a/sickchill/gui/slick/views/editShow.mako
+++ b/sickchill/gui/slick/views/editShow.mako
@@ -407,7 +407,7 @@
                                                         <optgroup data-season="${season}" label="${_('Show') if season == -1 else _('Season ') + str(season)}">
                                                             %if season in scene_exceptions:
                                                                 %for exception in scene_exceptions[season]:
-                                                                    <option ${disabled(exception["custom"] == False)} value="${exception["show_name"]}">
+                                                                    <option ${disabled(exception["custom"])} value="${exception["show_name"]}">
                                                                         ${exception["show_name"]}
                                                                     </option>
                                                                 %endfor

--- a/sickchill/oldbeard/notifiers/emby.py
+++ b/sickchill/oldbeard/notifiers/emby.py
@@ -57,12 +57,7 @@ class Notifier(object):
                 return False
 
             params = {}
-            if show:
-                params.update({"TvdbId": show.indexerid})
-                # Endpoint emby/Library/Series/Added is deprecated http://swagger.emby.media/?staticview=true#/LibraryService/postLibrarySeriesAdded
-                url = urljoin(settings.EMBY_HOST, "emby/Library/Media/Updated")
-            else:
-                url = urljoin(settings.EMBY_HOST, "emby/Library/Refresh")
+            url = urljoin(settings.EMBY_HOST, "emby/Library/Refresh")
 
             try:
                 response = requests.post(url, params=params, headers=self._make_headers())

--- a/sickchill/oldbeard/notifiers/nmjv2.py
+++ b/sickchill/oldbeard/notifiers/nmjv2.py
@@ -13,10 +13,11 @@ class Notifier(object):
         # Not implemented: Start the scanner when snatched does not make any sense
 
     def notify_download(self, ep_name):
-        self._notifyNMJ()
+        if settings.USE_NMJv2:
+            self._notifyNMJv2()
 
     def notify_subtitle_download(self, ep_name, lang):
-        self._notifyNMJ()
+        self._notifyNMJv2()
 
     @staticmethod
     def notify_update(new_version):
@@ -28,7 +29,7 @@ class Notifier(object):
         return False
 
     def test_notify(self, host):
-        return self._sendNMJ(host)
+        return self._sendNMJv2(host)
 
     @staticmethod
     def notify_settings(host, dbloc, instance):
@@ -69,7 +70,7 @@ class Notifier(object):
         return False
 
     @staticmethod
-    def _sendNMJ(host):
+    def _sendNMJv2(host):
         """
         Sends a NMJ update command to the specified machine
 
@@ -130,7 +131,7 @@ class Notifier(object):
                 logger.info("NMJv2 started background scan")
                 return True
 
-    def _notifyNMJ(self, host=None, force=False):
+    def _notifyNMJv2(self, host=None, force=False):
         """
         Sends a NMJ update command based on the SC config settings
 
@@ -140,7 +141,7 @@ class Notifier(object):
         force: If True then the notification will be sent even if NMJ is disabled in the config
         """
         if not settings.USE_NMJv2 and not force:
-            logger.debug("Notification for NMJ scan update not enabled, skipping this notification")
+            logger.debug("Notification for NMJv2 scan update not enabled, skipping this notification")
             return False
 
         # fill in omitted parameters
@@ -149,4 +150,4 @@ class Notifier(object):
 
         logger.debug("Sending scan command for NMJ ")
 
-        return self._sendNMJ(host)
+        return self._sendNMJv2(host)


### PR DESCRIPTION
Fix Emby notify to update.
Cut all the BS as Emby uses ffprobe / ffdettect so no need to focus on one specific show to update.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
	- Simplified the process for updating the Emby library by removing outdated code and streamlining the URL generation.
- **UI/UX**
	- Added a new label for the Emby API Key field indicating its source from Emby settings.
	- Restructured the layout by wrapping the input field and label in separate `div` elements within a `row`.
- **Code Logic**
	- Updated method calls and renamed methods related to Emby notifications to align with `settings.USE_NMJv2`.
	- Updated logging messages for clarity and consistency.
- **UI Enhancement**
	- Modified the condition for disabling an option in the `editShow` view based on `exception["custom"]`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->