### PR TITLE
Guessit list alterante fix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ flake8-quotes = "^3.3.0"
 flake8-docstrings = "^1.6.0"
 flake9 = "^3.8.3"
 codecov = "^2.1.12"
-pytest = ">=7.0.1,<9.0.0"
+pytest = ">=7.0.1,<9.0.0,!=8.2.0"
 isort = "^5.10.1"
 poethepoet = ">=0.16,<0.27"
 po2json = "^0.2.2"
@@ -158,6 +158,7 @@ builtins = ["_"]
 [tool.pytest.ini_options]
 testpaths = ["tests", "sickchill", "SickChill.py"]
 addopts = "--cov=sickchill --cov-report xml --no-cov-on-fail"
+filterwarnings = ['ignore:.*telnetlib.*is deprecated:DeprecationWarning']
 
 [tool.isort]
 profile = "black"

--- a/sickchill/oldbeard/postProcessor.py
+++ b/sickchill/oldbeard/postProcessor.py
@@ -1237,7 +1237,12 @@ class PostProcessor(object):
 def guessit_findit(name: str) -> Union["ParseResult", None]:
     logger.debug(f"Trying a new way to verify if we can parse this file; {name}")
     title = guessit(name, {"type": "episode"}).get("title")
+
     if title:
+        # if the title is a list instead of a string, then join it with spaces.
+        if isinstance(title, list):
+            title = " ".join(title)
+
         show: "TVShow" = helpers.get_show(title)
         if show:
             try:

--- a/sickchill/show/indexers/tvdb.py
+++ b/sickchill/show/indexers/tvdb.py
@@ -6,7 +6,6 @@ import traceback
 import requests
 import tvdbsimple
 
-# from sickchill import logger
 import sickchill.start
 from sickchill import logger, settings
 from sickchill.show.indexers.base import Indexer


### PR DESCRIPTION
Fix to convert `guessit title` returned as list to string at the origin of the problem.

This is an alternate to #8754 which I could replicate and possibly #8758 which couldn't be confirmed as yet to recieve sufficient data on cause to be able to replicate.

Chose to do here as it then reduces iterations rather than in `helpers.py` or `tvdb.py` code.