### PR TITLE
Fix GHSL-2024-288

### DIFF
--- a/sickchill/views/authentication.py
+++ b/sickchill/views/authentication.py
@@ -28,8 +28,7 @@ class LoginHandler(BaseHandler):
             logger.warning(_("User attempted a failed login to the SickChill web interface from IP: ") + self.request.remote_ip)
             login_error = _("Incorrect username or password! Both username and password are case sensitive!")
 
-        next_ = self.get_query_argument("next", next_)
-        self.redirect(next_ or "/" + settings.DEFAULT_PAGE + "/")
+        self.redirect("/" + settings.DEFAULT_PAGE + "/")
 
 
 class LogoutHandler(BaseHandler):


### PR DESCRIPTION
Proposed changes in this pull request:
- change the login page to redirect to `settings.DEFAULT_PAGE` instead of to the `next` parameter, which can be user-controlled. Please see GHSL-2024-288 (issue 5 in the report) for more information.

- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read [contribution guide](https://github.com/SickChill/SickChill/blob/master/.github/CONTRIBUTING.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Simplified login redirect logic to always direct users to the default page after login attempts.

- **Bug Fixes**
	- Maintained error message handling for login attempts without changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->