### PR TITLE
Emby notification :  upgrade library_update to latests api endpoints

### DIFF
--- a/sickchill/oldbeard/notifiers/emby.py
+++ b/sickchill/oldbeard/notifiers/emby.py
@@ -77,13 +77,13 @@ class Notifier(object):
             if not settings.EMBY_HOST:
                 logger.debug(_("EMBY: No host specified, check your settings"))
                 return False
-            params = {"UpdateType": "Created"}
+            params = {}
             try:
                 if show:
                     path = self._get_show_path(show.indexerid)
                     if path:
                         url = urljoin(settings.EMBY_HOST, "emby/Library/Media/Updated")
-                        params.update({"Path": path})
+                        params.update({"Updates": {"Path": path, "UpdateType": "Created"}})
                     else:
                         url = urljoin(settings.EMBY_HOST, "emby/Library/Refresh")
                 else:

--- a/sickchill/oldbeard/notifiers/emby.py
+++ b/sickchill/oldbeard/notifiers/emby.py
@@ -36,6 +36,28 @@ class Notifier(object):
             logger.warning(_("EMBY: Warning: Could not contact Emby at {url} {error}").format(url=url, error=error))
             return False
 
+    def _get_show_path(self, tvdbid):
+        """Get a show path in Emby library using Items endpoint
+
+        Returns:
+            The show path in Emby or empty
+
+        """
+        get_path_params = {"Recursive": "true", "Fields": "Path", "IncludeItemTypes": "Series"}
+        url = urljoin(settings.EMBY_HOST, "/Items")
+        try:
+            get_path_params.update({"AnyProviderIdEquals": "tvdb.{id}".format(id=tvdbid)})
+            items_response = requests.get(url, params=get_path_params, headers=self._make_headers())
+            items_response.raise_for_status()
+            if items_response.json()["TotalRecordCount"] == 1:
+                return items_response.json()["Items"][0]["Path"]
+            else:
+                return ""
+
+        except requests.exceptions.RequestException as error:
+            logger.warning(_("EMBY: Warning: Could not contact Emby at {url} {error}").format(url=url, error=error))
+            return None
+
     ##############################################################################
     # Public functions
     ##############################################################################
@@ -55,12 +77,20 @@ class Notifier(object):
             if not settings.EMBY_HOST:
                 logger.debug(_("EMBY: No host specified, check your settings"))
                 return False
-
-            params = {}
-            url = urljoin(settings.EMBY_HOST, "emby/Library/Refresh")
-
+            params = {"UpdateType": "Created"}
             try:
-                response = requests.post(url, params=params, headers=self._make_headers())
+                if show:
+                    path = self._get_show_path(show.indexerid)
+                    if path:
+                        url = urljoin(settings.EMBY_HOST, "emby/Library/Media/Updated")
+                        params.update({"Path": path})
+                    else:
+                        url = urljoin(settings.EMBY_HOST, "emby/Library/Refresh")
+                else:
+                    url = urljoin(settings.EMBY_HOST, "emby/Library/Refresh")
+
+                response = requests.post(url, json=params, headers=self._make_headers())
+
                 response.raise_for_status()
                 logger.debug(_("EMBY: HTTP status: {status_code}, response: {content}").format(status_code=response.status_code, content=response.content))
                 return True

--- a/sickchill/oldbeard/notifiers/emby.py
+++ b/sickchill/oldbeard/notifiers/emby.py
@@ -36,6 +36,28 @@ class Notifier(object):
             logger.warning(_("EMBY: Warning: Could not contact Emby at {url} {error}").format(url=url, error=error))
             return False
 
+    def _get_show_path(self, tvdbid):
+        """Get a show path in Emby library using Items endpoint
+
+        Returns:
+            The show path in Emby or empty
+
+        """
+        get_path_params = {"Recursive": "true", "Fields": "Path", "IncludeItemTypes": "Series"}
+        url = urljoin(settings.EMBY_HOST, "/Items")
+        try:
+            get_path_params.update({"AnyProviderIdEquals": "tvdb.{id}".format(id=tvdbid)})
+            items_response = requests.get(url, params=get_path_params, headers=self._make_headers())
+            items_response.raise_for_status()
+            if items_response.json()["TotalRecordCount"] == 1:
+                return items_response.json()["Items"][0]["Path"]
+            else:
+                return ""
+
+        except requests.exceptions.RequestException as error:
+            logger.warning(_("EMBY: Warning: Could not contact Emby at {url} {error}").format(url=url, error=error))
+            return None
+
     ##############################################################################
     # Public functions
     ##############################################################################
@@ -55,22 +77,22 @@ class Notifier(object):
             if not settings.EMBY_HOST:
                 logger.debug(_("EMBY: No host specified, check your settings"))
                 return False
-            params = {}
+            params = {"UpdateType": "Created"}
             try:
-                if show.location:
-                    url = urljoin(settings.EMBY_HOST, "emby/Library/Media/Updated")
-                    params = {"Updates": [{"Path": show.location, "UpdateType": "Created"}]}
+                if show:
+                    path = self._get_show_path(show.indexerid)
+                    if path:
+                        url = urljoin(settings.EMBY_HOST, "emby/Library/Media/Updated")
+                        params.update({"Path": path})
+                    else:
+                        url = urljoin(settings.EMBY_HOST, "emby/Library/Refresh")
                 else:
                     url = urljoin(settings.EMBY_HOST, "emby/Library/Refresh")
 
                 response = requests.post(url, json=params, headers=self._make_headers())
 
                 response.raise_for_status()
-                logger.debug(
-                    _("EMBY: HTTP status: {status_code}, {content}, params {params}").format(
-                        status_code=response.status_code, content=response.content, params=params
-                    )
-                )
+                logger.debug(_("EMBY: HTTP status: {status_code}, response: {content}").format(status_code=response.status_code, content=response.content))
                 return True
 
             except requests.exceptions.RequestException as error:

--- a/sickchill/oldbeard/notifiers/emby.py
+++ b/sickchill/oldbeard/notifiers/emby.py
@@ -55,15 +55,11 @@ class Notifier(object):
             if not settings.EMBY_HOST:
                 logger.debug(_("EMBY: No host specified, check your settings"))
                 return False
-            params = {"Updates": [{"Path": "", "UpdateType": "Created"}]}
+            params = {}
             try:
-                if show:
-                    path = show.location
-                    if path:
-                        url = urljoin(settings.EMBY_HOST, "emby/Library/Media/Updated")
-                        params.update({"Updates": [{"Path": path}]})
-                    else:
-                        url = urljoin(settings.EMBY_HOST, "emby/Library/Refresh")
+                if show.location:
+                    url = urljoin(settings.EMBY_HOST, "emby/Library/Media/Updated")
+                    params = {"Updates": [{"Path": show.location, "UpdateType": "Created"}]}
                 else:
                     url = urljoin(settings.EMBY_HOST, "emby/Library/Refresh")
 

--- a/sickchill/oldbeard/notifiers/emby.py
+++ b/sickchill/oldbeard/notifiers/emby.py
@@ -36,28 +36,6 @@ class Notifier(object):
             logger.warning(_("EMBY: Warning: Could not contact Emby at {url} {error}").format(url=url, error=error))
             return False
 
-    def _get_show_path(self, tvdbid):
-        """Get a show path in Emby library using Items endpoint
-
-        Returns:
-            The show path in Emby or empty
-
-        """
-        get_path_params = {"Recursive": "true", "Fields": "Path", "IncludeItemTypes": "Series"}
-        url = urljoin(settings.EMBY_HOST, "/Items")
-        try:
-            get_path_params.update({"AnyProviderIdEquals": "tvdb.{id}".format(id=tvdbid)})
-            items_response = requests.get(url, params=get_path_params, headers=self._make_headers())
-            items_response.raise_for_status()
-            if items_response.json()["TotalRecordCount"] == 1:
-                return items_response.json()["Items"][0]["Path"]
-            else:
-                return ""
-
-        except requests.exceptions.RequestException as error:
-            logger.warning(_("EMBY: Warning: Could not contact Emby at {url} {error}").format(url=url, error=error))
-            return None
-
     ##############################################################################
     # Public functions
     ##############################################################################
@@ -77,13 +55,13 @@ class Notifier(object):
             if not settings.EMBY_HOST:
                 logger.debug(_("EMBY: No host specified, check your settings"))
                 return False
-            params = {"UpdateType": "Created"}
+            params = {"Updates": [{"Path": "", "UpdateType": "Created"}]}
             try:
                 if show:
-                    path = self._get_show_path(show.indexerid)
+                    path = show.location
                     if path:
                         url = urljoin(settings.EMBY_HOST, "emby/Library/Media/Updated")
-                        params.update({"Path": path})
+                        params.update({"Updates": [{"Path": path}]})
                     else:
                         url = urljoin(settings.EMBY_HOST, "emby/Library/Refresh")
                 else:
@@ -92,7 +70,11 @@ class Notifier(object):
                 response = requests.post(url, json=params, headers=self._make_headers())
 
                 response.raise_for_status()
-                logger.debug(_("EMBY: HTTP status: {status_code}, response: {content}").format(status_code=response.status_code, content=response.content))
+                logger.debug(
+                    _("EMBY: HTTP status: {status_code}, {content}, params {params}").format(
+                        status_code=response.status_code, content=response.content, params=params
+                    )
+                )
                 return True
 
             except requests.exceptions.RequestException as error:


### PR DESCRIPTION
use endpoint `/media/updated` with path  param to refresh only needed show instead of full library scan

path is found by calling `/items` endpoint with indexerid (tvdbid in this case) and limiting results to only Series 
if we don't have exactly one result we fallback to a full library scan, this might happen for a new show added to SC but still not known to Emby for example


- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read [contribution guide](https://github.com/SickChill/SickChill/blob/master/.github/CONTRIBUTING.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced Emby integration to support show-specific updates in the library.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->