### PR TITLE
Only send `stop_at_ratio` and `stop_ratio` when ratio != -1 for deluge based clients

### DIFF
--- a/sickchill/oldbeard/clients/__deluge_base.py
+++ b/sickchill/oldbeard/clients/__deluge_base.py
@@ -29,7 +29,7 @@ class DelugeBase(object):
         options.update({"file_priorities": priority_map[result.priority]})
         # options.update({'file_priorities': priority_map[result.priority] * num_files})
 
-        if result.ratio:
+        if result.ratio and ( float(result.ratio) != -1.0 ):
             options.update({"stop_at_ratio": True})
             options.update({"stop_ratio": float(result.ratio)})
             # options.update({'remove_at_ratio': True})

--- a/sickchill/oldbeard/clients/__deluge_base.py
+++ b/sickchill/oldbeard/clients/__deluge_base.py
@@ -29,7 +29,7 @@ class DelugeBase(object):
         options.update({"file_priorities": priority_map[result.priority]})
         # options.update({'file_priorities': priority_map[result.priority] * num_files})
 
-        if result.ratio and ( float(result.ratio) != -1.0 ):
+        if result.ratio and float(result.ratio) != -1.0 and float(result.ratio) >= 0.0:
             options.update({"stop_at_ratio": True})
             options.update({"stop_ratio": float(result.ratio)})
             # options.update({'remove_at_ratio': True})


### PR DESCRIPTION
Only send `stop_at_ratio` and `stop_ratio` when ratio != -1 for deluge based clients.

Fixes:
- `-1` currently not behaving as disabled "stop on ratio" in deluge clients.

- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read [contribution guide](https://github.com/SickChill/SickChill/blob/master/.github/CONTRIBUTING.md)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Bug Fixes**
	- Improved ratio handling in Deluge clients by adding a check to prevent updates when the ratio is set to -1.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->