### PR TITLE
Skip inaccessible paths for default data dir resolution.

### DIFF
--- a/sickchill/helper/common.py
+++ b/sickchill/helper/common.py
@@ -440,6 +440,9 @@ def choose_data_dir(program_dir) -> Path:
     proper_data_dir = Path(appdirs.user_config_dir(appname="sickchill"))
     for location in [old_data_dir, old_profile_path, proper_data_dir]:
         for check in ["sickbeard.db", "sickchill.db", "config.ini"]:
-            if location.joinpath(check).exists():
-                return location.resolve()
+            try:
+                if location.joinpath(check).exists():
+                    return location.resolve()
+            except PermissionError:
+                continue
     return proper_data_dir.resolve()

--- a/sickchill/helper/common.py
+++ b/sickchill/helper/common.py
@@ -1,6 +1,7 @@
 import platform
 import re
 import uuid
+import os
 from fnmatch import fnmatch
 from os import PathLike
 from pathlib import Path
@@ -440,9 +441,6 @@ def choose_data_dir(program_dir) -> Path:
     proper_data_dir = Path(appdirs.user_config_dir(appname="sickchill"))
     for location in [old_data_dir, old_profile_path, proper_data_dir]:
         for check in ["sickbeard.db", "sickchill.db", "config.ini"]:
-            try:
-                if location.joinpath(check).exists():
-                    return location.resolve()
-            except PermissionError:
-                continue
+            if os.access(location.joinpath(check), os.R_OK):
+                return location.resolve()
     return proper_data_dir.resolve()


### PR DESCRIPTION
Fixes `PermissionError: [Errno 13] Permission denied: '/root/.config/sickchill/sickbeard.db'` when running as non-root user, despite passing `--data-dir` to a different path.

Proposed changes in this pull request:
- When resolving the default data-dir, skip any candidate paths which are inaccessible

- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read [contribution guide](https://github.com/SickChill/SickChill/blob/master/.github/CONTRIBUTING.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced error handling for directory access issues, improving the app's stability when encountering permission errors.
	- Improved the ability to verify file accessibility in directories, ensuring smoother operation when files exist but are not readable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->