### PR TITLE
fix: jellyfin test notification endpoint update

### DIFF
--- a/sickchill/oldbeard/notifiers/jellyfin.py
+++ b/sickchill/oldbeard/notifiers/jellyfin.py
@@ -16,7 +16,7 @@ class Notifier(object):
     ##############################################################################
 
     def test_notify(self, host, jellyfin_apikey):
-       """Handles testing Jellyfin connection via HTTP API
+        """Handles testing Jellyfin connection via HTTP API
         Returns:
             Returns True for no issue or False if there was an error
         """
@@ -67,3 +67,4 @@ class Notifier(object):
             except requests.exceptions.RequestException as error:
                 logger.warning(_("JELLYFIN: Warning: Could not contact Jellyfin at {url} {error}").format(url=url, error=error))
                 return False
+

--- a/sickchill/oldbeard/notifiers/jellyfin.py
+++ b/sickchill/oldbeard/notifiers/jellyfin.py
@@ -11,35 +11,32 @@ class Notifier(object):
     def _make_headers(self, jellyfin_apikey=None):
         return CaseInsensitiveDict({"X-Emby-Token": jellyfin_apikey or settings.JELLYFIN_APIKEY, "Content-Type": "application/json"})
 
-    def _notify_jellyfin(self, host=None, jellyfin_apikey=None):
-        """Handles notifying Jellyfin host via HTTP API
+    ##############################################################################
+    # Public functions
+    ##############################################################################
+
+    def test_notify(self, host, jellyfin_apikey):
+       """Handles testing Jellyfin connection via HTTP API
         Returns:
             Returns True for no issue or False if there was an error
         """
-        # https://api.jellyfin.org/#tag/System/operation/GetEndpointInfo
-        url = urljoin(host or settings.JELLYFIN_HOST, "System/Endpoint")
 
         if not settings.USE_JELLYFIN:
             logger.debug("Notification for Jellyfin not enabled, skipping this notification")
             return False
+
+        # https://api.jellyfin.org/#tag/System/operation/GetEndpointInfo
+        url = urljoin(host or settings.JELLYFIN_HOST, "System/Endpoint")
 
         try:
             response = requests.get(url, headers=self._make_headers(jellyfin_apikey))
             if response:
                 logger.debug(_("JELLYFIN: HTTP response: {content}").format(content=response.content))
             response.raise_for_status()
-
             return True
         except RequestException as error:
             logger.warning(_("JELLYFIN: Warning: Could not contact Jellyfin at {url} {error}").format(url=url, error=error))
             return False
-
-    ##############################################################################
-    # Public functions
-    ##############################################################################
-
-    def test_notify(self, host, jellyfin_apikey):
-        return self._notify_jellyfin(host, jellyfin_apikey)
 
     def update_library(self, show=None):
         """Handles updating the Jellyfin Media Server via HTTP API
@@ -69,5 +66,4 @@ class Notifier(object):
 
             except requests.exceptions.RequestException as error:
                 logger.warning(_("JELLYFIN: Warning: Could not contact Jellyfin at {url} {error}").format(url=url, error=error))
-
                 return False

--- a/sickchill/oldbeard/notifiers/jellyfin.py
+++ b/sickchill/oldbeard/notifiers/jellyfin.py
@@ -67,4 +67,3 @@ class Notifier(object):
             except requests.exceptions.RequestException as error:
                 logger.warning(_("JELLYFIN: Warning: Could not contact Jellyfin at {url} {error}").format(url=url, error=error))
                 return False
-

--- a/sickchill/oldbeard/notifiers/jellyfin.py
+++ b/sickchill/oldbeard/notifiers/jellyfin.py
@@ -11,21 +11,20 @@ class Notifier(object):
     def _make_headers(self, jellyfin_apikey=None):
         return CaseInsensitiveDict({"X-Emby-Token": jellyfin_apikey or settings.JELLYFIN_APIKEY, "Content-Type": "application/json"})
 
-    def _notify_jellyfin(self, message, host=None, jellyfin_apikey=None):
+    def _notify_jellyfin(self, host=None, jellyfin_apikey=None):
         """Handles notifying Jellyfin host via HTTP API
         Returns:
             Returns True for no issue or False if there was an error
         """
-        # https://api.jellyfin.org/#tag/Notifications/operation/CreateAdminNotification
-        url = urljoin(host or settings.JELLYFIN_HOST, "Notifications/Admin")
-        params = {"Name": "SickChill", "Description": message, "NotificationLevel": "Normal"}
+        # https://api.jellyfin.org/#tag/System/operation/GetEndpointInfo
+        url = urljoin(host or settings.JELLYFIN_HOST, "System/Endpoint")
 
         if not settings.USE_JELLYFIN:
             logger.debug("Notification for Jellyfin not enabled, skipping this notification")
             return False
 
         try:
-            response = requests.post(url, json=params, headers=self._make_headers(jellyfin_apikey))
+            response = requests.get(url, headers=self._make_headers(jellyfin_apikey))
             if response:
                 logger.debug(_("JELLYFIN: HTTP response: {content}").format(content=response.content))
             response.raise_for_status()
@@ -40,7 +39,7 @@ class Notifier(object):
     ##############################################################################
 
     def test_notify(self, host, jellyfin_apikey):
-        return self._notify_jellyfin(_("This is a test notification from SickChill"), host, jellyfin_apikey)
+        return self._notify_jellyfin(host, jellyfin_apikey)
 
     def update_library(self, show=None):
         """Handles updating the Jellyfin Media Server via HTTP API


### PR DESCRIPTION
## Summary

In a recent update to Jellyfin (v10.9.0), they have merged a [change ](https://github.com/jellyfin/jellyfin/releases/tag/v10.9.0) which removes the older Emby Notifications endpoint which sickchill used when checking if an api key and url provided were correct. 

My fix changes the endpoint used for something that does exist and still requires authentication. 

Jellyfin PR that removes the endpoint: https://github.com/jellyfin/jellyfin/pull/8952

## Proposed changes in this pull request:
- Replace `Notifications/Admin` endpoint with `System/Endpoint` for jellyfin notifier. 

## Checklist
- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read [contribution guide](https://github.com/SickChill/SickChill/blob/master/.github/CONTRIBUTING.md)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated Jellyfin notification to use the correct API endpoint and HTTP method, ensuring accurate data retrieval.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->