### PR TITLE
Pytest 8.2.0 errors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ flake8-quotes = "^3.3.0"
 flake8-docstrings = "^1.6.0"
 flake9 = "^3.8.3"
 codecov = "^2.1.12"
-pytest = ">=7.0.1,<9.0.0"
+pytest = ">=7.0.1,<9.0.0,!=8.2.0"
 isort = "^5.10.1"
 poethepoet = ">=0.16,<0.27"
 po2json = "^0.2.2"
@@ -158,6 +158,7 @@ builtins = ["_"]
 [tool.pytest.ini_options]
 testpaths = ["tests", "sickchill", "SickChill.py"]
 addopts = "--cov=sickchill --cov-report xml --no-cov-on-fail"
+filterwarnings = ['ignore:.*telnetlib.*is deprecated:DeprecationWarning']
 
 [tool.isort]
 profile = "black"


### PR DESCRIPTION
Per https://github.com/pytest-dev/pytest/issues/12263

Work around to avoid `AttributeError: property 'is_active' of 'Provider' object has no setter`
in test_snatch.

Plus ignore the `Warning` about `telnetlib` whilst looking why the build system was erroring 