### PR TITLE
(fix) error where logs did not have passwords and other items censored and UNDEFINED on first startup

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -300,3 +300,4 @@ beekeeper-alt = ">=2022.9.3"
 stevedore = "^5.1.0"
 cachecontrol = ">=0.13.1,<0.15.0"
 cinemagoer = {version = "^2023.5.1", allow-prereleases = true}
+appdirs = "^1.4.4"

--- a/sickchill/gui/slick/views/errorlogs.mako
+++ b/sickchill/gui/slick/views/errorlogs.mako
@@ -1,15 +1,15 @@
 <%inherit file="/layouts/main.mako" />
 <%!
-    from sickchill.oldbeard import classes
-    import sickchill
+    from sickchill.logging.weblog import WebErrorViewer
+    import logging
 %>
 <%block name="content">
     <%
-        if logLevel == sickchill.logger.WARNING:
-            errors = classes.WarningViewer.errors
+        if logLevel == logging.WARNING:
+            errors = WebErrorViewer.warnings
             title = _('WARNING logs')
         else:
-            errors = classes.ErrorViewer.errors
+            errors = WebErrorViewer.errors
             title = _('ERROR logs')
     %>
     <div class="row">

--- a/sickchill/gui/slick/views/layouts/main.mako
+++ b/sickchill/gui/slick/views/layouts/main.mako
@@ -120,6 +120,11 @@
         <nav class="navbar navbar-default navbar-fixed-top hidden-print">
             <div class="container-fluid">
                 <%
+                    if error_count == UNDEFINED:
+                        error_count = 0
+                    if warning_count == UNDEFINED:
+                        warning_count = 0
+
                     total_warning_error_count = error_count + warning_count + settings.NEWS_UNREAD
                     if total_warning_error_count:
                         if error_count:

--- a/sickchill/logging/weblog.py
+++ b/sickchill/logging/weblog.py
@@ -90,9 +90,6 @@ class __WebErrorViewer(object):
     def len(self):
         return self.num_errors() + self.num_warnings()
 
-    def get(self):
-        return self.__errors
-
 
 WebErrorViewer = __WebErrorViewer()
 

--- a/sickchill/logging/weblog.py
+++ b/sickchill/logging/weblog.py
@@ -1,0 +1,109 @@
+import datetime
+import logging
+import sys
+from logging import ERROR, WARNING
+
+from sickchill.helper.common import dateTimeFormat
+from sickchill.oldbeard.notifiers import notify_logged_error
+
+
+class __WebErrorViewer(object):
+    """
+    Keeps a static list of UIErrors to be displayed on the UI and allows
+    the list to be cleared.
+    """
+
+    __errors = []
+    __warnings = []
+
+    def __init__(self):
+        self.__errors = []
+        self.__warnings = []
+
+    def __len__(self):
+        return self.len()
+
+    def add_error(self, error):
+        self.__errors = [e for e in self.__errors if e.message != error.message]
+        self.__errors.append(error)
+
+    def add_warning(self, warning):
+        self.__warnings = [w for w in self.__warnings if w.message != warning.message]
+        self.__warnings.append(warning)
+
+    def add(self, record):
+        if record.levelno in (ERROR, WARNING):
+            ui_error = UIError(record.msg, record.levelno)
+            if record.levelno == ERROR:
+                self.add_error(ui_error)
+            if record.levelno == WARNING:
+                self.add_warning(ui_error)
+
+            if record.levelno == ERROR:
+                notify_logged_error(ui_error)
+
+    def get_errors(self):
+        return self.__errors
+
+    def get_warnings(self):
+        return self.__warnings
+
+    def have_errors(self):
+        return len(self.__errors)
+
+    def have_warnings(self):
+        return len(self.__warnings)
+
+    def clear_errors(self):
+        self.__errors = []
+
+    def clear_warnings(self):
+        self.__warnings = []
+
+    def clear(self, level: str) -> str:
+        level = logging.getLevelName(level.upper())
+        if level == logging.ERROR:
+            message = "Error logs cleared"
+            self.clear_errors()
+        elif level == logging.WARNING:
+            message = "Warning logs cleared"
+            self.clear_warnings()
+        else:
+            message = "Warning and Error logs cleared"
+            self.clear_warnings()
+            self.clear_errors()
+
+        return message
+
+    def num_errors(self):
+        return len(self.__errors)
+
+    def num_warnings(self):
+        return len(self.__warnings)
+
+    def has_errors(self):
+        return len(self.__errors) > 0
+
+    def has_warnings(self):
+        return len(self.__warnings) > 0
+
+    def len(self):
+        return self.num_errors() + self.num_warnings()
+
+    def get(self):
+        return self.__errors
+
+
+WebErrorViewer = __WebErrorViewer()
+
+
+class UIError(object):
+    """
+    Represents an error to be displayed in the web UI.
+    """
+
+    def __init__(self, message, level):
+        self.title = sys.exc_info()[-2] or message
+        self.message = message
+        self.time = datetime.datetime.now().strftime(dateTimeFormat)
+        self.level = level

--- a/sickchill/oldbeard/clients/download_station.py
+++ b/sickchill/oldbeard/clients/download_station.py
@@ -11,7 +11,7 @@ from sickchill import logger, settings
 from sickchill.oldbeard.clients.generic import GenericClient
 
 if TYPE_CHECKING:
-    from sickchill.oldbeard.classes import SearchResult
+    from sickchill.providers.result_classes import SearchResult
 
 
 class Client(GenericClient):

--- a/sickchill/oldbeard/clients/qbittorrent.py
+++ b/sickchill/oldbeard/clients/qbittorrent.py
@@ -7,7 +7,7 @@ from sickchill import logger, settings
 from sickchill.oldbeard.clients.generic import GenericClient
 
 if TYPE_CHECKING:  # pragma: no cover
-    from sickchill.oldbeard.classes import TorrentSearchResult
+    from sickchill.providers.result_classes import TorrentSearchResult
 
 
 class Client(GenericClient):

--- a/sickchill/oldbeard/clients/transmission.py
+++ b/sickchill/oldbeard/clients/transmission.py
@@ -6,7 +6,7 @@ from sickchill import settings
 from sickchill.oldbeard.clients.generic import GenericClient
 
 if TYPE_CHECKING:  # pragma: no cover
-    from sickchill.oldbeard.classes import TorrentSearchResult
+    from sickchill.providers.result_classes import TorrentSearchResult
 
 
 class Client(GenericClient):

--- a/sickchill/oldbeard/notifiers/discord.py
+++ b/sickchill/oldbeard/notifiers/discord.py
@@ -1,6 +1,10 @@
+from typing import TYPE_CHECKING
+
 from sickchill import logger, settings
 from sickchill.oldbeard import common
-from sickchill.oldbeard.classes import UIError
+
+if TYPE_CHECKING:
+    from sickchill.logging.weblog import UIError
 
 
 class Notifier(object):
@@ -28,7 +32,7 @@ class Notifier(object):
             title = common.notifyStrings[common.NOTIFY_LOGIN]
             self._notify_discord(title + " - " + update_text.format(ipaddress))
 
-    def notify_logged_error(self, ui_error: UIError):
+    def notify_logged_error(self, ui_error: "UIError"):
         if settings.USE_DISCORD:
             update_text = ui_error.message
             title = ui_error.title

--- a/sickchill/oldbeard/notifiers/pushbullet.py
+++ b/sickchill/oldbeard/notifiers/pushbullet.py
@@ -1,10 +1,13 @@
+from typing import TYPE_CHECKING
 from urllib.parse import urljoin
 
 from requests.structures import CaseInsensitiveDict
 
 from sickchill import logger, settings
 from sickchill.oldbeard import common, helpers
-from sickchill.oldbeard.classes import UIError
+
+if TYPE_CHECKING:
+    from sickchill.logging.weblog import UIError
 
 
 class Notifier(object):
@@ -54,7 +57,7 @@ class Notifier(object):
             pushbullet_api=None, event=common.notifyStrings[common.NOTIFY_LOGIN], message=common.notifyStrings[common.NOTIFY_LOGIN_TEXT].format(ipaddress)
         )
 
-    def notify_logged_error(self, ui_error: UIError):
+    def notify_logged_error(self, ui_error: "UIError"):
         self._sendPushbullet(pushbullet_api=None, event=ui_error.title, message=ui_error.message)
 
     def _sendPushbullet(self, pushbullet_api=None, pushbullet_device=None, pushbullet_channel=None, event=None, message=None, link=None, force=False):

--- a/sickchill/oldbeard/notifiers/pushover.py
+++ b/sickchill/oldbeard/notifiers/pushover.py
@@ -1,11 +1,11 @@
 # Author: Marvin Pinto <me@marvinp.ca>
 # Author: Dennis Lutter <lad1337@gmail.com>
 import time
+from typing import TYPE_CHECKING
 
 import requests
 
 from sickchill import logger, settings
-from sickchill.oldbeard.classes import UIError
 from sickchill.oldbeard.common import (
     NOTIFY_DOWNLOAD,
     NOTIFY_LOGIN,
@@ -17,6 +17,10 @@ from sickchill.oldbeard.common import (
     notifyStrings,
 )
 from sickchill.oldbeard.helpers import make_session
+
+if TYPE_CHECKING:
+    from sickchill.logging.weblog import UIError
+
 
 API_URL = "https://api.pushover.net/1/messages.json"
 
@@ -128,7 +132,7 @@ class Notifier(object):
             title = notifyStrings[NOTIFY_LOGIN]
             self._notify_pushover(title, update_text.format(ipaddress))
 
-    def notify_logged_error(self, ui_error: UIError):
+    def notify_logged_error(self, ui_error: "UIError"):
         if settings.USE_PUSHOVER:
             self._notify_pushover(title=ui_error.title, message=ui_error.message)
 

--- a/sickchill/oldbeard/notifiers/synologynotifier.py
+++ b/sickchill/oldbeard/notifiers/synologynotifier.py
@@ -1,9 +1,12 @@
 import os
 import subprocess
+from typing import TYPE_CHECKING
 
 from sickchill import logger, settings
 from sickchill.oldbeard import common
-from sickchill.oldbeard.classes import UIError
+
+if TYPE_CHECKING:
+    from sickchill.logging.weblog import UIError
 
 
 class Notifier(object):
@@ -31,7 +34,7 @@ class Notifier(object):
             title = common.notifyStrings[common.NOTIFY_LOGIN]
             self._send_synologyNotifier(update_text.format(ipaddress), title)
 
-    def notify_logged_error(self, ui_error: UIError):
+    def notify_logged_error(self, ui_error: "UIError"):
         if settings.USE_SYNOLOGYNOTIFIER and ui_error:
             update_text = ui_error.message
             title = ui_error.title

--- a/sickchill/oldbeard/nzbSplitter.py
+++ b/sickchill/oldbeard/nzbSplitter.py
@@ -2,8 +2,9 @@ import re
 from xml.etree import ElementTree
 
 from sickchill import logger
-from sickchill.oldbeard import classes, helpers
+from sickchill.oldbeard import helpers
 from sickchill.oldbeard.name_parser.parser import InvalidNameException, InvalidShowException, NameParser
+from sickchill.providers import result_classes
 
 
 def get_season_nzbs(name, url_data, season):
@@ -175,7 +176,7 @@ def split_result(obj):
         ep_obj_list = [obj.show.get_episode(season, ep) for ep in parsed_obj.episode_numbers]
 
         # make a result
-        cur_obj = classes.NZBDataSearchResult(ep_obj_list)
+        cur_obj = result_classes.NZBDataSearchResult(ep_obj_list)
         cur_obj.name = new_nzb
         cur_obj.provider = obj.provider
         cur_obj.quality = obj.quality

--- a/sickchill/oldbeard/nzbget.py
+++ b/sickchill/oldbeard/nzbget.py
@@ -10,7 +10,7 @@ from sickchill.oldbeard.common import Quality
 from sickchill.oldbeard.helpers import make_context
 
 if TYPE_CHECKING:
-    from sickchill.oldbeard.classes import SearchResult
+    from sickchill.providers.result_classes import SearchResult
 
 
 def get_proxy(https: bool, host: str, username: str, password: str, verify: bool) -> xmlrpc.client.ServerProxy:

--- a/sickchill/oldbeard/providers/btn.py
+++ b/sickchill/oldbeard/providers/btn.py
@@ -9,9 +9,10 @@ import jsonrpclib
 from sickchill import logger, settings
 from sickchill.helper.common import episode_num
 from sickchill.helper.exceptions import AuthException
-from sickchill.oldbeard import classes, scene_exceptions, tvcache
+from sickchill.oldbeard import scene_exceptions, tvcache
 from sickchill.oldbeard.common import cpu_presets
 from sickchill.oldbeard.helpers import sanitizeSceneName
+from sickchill.providers import result_classes
 from sickchill.providers.torrent.TorrentProvider import TorrentProvider
 
 if TYPE_CHECKING:
@@ -233,7 +234,7 @@ class Provider(TorrentProvider):
                     if result_date and (not search_date or result_date > search_date):
                         title, url = self._get_title_and_url(item)
                         if title and url:
-                            results.append(classes.Proper(title, url, result_date, self.show))
+                            results.append(result_classes.Proper(title, url, result_date, self.show))
 
         return results
 

--- a/sickchill/oldbeard/providers/hdbits.py
+++ b/sickchill/oldbeard/providers/hdbits.py
@@ -5,7 +5,8 @@ from urllib.parse import urlencode, urljoin
 
 from sickchill import logger
 from sickchill.helper.exceptions import AuthException
-from sickchill.oldbeard import classes, tvcache
+from sickchill.oldbeard import tvcache
+from sickchill.providers import result_classes
 from sickchill.providers.torrent.TorrentProvider import TorrentProvider
 
 if TYPE_CHECKING:
@@ -91,7 +92,7 @@ class Provider(TorrentProvider):
 
                     if result_date and (not search_date or result_date > search_date):
                         title, url = self._get_title_and_url(item)
-                        results.append(classes.Proper(title, url, result_date, self.show))
+                        results.append(result_classes.Proper(title, url, result_date, self.show))
 
         return results
 

--- a/sickchill/oldbeard/sab.py
+++ b/sickchill/oldbeard/sab.py
@@ -8,7 +8,7 @@ from sickchill.oldbeard import helpers
 session = helpers.make_session()
 
 if TYPE_CHECKING:
-    from sickchill.oldbeard.classes import SearchResult
+    from sickchill.providers.result_classes import SearchResult
 
 
 def send_nzb(result: "SearchResult"):

--- a/sickchill/oldbeard/search.py
+++ b/sickchill/oldbeard/search.py
@@ -13,7 +13,7 @@ from sickchill.providers.GenericProvider import GenericProvider
 from sickchill.show.History import History
 
 if TYPE_CHECKING:  # pragma: no cover
-    from sickchill.oldbeard.classes import SearchResult
+    from sickchill.providers.result_classes import SearchResult
 
 from sickchill.oldbeard import clients, common, db, helpers, notifiers, nzbget, nzbSplitter, sab, show_name_helpers, ui
 from sickchill.oldbeard.common import MULTI_EP_RESULT, Quality, SEASON_RESULT, SNATCHED, SNATCHED_BEST, SNATCHED_PROPER

--- a/sickchill/providers/GenericProvider.py
+++ b/sickchill/providers/GenericProvider.py
@@ -15,13 +15,13 @@ import sickchill.oldbeard
 from sickchill import logger
 from sickchill.helper.common import sanitize_filename, valid_url
 from sickchill.oldbeard import filters
-from sickchill.oldbeard.classes import Proper, SearchResult
 from sickchill.oldbeard.common import MULTI_EP_RESULT, Quality, SEASON_RESULT
 from sickchill.oldbeard.db import DBConnection
 from sickchill.oldbeard.helpers import download_file, getURL, make_session, remove_file_failed
 from sickchill.oldbeard.name_parser.parser import InvalidNameException, InvalidShowException, NameParser
 from sickchill.oldbeard.show_name_helpers import allPossibleShowNames
 from sickchill.oldbeard.tvcache import TVCache
+from sickchill.providers.result_classes import Proper, SearchResult
 
 if TYPE_CHECKING:
     from sickchill.tv import TVEpisode

--- a/sickchill/providers/nzb/NZBProvider.py
+++ b/sickchill/providers/nzb/NZBProvider.py
@@ -1,7 +1,7 @@
 from sickchill import logger, settings
 from sickchill.helper.common import try_int
-from sickchill.oldbeard.classes import NZBSearchResult, TorrentSearchResult
 from sickchill.providers.GenericProvider import GenericProvider
+from sickchill.providers.result_classes import NZBSearchResult, TorrentSearchResult
 
 
 class NZBProvider(GenericProvider):

--- a/sickchill/providers/result_classes.py
+++ b/sickchill/providers/result_classes.py
@@ -1,10 +1,7 @@
-import datetime
 import re
-import sys
 from typing import List, TYPE_CHECKING, Union
 
 import sickchill
-from sickchill.helper.common import dateTimeFormat
 from sickchill.oldbeard.common import Quality
 
 if TYPE_CHECKING:
@@ -188,64 +185,3 @@ class Proper(object):
         return "{date} {name} {season}x{episode} of {series_id} from {indexer}".format(
             date=self.date, name=self.name, season=self.season, episode=self.episode, series_id=self.indexerid, indexer=sickchill.indexer.name(self.indexer)
         )
-
-
-class ErrorViewer(object):
-    """
-    Keeps a static list of UIErrors to be displayed on the UI and allows
-    the list to be cleared.
-    """
-
-    errors = []
-
-    def __init__(self):
-        ErrorViewer.errors = []
-
-    @staticmethod
-    def add(error):
-        ErrorViewer.errors = [e for e in ErrorViewer.errors if e.message != error.message]
-        ErrorViewer.errors.append(error)
-
-    @staticmethod
-    def clear():
-        ErrorViewer.errors = []
-
-    @staticmethod
-    def get():
-        return ErrorViewer.errors
-
-
-class WarningViewer(object):
-    """
-    Keeps a static list of (warning) UIErrors to be displayed on the UI and allows
-    the list to be cleared.
-    """
-
-    errors = []
-
-    def __init__(self):
-        WarningViewer.errors = []
-
-    @staticmethod
-    def add(error):
-        WarningViewer.errors = [e for e in WarningViewer.errors if e.message != error.message]
-        WarningViewer.errors.append(error)
-
-    @staticmethod
-    def clear():
-        WarningViewer.errors = []
-
-    @staticmethod
-    def get():
-        return WarningViewer.errors
-
-
-class UIError(object):
-    """
-    Represents an error to be displayed in the web UI.
-    """
-
-    def __init__(self, message):
-        self.title = sys.exc_info()[-2] or message
-        self.message = message
-        self.time = datetime.datetime.now().strftime(dateTimeFormat)

--- a/sickchill/providers/torrent/TorrentProvider.py
+++ b/sickchill/providers/torrent/TorrentProvider.py
@@ -4,10 +4,10 @@ import bencode
 
 from sickchill import logger, settings
 from sickchill.helper.common import try_int
-from sickchill.oldbeard.classes import Proper, TorrentSearchResult
 from sickchill.oldbeard.common import Quality
 from sickchill.oldbeard.db import DBConnection
 from sickchill.providers.GenericProvider import GenericProvider
+from sickchill.providers.result_classes import Proper, TorrentSearchResult
 from sickchill.show.Show import Show
 
 

--- a/sickchill/show/History.py
+++ b/sickchill/show/History.py
@@ -7,7 +7,7 @@ import subliminal
 
 from sickchill import logger, settings
 from sickchill.helper.metaclasses import Singleton
-from sickchill.oldbeard.classes import SearchResult
+from sickchill.providers.result_classes import SearchResult
 
 if TYPE_CHECKING:
     from sickchill.tv import TVEpisode, TVShow

--- a/sickchill/views/api/webapi.py
+++ b/sickchill/views/api/webapi.py
@@ -17,7 +17,8 @@ from sickchill.helper.common import dateFormat, dateTimeFormat, pretty_file_size
 from sickchill.helper.exceptions import ShowDirectoryNotFoundException
 from sickchill.helper.quality import get_quality_string
 from sickchill.init_helpers import get_current_version
-from sickchill.oldbeard import classes, db, helpers, network_timezones, scdatetime, search_queue, ui
+from sickchill.logging.weblog import WebErrorViewer
+from sickchill.oldbeard import db, helpers, network_timezones, scdatetime, search_queue, ui
 from sickchill.oldbeard.common import (
     ARCHIVED,
     DOWNLOADED,
@@ -1296,18 +1297,8 @@ class CMDLogsClear(ApiCall):
 
     def run(self):
         """Clear the logs"""
-        if self.level == "error":
-            msg = "Error logs cleared"
-
-            classes.ErrorViewer.clear()
-        elif self.level == "warning":
-            msg = "Warning logs cleared"
-
-            classes.WarningViewer.clear()
-        else:
-            return _responds(RESULT_FAILURE, msg="Unknown log level: {0}".format(self.level))
-
-        return _responds(RESULT_SUCCESS, msg=msg)
+        message = WebErrorViewer.clear(self.level)
+        return _responds(RESULT_SUCCESS, msg=message)
 
 
 # noinspection PyAbstractClass

--- a/sickchill/views/common.py
+++ b/sickchill/views/common.py
@@ -8,7 +8,8 @@ from mako.template import Template
 from tornado.escape import linkify
 
 from sickchill import logger, settings
-from sickchill.oldbeard import classes, helpers
+from sickchill.logging.weblog import WebErrorViewer
+from sickchill.oldbeard import helpers
 
 mako_lookup = {}
 
@@ -43,8 +44,8 @@ class PageTemplate(Template):
         self.context["reverse_url"] = rh.reverse_url
         self.context["linkify"] = linkify
 
-        self.context["error_count"] = len(classes.ErrorViewer.errors)
-        self.context["warning_count"] = len(classes.WarningViewer.errors)
+        self.context["error_count"] = WebErrorViewer.num_errors()
+        self.context["warning_count"] = WebErrorViewer.num_warnings()
         self.context["process_id"] = str(settings.PID)
 
         self.context["title"] = "FixME"

--- a/sickchill/views/home.py
+++ b/sickchill/views/home.py
@@ -28,6 +28,7 @@ from sickchill.oldbeard.scene_numbering import (
     set_scene_numbering,
 )
 from sickchill.oldbeard.trakt_api import TraktAPI
+from sickchill.providers import result_classes
 from sickchill.providers.GenericProvider import GenericProvider
 from sickchill.providers.metadata.generic import GenericMetadata
 from sickchill.providers.metadata.helpers import getShowImage
@@ -1823,11 +1824,11 @@ class Home(WebRoot):
         if result:
             provider = sickchill.oldbeard.providers.getProviderClass(result.get("provider"))
             if provider.provider_type == GenericProvider.TORRENT:
-                result = sickchill.oldbeard.classes.TorrentSearchResult.make_result(result)
+                result = result_classes.TorrentSearchResult.make_result(result)
             elif provider.provider_type == GenericProvider.NZB:
-                result = sickchill.oldbeard.classes.NZBSearchResult.make_result(result)
+                result = result_classes.NZBSearchResult.make_result(result)
             elif provider.provider_type == GenericProvider.NZBDATA:
-                result = sickchill.oldbeard.classes.NZBDataSearchResult.make_result(result)
+                result = result_classes.NZBDataSearchResult.make_result(result)
             else:
                 result = json.dumps({"result": "failure", "message": _("Result provider not found, cannot determine type")})
         else:
@@ -1835,7 +1836,7 @@ class Home(WebRoot):
 
         if isinstance(result, str):
             sickchill.logger.info(_("Could not snatch manually selected result: {result}").format(result=result))
-        elif isinstance(result, sickchill.oldbeard.classes.SearchResult):
+        elif isinstance(result, result_classes.SearchResult):
             sickchill.oldbeard.search.snatch_episode(result, SNATCHED_BEST)
 
         return self.redirect("/home/displayShow?show=" + show)

--- a/sickchill/views/logs.py
+++ b/sickchill/views/logs.py
@@ -3,7 +3,7 @@ from tornado.web import addslash
 import sickchill.oldbeard
 from sickchill import logger
 from sickchill.helper import try_int
-from sickchill.oldbeard import classes
+from sickchill.logging.weblog import WebErrorViewer
 from sickchill.views.common import PageTemplate
 from sickchill.views.index import WebRoot
 from sickchill.views.routes import Route
@@ -46,19 +46,15 @@ class ErrorLogs(WebRoot):
 
     @staticmethod
     def haveErrors():
-        return len(classes.ErrorViewer.errors) > 0
+        return WebErrorViewer.have_errors()
 
     @staticmethod
     def haveWarnings():
-        return len(classes.WarningViewer.errors) > 0
+        return WebErrorViewer.have_warnings()
 
     def clearerrors(self):
         level = try_int(self.get_query_argument("level", str(logger.ERROR)), logger.ERROR)
-        if int(level) == logger.WARNING:
-            classes.WarningViewer.clear()
-        else:
-            classes.ErrorViewer.clear()
-
+        WebErrorViewer.clear(level)
         return self.redirect("/errorlogs/viewlog/")
 
     def viewlog(self):

--- a/tests/test_snatch.py
+++ b/tests/test_snatch.py
@@ -103,7 +103,6 @@ class SearchTest(conftest.SickChillTestDBCase):
             provider.enabled = True
 
         for show_name, data in TESTS_DATA.items():
-
             if not data["active"]:
                 continue
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -9726,16 +9726,7 @@ string-template@~0.2.1:
   resolved "https://registry.yarnpkg.com/string-template/-/string-template-0.2.1.tgz#42932e598a352d01fc22ec3367d9d84eec6c9add"
   integrity sha512-Yptehjogou2xm4UJbxJ4CxgZx12HBfeystp0y3x7s4Dj32ltVVG1Gg8YhKjHZkHicuKpZX/ffilA8505VbUbpw==
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -9836,7 +9827,7 @@ stringify-object@^3.3.0:
     is-obj "^1.0.1"
     is-regexp "^1.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -9849,13 +9840,6 @@ strip-ansi@^3.0.0:
   integrity sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==
   dependencies:
     ansi-regex "^2.0.0"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1, strip-ansi@^7.1.0:
   version "7.1.0"
@@ -11163,7 +11147,7 @@ workbox-window@7.1.0:
     "@types/trusted-types" "^2.0.2"
     workbox-core "7.1.0"
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -11176,15 +11160,6 @@ wrap-ansi@^6.0.1:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
(fix) error where logs did not have passwords and other items censored
(fix) error on first startup of UNDEFINED comparison if page loads before the error viewer has loaded
(refactor) move ErrorViewer and WarningViewer into a sinlge class called WebErrorViewer and add utility functions, which cleaned up code and moved it to sickchill.logging.weblog (refactor) move sickchill.oldbeard.classes to sickchill.providers.result_classes
