### PR TITLE
Maintain scheme when building the qBittorrent client

### DIFF
--- a/sickchill/oldbeard/clients/qbittorrent.py
+++ b/sickchill/oldbeard/clients/qbittorrent.py
@@ -11,9 +11,9 @@ if TYPE_CHECKING:  # pragma: no cover
 
 
 class Client(GenericClient):
-    def __init__(self, host: str = None, username: str = None, password: str = None):
-        super().__init__("qBittorrent", host, username, password)
-        parsed_url = urlparse(self.host or settings.TORRENT_HOST)
+    def __init__(self, url: str = None, username: str = None, password: str = None):
+        super().__init__("qBittorrent", url, username, password)
+        parsed_url = urlparse(self.url or settings.TORRENT_HOST)
         self.url = parsed_url.geturl()
         self.port = parsed_url.port
         logger.debug(f"qBittorrent URL: {self.url}")

--- a/sickchill/oldbeard/clients/qbittorrent.py
+++ b/sickchill/oldbeard/clients/qbittorrent.py
@@ -14,10 +14,11 @@ class Client(GenericClient):
     def __init__(self, host: str = None, username: str = None, password: str = None):
         super().__init__("qBittorrent", host, username, password)
         parsed_url = urlparse(self.host or settings.TORRENT_HOST)
-        self.host = parsed_url.hostname
+        self.url = parsed_url.geturl()
         self.port = parsed_url.port
+        logger.debug(f"qBittorrent URL: {self.url}")
         self.api = qbittorrentapi.Client(
-            host=self.host,
+            host=self.url,
             port=self.port or None,
             username=self.username or settings.TORRENT_USERNAME,
             password=self.password or settings.TORRENT_PASSWORD,


### PR DESCRIPTION
Fixes #

Proposed changes in this pull request:
- Maintain the scheme when parsing the URL provided by the user. 
- Only affects the qBittorrent client.

- [ ] PR is based on the DEVELOP branch
- [ ] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read [contribution guide](https://github.com/SickChill/SickChill/blob/master/.github/CONTRIBUTING.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
	- Updated the qBittorrent client initialization to use the full URL for enhanced connectivity and added logging for the qBittorrent URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->