### PR TITLE
Mako 1.3.7 avoidance

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -262,7 +262,7 @@ configobj = "^5.0.6"
 greenlet = {version = ">=2.0.0", allow-prereleases = true}
 ipaddress = "^1.0.23"
 jsonrpclib-pelix = "^0.4.2"
-Mako = "^1.1.4"
+Mako = "^1.1.4,!=1.3.7"
 markdown2 = "^2.4.0"
 pyOpenSSL = ">=20.0.1,<25.0.0"
 python-dateutil = "^2.8.1"


### PR DESCRIPTION
Initial lazy fix to issue created by Mako 1.3.7 by avoiding it at this initial stage.

```
Error !
NameError: 'trim' is not defined

111 try:
112   trim = context['trim']
113 except KeyError:
114   raise NameError("'trim' is not defined")
115 try:
116   action = context['action']
117 except KeyError:
118   raise NameError("'action' is not defined")
119 try:

SickChill/sickchill/gui/slick/views/layouts/main.mako, line 0:
0

SickChill/.venv/lib/python3.11/site-packages/mako/runtime.py, line 936:
936 callable_(context, *args, **kwargs)

```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated project version to `2024.3.1`.
	- Refined dependency management for `Mako` to exclude version `1.3.7`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->