### PR TITLE
Add MusicBrainz integration for music management

### DIFF
--- a/SickChill.py
+++ b/SickChill.py
@@ -27,6 +27,7 @@ from sickchill import logger, settings
 from sickchill.helper.common import choose_data_dir
 from sickchill.init_helpers import check_installed, get_current_version, remove_pid_file, setup_gettext
 from sickchill.movies import MovieList
+from sickchill.music import MusicList
 from sickchill.oldbeard.name_parser.parser import NameParser, ParseResult
 
 setup_gettext()
@@ -216,6 +217,8 @@ class SickChill:
 
         if settings.DEVELOPER:
             settings.movie_list = MovieList()
+        if settings.USE_MUSICBRAINZ:
+            settings.music_list = MusicList()
 
         web_options = {"debug": args.debug}
         if self.forced_port:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -297,6 +297,7 @@ requests = "^2.25.1"
 babelfish = ">=0.6.0"
 kodipydent-alt = ">=2022.9.3"
 beekeeper-alt = ">=2022.9.3"
+musicbrainzngs = ">=0.7.1"
 
 stevedore = "^5.1.0"
 cachecontrol = ">=0.13.1,<0.15.0"

--- a/sickchill/gui/slick/js/music.js
+++ b/sickchill/gui/slick/js/music.js
@@ -1,0 +1,11 @@
+// Music page specific JavaScript
+$(document).ready(function() {
+    // Apply background image if FANART_BACKGROUND is enabled
+    if (metaToBool('settings.FANART_BACKGROUND')) {
+        const backgroundPath = getMeta('showBackgroundImage');
+        if (backgroundPath) {
+            $.backstretch(backgroundPath);
+            $('.backstretch').css('opacity', getMeta('settings.FANART_BACKGROUND_OPACITY')).fadeIn('500');
+        }
+    }
+});

--- a/sickchill/gui/slick/js/musicRootDirs.js
+++ b/sickchill/gui/slick/js/musicRootDirs.js
@@ -1,0 +1,227 @@
+// Avoid `console` errors in browsers that lack a console.
+(function () {
+    let method;
+    const noop = function () {};
+
+    const methods = [
+        'assert',
+        'clear',
+        'count',
+        'debug',
+        'dir',
+        'dirxml',
+        'error',
+        'exception',
+        'group',
+        'groupCollapsed',
+        'groupEnd',
+        'info',
+        'log',
+        'markTimeline',
+        'profile',
+        'profileEnd',
+        'table',
+        'time',
+        'timeEnd',
+        'timeStamp',
+        'trace',
+        'warn',
+    ];
+    let length = methods.length;
+    const console = window.console || {};
+
+    while (length > 0) {
+        length--;
+        method = methods[length];
+
+        // Only stub undefined methods.
+        console[method] ||= noop;
+    }
+})();
+
+$(document).ready(() => {
+    function setDefault(which, force) {
+        if (which === undefined || which.length === 0) {
+            return;
+        }
+
+        if ($('#whichDefaultMusicRootDir').val() === which && force !== true) {
+            return;
+        }
+
+        console.log('setting default to ' + which);
+
+        // Put an asterisk on the text
+        if ($('#' + which).text().charAt(0) !== '*') {
+            $('#' + which).text('*' + $('#' + which).text());
+        }
+
+        // If there's an existing one then take the asterisk off
+        if ($('#whichDefaultMusicRootDir').val() && force !== true) {
+            const oldDefault = $('#' + $('#whichDefaultMusicRootDir').val());
+            oldDefault.text(oldDefault.text().slice(1));
+        }
+
+        $('#whichDefaultMusicRootDir').val(which);
+    }
+
+    function syncOptionIDs() {
+        // Re-sync option ids
+        let index = 0;
+        $('#musicRootDirs option').each(function () {
+            index++;
+            $(this).attr('id', 'rd-' + index);
+        });
+    }
+
+    function refreshRootDirectories() {
+        if ($('#musicRootDirs').length === 0) {
+            return;
+        }
+
+        let doDisable = 'true';
+
+        // Re-sync option ids
+        syncOptionIDs();
+
+        // If nothing's selected then select the default
+        if ($('#musicRootDirs option:selected').length === 0 && $('#whichDefaultMusicRootDir').val().length > 0) {
+            $('#' + $('#whichDefaultMusicRootDir').val()).prop('selected', true);
+        }
+
+        // If something's selected then we have some behavior to figure out
+        if ($('#musicRootDirs option:selected').length > 0) {
+            doDisable = '';
+        }
+
+        // Update the elements
+        $('#deleteMusicRootDir').prop('disabled', doDisable);
+        $('#defaultMusicRootDir').prop('disabled', doDisable);
+        $('#editMusicRootDir').prop('disabled', doDisable);
+
+        let logString = '';
+        let directoryString = '';
+        if ($('#whichDefaultMusicRootDir').val().length >= 4) {
+            directoryString = $('#whichDefaultMusicRootDir').val().slice(3);
+        }
+
+        $('#musicRootDirs option').each(function () {
+            logString += $(this).val() + '=' + $(this).text() + '->' + $(this).attr('id') + '\n';
+            if (directoryString.length > 0) {
+                directoryString += '|' + $(this).val();
+            }
+        });
+        logString += 'def: ' + $('#whichDefaultMusicRootDir').val();
+        console.log(logString);
+
+        $('#musicRootDirText').val(directoryString);
+        $('#musicRootDirText').change();
+        console.log('musicRootDirText: ' + $('#musicRootDirText').val());
+    }
+
+    function postRootDirectories() {
+        refreshRootDirectories();
+        $.post(scRoot + '/config/general/saveMusicRootDirs', {musicRootDirString: $('#musicRootDirText').val()});
+    }
+
+    function addRootDirectory(path) {
+        if (path.length === 0) {
+            return;
+        }
+
+        // Check if it's the first one
+        let isDefault = false;
+        if ($('#whichDefaultMusicRootDir').val().length === 0) {
+            isDefault = true;
+        }
+
+        $('#musicRootDirs').append('<option value="' + path + '">' + path + '</option>');
+
+        syncOptionIDs();
+
+        if (isDefault) {
+            setDefault($('#musicRootDirs option').attr('id'));
+        }
+
+        postRootDirectories();
+    }
+
+    function editRootDirectory(path) {
+        if (path.length === 0) {
+            return;
+        }
+
+        // As long as something is selected
+        if ($('#musicRootDirs option:selected').length > 0) {
+            // Update the selected one with the provided path
+            if ($('#musicRootDirs option:selected').attr('id') === $('#whichDefaultMusicRootDir').val()) {
+                $('#musicRootDirs option:selected').text('*' + path);
+            } else {
+                $('#musicRootDirs option:selected').text(path);
+            }
+
+            $('#musicRootDirs option:selected').val(path);
+        }
+
+        postRootDirectories();
+    }
+
+    $('#addMusicRootDir').on('click', function () {
+        $(this).nFileBrowser(addRootDirectory);
+    });
+    $('#editMusicRootDir').on('click', function () {
+        $(this).nFileBrowser(editRootDirectory, {
+            initialDir: $('#musicRootDirs option:selected').val(),
+        });
+    });
+
+    $('#deleteMusicRootDir').on('click', () => {
+        if ($('#musicRootDirs option:selected').length > 0) {
+            const toDelete = $('#musicRootDirs option:selected');
+            const newDefault = (toDelete.attr('id') === $('#whichDefaultMusicRootDir').val());
+            const deletedNumber = $('#musicRootDirs option:selected').attr('id').slice(3);
+
+            toDelete.remove();
+            syncOptionIDs();
+
+            if (newDefault) {
+                console.log('new default when deleting');
+
+                // We deleted the default so this isn't valid anymore
+                $('#whichDefaultMusicRootDir').val('');
+
+                // If we're deleting the default and there are options left then pick a new default
+                if ($('#musicRootDirs option').length > 0) {
+                    setDefault($('#musicRootDirs option').attr('id'));
+                }
+            } else if ($('#whichDefaultMusicRootDir').val().length > 0) {
+                const oldDefaultNumber = $('#whichDefaultMusicRootDir').val().slice(3);
+                if (oldDefaultNumber > deletedNumber) {
+                    $('#whichDefaultMusicRootDir').val('rd-' + (oldDefaultNumber - 1));
+                }
+            }
+        }
+
+        refreshRootDirectories();
+        $.post(scRoot + '/config/general/saveMusicRootDirs', {
+            musicRootDirString: $('#musicRootDirText').val(),
+        });
+    });
+
+    $('#defaultMusicRootDir').on('click', () => {
+        if ($('#musicRootDirs option:selected').length > 0) {
+            setDefault($('#musicRootDirs option:selected').attr('id'));
+        }
+
+        refreshRootDirectories();
+        $.post(scRoot + '/config/general/saveMusicRootDirs', {
+            musicRootDirString: $('#musicRootDirText').val(),
+        });
+    });
+    $('#musicRootDirs').click(refreshRootDirectories);
+
+    // Set up buttons on page load
+    syncOptionIDs();
+    setDefault($('#whichDefaultMusicRootDir').val(), true);
+    refreshRootDirectories();
+});

--- a/sickchill/gui/slick/views/config_general.mako
+++ b/sickchill/gui/slick/views/config_general.mako
@@ -240,6 +240,44 @@
                             </div>
                         </div>
 
+                        <div class="field-pair row">
+                            <div class="col-lg-3 col-md-4 col-sm-5 col-xs-12">
+                                <label class="component-title">${_('Music root directories')}</label>
+                            </div>
+                            <div class="col-lg-9 col-md-8 col-sm-7 col-xs-12 component-desc">
+                                <div class="row">
+                                    <div class="col-md-12">
+                                        <span>${_('where the files of music artists are located')}</span>
+                                    </div>
+                                </div>
+                                <div class="row">
+                                    <div class="col-lg-6 col-md-8 col-sm-12 col-xs-12">
+                                        <%include file="/inc_musicRootDirs.mako" />
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <input type="hidden" name="music_root_dirs" id="musicRootDirText" value="${settings.MUSIC_ROOT_DIRS}" />
+
+                        <div class="field-pair row">
+                            <div class="col-lg-3 col-md-4 col-sm-5 col-xs-12">
+                                <label class="component-title">${_('Music download directory')}</label>
+                            </div>
+                            <div class="col-lg-9 col-md-8 col-sm-7 col-xs-12 component-desc">
+                                <div class="row">
+                                    <div class="col-md-12">
+                                        <input type="text" name="music_download_dir" id="music_download_dir" value="${settings.MUSIC_DOWNLOAD_DIR}"
+                                               class="form-control input-sm input350" autocapitalize="off" />
+                                    </div>
+                                </div>
+                                <div class="row">
+                                    <div class="col-md-12">
+                                        <span>${_('where music downloads are stored temporarily')}</span>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+
                         <div class="row">
                             <div class="col-md-12">
                                 <input type="submit" class="btn config_submitter" value="${_('Save Changes')}" />
@@ -1129,6 +1167,20 @@
                                     <div class="col-md-12">
                                         <input type="checkbox" name="ignore_broken_symlinks" id="ignore_broken_symlinks" ${checked(settings.IGNORE_BROKEN_SYMLINKS)}/>
                                         <label for="ignore_broken_symlinks">${_('If checked, broken symbolic links warnings generated when calculating show size will be logged as debug')}</label>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+
+                        <div class="field-pair row">
+                            <div class="col-lg-3 col-md-4 col-sm-5 col-xs-12">
+                                <label class="component-title">${_('Enable MusicBrainz')}</label>
+                            </div>
+                            <div class="col-lg-9 col-md-8 col-sm-7 col-xs-12 component-desc">
+                                <div class="row">
+                                    <div class="col-md-12">
+                                        <input type="checkbox" name="use_musicbrainz" id="use_musicbrainz" ${checked(settings.USE_MUSICBRAINZ)}/>
+                                        <label for="use_musicbrainz">${_('enable MusicBrainz and music management')}</label>
                                     </div>
                                 </div>
                             </div>

--- a/sickchill/gui/slick/views/inc_musicRootDirs.mako
+++ b/sickchill/gui/slick/views/inc_musicRootDirs.mako
@@ -1,0 +1,37 @@
+<%
+    from sickchill import settings
+
+    if settings.MUSIC_ROOT_DIRS:
+        backend_pieces = settings.MUSIC_ROOT_DIRS.split('|')
+        backend_default = 'rd-' + backend_pieces[0]
+        backend_dirs = backend_pieces[1:]
+    else:
+        backend_default = ''
+        backend_dirs = []
+%>
+
+<div class="row">
+    <div class="col-md-12">
+        <span id="sampleMusicRootDir"></span>
+
+        <input type="hidden" id="whichDefaultMusicRootDir" value="${backend_default}" />
+        <div class="rootdir-selectbox">
+            <select name="musicRootDir" id="musicRootDirs" size="6" title="Music root directory">
+                % for cur_dir in backend_dirs:
+                    <option value="${cur_dir}">${cur_dir}</option>
+                % endfor
+            </select>
+        </div>
+    </div>
+</div>
+<div class="row">
+    <div class="col-md-12">
+        <div id="musicRootDirsControls" class="rootdir-controls">
+            <input class="btn" type="button" id="addMusicRootDir" value="${_('New')}" />
+            <input class="btn" type="button" id="editMusicRootDir" value="${_('Edit')}" />
+            <input class="btn" type="button" id="deleteMusicRootDir" value="${_('Delete')}" />
+            <input class="btn" type="button" id="defaultMusicRootDir" value="${_('Set as default')} *" />
+        </div>
+        <input type="text" style="display: none" id="musicRootDirText" autocapitalize="off" />
+    </div>
+</div>

--- a/sickchill/gui/slick/views/layouts/main.mako
+++ b/sickchill/gui/slick/views/layouts/main.mako
@@ -180,6 +180,18 @@
                                 <i class="clearfix"></i>
                             </li>
                             % endif
+                            % if settings.USE_MUSICBRAINZ:
+                            <li id="NAVmusic" class="navbar-split dropdown${('', ' active')[topmenu == 'music']}">
+                                <a href="${reverse_url('music', '')}" class="dropdown-toggle" aria-haspopup="true" data-toggle="dropdown" data-hover="dropdown"><span>${_('Music')}</span>
+                                    <b class="caret"></b>
+                                </a>
+                                <ul class="dropdown-menu">
+                                    <li><a href="${reverse_url('music', '')}"><i class="fa fa-fw fa-home"></i>&nbsp;${_('Artist List')}</a></li>
+                                    <li><a href="${reverse_url('music-search', 'search')}"><i class="fa fa-fw fa-music"></i>&nbsp;${_('Add Artists')}</a></li>
+                                </ul>
+                                <i class="clearfix"></i>
+                            </li>
+                            % endif
                             <li id="NAVschedule"${('', ' class="active"')[topmenu == 'schedule']}>
                                 <a href="${static_url('schedule/', include_version=False)}">${_('Schedule')}</a>
                             </li>
@@ -403,6 +415,7 @@
                 <script type="text/javascript" src="${static_url('js/lib/formwizard.js')}"></script><!-- Can't be added to bower -->
                 <script type="text/javascript" src="${static_url('js/parsers.js')}"></script>
                 <script type="text/javascript" src="${static_url('js/rootDirs.js')}"></script>
+                <script type="text/javascript" src="${static_url('js/musicRootDirs.js')}"></script>
                 % if settings.DEVELOPER:
                     <script type="text/javascript" src="${static_url('js/core.js')}"></script>
                 % else:

--- a/sickchill/gui/slick/views/music/album_details.mako
+++ b/sickchill/gui/slick/views/music/album_details.mako
@@ -1,0 +1,138 @@
+<%inherit file="../layouts/main.mako"/>
+<%!
+    import datetime
+    import os
+    import re
+    from sickchill import settings
+    from sickchill.helper.common import pretty_file_size
+    from sickchill.oldbeard import helpers
+    from sickchill.oldbeard.databases.music import AlbumStatus
+%>
+<%block name="metas">
+    <meta data-var="showBackgroundImage" data-content="${static_url(album.image_url('poster'))}">
+</%block>
+<%block name="content">
+    <div class="row">
+        <div class="col-md-12">
+            <div class="pull-right">
+                <a href="${reverse_url('music-details', 'details', album.artist.slug)}" class="btn btn-default">
+                    <i class="fa fa-arrow-left"></i> ${_('Back to Artist')}
+                </a>
+            </div>
+            <h1 class="header">${album.name}</h1>
+            <h4>${album.artist.name}</h4>
+        </div>
+    </div>
+
+    <div class="row">
+        <div class="col-md-12">
+            <div class="panel panel-default">
+                <div class="panel-heading">
+                    <h3 class="panel-title">${_('Album Information')}</h3>
+                </div>
+                <div class="panel-body">
+                    <div class="row">
+                        <div class="col-md-3">
+                            <div class="album-cover">
+                                <img src="${static_url(album.image_url('poster'))}" class="img-responsive" alt="${album.name}">
+                            </div>
+                        </div>
+                        <div class="col-md-9">
+                            <table class="table">
+                                <tr>
+                                    <th>${_('Title')}</th>
+                                    <td>${album.name}</td>
+                                </tr>
+                                <tr>
+                                    <th>${_('Artist')}</th>
+                                    <td>
+                                        <a href="${reverse_url('music-details', 'details', album.artist.slug)}">
+                                            ${album.artist.name}
+                                        </a>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>${_('Year')}</th>
+                                    <td>${album.year or _('Unknown')}</td>
+                                </tr>
+                                <tr>
+                                    <th>${_('Type')}</th>
+                                    <td>${album.type}</td>
+                                </tr>
+                                <tr>
+                                    <th>${_('Tracks')}</th>
+                                    <td>${album.tracks}</td>
+                                </tr>
+                                <tr>
+                                    <th>${_('MusicBrainz ID')}</th>
+                                    <td>${album.musicbrainz_id}</td>
+                                </tr>
+                                <tr>
+                                    <th>${_('Status')}</th>
+                                    <td>
+                                        % if album.status == AlbumStatus.WANTED:
+                                            <span class="label label-info">${_('Wanted')}</span>
+                                        % elif album.status == AlbumStatus.SNATCHED:
+                                            <span class="label label-primary">${_('Snatched')}</span>
+                                        % elif album.status == AlbumStatus.DOWNLOADED:
+                                            <span class="label label-success">${_('Downloaded')}</span>
+                                        % elif album.status == AlbumStatus.SKIPPED:
+                                            <span class="label label-default">${_('Skipped')}</span>
+                                        % elif album.status == AlbumStatus.IGNORED:
+                                            <span class="label label-warning">${_('Ignored')}</span>
+                                        % else:
+                                            <span class="label label-default">${_('Unknown')}</span>
+                                        % endif
+                                    </td>
+                                </tr>
+                            </table>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="row">
+        <div class="col-md-12">
+            <div class="panel panel-default">
+                <div class="panel-heading">
+                    <h3 class="panel-title">${_('Track List')}</h3>
+                </div>
+                <div class="panel-body">
+                    <div class="table-responsive">
+                        <table class="table">
+                            <thead>
+                                <tr>
+                                    <th>${_('#')}</th>
+                                    <th>${_('Title')}</th>
+                                    <th>${_('Duration')}</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                % if album.musicbrainz_data and 'tracks' in album.musicbrainz_data:
+                                    % for track in album.musicbrainz_data['tracks']:
+                                        <tr>
+                                            <td>${track.get('position', '')}</td>
+                                            <td>${track.get('title', '')}</td>
+                                            <td>${track.get('duration', '')}</td>
+                                        </tr>
+                                    % endfor
+                                % else:
+                                    <tr>
+                                        <td colspan="3">${_('No track information available')}</td>
+                                    </tr>
+                                % endif
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+</%block>
+
+<%block name="scripts">
+    <script type="text/javascript" src="${static_url('js/music.js')}"></script>
+</%block>

--- a/sickchill/gui/slick/views/music/details.mako
+++ b/sickchill/gui/slick/views/music/details.mako
@@ -1,0 +1,289 @@
+<%inherit file="../layouts/main.mako"/>
+<%!
+    import datetime
+    import os
+    import re
+    from sickchill import settings
+    from sickchill.helper.common import pretty_file_size
+    from sickchill.oldbeard import helpers
+    from sickchill.oldbeard.databases.music import AlbumStatus
+%>
+<%block name="metas">
+    <meta data-var="showBackgroundImage" data-content="${static_url(artist.image_url('poster'))}">
+</%block>
+
+<%block name="content">
+    <div class="row">
+        <div class="col-md-12">
+            <div class="pull-right">
+                <a href="${reverse_url('music-index', 'index')}" class="btn btn-default">
+                    <i class="fa fa-arrow-left"></i> ${_('Back to Artist List')}
+                </a>
+                <a href="${reverse_url('music-remove', 'remove', artist.pk)}" class="btn btn-danger">
+                    <i class="fa fa-trash"></i> ${_('Remove Artist')}
+                </a>
+            </div>
+            <h1 class="header">${artist.name}</h1>
+        </div>
+    </div>
+
+    <div class="row">
+        <div class="col-md-12">
+            <div class="panel panel-default">
+                <div class="panel-heading">
+                    <h3 class="panel-title">${_('Artist Information')}</h3>
+                </div>
+                <div class="panel-body">
+                    <div class="row">
+                        <div class="col-md-3">
+                            <div class="artist-poster">
+                                <img src="${static_url(artist.image_url('poster'))}" class="img-responsive" alt="${artist.name}">
+                            </div>
+                        </div>
+                        <div class="col-md-9">
+                            <table class="table">
+                                <tr>
+                                    <th>${_('Name')}</th>
+                                    <td>${artist.name}</td>
+                                </tr>
+                                <tr>
+                                    <th>${_('Sort Name')}</th>
+                                    <td>${artist.sort_name}</td>
+                                </tr>
+                                <tr>
+                                    <th>${_('Country')}</th>
+                                    <td>${artist.country or _('Unknown')}</td>
+                                </tr>
+                                <tr>
+                                    <th>${_('MusicBrainz ID')}</th>
+                                    <td>${artist.musicbrainz_id}</td>
+                                </tr>
+                                <tr>
+                                    <th>${_('Genres')}</th>
+                                    <td>
+                                        % if artist.musicbrainz_genres:
+                                            ${', '.join([genre.pk for genre in artist.musicbrainz_genres])}
+                                        % else:
+                                            ${_('No genres')}
+                                        % endif
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>${_('Location')}</th>
+                                    <td>
+                                        <form action="${reverse_url('music-set_artist_location', 'set_artist_location', artist.pk)}" method="post" class="form-inline">
+                                            <div class="input-group">
+                                                <input type="text" name="location" value="${artist.location or ''}" class="form-control" placeholder="${_('Artist location')}">
+                                                <span class="input-group-btn">
+                                                    <button class="btn btn-primary" type="submit">${_('Set Location')}</button>
+                                                </span>
+                                            </div>
+                                        </form>
+                                    </td>
+                                </tr>
+                            </table>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="row">
+        <div class="col-md-12">
+            <div class="panel panel-default">
+                <div class="panel-heading">
+                    <h3 class="panel-title">${_('Albums')}</h3>
+                </div>
+                <div class="panel-body">
+                    <!-- Album status filter -->
+                    <div class="row">
+                        <div class="col-lg-8 col-md-8 col-sm-12 col-xs-12 pull-right">
+                            <div class="pull-right" id="checkboxControls">
+                                <div style="padding-bottom: 5px;">
+                                    <label class="pull-right" for="wanted"><span class="wanted"><input type="checkbox" id="wanted" checked="checked" /> ${_('Wanted')}</span></label>
+                                    <label class="pull-right" for="snatched"><span class="snatched"><input type="checkbox" id="snatched" checked="checked" /> ${_('Snatched')}</span></label>
+                                    <label class="pull-right" for="downloaded"><span class="good"><input type="checkbox" id="downloaded" checked="checked" /> ${_('Downloaded')}</span></label>
+                                    <label class="pull-right" for="skipped"><span class="skipped"><input type="checkbox" id="skipped" checked="checked" /> ${_('Skipped')}</span></label>
+                                    <label class="pull-right" for="ignored"><span class="ignored"><input type="checkbox" id="ignored" checked="checked" /> ${_('Ignored')}</span></label>
+                                </div>
+                                <div class="clearfix"></div>
+                            </div>
+                        </div>
+                    </div>
+
+                    <!-- Album selector -->
+                    <div class="row">
+                        <div class="col-lg-12 col-md-12 col-sm-12 col-xs-12" style="padding-bottom: 5px; padding-top: 5px;">
+                            ${_('Change selected albums to')}:<br>
+                            <select id="statusSelect" class="form-control form-control-inline input-sm" title="Change Status">
+                                <option value="${AlbumStatus.WANTED}">${_('Wanted')}</option>
+                                <option value="${AlbumStatus.SKIPPED}">${_('Skipped')}</option>
+                                <option value="${AlbumStatus.IGNORED}">${_('Ignored')}</option>
+                            </select>
+                            <input type="hidden" id="artistID" value="${artist.pk}" />
+                            <input class="btn btn-inline" type="button" id="changeStatus" value="Go" />
+                        </div>
+                    </div>
+
+                    <div class="table-responsive">
+                        <table class="table">
+                            <thead>
+                                <tr>
+                                    <th class="col-checkbox">
+                                        <input type="checkbox" class="albumCheck" id="selectAll" />
+                                    </th>
+                                    <th>${_('Album')}</th>
+                                    <th>${_('Year')}</th>
+                                    <th>${_('Type')}</th>
+                                    <th>${_('Tracks')}</th>
+                                    <th>${_('Status')}</th>
+                                    <th>${_('Actions')}</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                % if artist.albums:
+                                    % for album in artist.albums:
+                                        <%
+                                            status_class = ""
+                                            if album.status == AlbumStatus.WANTED:
+                                                status_class = "wanted"
+                                            elif album.status == AlbumStatus.SNATCHED:
+                                                status_class = "snatched"
+                                            elif album.status == AlbumStatus.DOWNLOADED:
+                                                status_class = "good"
+                                            elif album.status == AlbumStatus.SKIPPED:
+                                                status_class = "skipped"
+                                            elif album.status == AlbumStatus.IGNORED:
+                                                status_class = "ignored"
+                                        %>
+                                        <tr class="${status_class}">
+                                            <td class="col-checkbox">
+                                                <input type="checkbox" class="albumCheck" id="album-${album.pk}" name="album-${album.pk}" />
+                                            </td>
+                                            <td>
+                                                <a href="${reverse_url('music-album_details', 'album_details', album.slug)}">
+                                                    ${album.name}
+                                                </a>
+                                            </td>
+                                            <td>${album.year or _('Unknown')}</td>
+                                            <td>${album.type}</td>
+                                            <td>${album.tracks}</td>
+                                            <td>
+                                                % if album.status == AlbumStatus.WANTED:
+                                                    <span class="label label-info">${_('Wanted')}</span>
+                                                % elif album.status == AlbumStatus.SNATCHED:
+                                                    <span class="label label-primary">${_('Snatched')}</span>
+                                                % elif album.status == AlbumStatus.DOWNLOADED:
+                                                    <span class="label label-success">${_('Downloaded')}</span>
+                                                % elif album.status == AlbumStatus.SKIPPED:
+                                                    <span class="label label-default">${_('Skipped')}</span>
+                                                % elif album.status == AlbumStatus.IGNORED:
+                                                    <span class="label label-warning">${_('Ignored')}</span>
+                                                % else:
+                                                    <span class="label label-default">${_('Unknown')}</span>
+                                                % endif
+                                            </td>
+                                            <td>
+                                                <div class="btn-group">
+                                                    <a href="${reverse_url('music-album_details', 'album_details', album.slug)}" class="btn btn-sm btn-primary">
+                                                        <i class="fa fa-info-circle"></i> ${_('Details')}
+                                                    </a>
+                                                    <button type="button" class="btn btn-sm btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                                                        <span class="caret"></span>
+                                                    </button>
+                                                    <ul class="dropdown-menu dropdown-menu-right">
+                                                        <li><a href="${reverse_url('music-set_album_status', 'set_album_status', album.pk)}?status=${AlbumStatus.WANTED}"><i class="fa fa-search"></i> ${_('Set Wanted')}</a></li>
+                                                        <li><a href="${reverse_url('music-set_album_status', 'set_album_status', album.pk)}?status=${AlbumStatus.SKIPPED}"><i class="fa fa-step-forward"></i> ${_('Set Skipped')}</a></li>
+                                                        <li><a href="${reverse_url('music-set_album_status', 'set_album_status', album.pk)}?status=${AlbumStatus.IGNORED}"><i class="fa fa-ban"></i> ${_('Set Ignored')}</a></li>
+                                                        <li role="separator" class="divider"></li>
+                                                        <li><a href="${reverse_url('music-search_album', 'search_album', album.pk)}"><i class="fa fa-search"></i> ${_('Search Now')}</a></li>
+                                                    </ul>
+                                                </div>
+                                            </td>
+                                        </tr>
+                                    % endfor
+                                % else:
+                                    <tr>
+                                        <td colspan="7">${_('No albums found')}</td>
+                                    </tr>
+                                % endif
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- JavaScript for album status management -->
+    <script type="text/javascript">
+        // Use vanilla JavaScript instead of jQuery to avoid dependency issues
+        document.addEventListener('DOMContentLoaded', function() {
+            // Filter albums by status
+            var statusFilters = document.querySelectorAll('#wanted, #snatched, #downloaded, #skipped, #ignored');
+            statusFilters.forEach(function(filter) {
+                filter.addEventListener('click', function() {
+                    var statusClass = this.id;
+                    var rows = document.querySelectorAll('.' + statusClass);
+                    rows.forEach(function(row) {
+                        row.style.display = filter.checked ? '' : 'none';
+                    });
+                });
+            });
+
+            // Select all albums
+            var selectAll = document.getElementById('selectAll');
+            selectAll.addEventListener('click', function() {
+                var albumChecks = document.querySelectorAll('.albumCheck');
+                albumChecks.forEach(function(check) {
+                    check.checked = selectAll.checked;
+                });
+            });
+
+            // Change status for selected albums
+            var changeStatus = document.getElementById('changeStatus');
+            changeStatus.addEventListener('click', function() {
+                var selectedAlbums = [];
+                var albumChecks = document.querySelectorAll('.albumCheck:checked');
+                albumChecks.forEach(function(check) {
+                    if (check.id !== 'selectAll') {
+                        selectedAlbums.push(check.id.replace('album-', ''));
+                    }
+                });
+
+                if (selectedAlbums.length === 0) {
+                    alert('${_("No albums selected")}');
+                    return;
+                }
+
+                var status = document.getElementById('statusSelect').value;
+                var artistID = document.getElementById('artistID').value;
+
+                // Send AJAX request to update album status
+                var xhr = new XMLHttpRequest();
+                xhr.open('POST', '${reverse_url('music-set_albums_status', 'set_albums_status')}', true);
+                xhr.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded');
+                xhr.onload = function() {
+                    if (xhr.status === 200) {
+                        // Reload the page to show updated statuses
+                        window.location.reload();
+                    } else {
+                        alert('${_("Error updating album status")}: ' + xhr.statusText);
+                        console.log("Error details:", xhr.responseText);
+                    }
+                };
+                xhr.onerror = function() {
+                    alert('${_("Error updating album status")}: Network error');
+                };
+                xhr.send('albums=' + encodeURIComponent(selectedAlbums.join(',')) +
+                         '&status=' + encodeURIComponent(status) +
+                         '&artist=' + encodeURIComponent(artistID));
+            });
+        });
+    </script>
+</%block>
+
+<%block name="scripts">
+    <script type="text/javascript" src="${static_url('js/music.js')}"></script>
+</%block>

--- a/sickchill/gui/slick/views/music/index.mako
+++ b/sickchill/gui/slick/views/music/index.mako
@@ -1,0 +1,108 @@
+<%inherit file="../layouts/main.mako"/>
+<%!
+    import datetime
+    import os
+    import re
+    from sickchill import settings
+    from sickchill.helper.common import pretty_file_size
+    from sickchill.oldbeard import helpers
+    
+    def selected(condition):
+        return 'selected="selected"' if condition else ''
+%>
+<%block name="content">
+    <div class="row">
+        <div class="col-md-12">
+            % if not settings.USE_MUSICBRAINZ:
+                <div class="alert alert-info">
+                    <p>${_('Music support is currently disabled. To enable it, go to Settings -> General and enable MusicBrainz.')}</p>
+                </div>
+            % else:
+                <div class="row">
+                    <div class="col-md-12">
+                        <div class="pull-right">
+                            <a href="${reverse_url('music-search', 'search')}" class="btn btn-primary">
+                                <i class="fa fa-search"></i> ${_('Search for Artist')}
+                            </a>
+                        </div>
+                        <h1 class="header">${header}</h1>
+                    </div>
+                </div>
+
+                <div class="row">
+                    <div class="col-md-12">
+                        <div class="text-center">
+                            % if settings.MUSIC_ROOT_DIRS:
+                                <span class="show-option">${_('Root')}:</span>
+                                <label>
+                                    <form method="post" action="" id="rootDirForm">
+                                        <select id="rootDirSelect" name="root" class="form-control form-control-inline input200" title="Root Select">
+                                        <option value="-1" ${selected(selected_root == '-1')}>${_('All')}</option>
+                                        % for root_dir in settings.MUSIC_ROOT_DIRS.split('|')[1:]:
+                                            <option value="${loop.index}" ${selected(selected_root == str(loop.index))}>${root_dir}</option>
+                                        % endfor
+                                        </select>
+                                    </form>
+                                </label>
+                            % endif
+                        </div>
+                    </div>
+                </div>
+                <div class="row">
+                    <div class="col-md-12">
+                        <div class="table-responsive">
+                            <table class="table">
+                                <thead>
+                                    <tr>
+                                        <th>${_('Artist')}</th>
+                                        <th>${_('Country')}</th>
+                                        <th>${_('Albums')}</th>
+                                        <th>${_('Actions')}</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    % if music and list(music):
+                                        % for artist in music:
+                                            <tr>
+                                                <td>
+                                                    <a href="${reverse_url('music-details', 'details', artist.slug)}">
+                                                        ${artist.name}
+                                                    </a>
+                                                </td>
+                                                <td>${artist.country or 'Unknown'}</td>
+                                                <td>${len(artist.albums)}</td>
+                                                <td>
+                                                    <a href="${reverse_url('music-details', 'details', artist.slug)}" class="btn btn-sm btn-primary">
+                                                        <i class="fa fa-info-circle"></i> ${_('Details')}
+                                                    </a>
+                                                    <a href="${reverse_url('music-remove', 'remove', artist.pk)}" class="btn btn-sm btn-danger">
+                                                        <i class="fa fa-trash"></i> ${_('Remove')}
+                                                    </a>
+                                                </td>
+                                            </tr>
+                                        % endfor
+                                    % else:
+                                        <tr>
+                                            <td colspan="4">${_('No artists found')}</td>
+                                        </tr>
+                                    % endif
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+                </div>
+            % endif
+        </div>
+    </div>
+
+    <script type="text/javascript">
+        document.addEventListener('DOMContentLoaded', function() {
+            var rootDirSelect = document.getElementById('rootDirSelect');
+            if (rootDirSelect) {
+                rootDirSelect.addEventListener('change', function() {
+                    document.getElementById('rootDirForm').submit();
+                });
+            }
+        });
+    </script>
+</%block>

--- a/sickchill/gui/slick/views/music/remove.mako
+++ b/sickchill/gui/slick/views/music/remove.mako
@@ -1,0 +1,36 @@
+<%inherit file="../layouts/main.mako"/>
+<%!
+    import datetime
+    import os
+    import re
+    from sickchill import settings
+    from sickchill.helper.common import pretty_file_size
+    from sickchill.oldbeard import helpers
+%>
+<%block name="content">
+    <div class="row">
+        <div class="col-md-12">
+            <div class="pull-right">
+                <a href="${reverse_url('music-index', 'index')}" class="btn btn-default">
+                    <i class="fa fa-arrow-left"></i> ${_('Back to Artist List')}
+                </a>
+            </div>
+            <h1 class="header">${header}</h1>
+        </div>
+    </div>
+    
+    <div class="row">
+        <div class="col-md-12">
+            <div class="alert alert-success">
+                <p>${_('Artist has been removed from your library.')}</p>
+            </div>
+            <p>${_('You will be redirected to the artist list in 5 seconds.')}</p>
+        </div>
+    </div>
+    
+    <script type="text/javascript">
+        setTimeout(function() {
+            window.location.href = "${reverse_url('music-index', 'index')}";
+        }, 5000);
+    </script>
+</%block>

--- a/sickchill/gui/slick/views/music/search.mako
+++ b/sickchill/gui/slick/views/music/search.mako
@@ -1,0 +1,83 @@
+<%inherit file="../layouts/main.mako"/>
+<%!
+    import datetime
+    import os
+    import re
+    from sickchill import settings
+    from sickchill.helper.common import pretty_file_size
+    from sickchill.oldbeard import helpers
+%>
+<%block name="content">
+    <div class="row">
+        <div class="col-md-12">
+            <h1 class="header">${header}</h1>
+        </div>
+    </div>
+    <div class="row">
+        <div class="col-md-12">
+            <form method="post" action="${reverse_url('music-search', 'search')}" class="form-horizontal">
+                <div class="form-group">
+                    <label for="query" class="col-sm-2 control-label">${_('Artist Name')}</label>
+                    <div class="col-sm-10">
+                        <input type="text" name="query" id="query" value="${query}" class="form-control" placeholder="${_('Artist name')}">
+                    </div>
+                </div>
+                <div class="form-group">
+                    <div class="col-sm-offset-2 col-sm-10">
+                        <button type="submit" class="btn btn-primary">
+                            <i class="fa fa-search"></i> ${_('Search')}
+                        </button>
+                    </div>
+                </div>
+            </form>
+        </div>
+    </div>
+    % if search_results:
+        <div class="row">
+            <div class="col-md-12">
+                <h2>${_('Search Results')}</h2>
+                <div class="table-responsive">
+                    <table class="table">
+                        <thead>
+                            <tr>
+                                <th>${_('Artist')}</th>
+                                <th>${_('Score')}</th>
+                                <th>${_('Actions')}</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            % for result in search_results:
+                                <tr>
+                                    <td>${result.get('name', '')}</td>
+                                    <td>${result.get('ext:score', '0')}</td>
+                                    <td>
+                                        <form method="post" action="${reverse_url('music-add', 'add')}">
+                                            <input type="hidden" name="musicbrainz" value="${result.get('id', '')}">
+                                            <div class="form-group">
+                                                <label for="location">${_('Location')}</label>
+                                                % if settings.MUSIC_ROOT_DIRS:
+                                                    <div class="row">
+                                                        <div class="col-md-12">
+                                                            <%include file="/inc_musicRootDirs.mako" />
+                                                        </div>
+                                                    </div>
+                                                % else:
+                                                    <div class="alert alert-warning">
+                                                        ${_('No music root directories defined. Please add one in Settings -> General.')}
+                                                    </div>
+                                                % endif
+                                            </div>
+                                            <button type="submit" class="btn btn-sm btn-success">
+                                                <i class="fa fa-plus"></i> ${_('Add')}
+                                            </button>
+                                        </form>
+                                    </td>
+                                </tr>
+                            % endfor
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+    % endif
+</%block>

--- a/sickchill/music.py
+++ b/sickchill/music.py
@@ -1,0 +1,921 @@
+import datetime
+import json
+import logging
+import os
+import threading
+import traceback
+
+import musicbrainzngs
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+
+from . import settings
+from .oldbeard import clients, generic_queue
+from .oldbeard.databases import music
+from .oldbeard.db import db_cons, db_full_path, db_locks
+from .providers.metadata.musicbrainz import MusicBrainzMetadata
+
+logger = logging.getLogger("sickchill.music")
+
+class MusicQueue(generic_queue.GenericQueue):
+    """
+    Queue for background music operations
+    """
+    def __init__(self):
+        super().__init__()
+        self.queue_name = "MUSICQUEUE"
+
+    def is_in_add_queue(self, artist_id):
+        """
+        Check if an artist is already in the add queue
+        """
+        for cur_item in self.queue + [self.currentItem]:
+            if isinstance(cur_item, MusicQueueItemAdd) and cur_item.artist_id == artist_id:
+                return True
+        return False
+
+class MusicQueueItemAdd(generic_queue.QueueItem):
+    """
+    Queue item for adding an artist
+    """
+    def __init__(self, artist_id, root_dir=None):
+        super().__init__("Add Artist", 1)  # 1 = ADD action
+        self.artist_id = artist_id
+        self.root_dir = root_dir
+        self.priority = generic_queue.QueuePriorities.HIGH
+        self.name = f"ADD-{artist_id}"
+        self.success = None
+        self.added_artist = None
+
+    def run(self):
+        """
+        Run the add artist task
+        """
+        try:
+            logger.info(f"Starting to add artist {self.artist_id}")
+            
+            # Check if we have a root directory set
+            root_dir = self.root_dir
+            if not root_dir and settings.MUSIC_ROOT_DIRS:
+                # Use the first root directory if available
+                root_dirs = settings.MUSIC_ROOT_DIRS.split('|')
+                if len(root_dirs) > 1 and root_dirs[1]:
+                    root_dir = root_dirs[1]
+            
+            # If we still don't have a root directory, use MUSIC_DOWNLOAD_DIR
+            if not root_dir and settings.MUSIC_DOWNLOAD_DIR:
+                root_dir = settings.MUSIC_DOWNLOAD_DIR
+                
+            if not root_dir:
+                logger.warning("No music root directory or download directory set. Artist will be added without a location.")
+                
+            self.added_artist = settings.music_list._add_artist_from_musicbrainz(self.artist_id, root_dir)
+            if self.added_artist:
+                self.success = True
+                logger.info(f"Successfully added artist {self.added_artist.name}")
+                # Check if the artist has albums
+                album_count = len(self.added_artist.albums)
+                logger.info(f"Artist {self.added_artist.name} has {album_count} albums in database")
+            else:
+                self.success = False
+                logger.error(f"Failed to add artist {self.artist_id}")
+        except Exception as e:
+            self.success = False
+            logger.error(f"Error adding artist {self.artist_id}: {e}")
+            logger.error(f"Exception traceback: {traceback.format_exc()}")
+
+
+class MusicList:
+    def __init__(self):
+        # Set up MusicBrainz API
+        musicbrainzngs.set_useragent(
+            settings.MUSICBRAINZ_USER_AGENT,
+            settings.BRANCH,
+            settings.MUSICBRAINZ_CONTACT,
+        )
+
+        # Suppress lower level logs from the musicbrainzngs library
+        logging.getLogger("musicbrainzngs").setLevel(logging.WARNING)
+
+        self.filename = "music.db"
+        self.full_path = db_full_path(self.filename)
+
+        if self.filename not in db_cons or not db_cons[self.filename]:
+            music.Session.configure(
+                bind=create_engine(
+                    f"sqlite:///{self.full_path}",
+                    connect_args={"check_same_thread": False},
+                    json_serializer=lambda obj: json.dumps(obj, ensure_ascii=False),
+                )
+            )
+            self.session: Session = music.Session()
+            music.Base.metadata.create_all(self.session.bind, checkfirst=True)
+
+            db_locks[self.filename] = threading.Lock()
+            db_cons[self.filename] = self.session
+        else:
+            self.session: Session = db_cons[self.filename]
+
+    def __iter__(self):
+        for item in self.artist_query.all():
+            yield item
+
+    def __getitem__(self, pk):
+        return self.artist_query.get(pk)
+
+    def __contains__(self, pk):
+        try:
+            self.__getitem__(pk)
+            return True
+        except KeyError:
+            return False
+
+    def search_musicbrainz(self, query=None, artist_id=None):
+        """
+        Search for artists on MusicBrainz.
+
+        Args:
+            query: Artist name to search for
+            artist_id: MusicBrainz artist ID
+
+        Returns:
+            List of artist results
+        """
+        if artist_id:
+            try:
+                result = musicbrainzngs.get_artist_by_id(artist_id)
+                return [result["artist"]]
+            except musicbrainzngs.WebServiceError as e:
+                logger.error(f"MusicBrainz API error while getting artist by ID: {e}")
+                return []
+        elif query:
+            try:
+                result = musicbrainzngs.search_artists(query, limit=10)
+                return result.get("artist-list", [])
+            except musicbrainzngs.WebServiceError as e:
+                logger.error(f"MusicBrainz API error while searching for artist: {e}")
+                return []
+        else:
+            raise Exception("Query or artist ID is required!")
+
+    def add_from_musicbrainz(self, artist_id: str, root_dir=None):
+        """
+        Add an artist from MusicBrainz by adding it to the queue.
+
+        Args:
+            artist_id: MusicBrainz artist ID
+            root_dir: Root directory for the artist (optional)
+
+        Returns:
+            True if the artist was added to the queue, False otherwise
+        """
+        if not artist_id:
+            logger.error("No artist ID provided")
+            return False
+
+        # Check if the artist already exists
+        existing_artist = self._check_existing_indexer_data(artist_id, "artist")
+        if existing_artist:
+            # If the artist exists but doesn't have a location and we have a root_dir,
+            # update the artist's location
+            if not existing_artist.location and root_dir:
+                existing_artist.location = os.path.join(root_dir, existing_artist.name)
+                logger.info(f"Setting location for existing artist {existing_artist.name} to {existing_artist.location}")
+                
+                # Create the directory if it doesn't exist
+                if not os.path.isdir(existing_artist.location):
+                    try:
+                        os.makedirs(existing_artist.location)
+                    except OSError as e:
+                        logger.error(f"Failed to create artist directory: {e}")
+                
+                # Update album locations
+                for album in existing_artist.albums:
+                    if not album.location:
+                        album.location = os.path.join(existing_artist.location, album.name)
+                        logger.info(f"Setting location for album {album.name} to {album.location}")
+                
+                # Commit changes
+                self.commit()
+            
+            return existing_artist
+
+        # Check if the artist is already in the queue
+        if settings.musicQueueScheduler.action.is_in_add_queue(artist_id):
+            logger.debug(f"Artist {artist_id} is already in the queue")
+            return True
+
+        # Add the artist to the queue
+        queue_item = MusicQueueItemAdd(artist_id, root_dir)
+        settings.musicQueueScheduler.action.add_item(queue_item)
+
+        logger.debug(f"Added artist {artist_id} to the queue")
+        return True
+
+    def _add_artist_from_musicbrainz(self, artist_id: str, root_dir=None):
+        """
+        Internal method to add an artist from MusicBrainz.
+        This is called by the queue item.
+
+        Args:
+            artist_id: MusicBrainz artist ID
+            root_dir: Root directory for the artist (optional)
+
+        Returns:
+            Artist object
+        """
+        logger.debug(f"Adding artist from MusicBrainz with id: {artist_id}")
+
+        try:
+            # Check if the indexer data already exists
+            existing_artist = self._check_existing_indexer_data(artist_id, "artist")
+            if existing_artist:
+                logger.info(f"Artist {existing_artist.name} already exists, retrieving albums")
+                
+                # Set artist location if it's not set and root_dir is provided
+                if not existing_artist.location and root_dir:
+                    existing_artist.location = os.path.join(root_dir, existing_artist.name)
+                    logger.info(f"Setting location for existing artist {existing_artist.name} to {existing_artist.location}")
+                    
+                    # Create the directory if it doesn't exist
+                    if not os.path.isdir(existing_artist.location):
+                        try:
+                            os.makedirs(existing_artist.location)
+                        except OSError as e:
+                            logger.error(f"Failed to create artist directory: {e}")
+                
+                # Get albums for this artist even if it already exists
+                albums = self.get_albums_for_artist(existing_artist)
+                
+                # Set album locations if they're not set
+                if existing_artist.location:
+                    for album in albums:
+                        if not album.location:
+                            album.location = os.path.join(existing_artist.location, album.name)
+                            logger.info(f"Setting location for album {album.name} to {album.location}")
+                            
+                            # Create the directory if it doesn't exist
+                            if not os.path.isdir(album.location):
+                                try:
+                                    os.makedirs(album.location)
+                                except OSError as e:
+                                    logger.error(f"Failed to create album directory: {e}")
+
+                # Try to fetch artist image if it doesn't exist
+                if not existing_artist.poster:
+                    metadata_provider = MusicBrainzMetadata()
+                    metadata_provider.save_artist_poster(existing_artist)
+
+                # Commit changes to the database
+                self.commit()
+                
+                return existing_artist
+
+            # Get artist info from MusicBrainz
+            mb_artist = musicbrainzngs.get_artist_by_id(artist_id, includes=["aliases", "tags"])["artist"]
+
+            # Create artist instance
+            name = mb_artist.get("name", "")
+            sort_name = mb_artist.get("sort-name", name)
+            country = mb_artist.get("country", "")
+
+            instance = music.Artist(name=name, sort_name=sort_name, country=country)
+            
+            # Set artist location if root_dir is provided
+            if root_dir:
+                instance.location = os.path.join(root_dir, name)
+                logger.info(f"Setting location for new artist {name} to {instance.location}")
+                
+                # Create the directory if it doesn't exist
+                if not os.path.isdir(instance.location):
+                    try:
+                        os.makedirs(instance.location)
+                    except OSError as e:
+                        logger.error(f"Failed to create artist directory: {e}")
+
+            # Create indexer data
+            mb_data = music.IndexerData(site="musicbrainz", data=mb_artist, pk=artist_id)
+
+            # Add the indexer_data to the session first
+            self.session.add(mb_data)
+            self.session.flush()
+
+            # Add genres from tags
+            if "tag-list" in mb_artist:
+                with self.session.no_autoflush:
+                    for tag in mb_artist["tag-list"]:
+                        if "name" in tag and int(tag.get("count", 0)) > 0:
+                            genre_name = tag["name"]
+                            logger.debug(f"Adding genre {genre_name}")
+                            genre = self.get_genre(genre_name)
+                            if not genre:
+                                genre = music.Genres(pk=genre_name)
+                                self.session.add(genre)
+                            else:
+                                # Merge the genre into the current session
+                                genre = self.session.merge(genre)
+                            mb_data.genres.append(genre)
+
+            instance.indexer_data.append(mb_data)
+
+            # Add the artist to the session
+            self.session.add(instance)
+
+            # Commit the artist first to ensure it has a valid pk
+            self.commit()
+
+            # Get albums for this artist
+            albums = self.get_albums_for_artist(instance)
+            logger.info(f"Added artist {instance.name} with {len(albums)} albums")
+
+            # Try to fetch artist image
+            metadata_provider = MusicBrainzMetadata()
+            metadata_provider.save_artist_poster(instance)
+
+            return instance
+
+        except musicbrainzngs.WebServiceError as e:
+            logger.error(f"MusicBrainz API error while adding artist: {e}")
+            self.session.rollback()
+            return None
+        except Exception as e:
+            logger.error(f"Error while adding artist: {e}")
+            self.session.rollback()
+            return None
+
+    def get_genre(self, name):
+        """
+        Get a genre by name.
+
+        Args:
+            name: Genre name
+
+        Returns:
+            Genre object or None if not found
+        """
+        with self.session.no_autoflush:
+            return self.session.query(music.Genres).filter_by(pk=name).first()
+
+    def get_albums_for_artist(self, artist_obj):
+        """
+        Get albums for an artist and add them to the database.
+
+        Args:
+            artist_obj: Artist object
+
+        Returns:
+            List of Album objects
+        """
+        artist_id = artist_obj.musicbrainz_id
+        if not artist_id:
+            logger.error(f"No MusicBrainz ID for artist {artist_obj.name}")
+            return []
+
+        albums = []
+        offset = 0
+        limit = 25
+        chunk_size = 10  # Process albums in chunks of 10
+        current_chunk = []
+
+        # Initialize metadata provider for album covers
+        metadata_provider = MusicBrainzMetadata()
+
+        try:
+            while True:
+                logger.debug(f"Retrieving albums for {artist_obj.name} (offset: {offset}, limit: {limit})")
+                result = musicbrainzngs.browse_release_groups(
+                    artist=artist_id,
+                    release_type=["album", "ep", "single"],
+                    limit=limit,
+                    offset=offset
+                )
+
+                release_groups = result.get("release-group-list", [])
+                if not release_groups:
+                    break
+
+                logger.debug(f"Retrieved {len(release_groups)} release groups")
+
+                for release_group in release_groups:
+                    album_id = release_group.get("id", "")
+                    album_title = release_group.get("title", "")
+                    album_type = release_group.get("type", "Album")
+
+                    # Get the first date if available
+                    first_release_date = release_group.get("first-release-date", "")
+                    year = None
+                    date = None
+
+                    if first_release_date:
+                        try:
+                            if len(first_release_date) >= 4:
+                                year = int(first_release_date[:4])
+                            if len(first_release_date) >= 10:
+                                date = datetime.datetime.strptime(first_release_date[:10], "%Y-%m-%d").date()
+                        except ValueError:
+                            pass
+
+                    # Check if album already exists
+                    existing_album = self._check_existing_indexer_data(album_id, "album")
+                    if existing_album:
+                        albums.append(existing_album)
+
+                        # Try to fetch album cover if it doesn't exist
+                        if not existing_album.poster:
+                            metadata_provider.save_album_cover(existing_album)
+
+                        # Check if track information is available
+                        mb_data = existing_album.musicbrainz_data
+                        if not mb_data or "tracks" not in mb_data:
+                            try:
+                                logger.debug(f"Fetching track information for existing album {existing_album.name}")
+                                self._update_album_tracks(existing_album, album_id)
+                            except Exception as e:
+                                logger.error(f"Error updating track information for album {existing_album.name}: {e}")
+
+                        continue
+
+                    # Get more detailed info about the release group
+                    try:
+                        logger.debug(f"Getting details for album {album_title} ({album_id})")
+                        release_group_info = musicbrainzngs.get_release_group_by_id(
+                            album_id,
+                            includes=["releases", "tags"]
+                        )["release-group"]
+
+                        # Get track information
+                        tracks, track_list = self._get_album_tracks(release_group_info)
+
+                        # Add track list to release group info
+                        release_group_info["tracks"] = track_list
+                    except Exception as e:
+                        logger.error(f"Error getting detailed album info: {e}")
+                        release_group_info = {}
+
+                    # Create album instance
+                    album = music.Album(
+                        name=album_title,
+                        year=year or 0,
+                        artist_pk=artist_obj.pk,
+                        tracks=tracks,
+                        album_type=album_type
+                    )
+
+                    if date:
+                        album.date = date
+
+                    # Create indexer data
+                    mb_data = music.IndexerData(site="musicbrainz", data=release_group_info, pk=album_id)
+
+                    # Add the indexer_data to the session first
+                    self.session.add(mb_data)
+                    self.session.flush()
+
+                    # Add genres from tags
+                    if "tag-list" in release_group_info:
+                        with self.session.no_autoflush:
+                            for tag in release_group_info["tag-list"]:
+                                if "name" in tag and int(tag.get("count", 0)) > 0:
+                                    genre_name = tag["name"]
+                                    logger.debug(f"Adding genre {genre_name}")
+                                    genre = self.get_genre(genre_name)
+                                    if not genre:
+                                        genre = music.Genres(pk=genre_name)
+                                        self.session.add(genre)
+                                    else:
+                                        # Merge the genre into the current session
+                                        genre = self.session.merge(genre)
+                                    mb_data.genres.append(genre)
+
+                    album.indexer_data.append(mb_data)
+                    
+                    # Set album location if artist has a location
+                    if artist_obj.location and not album.location:
+                        album.location = os.path.join(artist_obj.location, album.name)
+                        logger.info(f"Setting location for album {album.name} to {album.location}")
+                        
+                        # Create the directory if it doesn't exist
+                        if not os.path.isdir(album.location):
+                            try:
+                                os.makedirs(album.location)
+                            except OSError as e:
+                                logger.error(f"Failed to create album directory: {e}")
+                    
+                    albums.append(album)
+                    current_chunk.append(album)
+
+                    # Add album to session
+                    self.session.add(album)
+
+                    # Commit albums in chunks
+                    if len(current_chunk) >= chunk_size:
+                        logger.debug(f"Committing chunk of {len(current_chunk)} albums")
+                        self.commit()
+                        logger.info(f"Added chunk of {len(current_chunk)} albums for artist {artist_obj.name}")
+
+                        # Try to fetch album covers for the committed albums
+                        for album_obj in current_chunk:
+                            metadata_provider.save_album_cover(album_obj)
+
+                        current_chunk = []
+
+                offset += limit
+                if len(release_groups) < limit:
+                    break
+
+            # Commit any remaining albums
+            if current_chunk:
+                logger.debug(f"Committing final chunk of {len(current_chunk)} albums")
+                self.commit()
+                logger.info(f"Added final chunk of {len(current_chunk)} albums for artist {artist_obj.name}")
+
+                # Try to fetch album covers for the remaining albums
+                for album_obj in current_chunk:
+                    metadata_provider.save_album_cover(album_obj)
+
+            logger.info(f"Total: Added {len(albums)} albums for artist {artist_obj.name}")
+            return albums
+
+        except musicbrainzngs.WebServiceError as e:
+            logger.error(f"MusicBrainz API error while getting albums: {e}")
+            # Try to commit any albums we've processed so far
+            if current_chunk:
+                try:
+                    self.commit()
+                    logger.info(f"Saved {len(current_chunk)} albums before error")
+                except Exception:
+                    logger.error("Failed to save albums after API error")
+            return albums
+        except Exception as e:
+            logger.error(f"Error while getting albums: {e}")
+            logger.error(f"Exception traceback: {traceback.format_exc()}")
+            # Try to commit any albums we've processed so far
+            if current_chunk:
+                try:
+                    self.commit()
+                    logger.info(f"Saved {len(current_chunk)} albums before error")
+                except Exception:
+                    logger.error("Failed to save albums after error")
+            return albums
+
+    def _get_album_tracks(self, release_group_info):
+        """
+        Extract track information from a release group.
+
+        Args:
+            release_group_info: Release group information from MusicBrainz
+
+        Returns:
+            Tuple of (track_count, track_list)
+        """
+        tracks = 0
+        track_list = []
+
+        if "release-list" in release_group_info and release_group_info["release-list"]:
+            first_release = release_group_info["release-list"][0]
+            release_id = first_release.get("id")
+
+            if release_id:
+                try:
+                    release_info = musicbrainzngs.get_release_by_id(
+                        release_id,
+                        includes=["recordings", "media"]
+                    )["release"]
+
+                    if "medium-list" in release_info:
+                        for medium in release_info["medium-list"]:
+                            medium_tracks = int(medium.get("track-count", 0))
+                            tracks += medium_tracks
+
+                            # Extract track information
+                            if "track-list" in medium:
+                                for track in medium["track-list"]:
+                                    track_info = {
+                                        "position": track.get("position", ""),
+                                        "title": track.get("title", ""),
+                                        "duration": track.get("length", ""),
+                                    }
+
+                                    # Format duration from milliseconds to MM:SS
+                                    if track_info["duration"]:
+                                        try:
+                                            ms = int(track_info["duration"])
+                                            seconds = ms // 1000
+                                            minutes = seconds // 60
+                                            seconds = seconds % 60
+                                            track_info["duration"] = f"{minutes}:{seconds:02d}"
+                                        except (ValueError, TypeError):
+                                            pass
+
+                                    track_list.append(track_info)
+                except Exception as e:
+                    logger.error(f"Error getting release information: {e}")
+
+        return tracks, track_list
+
+    def _update_album_tracks(self, album_obj, album_id):
+        """
+        Update an album with track information.
+
+        Args:
+            album_obj: Album object to update
+            album_id: MusicBrainz ID of the album
+
+        Returns:
+            True if successful, False otherwise
+        """
+        try:
+            # Get more detailed info about the release group
+            release_group_info = musicbrainzngs.get_release_group_by_id(
+                album_id,
+                includes=["releases", "tags"]
+            )["release-group"]
+
+            # Get track information
+            _, track_list = self._get_album_tracks(release_group_info)
+
+            # Update the album's MusicBrainz data with track information
+            for indexer_data in album_obj.indexer_data:
+                if indexer_data.site == "musicbrainz":
+                    data = indexer_data.data
+                    data["tracks"] = track_list
+                    indexer_data.data = data
+                    self.session.add(indexer_data)
+                    self.session.flush()
+                    logger.debug(f"Updated track information for album {album_obj.name}")
+                    return True
+
+            return False
+        except Exception as e:
+            logger.error(f"Error updating track information: {e}")
+            return False
+
+    def _check_existing_indexer_data(self, pk, data_type="artist"):
+        """
+        Check if an IndexerData record exists and handle orphaned records.
+
+        Args:
+            pk: Primary key (ID) to check for
+            data_type: Type of data ("artist" or "album")
+
+        Returns:
+            The associated artist/album object if it exists, None otherwise
+        """
+        existing = self.session.query(music.IndexerData).filter_by(pk=pk).first()
+        if not existing:
+            return None
+
+        # Check if this is an orphaned record
+        if data_type == "artist" and existing.artist:
+            logger.debug(f"Artist already existed as {existing.artist.name}")
+            return existing.artist
+        elif data_type == "album" and existing.album:
+            logger.debug(f"Album already existed as {existing.album.name}")
+            return existing.album
+        else:
+            # This is an orphaned record, clean it up
+            logger.debug(f"Found orphaned IndexerData record for {data_type} {pk}, removing it")
+
+            try:
+                # First, delete any associated genres to avoid NOT NULL constraint violations
+                if existing.genres:
+                    for genre in existing.genres:
+                        self.session.delete(genre)
+                    self.session.flush()
+
+                # Now delete the indexer data record
+                self.session.delete(existing)
+                self.session.commit()
+            except Exception as e:
+                logger.error(f"Error cleaning up orphaned record: {e}")
+                self.session.rollback()
+
+            return None
+
+    def commit(self, instance=None):
+        logger.debug("Committing")
+        try:
+            if instance:
+                self.session.add(instance)
+            self.session.flush()
+            self.session.commit()
+        except Exception as e:
+            logger.error(f"Error committing to database: {e}")
+            self.session.rollback()
+            raise
+
+    def delete_artist(self, pk):
+        instance = self.artist_query.get(pk)
+        if instance:
+            # Delete all albums for this artist
+            for album in instance.albums:
+                self.delete_album(album.pk)
+
+            # Delete the artist
+            self.session.delete(instance)
+            self.commit()
+
+    def delete_album(self, pk):
+        instance = self.album_query.get(pk)
+        if instance:
+            self.session.delete(instance)
+            self.commit()
+
+    @property
+    def artist_query(self):
+        return self.session.query(music.Artist)
+
+    @property
+    def album_query(self):
+        return self.session.query(music.Album)
+
+    def artist_by_slug(self, slug):
+        return self.artist_query.filter_by(slug=slug).first()
+
+    def album_by_slug(self, slug):
+        return self.album_query.filter_by(slug=slug).first()
+
+    def search_providers(self, album_obj: music.Album):
+        """
+        Search providers for an album.
+
+        Args:
+            album_obj: Album object to search for
+
+        Returns:
+            List of search results
+        """
+        strings = album_obj.search_strings()
+        for provider in settings.providerList:
+            if provider.can_backlog and provider.backlog_enabled and provider.supports_movies:  # Reuse movie support for now
+                results = provider.search(strings)
+                for result in results:
+                    music_result = music.MusicResult(result=result, album=album_obj, provider=provider)
+                    self.session.add(music_result)
+
+                self.commit(album_obj)
+                # TODO: Check if we need to break out here and stop hitting providers if we found a good result
+
+    def snatch_album(self, result: music.MusicResult):
+        """
+        Snatch an album result.
+
+        Args:
+            result: MusicResult object to snatch
+
+        Returns:
+            bool: True if successful, False otherwise
+        """
+        if not result or not result.album:
+            logger.error("Invalid result or album")
+            return False
+
+        album = result.album
+        artist = self.artist_query.get(album.artist_pk)
+
+        if not artist:
+            logger.error(f"Could not find artist for album {album.name}")
+            return False
+
+        logger.info(f"Snatching {album.name} by {artist.name} from {result.provider.name}")
+
+        try:
+            # Extract necessary information from the result
+            download_url = result.url
+            download_name = result.name
+            download_size = result.size
+            download_provider = result.provider
+
+            # Check if MUSIC_DOWNLOAD_DIR is set
+            if not settings.MUSIC_DOWNLOAD_DIR:
+                logger.error("No music download directory set. Please set MUSIC_DOWNLOAD_DIR in Settings -> General.")
+                return False
+                
+            # Check if artist has a location set
+            if not artist.location:
+                # If artist doesn't have a location, use MUSIC_DOWNLOAD_DIR/artist.name
+                artist.location = os.path.join(settings.MUSIC_DOWNLOAD_DIR, artist.name)
+                logger.info(f"Setting artist location to {artist.location}")
+                
+                # Create the directory if it doesn't exist
+                if not os.path.isdir(artist.location):
+                    try:
+                        os.makedirs(artist.location)
+                    except OSError as e:
+                        logger.error(f"Failed to create artist directory: {e}")
+                        return False
+            
+            # Check if album has a location set
+            if not album.location:
+                # If album doesn't have a location, use artist.location/album.name
+                album.location = os.path.join(artist.location, album.name)
+                logger.info(f"Setting album location to {album.location}")
+            
+            # Use album location as download directory
+            download_dir = album.location
+            
+            # Ensure download directory exists
+            if not os.path.isdir(download_dir):
+                try:
+                    os.makedirs(download_dir)
+                except OSError as e:
+                    logger.error(f"Failed to create album directory: {e}")
+                    return False
+
+            # Get the appropriate download client
+            download_client = clients.getClientInstance(settings.TORRENT_METHOD)()
+
+            if not download_client:
+                logger.error(f"Could not get download client {settings.TORRENT_METHOD}")
+                return False
+
+            # Send the download to the client
+            download_result = download_client.sendTORRENT(
+                download_url,
+                download_name,
+                download_dir
+            )
+
+            if not download_result:
+                logger.error(f"Failed to send download to client: {download_name}")
+                return False
+
+            # Update album status
+            album.status = music.AlbumStatus.SNATCHED
+            album.provider = download_provider
+            album.size = download_size
+
+            # Add to download history
+            history = music.MusicHistory(
+                album=album,
+                provider=download_provider,
+                quality=None,  # Quality not available in MusicResult
+                date=datetime.datetime.now()
+            )
+
+            self.session.add(history)
+            self.commit()
+
+            logger.info(f"Successfully snatched {album.name} by {artist.name}")
+            return True
+
+        except Exception as e:
+            logger.error(f"Error snatching album {album.name}: {e}")
+            return False
+
+    def search_thread(self):
+        """
+        Thread for searching for new albums.
+
+        This method checks for new albums for all artists in the database
+        and adds them to the database. It also triggers searches for these
+        new albums on providers if auto_search is enabled.
+        """
+        logger.info("Starting music search thread")
+
+        try:
+            # Get all artists from the database
+            artists = self.artist_query.all()
+
+            if not artists:
+                logger.debug("No artists found in database")
+                return
+
+            logger.info(f"Checking for new albums for {len(artists)} artists")
+
+            for artist in artists:
+                logger.debug(f"Checking for new albums for {artist.name}")
+
+                # Get current albums for this artist
+                current_albums = {album.musicbrainz_id for album in artist.albums if album.musicbrainz_id}
+
+                # Get albums from MusicBrainz
+                new_albums = []
+                try:
+                    albums = self.get_albums_for_artist(artist)
+
+                    # Filter out albums that are already in the database
+                    new_albums = [album for album in albums if album.musicbrainz_id not in current_albums]
+
+                    if new_albums:
+                        logger.info(f"Found {len(new_albums)} new albums for {artist.name}")
+
+                        # Commit changes to database
+                        self.commit()
+
+                        # Search for new albums if auto_search is enabled
+                        if settings.MUSIC_AUTO_SEARCH:
+                            for album in new_albums:
+                                logger.debug(f"Searching for {album.name}")
+                                self.search_providers(album)
+                    else:
+                        logger.debug(f"No new albums found for {artist.name}")
+
+                except Exception as e:
+                    logger.error(f"Error checking for new albums for {artist.name}: {e}")
+                    continue
+
+            logger.info("Finished music search thread")
+
+        except Exception as e:
+            logger.error(f"Error in music search thread: {e}")

--- a/sickchill/oldbeard/config.py
+++ b/sickchill/oldbeard/config.py
@@ -288,6 +288,45 @@ def change_tv_download_dir(tv_download_dir):
     return True
 
 
+def change_music_download_dir(music_download_dir):
+    """
+    Change MUSIC_DOWNLOAD directory (used by music downloader)
+
+    :param music_download_dir: New music download directory
+    :return: True on success, False on failure
+    """
+    if music_download_dir == "":
+        settings.MUSIC_DOWNLOAD_DIR = ""
+        return True
+
+    if settings.MUSIC_DOWNLOAD_DIR is None or os.path.normpath(settings.MUSIC_DOWNLOAD_DIR) != os.path.normpath(music_download_dir):
+        if helpers.makeDir(music_download_dir):
+            settings.MUSIC_DOWNLOAD_DIR = os.path.normpath(music_download_dir)
+            logger.info("Changed Music download folder to " + music_download_dir)
+        else:
+            return False
+
+    return True
+
+
+def change_music_root_dirs(music_root_dirs):
+    """
+    Change MUSIC_ROOT_DIRS setting (used for music library location)
+
+    :param music_root_dirs: New music root directories
+    :return: True on success, False on failure
+    """
+    if music_root_dirs == "":
+        settings.MUSIC_ROOT_DIRS = ""
+        return True
+
+    if settings.MUSIC_ROOT_DIRS is None or music_root_dirs != settings.MUSIC_ROOT_DIRS:
+        settings.MUSIC_ROOT_DIRS = music_root_dirs
+        return True
+
+    return True
+
+
 def change_unpack_dir(unpack_dir):
     """
     Change UNPACK directory (used by postprocessor)

--- a/sickchill/oldbeard/databases/music.py
+++ b/sickchill/oldbeard/databases/music.py
@@ -1,0 +1,395 @@
+import datetime
+import logging
+import os
+from typing import List
+
+from slugify import slugify
+from sqlalchemy import ForeignKey, JSON
+from sqlalchemy.event import listen
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship, sessionmaker
+
+from sickchill import settings
+
+logger = logging.getLogger("sickchill.music")
+
+
+class AlbumStatus:
+    """Album status constants"""
+    WANTED = 1
+    SNATCHED = 2
+    DOWNLOADED = 3
+    SKIPPED = 4
+    IGNORED = 5
+
+
+class Base(DeclarativeBase):
+    """Declarative Base Class"""
+
+
+Session = sessionmaker()
+
+
+class Artist(Base):
+    __tablename__ = "artist"
+    pk: Mapped[int] = mapped_column(primary_key=True)
+    name: Mapped[str]
+    sort_name: Mapped[str]
+    country: Mapped[str] = mapped_column(nullable=True)
+    status: Mapped[int] = mapped_column(nullable=True)
+    paused: Mapped[bool] = mapped_column(default=False)
+    location: Mapped[str] = mapped_column(nullable=True)
+    start: Mapped[datetime.timedelta] = mapped_column(default=datetime.timedelta(days=-7))
+    interval: Mapped[datetime.timedelta] = mapped_column(default=datetime.timedelta(days=1))
+    added: Mapped[datetime.datetime] = mapped_column(default=datetime.datetime.now)
+    updated: Mapped[datetime.datetime] = mapped_column(onupdate=datetime.datetime.now)
+    searched: Mapped[datetime.datetime] = mapped_column(nullable=True)
+    slug: Mapped[str] = mapped_column(nullable=True)
+
+    albums: Mapped[List["Album"]] = relationship(backref="artist")
+    images: Mapped[List["Images"]] = relationship(backref="artist")
+    indexer_data: Mapped[List["IndexerData"]] = relationship(backref="artist")
+
+    def __init__(self, name: str, sort_name: str = None, country: str = None):
+        self.name = name
+        self.sort_name = sort_name or name
+        self.country = country
+        self.updated = datetime.datetime.now()  # Set updated field to current datetime
+
+    @property
+    def poster(self):
+        """
+        Returns the local file path to the artist poster image.
+        If the image doesn't exist locally, returns an empty string.
+        """
+        # Check if we have any images in the database
+        if self.images:
+            for image in self.images:
+                if image.style == 1:  # Assuming style 1 is for posters
+                    return image.path
+
+        # If no image in database, check if there's a file in the expected location
+        if self.location:
+            poster_path = os.path.join(self.location, "artist-poster.jpg")
+            if os.path.isfile(poster_path):
+                return poster_path
+
+        return ""
+
+    def image_url(self, which):
+        """
+        Returns a web-accessible URL for the artist image.
+        
+        :param which: Type of image ('poster', 'banner', 'fanart')
+        :return: URL to the image
+        """
+        from sickchill import settings
+
+        if which != 'poster':
+            return "images/poster.png"
+
+        if not self.poster:
+            return "images/poster.png"
+
+        # Use the image cache to get a web-accessible URL
+        cache_dir = os.path.abspath(os.path.join(settings.CACHE_DIR, "images"))
+        cache_file = os.path.join(cache_dir, f"artist-{self.pk}.jpg")
+
+        # If the cache file doesn't exist, copy the poster to the cache
+        if not os.path.isfile(cache_file) and os.path.isfile(self.poster):
+            if not os.path.isdir(cache_dir):
+                os.makedirs(cache_dir)
+            try:
+                import shutil
+                shutil.copy(self.poster, cache_file)
+            except Exception as e:
+                logger.error(f"Error copying artist poster to cache: {e}")
+                return "images/poster.png"
+
+        # Return the URL to the cached image
+        if os.path.isfile(cache_file):
+            return f"cache/images/artist-{self.pk}.jpg"
+
+        return "images/poster.png"
+
+    def __get_named_indexer_data(self, name):
+        if self.indexer_data:
+            for data in self.indexer_data:
+                if data.site == name:
+                    return data
+
+    @property
+    def musicbrainz_data(self):
+        data = self.__get_named_indexer_data("musicbrainz")
+        if data:
+            return data.data
+        return dict()
+
+    @property
+    def musicbrainz_id(self):
+        data = self.__get_named_indexer_data("musicbrainz")
+        if data:
+            return data.pk
+        return ""
+
+    @property
+    def musicbrainz_genres(self):
+        data = self.__get_named_indexer_data("musicbrainz")
+        if data:
+            return data.genres
+        return []
+
+    def __get_indexer_values(self, name, keys: list):
+        try:
+            data = getattr(self, f"{name}_data")
+            for key in keys:
+                data = data[key]
+            return data
+        except AttributeError:
+            logger.debug(f"We do not have data for {name}")
+        except (IndexError, KeyError):
+            logger.debug(f"KeyError: {name}{''.join([f'[{k}]' for k in keys])}")
+
+    @staticmethod
+    def slugify(target, value, old_value, initiator):
+        if value and (not target.slug or value != old_value):
+            target.slug = slugify(value)
+
+    def search_strings(self):
+        return {"Artist": [self.name]}
+
+    def __repr__(self):
+        return f"{self.name}"
+
+
+listen(Artist.name, "set", Artist.slugify, retval=False)
+
+
+class Album(Base):
+    __tablename__ = "album"
+    pk: Mapped[int] = mapped_column(primary_key=True)
+    name: Mapped[str]
+    date: Mapped[datetime.date] = mapped_column(nullable=True)
+    year: Mapped[int]
+    status: Mapped[int] = mapped_column(nullable=True)
+    paused: Mapped[bool] = mapped_column(default=False)
+    location: Mapped[str] = mapped_column(nullable=True)
+    tracks: Mapped[int]
+    type: Mapped[str]  # Album, EP, Single, etc.
+    added: Mapped[datetime.datetime] = mapped_column(default=datetime.datetime.now)
+    updated: Mapped[datetime.datetime] = mapped_column(onupdate=datetime.datetime.now)
+    completed: Mapped[datetime.datetime] = mapped_column(nullable=True)
+    searched: Mapped[datetime.datetime] = mapped_column(nullable=True)
+    slug: Mapped[str] = mapped_column(nullable=True)
+
+    artist_pk: Mapped[int] = mapped_column(ForeignKey("artist.pk"))
+    results: Mapped[List["MusicResult"]] = relationship(backref="album")
+
+    images: Mapped[List["Images"]] = relationship(backref="album")
+    indexer_data: Mapped[List["IndexerData"]] = relationship(backref="album")
+
+    def __init__(self, name: str, year: int, artist_pk: int, tracks: int = 0, album_type: str = "Album"):
+        self.name = name
+        self.year = year
+        self.artist_pk = artist_pk
+        self.tracks = tracks
+        self.type = album_type
+        self.status = AlbumStatus.IGNORED
+        self.updated = datetime.datetime.now()  # Set updated field to current datetime
+
+    @property
+    def poster(self):
+        """
+        Returns the local file path to the album cover image.
+        If the image doesn't exist locally, returns an empty string.
+        """
+        # Check if we have any images in the database
+        if self.images:
+            for image in self.images:
+                if image.style == 1:  # Assuming style 1 is for covers
+                    return image.path
+
+        # If no image in database, check if there's a file in the expected location
+        if self.location:
+            cover_path = os.path.join(self.location, "cover.jpg")
+            if os.path.isfile(cover_path):
+                return cover_path
+
+        return ""
+
+    def image_url(self, which):
+        """
+        Returns a web-accessible URL for the album image.
+
+        :param which: Type of image ('poster', 'banner', 'fanart')
+        :return: URL to the image
+        """
+
+
+        if which != 'poster':
+            return "images/poster.png"
+
+        if not self.poster:
+            return "images/poster.png"
+
+        # Use the image cache to get a web-accessible URL
+        cache_dir = os.path.abspath(os.path.join(settings.CACHE_DIR, "images"))
+        cache_file = os.path.join(cache_dir, f"album-{self.pk}.jpg")
+
+        # If the cache file doesn't exist, copy the poster to the cache
+        if not os.path.isfile(cache_file) and os.path.isfile(self.poster):
+            if not os.path.isdir(cache_dir):
+                os.makedirs(cache_dir)
+            try:
+                import shutil
+                shutil.copy(self.poster, cache_file)
+            except Exception as e:
+                logger.error(f"Error copying album poster to cache: {e}")
+                return "images/poster.png"
+
+        # Return the URL to the cached image
+        if os.path.isfile(cache_file):
+            return f"cache/images/album-{self.pk}.jpg"
+
+        return "images/poster.png"
+
+    def __get_named_indexer_data(self, name):
+        if self.indexer_data:
+            for data in self.indexer_data:
+                if data.site == name:
+                    return data
+
+    @property
+    def musicbrainz_data(self):
+        data = self.__get_named_indexer_data("musicbrainz")
+        if data:
+            return data.data
+        return dict()
+
+    @property
+    def musicbrainz_id(self):
+        data = self.__get_named_indexer_data("musicbrainz")
+        if data:
+            return data.pk
+        return ""
+
+    @staticmethod
+    def slugify(target, value, old_value, initiator):
+        if value and (not target.slug or value != old_value):
+            target.slug = slugify(value)
+
+    def search_strings(self):
+        return {"Album": [f"{self.artist.name} {self.name}"]}
+
+    def __repr__(self):
+        return f"{self.name}"
+
+
+listen(Album.name, "set", Album.slugify, retval=False)
+
+
+class MusicResult(Base):
+    __tablename__ = "music_result"
+    pk: Mapped[int] = mapped_column(primary_key=True)
+    name: Mapped[str]
+    title: Mapped[str]
+    url: Mapped[str]
+    size: Mapped[int]
+    year: Mapped[int]
+    provider: Mapped[str]
+    seeders: Mapped[int]
+    leechers: Mapped[int]
+    info_hash: Mapped[str]
+    group: Mapped[str]
+    kind: Mapped[str]
+    guess = mapped_column(JSON)
+    found: Mapped[datetime.datetime] = mapped_column(default=datetime.datetime.now)
+    updated: Mapped[datetime.datetime] = mapped_column(onupdate=datetime.datetime.now)
+
+    album_pk: Mapped[int] = mapped_column(ForeignKey("album.pk"))
+
+    session = Session()
+
+    def __init__(self, result: dict, album, provider):
+        self.info_hash = result.get("hash", "")
+        self.url = result.get("link", "")
+        self.name = result.get("title", "")
+        self.title = album.name
+        self.group = result.get("release_group", "")
+        self.seeders = result.get("seeders", 0)
+        self.leechers = result.get("leechers", 0)
+        self.size = result.get("size", 0)
+        self.year = album.year
+        self.kind = provider.provider_type
+        self.provider = provider.get_id()
+        self.album = album
+        self.album_pk = album.pk
+        self.guess = result.get("guess", {})
+        self.updated = datetime.datetime.now()
+
+    def __repr__(self):
+        return f"{self.name}"
+
+
+class Images(Base):
+    __tablename__ = "music_images"
+
+    url: Mapped[str] = mapped_column(primary_key=True)
+    path: Mapped[str]
+    site: Mapped[str]
+    style: Mapped[int]
+
+    artist_pk: Mapped[int] = mapped_column(ForeignKey("artist.pk"), nullable=True)
+    album_pk: Mapped[int] = mapped_column(ForeignKey("album.pk"), nullable=True)
+
+    def __init__(self, site: str, url: str, path: str, style: int, artist_pk: int = None, album_pk: int = None):
+        self.url = url
+        self.path = path
+        self.site = site
+        self.style = style
+        self.artist_pk = artist_pk
+        self.album_pk = album_pk
+
+
+class IndexerData(Base):
+    __tablename__ = "music_indexer_data"
+    pk: Mapped[str] = mapped_column(primary_key=True)
+    site: Mapped[str]
+    data = mapped_column(JSON)
+
+    artist_pk: Mapped[int] = mapped_column(ForeignKey("artist.pk"), nullable=True)
+    album_pk: Mapped[int] = mapped_column(ForeignKey("album.pk"), nullable=True)
+
+    genres: Mapped[List["Genres"]] = relationship(backref="indexer_data")
+
+    def __repr__(self):
+        if self.artist:
+            return f"[{self.__tablename__.replace('_', ' ').title()}] {self.site}: {self.pk} - {self.artist.name}"
+        elif self.album:
+            return f"[{self.__tablename__.replace('_', ' ').title()}] {self.site}: {self.pk} - {self.album.name}"
+        return f"[{self.__tablename__.replace('_', ' ').title()}] {self.site}: {self.pk}"
+
+
+class Genres(Base):
+    __tablename__ = "music_genres"
+    pk: Mapped[str] = mapped_column(primary_key=True)
+    indexer_data_pk: Mapped[int] = mapped_column(ForeignKey("music_indexer_data.pk"))
+
+
+class MusicHistory(Base):
+    __tablename__ = "music_history"
+    pk: Mapped[int] = mapped_column(primary_key=True)
+    album_pk: Mapped[int] = mapped_column(ForeignKey("album.pk"))
+    provider: Mapped[str]
+    quality: Mapped[str] = mapped_column(nullable=True)
+    date: Mapped[datetime.datetime] = mapped_column(default=datetime.datetime.now)
+
+    album: Mapped["Album"] = relationship(backref="history")
+
+    def __init__(self, album, provider, quality=None, date=None):
+        self.album = album
+        self.album_pk = album.pk
+        self.provider = provider
+        self.quality = quality
+        if date:
+            self.date = date

--- a/sickchill/providers/metadata/musicbrainz.py
+++ b/sickchill/providers/metadata/musicbrainz.py
@@ -1,0 +1,720 @@
+"""MusicBrainz metadata provider for SickChill."""
+
+import logging
+import os
+from typing import Dict, List, Optional, Union
+from xml.etree import ElementTree
+
+import musicbrainzngs
+import requests
+
+from sickchill import logger, settings
+from sickchill.oldbeard.databases import music
+from sickchill.oldbeard.helpers import chmodAsParent
+
+from .generic import GenericMetadata
+
+
+class MusicBrainzMetadata(GenericMetadata):
+    """
+    Metadata provider for music using the MusicBrainz API.
+    """
+
+    def __init__(
+        self,
+        show_metadata=False,
+        episode_metadata=False,
+        fanart=False,
+        poster=False,
+        banner=False,
+        episode_thumbnails=False,
+        season_posters=False,
+        season_banners=False,
+        season_all_poster=False,
+        season_all_banner=False,
+    ):
+        super().__init__(
+            show_metadata,
+            episode_metadata,
+            fanart,
+            poster,
+            banner,
+            episode_thumbnails,
+            season_posters,
+            season_banners,
+            season_all_poster,
+            season_all_banner,
+        )
+        self.name = "MusicBrainz"
+
+        # Set up MusicBrainz API
+        musicbrainzngs.set_useragent(
+            settings.MUSICBRAINZ_USER_AGENT, 
+            settings.BRANCH, 
+            settings.MUSICBRAINZ_CONTACT,
+        )
+
+        # Suppress warnings from the musicbrainzngs library
+        logging.getLogger("musicbrainzngs").setLevel(logging.WARNING)
+
+        # Define file names for artist and album metadata
+        self._artist_metadata_filename = "artist.nfo"
+        self._album_metadata_filename = "album.nfo"
+
+        # Define image file names
+        self.artist_poster_name = "artist-poster.jpg"
+        self.album_cover_name = "cover.jpg"
+
+    def get_artist_file_path(self, artist_obj):
+        """
+        Returns the path to the artist metadata file.
+
+        artist_obj: An Artist object for which to create the metadata
+        """
+        return os.path.join(artist_obj.location, self._artist_metadata_filename)
+
+    def get_album_file_path(self, album_obj):
+        """
+        Returns the path to the album metadata file.
+
+        album_obj: An Album object for which to create the metadata
+        """
+        return os.path.join(album_obj.location, self._album_metadata_filename)
+
+    def get_artist_poster_path(self, artist_obj):
+        """
+        Returns the path to the artist poster image.
+
+        artist_obj: An Artist object for which to get the poster path
+        """
+        return os.path.join(artist_obj.location, self.artist_poster_name)
+
+    def get_album_cover_path(self, album_obj):
+        """
+        Returns the path to the album cover image.
+
+        album_obj: An Album object for which to get the cover path
+        """
+        return os.path.join(album_obj.location, self.album_cover_name)
+
+    def _has_artist_metadata(self, artist_obj):
+        """
+        Check if artist metadata file exists.
+
+        artist_obj: An Artist object to check
+        """
+        return self._check_exists(self.get_artist_file_path(artist_obj))
+
+    def _has_album_metadata(self, album_obj):
+        """
+        Check if album metadata file exists.
+
+        album_obj: An Album object to check
+        """
+        return self._check_exists(self.get_album_file_path(album_obj))
+
+    def _has_artist_poster(self, artist_obj):
+        """
+        Check if artist poster exists.
+
+        artist_obj: An Artist object to check
+        """
+        return self._check_exists(self.get_artist_poster_path(artist_obj))
+
+    def _has_album_cover(self, album_obj):
+        """
+        Check if album cover exists.
+
+        album_obj: An Album object to check
+        """
+        return self._check_exists(self.get_album_cover_path(album_obj))
+
+    def _artist_data(self, artist_obj) -> Union[ElementTree.ElementTree, None]:
+        """
+        Generate XML data for an artist.
+
+        artist_obj: An Artist object for which to create the metadata
+        """
+        if not artist_obj:
+            return None
+
+        try:
+            # Create the XML structure for the artist
+            artist_xml = ElementTree.Element("artist")
+
+            ElementTree.SubElement(artist_xml, "name").text = artist_obj.name
+            ElementTree.SubElement(artist_xml, "sortname").text = artist_obj.sort_name
+            ElementTree.SubElement(artist_xml, "musicbrainzid").text = artist_obj.musicbrainz_id
+
+            if artist_obj.country:
+                ElementTree.SubElement(artist_xml, "country").text = artist_obj.country
+
+            # Add genres
+            genres_xml = ElementTree.SubElement(artist_xml, "genres")
+            for genre in artist_obj.musicbrainz_genres:
+                ElementTree.SubElement(genres_xml, "genre").text = genre.pk
+
+            # Create the XML tree
+            xml_data = ElementTree.ElementTree(artist_xml)
+
+            return xml_data
+        except Exception as e:
+            logger.error(f"Error generating artist XML data: {e}")
+            return None
+
+    def _album_data(self, album_obj) -> Union[ElementTree.ElementTree, None]:
+        """
+        Generate XML data for an album.
+
+        album_obj: An Album object for which to create the metadata
+        """
+        if not album_obj:
+            return None
+
+        try:
+            # Create the XML structure for the album
+            album_xml = ElementTree.Element("album")
+
+            ElementTree.SubElement(album_xml, "title").text = album_obj.name
+            ElementTree.SubElement(album_xml, "artist").text = album_obj.artist.name
+            ElementTree.SubElement(album_xml, "year").text = str(album_obj.year)
+            ElementTree.SubElement(album_xml, "musicbrainzid").text = album_obj.musicbrainz_id
+            ElementTree.SubElement(album_xml, "type").text = album_obj.type
+            ElementTree.SubElement(album_xml, "tracks").text = str(album_obj.tracks)
+
+            if album_obj.date:
+                ElementTree.SubElement(album_xml, "releasedate").text = str(album_obj.date)
+
+            # Create the XML tree
+            xml_data = ElementTree.ElementTree(album_xml)
+
+            return xml_data
+        except Exception as e:
+            logger.error(f"Error generating album XML data: {e}")
+            return None
+
+    def create_artist_metadata(self, artist_obj):
+        """
+        Create metadata for an artist.
+
+        artist_obj: An Artist object for which to create the metadata
+        """
+        if not artist_obj or self._has_artist_metadata(artist_obj):
+            return False
+
+        logger.debug(f"Creating artist metadata for {artist_obj.name}")
+        return self.write_artist_file(artist_obj)
+
+    def create_album_metadata(self, album_obj):
+        """
+        Create metadata for an album.
+
+        album_obj: An Album object for which to create the metadata
+        """
+        if not album_obj or self._has_album_metadata(album_obj):
+            return False
+
+        logger.debug(f"Creating album metadata for {album_obj.name}")
+        return self.write_album_file(album_obj)
+
+    def create_artist_poster(self, artist_obj):
+        """
+        Create poster for an artist.
+
+        artist_obj: An Artist object for which to create the poster
+        """
+        if not artist_obj or self._has_artist_poster(artist_obj):
+            return False
+
+        logger.debug(f"Creating artist poster for {artist_obj.name}")
+        return self.save_artist_poster(artist_obj)
+
+    def create_album_cover(self, album_obj):
+        """
+        Create cover for an album.
+
+        album_obj: An Album object for which to create the cover
+        """
+        if not album_obj or self._has_album_cover(album_obj):
+            return False
+
+        logger.debug(f"Creating album cover for {album_obj.name}")
+        return self.save_album_cover(album_obj)
+
+    def write_artist_file(self, artist_obj):
+        """
+        Write artist metadata to file.
+
+        artist_obj: An Artist object for which to write the metadata
+        """
+        data = self._artist_data(artist_obj)
+        if not data:
+            return False
+
+        nfo_file_path = self.get_artist_file_path(artist_obj)
+        nfo_file_dir = os.path.dirname(nfo_file_path)
+
+        try:
+            if not os.path.isdir(nfo_file_dir):
+                logger.debug(f"Metadata dir didn't exist, creating it at {nfo_file_dir}")
+                os.makedirs(nfo_file_dir)
+                chmodAsParent(nfo_file_dir)
+
+            logger.debug(f"Writing artist nfo file to {nfo_file_path}")
+
+            nfo_file = open(nfo_file_path, "wb")
+            data.write(nfo_file, encoding="UTF-8", xml_declaration=True)
+            nfo_file.close()
+            chmodAsParent(nfo_file_path)
+        except IOError as error:
+            logger.error(f"Unable to write file to {nfo_file_path} - are you sure the folder is writable? {error}")
+            return False
+
+        return True
+
+    def write_album_file(self, album_obj):
+        """
+        Write album metadata to file.
+
+        album_obj: An Album object for which to write the metadata
+        """
+        data = self._album_data(album_obj)
+        if not data:
+            return False
+
+        nfo_file_path = self.get_album_file_path(album_obj)
+        nfo_file_dir = os.path.dirname(nfo_file_path)
+
+        try:
+            if not os.path.isdir(nfo_file_dir):
+                logger.debug(f"Metadata dir didn't exist, creating it at {nfo_file_dir}")
+                os.makedirs(nfo_file_dir)
+                chmodAsParent(nfo_file_dir)
+
+            logger.debug(f"Writing album nfo file to {nfo_file_path}")
+
+            nfo_file = open(nfo_file_path, "wb")
+            data.write(nfo_file, encoding="UTF-8", xml_declaration=True)
+            nfo_file.close()
+            chmodAsParent(nfo_file_path)
+        except IOError as error:
+            logger.error(f"Unable to write file to {nfo_file_path} - are you sure the folder is writable? {error}")
+            return False
+
+        return True
+
+    def save_artist_poster(self, artist_obj):
+        """
+        Save artist poster image.
+
+        artist_obj: An Artist object for which to save the poster
+        """
+        if not artist_obj or not artist_obj.musicbrainz_id:
+            logger.error(f"No MusicBrainz ID for artist {artist_obj.name if artist_obj else 'None'}")
+            return False
+
+        # Check if artist has a location set
+        if not artist_obj.location:
+            logger.error(f"No location set for artist {artist_obj.name}")
+            return False
+
+        try:
+            # For artists, we'll use the cover of their most popular album as the artist image
+            # First, get all albums for this artist
+            result = musicbrainzngs.browse_release_groups(
+                artist=artist_obj.musicbrainz_id,
+                release_type=["album"],
+                limit=1
+            )
+
+            release_groups = result.get("release-group-list", [])
+            if not release_groups:
+                logger.warning(f"No albums found for artist {artist_obj.name}")
+                return False
+
+            # Get the first album's ID
+            album_id = release_groups[0].get("id", "")
+            if not album_id:
+                logger.warning(f"No album ID found for artist {artist_obj.name}")
+                return False
+
+            # Try to get images for the release group using musicbrainzngs
+            image_data = None
+
+            try:
+                # Try to get images for the release group
+                logger.debug(f"Getting images for release group {album_id}")
+                image_list = musicbrainzngs.get_release_group_image_list(album_id)
+
+                # Check if there are any front images
+                front_images = [img for img in image_list["images"] if img.get("front", False)]
+
+                if front_images:
+                    # Use the first front image
+                    image_url = front_images[0]["image"]
+                    logger.debug(f"Found front image for release group: {image_url}")
+
+                    # Download the image
+                    response = requests.get(image_url)
+                    if response.status_code == 200:
+                        image_data = response.content
+                    else:
+                        logger.warning(f"Failed to download image from {image_url}")
+                else:
+                    # If no front images, try to use any image
+                    if image_list["images"]:
+                        image_url = image_list["images"][0]["image"]
+                        logger.debug(f"No front image found, using first available: {image_url}")
+
+                        # Download the image
+                        response = requests.get(image_url)
+                        if response.status_code == 200:
+                            image_data = response.content
+                        else:
+                            logger.warning(f"Failed to download image from {image_url}")
+            except musicbrainzngs.ResponseError as e:
+                logger.debug(f"No images found for release group {album_id}: {e}")
+            except Exception as e:
+                logger.debug(f"Error getting images for release group: {e}")
+
+            # If we couldn't get images for the release group, try to find a release
+            if not image_data:
+                try:
+                    # Get more detailed info about the release group to find releases
+                    release_group_info = musicbrainzngs.get_release_group_by_id(
+                        album_id,
+                        includes=["releases"]
+                    )["release-group"]
+
+                    if "release-list" in release_group_info and release_group_info["release-list"]:
+                        # Get the first release ID
+                        first_release = release_group_info["release-list"][0]
+                        release_id = first_release.get("id")
+
+                        if release_id:
+                            logger.debug(f"Found release ID {release_id} for album {album_id}")
+                            try:
+                                # Try to get images for this release
+                                image_list = musicbrainzngs.get_image_list(release_id)
+
+                                # Check if there are any front images
+                                front_images = [img for img in image_list["images"] if img.get("front", False)]
+
+                                if front_images:
+                                    # Use the first front image
+                                    image_url = front_images[0]["image"]
+                                    logger.debug(f"Found front image for release: {image_url}")
+
+                                    # Download the image
+                                    response = requests.get(image_url)
+                                    if response.status_code == 200:
+                                        image_data = response.content
+                                    else:
+                                        logger.warning(f"Failed to download image from {image_url}")
+                                else:
+                                    # If no front images, try to use any image
+                                    if image_list["images"]:
+                                        image_url = image_list["images"][0]["image"]
+                                        logger.debug(f"No front image found, using first available: {image_url}")
+
+                                        # Download the image
+                                        response = requests.get(image_url)
+                                        if response.status_code == 200:
+                                            image_data = response.content
+                                        else:
+                                            logger.warning(f"Failed to download image from {image_url}")
+                            except musicbrainzngs.ResponseError as e:
+                                logger.warning(f"No images found for release {release_id}: {e}")
+                            except Exception as e:
+                                logger.warning(f"Error getting images for release {release_id}: {e}")
+                except Exception as e:
+                    logger.warning(f"Error getting release information: {e}")
+
+            # If we still don't have an image, return False
+            if not image_data:
+                logger.warning(f"No cover art found for artist {artist_obj.name}")
+                return False
+
+            # Save the image to the artist poster path
+            poster_path = self.get_artist_poster_path(artist_obj)
+            poster_dir = os.path.dirname(poster_path)
+
+            if not os.path.isdir(poster_dir):
+                logger.debug(f"Artist poster dir didn't exist, creating it at {poster_dir}")
+                os.makedirs(poster_dir)
+                chmodAsParent(poster_dir)
+
+            with open(poster_path, "wb") as f:
+                f.write(image_data)
+
+            chmodAsParent(poster_path)
+            logger.info(f"Saved artist poster for {artist_obj.name}")
+            return True
+
+        except Exception as e:
+            logger.error(f"Error saving artist poster: {e}")
+            return False
+
+    def save_album_cover(self, album_obj):
+        """
+        Save album cover image.
+
+        album_obj: An Album object for which to save the cover
+        """
+        if not album_obj or not album_obj.musicbrainz_id:
+            logger.error(f"No MusicBrainz ID for album {album_obj.name if album_obj else 'None'}")
+            return False
+
+        # Check if album has a location set
+        if not album_obj.location:
+            logger.error(f"No location set for album {album_obj.name}")
+            return False
+
+        try:
+            # First try to get cover art for the release group using musicbrainzngs
+            image_data = None
+
+            try:
+                # Try to get images for the release group
+                logger.debug(f"Getting images for release group {album_obj.musicbrainz_id}")
+                image_list = musicbrainzngs.get_release_group_image_list(album_obj.musicbrainz_id)
+
+                # Check if there are any front images
+                front_images = [img for img in image_list["images"] if img.get("front", False)]
+
+                if front_images:
+                    # Use the first front image
+                    image_url = front_images[0]["image"]
+                    logger.debug(f"Found front image for release group: {image_url}")
+
+                    # Download the image
+                    response = requests.get(image_url)
+                    if response.status_code == 200:
+                        image_data = response.content
+                    else:
+                        logger.warning(f"Failed to download image from {image_url}")
+                else:
+                    # If no front images, try to use any image
+                    if image_list["images"]:
+                        image_url = image_list["images"][0]["image"]
+                        logger.debug(f"No front image found, using first available: {image_url}")
+
+                        # Download the image
+                        response = requests.get(image_url)
+                        if response.status_code == 200:
+                            image_data = response.content
+                        else:
+                            logger.warning(f"Failed to download image from {image_url}")
+            except musicbrainzngs.ResponseError as e:
+                logger.debug(f"No images found for release group {album_obj.musicbrainz_id}: {e}")
+            except Exception as e:
+                logger.debug(f"Error getting images for release group: {e}")
+
+            # If we couldn't get images for the release group, try to find a release
+            if not image_data:
+                # Check if we have release information in the album's MusicBrainz data
+                mb_data = album_obj.musicbrainz_data
+                release_id = None
+
+                if mb_data and "release-list" in mb_data and mb_data["release-list"]:
+                    # Get the first release ID
+                    first_release = mb_data["release-list"][0]
+                    release_id = first_release.get("id")
+
+                    if release_id:
+                        logger.debug(f"Found release ID {release_id} for album {album_obj.name}")
+                        try:
+                            # Try to get images for this release
+                            image_list = musicbrainzngs.get_image_list(release_id)
+
+                            # Check if there are any front images
+                            front_images = [img for img in image_list["images"] if img.get("front", False)]
+
+                            if front_images:
+                                # Use the first front image
+                                image_url = front_images[0]["image"]
+                                logger.debug(f"Found front image for release: {image_url}")
+
+                                # Download the image
+                                response = requests.get(image_url)
+                                if response.status_code == 200:
+                                    image_data = response.content
+                                else:
+                                    logger.warning(f"Failed to download image from {image_url}")
+                            else:
+                                # If no front images, try to use any image
+                                if image_list["images"]:
+                                    image_url = image_list["images"][0]["image"]
+                                    logger.debug(f"No front image found, using first available: {image_url}")
+
+                                    # Download the image
+                                    response = requests.get(image_url)
+                                    if response.status_code == 200:
+                                        image_data = response.content
+                                    else:
+                                        logger.warning(f"Failed to download image from {image_url}")
+                        except musicbrainzngs.ResponseError as e:
+                            logger.warning(f"No images found for release {release_id}: {e}")
+                        except Exception as e:
+                            logger.warning(f"Error getting images for release {release_id}: {e}")
+                    else:
+                        logger.warning(f"No release ID found for album {album_obj.name}")
+                else:
+                    logger.warning(f"No release information found for album {album_obj.name}")
+
+            # If we still don't have an image, return False
+            if not image_data:
+                logger.warning(f"No cover art found for album {album_obj.name}")
+                return False
+
+            # Save the image to the album cover path
+            cover_path = self.get_album_cover_path(album_obj)
+            cover_dir = os.path.dirname(cover_path)
+
+            if not os.path.isdir(cover_dir):
+                logger.debug(f"Album cover dir didn't exist, creating it at {cover_dir}")
+                os.makedirs(cover_dir)
+                chmodAsParent(cover_dir)
+
+            with open(cover_path, "wb") as f:
+                f.write(image_data)
+
+            chmodAsParent(cover_path)
+            logger.info(f"Saved album cover for {album_obj.name}")
+            return True
+
+        except Exception as e:
+            logger.error(f"Error saving album cover: {e}")
+            return False
+
+    def find_artist(self, name: str) -> Optional[Dict[str, str]]:
+        """
+        Find an artist by name and return their ID and name.
+
+        Args:
+            name: Name of the artist to search for.
+
+        Returns:
+            Optional[Dict[str, str]]: Dictionary with artist ID and name if found, None otherwise.
+        """
+        logger.info(f"Searching for artist: {name}")
+        try:
+            result = musicbrainzngs.search_artists(name, limit=10)
+            artists = result.get("artist-list", [])
+
+            if not artists:
+                logger.warning(f"No artists found for query: {name}")
+                return None
+
+            # Find the best match
+            for artist in artists:
+                artist_name = artist.get("name", "")
+                artist_id = artist.get("id", "")
+                score = int(artist.get("ext:score", "0"))
+
+                logger.debug(f"Found artist: {artist_name} (ID: {artist_id}, Score: {score})")
+
+                # Consider it a match if the score is high enough
+                if score > 90:
+                    logger.info(f"Selected artist: {artist_name} (ID: {artist_id})")
+                    return {"id": artist_id, "name": artist_name}
+
+            # If no high-score match, return the first result
+            artist = artists[0]
+            artist_name = artist.get("name", "")
+            artist_id = artist.get("id", "")
+            logger.info(f"Selected artist (best match): {artist_name} (ID: {artist_id})")
+            return {"id": artist_id, "name": artist_name}
+
+        except musicbrainzngs.WebServiceError as e:
+            logger.error(f"MusicBrainz API error while searching for artist: {e}")
+            return None
+        except Exception as e:
+            logger.error(f"Error while searching for artist: {e}")
+            return None
+
+    def get_albums(self, artist_id: str, artist_name: str, max_albums: int = 50) -> List[Dict]:
+        """
+        Get albums for an artist.
+
+        Args:
+            artist_id: MusicBrainz ID of the artist.
+            artist_name: Name of the artist (for reference).
+            max_albums: Maximum number of albums to retrieve.
+
+        Returns:
+            List[Dict]: List of albums by the artist.
+        """
+        logger.info(f"Retrieving albums for artist: {artist_name} (ID: {artist_id})")
+        albums = []
+        offset = 0
+        limit = 25
+        total_albums = 0
+        album_count = 0
+
+        try:
+            # Get the artist's release groups (albums)
+            while True and album_count < max_albums:
+                try:
+                    result = musicbrainzngs.browse_release_groups(
+                        artist=artist_id,
+                        release_type=["album", "ep"],
+                        limit=limit,
+                        offset=offset,
+                    )
+                    release_groups = result.get("release-group-list", [])
+                    total_albums = int(result.get("release-group-count", "0"))
+
+                    if not release_groups:
+                        break
+                except Exception as e:
+                    logger.error(f"Error retrieving release groups: {e}")
+                    break
+
+                for release_group in release_groups:
+                    album_id = release_group.get("id", "")
+                    album_title = release_group.get("title", "")
+                    album_type = release_group.get("type", "Album")
+
+                    # Get the first date if available
+                    first_release_date = release_group.get("first-release-date", "")
+                    year = None
+                    if first_release_date and len(first_release_date) >= 4:
+                        try:
+                            year = int(first_release_date[:4])
+                        except ValueError:
+                            pass
+
+                    # Get track count if available
+                    tracks = 0
+
+                    album = {
+                        "id": album_id,
+                        "title": album_title,
+                        "artist": artist_name,
+                        "artist_id": artist_id,
+                        "year": year,
+                        "tracks": tracks,
+                        "type": album_type,
+                    }
+                    albums.append(album)
+                    album_count += 1
+                    logger.debug(f"Added album: {album_title} ({year})")
+
+                    if album_count >= max_albums:
+                        logger.info(f"Reached maximum album limit ({max_albums})")
+                        break
+
+                offset += limit
+                if offset >= total_albums or album_count >= max_albums:
+                    break
+
+            logger.info(f"Retrieved {len(albums)} albums for artist: {artist_name}")
+            return albums
+
+        except musicbrainzngs.WebServiceError as e:
+            logger.error(f"MusicBrainz API error while retrieving albums: {e}")
+            return albums
+        except Exception as e:
+            logger.error(f"Error while retrieving albums: {e}")
+            return albums

--- a/sickchill/settings.py
+++ b/sickchill/settings.py
@@ -10,6 +10,7 @@ from sickchill.oldbeard.numdict import NumDict
 
 if TYPE_CHECKING:
     from sickchill.movies import MovieList
+    from sickchill.music import MusicList
 
 setup_gettext()
 
@@ -77,6 +78,7 @@ BOXCAR2_ACCESSTOKEN = None
 BOXCAR2_NOTIFY_ONDOWNLOAD = False
 BOXCAR2_NOTIFY_ONSNATCH = False
 BOXCAR2_NOTIFY_ONSUBTITLEDOWNLOAD = False
+BRANCH = "master"
 CACHE_DIR = None
 CALENDAR_ICONS = False
 CALENDAR_UNPROTECTED = False
@@ -583,7 +585,15 @@ WEB_USERNAME = None
 WINDOWS_SHARES = {}
 
 movie_list: "MovieList" = None
+music_list: "MusicList" = None
 
+# MusicBrainz settings
+USE_MUSICBRAINZ = False
+MUSICBRAINZ_USER_AGENT = "SickChill"
+MUSICBRAINZ_APP_VERSION = "1.0"
+MUSICBRAINZ_CONTACT = "https://sickchill.github.io/"
+MUSIC_ROOT_DIRS = None
+MUSIC_DOWNLOAD_DIR = None
 
 def get_backlog_cycle_time():
     # backlog timer multiple of daily frequency and ensure multiple per mako 'step="60"'

--- a/sickchill/views/__init__.py
+++ b/sickchill/views/__init__.py
@@ -22,5 +22,6 @@ from sickchill.views.index import BaseHandler, WebHandler, WebRoot
 from sickchill.views.logs import ErrorLogs
 from sickchill.views.manage import AddShows, Manage, ManageSearches, PostProcess
 from sickchill.views.movies import MoviesHandler
+from sickchill.views.music import MusicHandler
 from sickchill.views.news import HomeNews
 from sickchill.views.routes import Route

--- a/sickchill/views/config/general.py
+++ b/sickchill/views/config/general.py
@@ -30,6 +30,9 @@ class ConfigGeneral(Config):
     def saveRootDirs(self):
         settings.ROOT_DIRS = self.get_body_argument("rootDirString")
 
+    def saveMusicRootDirs(self):
+        settings.MUSIC_ROOT_DIRS = self.get_body_argument("musicRootDirString")
+
     def saveAddShowDefaults(self):
         any_qualities = [int(quality) for quality in self.get_body_arguments("anyQualities[]")]
         best_qualities = [int(quality) for quality in self.get_body_arguments("bestQualities[]")]
@@ -63,6 +66,7 @@ class ConfigGeneral(Config):
         time_preset = self.get_body_argument("time_preset", default=None)
         indexer_timeout = self.get_body_argument("indexer_timeout", default=None)
         log_dir = self.get_body_argument("log_dir", default="")
+        music_download_dir = self.get_body_argument("music_download_dir", default="")
 
         results = []
 
@@ -85,6 +89,8 @@ class ConfigGeneral(Config):
         settings.LOG_SIZE = float(self.get_body_argument("log_size", default="1"))
         if not config.change_log_dir(log_dir):
             results += [_("Unable to create directory {log_dir} or it is not writable, log directory not changed.").format(log_dir=os.path.normpath(log_dir))]
+        if not config.change_music_download_dir(music_download_dir):
+            results += [_("Unable to create directory {directory} or it is not writable, music download directory not changed.").format(directory=os.path.normpath(music_download_dir))]
         settings.WEB_LOG = config.checkbox_to_value(self.get_body_argument("web_log", default=None))
 
         settings.TRASH_REMOVE_SHOW = config.checkbox_to_value(self.get_body_argument("trash_remove_show", default=None))
@@ -111,6 +117,8 @@ class ConfigGeneral(Config):
 
         settings.SSL_VERIFY = config.checkbox_to_value(self.get_body_argument("ssl_verify", default=None))
         helpers.set_opener(settings.SSL_VERIFY)
+        
+        settings.USE_MUSICBRAINZ = config.checkbox_to_value(self.get_body_argument("use_musicbrainz", default=None))
 
         settings.COMING_EPS_MISSED_RANGE = config.min_max(coming_eps_missed_range, 7, 0, 42810)
 

--- a/sickchill/views/music.py
+++ b/sickchill/views/music.py
@@ -1,0 +1,338 @@
+import logging
+import os
+
+from sickchill import settings
+from sickchill.oldbeard import config
+from sickchill.oldbeard.databases import music
+from sickchill.oldbeard.databases.music import AlbumStatus
+
+from .common import PageTemplate
+from .index import WebRoot
+from .routes import Route
+
+logger = logging.getLogger("sickchill.music")
+
+
+@Route("/music(/?.*)", name="music")
+class MusicHandler(WebRoot):
+    """
+    Handler for music-related pages
+    """
+    def _genericMessage(self, subject=None, message=None):
+        t = PageTemplate(rh=self, filename="genericMessage.mako")
+        return t.render(message=message, subject=subject, topmenu="music", title="")
+
+    def index(self):
+        t = PageTemplate(rh=self, filename="music/index.mako")
+        selected_root = self.get_body_argument("root", "")
+
+        if selected_root and settings.MUSIC_ROOT_DIRS:
+            backend_dirs = settings.MUSIC_ROOT_DIRS.split("|")[1:]
+            try:
+                assert selected_root != "-1"
+                selected_root_dir = backend_dirs[int(selected_root)]
+            except (IndexError, ValueError, TypeError, AssertionError):
+                selected_root_dir = ""
+        else:
+            selected_root_dir = ""
+
+        artists = []
+        for artist in settings.music_list:
+            if not selected_root_dir or (artist.location and artist.location.startswith(selected_root_dir)):
+                artists.append(artist)
+
+        return t.render(
+            title=_("Music"),
+            header=_("Artist List"),
+            topmenu="music",
+            music=artists,
+            controller="music",
+            action="index",
+            selected_root=selected_root or "-1",
+        )
+
+    def search(self):
+        query = self.get_body_argument("query", "")
+        search_results = []
+        if query:
+            search_results = settings.music_list.search_musicbrainz(query=query)
+        t = PageTemplate(rh=self, filename="music/search.mako")
+        return t.render(
+            title=_("Music"),
+            header=_("Artist Search"),
+            topmenu="music",
+            controller="music",
+            action="search",
+            search_results=search_results,
+            music=settings.music_list,
+            query=query,
+        )
+
+    def add(self):
+        artist = None
+        artist_id = self.get_body_argument("musicbrainz", None)
+        
+        # Get the selected root directory
+        selected_dir = None
+        if settings.MUSIC_ROOT_DIRS:
+            music_root_dir = self.get_body_argument("musicRootDir", None)
+            if music_root_dir:
+                selected_dir = music_root_dir
+        
+        if artist_id:
+            result = settings.music_list.add_from_musicbrainz(artist_id=artist_id)
+
+            # If result is an Artist object, use it
+            if hasattr(result, 'slug'):
+                artist = result
+                
+                # Set the artist location if a root directory was selected
+                if selected_dir:
+                    # Create the artist directory path
+                    artist_dir = os.path.join(selected_dir, artist.name)
+                    
+                    # Check if the directory exists or if we should create it
+                    if not (os.path.isdir(artist_dir) or settings.CREATE_MISSING_SHOW_DIRS):
+                        return self._genericMessage(_("Error"), _("Location does not exist and CREATE_MISSING_SHOW_DIRS is disabled"))
+                    
+                    # Create the directory if it doesn't exist
+                    if not os.path.isdir(artist_dir):
+                        try:
+                            os.makedirs(artist_dir)
+                        except OSError as e:
+                            return self._genericMessage(_("Error"), _("Failed to create directory: {error}").format(error=str(e)))
+                    
+                    # Set the artist location
+                    artist.location = artist_dir
+                    
+                    # Set album locations
+                    for album in artist.albums:
+                        album.location = os.path.join(artist_dir, album.name)
+                    
+                    # Save changes to the database
+                    settings.music_list.commit()
+                
+            # If result is True, the artist was added to the queue
+            elif result is True:
+                # Redirect to the index page with a message
+                return self.redirect(self.reverse_url("music", ""))
+
+        if not artist:
+            return self.redirect(self.reverse_url("music-search", "search"))
+
+        return self.redirect(self.reverse_url("music-details", "details", artist.slug))
+
+    def remove(self):
+        pk = self.path_kwargs.get("pk")
+        if pk is not None:
+            if not settings.music_list.artist_query.get(pk):
+                return self._genericMessage(_("Error"), _("Artist not found"))
+
+            settings.music_list.delete_artist(pk)
+
+        t = PageTemplate(rh=self, filename="music/remove.mako")
+        return t.render(
+            title=_("Music"),
+            header=_("Artist Remove"),
+            topmenu="music",
+            music=settings.music_list,
+            controller="music",
+            action="remove",
+        )
+
+    def details(self):
+        artist = settings.music_list.artist_by_slug(self.path_kwargs.get("slug"))
+        if not artist:
+            return self._genericMessage(_("Error"), _("Artist not found"))
+
+        t = PageTemplate(rh=self, filename="music/details.mako")
+        return t.render(
+            title=_("Music"),
+            header=_("Artist Details"),
+            topmenu="music",
+            controller="music",
+            action="details",
+            artist=artist,
+            artist_message=None,
+        )
+
+    def album_details(self):
+        album = settings.music_list.album_by_slug(self.path_kwargs.get("slug"))
+        if not album:
+            return self._genericMessage(_("Error"), _("Album not found"))
+
+        t = PageTemplate(rh=self, filename="music/album_details.mako")
+        return t.render(
+            title=_("Music"),
+            header=_("Album Details"),
+            topmenu="music",
+            controller="music",
+            action="album_details",
+            album=album,
+            album_message=None,
+        )
+
+    def set_album_status(self):
+        """
+        Set the status of a single album
+        """
+        album_id = self.path_kwargs.get("pk")
+        status = self.get_query_argument("status", None)
+
+        if not album_id or not status:
+            return self._genericMessage(_("Error"), _("Missing album ID or status"))
+
+        try:
+            status = int(status)
+            if status not in [AlbumStatus.WANTED, AlbumStatus.SKIPPED, AlbumStatus.IGNORED]:
+                return self._genericMessage(_("Error"), _("Invalid status"))
+        except ValueError:
+            return self._genericMessage(_("Error"), _("Invalid status value"))
+
+        album = settings.music_list.album_query.get(album_id)
+        if not album:
+            return self._genericMessage(_("Error"), _("Album not found"))
+
+        # Update album status
+        album.status = status
+        settings.music_list.commit()
+
+        # Redirect back to the artist details page
+        return self.redirect(self.reverse_url("music-details", "details", album.artist.slug))
+
+    def set_albums_status(self):
+        """
+        Set the status of multiple albums via AJAX
+        """
+        # Log all request arguments for debugging
+        logger.debug(f"set_albums_status request arguments: {self.request.arguments}")
+
+        albums = self.get_body_argument("albums", "")
+        status = self.get_body_argument("status", None)
+        artist_id = self.get_body_argument("artist", None)
+
+        logger.debug(f"set_albums_status parameters: albums={albums}, status={status}, artist_id={artist_id}")
+
+        if not albums or not status:
+            logger.error("Missing albums or status in request")
+            return self.write({"success": False, "message": _("Missing albums or status")})
+
+        try:
+            status = int(status)
+            if status not in [AlbumStatus.WANTED, AlbumStatus.SKIPPED, AlbumStatus.IGNORED]:
+                logger.error(f"Invalid status value: {status}")
+                return self.write({"success": False, "message": _("Invalid status")})
+        except ValueError:
+            logger.error(f"Invalid status value (not an integer): {status}")
+            return self.write({"success": False, "message": _("Invalid status value")})
+
+        album_ids = albums.split(",")
+        logger.debug(f"Processing album IDs: {album_ids}")
+        updated = 0
+
+        for album_id in album_ids:
+            try:
+                album = settings.music_list.album_query.get(int(album_id))
+                if album:
+                    album.status = status
+                    updated += 1
+                    logger.debug(f"Updated album {album_id} status to {status}")
+                else:
+                    logger.error(f"Album not found: {album_id}")
+            except (ValueError, TypeError):
+                logger.error(f"Invalid album ID: {album_id}")
+
+        if updated > 0:
+            settings.music_list.commit()
+            logger.debug(f"Committed {updated} album status changes")
+
+        return self.write({"success": True, "message": f"{updated} albums updated"})
+
+    def search_album(self):
+        """
+        Search for an album on providers
+        """
+        album_id = self.path_kwargs.get("pk")
+
+        if not album_id:
+            return self._genericMessage(_("Error"), _("Missing album ID"))
+
+        album = settings.music_list.album_query.get(album_id)
+        if not album:
+            return self._genericMessage(_("Error"), _("Album not found"))
+
+        # Search for the album on providers
+        settings.music_list.search_providers(album)
+
+        # Redirect to album details page
+        return self.redirect(self.reverse_url("music-album_details", "album_details", album.slug))
+
+    def snatch_album(self):
+        """
+        Snatch a specific album result
+        """
+        result_id = self.path_kwargs.get("pk")
+
+        if not result_id:
+            return self._genericMessage(_("Error"), _("Missing result ID"))
+
+        result = settings.music_list.session.query(music.MusicResult).get(result_id)
+        if not result:
+            return self._genericMessage(_("Error"), _("Result not found"))
+
+        # Snatch the album
+        success = settings.music_list.snatch_album(result)
+
+        if success:
+            # Redirect to album details page
+            return self.redirect(self.reverse_url("music-album_details", "album_details", result.album.slug))
+        else:
+            return self._genericMessage(_("Error"), _("Failed to snatch album"))
+            
+    def set_artist_location(self):
+        """
+        Set the location for an artist and all its albums
+        """
+        artist_id = self.path_kwargs.get("pk")
+        location = self.get_body_argument("location", None)
+
+        if not artist_id or not location:
+            return self._genericMessage(_("Error"), _("Missing artist ID or location"))
+
+        artist = settings.music_list.artist_query.get(artist_id)
+        if not artist:
+            return self._genericMessage(_("Error"), _("Artist not found"))
+
+        # Normalize the location path
+        location = os.path.normpath(location)
+        
+        # Check if the location exists or if we should create it
+        if not (os.path.isdir(location) or settings.CREATE_MISSING_SHOW_DIRS):
+            return self._genericMessage(_("Error"), _("Location does not exist and CREATE_MISSING_SHOW_DIRS is disabled"))
+        
+        # Create the directory if it doesn't exist
+        if not os.path.isdir(location):
+            try:
+                os.makedirs(location)
+            except OSError as e:
+                return self._genericMessage(_("Error"), _("Failed to create directory: {error}").format(error=str(e)))
+        
+        # Update the artist location
+        old_location = artist.location
+        artist.location = location
+        
+        # Update all album locations
+        for album in artist.albums:
+            if old_location and album.location and album.location.startswith(old_location):
+                # If the album had a location under the old artist location, update it
+                album_relative_path = os.path.relpath(album.location, old_location)
+                album.location = os.path.join(location, album_relative_path)
+            else:
+                # Otherwise, set it to a new location under the artist directory
+                album.location = os.path.join(location, album.name)
+        
+        # Save changes to the database
+        settings.music_list.commit()
+        
+        # Redirect back to the artist details page
+        return self.redirect(self.reverse_url("music-details", "details", artist.slug))

--- a/sickchill/views/server_settings.py
+++ b/sickchill/views/server_settings.py
@@ -12,7 +12,7 @@ from tornado.web import Application, RedirectHandler, StaticFileHandler, url
 import sickchill.start
 from sickchill import logger, settings
 from sickchill.oldbeard.helpers import create_https_certificates, generateApiKey
-from sickchill.views import CalendarHandler, LoginHandler, LogoutHandler, MoviesHandler
+from sickchill.views import CalendarHandler, LoginHandler, LogoutHandler, MoviesHandler, MusicHandler
 from sickchill.views.api import ApiHandler, KeyHandler
 from sickchill.views.routes import Route
 
@@ -165,6 +165,18 @@ class SCWebServer(threading.Thread):
                 url(rf'{self.options["web_root"]}/movies/(?P<route>search)/', MoviesHandler, name="movies-search"),
                 url(rf'{self.options["web_root"]}/movies/(?P<route>list)/', MoviesHandler, name="movies-list"),
                 url(rf'{self.options["web_root"]}/movies/(.*)', MoviesHandler, name="movies"),
+                url(rf'{self.options["web_root"]}/music/(?P<route>index)/', MusicHandler, name="music-index"),
+                url(rf'{self.options["web_root"]}/music/(?P<route>details)/(?P<slug>.*)/', MusicHandler, name="music-details"),
+                url(rf'{self.options["web_root"]}/music/(?P<route>album_details)/(?P<slug>.*)/', MusicHandler, name="music-album_details"),
+                url(rf'{self.options["web_root"]}/music/(?P<route>remove)/(?P<pk>.*)/', MusicHandler, name="music-remove"),
+                url(rf'{self.options["web_root"]}/music/(?P<route>add)/', MusicHandler, name="music-add"),
+                url(rf'{self.options["web_root"]}/music/(?P<route>search)/', MusicHandler, name="music-search"),
+                url(rf'{self.options["web_root"]}/music/(?P<route>set_album_status)/(?P<pk>.*)/', MusicHandler, name="music-set_album_status"),
+                url(rf'{self.options["web_root"]}/music/(?P<route>set_albums_status)/', MusicHandler, name="music-set_albums_status"),
+                url(rf'{self.options["web_root"]}/music/(?P<route>search_album)/(?P<pk>.*)/', MusicHandler, name="music-search_album"),
+                url(rf'{self.options["web_root"]}/music/(?P<route>snatch_album)/(?P<pk>.*)/', MusicHandler, name="music-snatch_album"),
+                url(rf'{self.options["web_root"]}/music/(?P<route>set_artist_location)/(?P<pk>.*)/', MusicHandler, name="music-set_artist_location"),
+                url(rf'{self.options["web_root"]}/music/(.*)', MusicHandler, name="music"),
                 # routes added by @route decorator
                 # Plus naked index with missing web_root prefix
             ]

--- a/tests/test_music.py
+++ b/tests/test_music.py
@@ -1,0 +1,296 @@
+"""
+Test music module
+"""
+
+import unittest
+from unittest import mock
+
+import musicbrainzngs
+
+from sickchill import settings
+from sickchill.music import MusicList
+from sickchill.oldbeard.databases import music
+from tests import conftest
+
+
+class MusicListTests(conftest.SickChillTestDBCase):
+    """
+    Test music list
+    """
+
+    def setUp(self):
+        """
+        Set up tests
+        """
+        super().setUp()
+        settings.MUSIC_DOWNLOAD_DIR = conftest.TEST_DIR
+        settings.MUSIC_AUTO_SEARCH = False
+        self.music_list = MusicList()
+
+    def tearDown(self):
+        """
+        Tear down tests
+        """
+        super().tearDown()
+
+    @mock.patch('musicbrainzngs.search_artists')
+    def test_search_musicbrainz(self, mock_search_artists):
+        """
+        Test searching for artists on MusicBrainz
+        """
+        # Mock the MusicBrainz API response
+        mock_search_artists.return_value = {
+            "artist-list": [
+                {
+                    "id": "test-artist-id",
+                    "name": "Test Artist",
+                    "sort-name": "Artist, Test",
+                    "country": "US"
+                }
+            ]
+        }
+
+        # Test searching by query
+        results = self.music_list.search_musicbrainz(query="Test Artist")
+        assert len(results) == 1
+        assert results[0]["id"] == "test-artist-id"
+        assert results[0]["name"] == "Test Artist"
+        mock_search_artists.assert_called_once_with("Test Artist", limit=10)
+
+    @mock.patch('musicbrainzngs.get_artist_by_id')
+    def test_search_musicbrainz_by_id(self, mock_get_artist_by_id):
+        """
+        Test searching for artists on MusicBrainz by ID
+        """
+        # Mock the MusicBrainz API response
+        mock_get_artist_by_id.return_value = {
+            "artist": {
+                "id": "test-artist-id",
+                "name": "Test Artist",
+                "sort-name": "Artist, Test",
+                "country": "US"
+            }
+        }
+
+        # Test searching by ID
+        results = self.music_list.search_musicbrainz(artist_id="test-artist-id")
+        assert len(results) == 1
+        assert results[0]["id"] == "test-artist-id"
+        assert results[0]["name"] == "Test Artist"
+        mock_get_artist_by_id.assert_called_once_with("test-artist-id")
+
+    @mock.patch('musicbrainzngs.get_artist_by_id')
+    def test_add_from_musicbrainz(self, mock_get_artist_by_id):
+        """
+        Test adding an artist from MusicBrainz
+        """
+        # Mock the MusicBrainz API response
+        mock_get_artist_by_id.return_value = {
+            "artist": {
+                "id": "test-artist-id",
+                "name": "Test Artist",
+                "sort-name": "Artist, Test",
+                "country": "US",
+                "tag-list": [
+                    {"name": "rock", "count": "10"},
+                    {"name": "pop", "count": "5"}
+                ]
+            }
+        }
+
+        # Mock the get_albums_for_artist method
+        with mock.patch.object(self.music_list, 'get_albums_for_artist') as mock_get_albums:
+            mock_get_albums.return_value = []
+            
+            # Add artist from MusicBrainz
+            artist = self.music_list.add_from_musicbrainz("test-artist-id")
+            
+            # Verify artist was added correctly
+            assert artist is not None
+            assert artist.name == "Test Artist"
+            assert artist.sort_name == "Artist, Test"
+            assert artist.country == "US"
+            
+            # Verify indexer data was added
+            assert len(artist.indexer_data) == 1
+            indexer_data = artist.indexer_data[0]
+            assert indexer_data.site == "musicbrainz"
+            assert indexer_data.pk == "test-artist-id"
+            
+            # Verify genres were added
+            assert len(indexer_data.genres) == 2
+            genre_names = [genre.pk for genre in indexer_data.genres]
+            assert "rock" in genre_names
+            assert "pop" in genre_names
+            
+            # Verify get_albums_for_artist was called
+            mock_get_albums.assert_called_once_with(artist)
+
+    @mock.patch('musicbrainzngs.browse_release_groups')
+    @mock.patch('musicbrainzngs.get_release_group_by_id')
+    @mock.patch('musicbrainzngs.get_release_by_id')
+    def test_get_albums_for_artist(self, mock_get_release, mock_get_release_group, mock_browse_release_groups):
+        """
+        Test getting albums for an artist
+        """
+        # Create a test artist
+        artist = music.Artist(name="Test Artist", sort_name="Artist, Test", country="US")
+        indexer_data = music.IndexerData(site="musicbrainz", pk="test-artist-id")
+        artist.indexer_data.append(indexer_data)
+        self.music_list.commit(artist)
+        
+        # Mock the MusicBrainz API responses
+        mock_browse_release_groups.return_value = {
+            "release-group-list": [
+                {
+                    "id": "test-album-id",
+                    "title": "Test Album",
+                    "type": "Album",
+                    "first-release-date": "2020-01-01"
+                }
+            ]
+        }
+        
+        mock_get_release_group.return_value = {
+            "release-group": {
+                "id": "test-album-id",
+                "title": "Test Album",
+                "type": "Album",
+                "first-release-date": "2020-01-01",
+                "release-list": [
+                    {
+                        "id": "test-release-id",
+                        "title": "Test Album"
+                    }
+                ],
+                "tag-list": [
+                    {"name": "rock", "count": "10"},
+                    {"name": "pop", "count": "5"}
+                ]
+            }
+        }
+        
+        mock_get_release.return_value = {
+            "release": {
+                "id": "test-release-id",
+                "title": "Test Album",
+                "medium-list": [
+                    {
+                        "track-count": 10
+                    }
+                ]
+            }
+        }
+        
+        # Get albums for artist
+        albums = self.music_list.get_albums_for_artist(artist)
+        
+        # Verify album was added correctly
+        assert len(albums) == 1
+        album = albums[0]
+        assert album.name == "Test Album"
+        assert album.year == 2020
+        assert album.tracks == 10
+        assert album.album_type == "Album"
+        
+        # Verify indexer data was added
+        assert len(album.indexer_data) == 1
+        indexer_data = album.indexer_data[0]
+        assert indexer_data.site == "musicbrainz"
+        assert indexer_data.pk == "test-album-id"
+        
+        # Verify genres were added
+        assert len(indexer_data.genres) == 2
+        genre_names = [genre.pk for genre in indexer_data.genres]
+        assert "rock" in genre_names
+        assert "pop" in genre_names
+
+    @mock.patch('sickchill.music.MusicList.search_providers')
+    def test_search_thread(self, mock_search_providers):
+        """
+        Test the search thread functionality
+        """
+        # Create a test artist with albums
+        artist = music.Artist(name="Test Artist", sort_name="Artist, Test", country="US")
+        indexer_data = music.IndexerData(site="musicbrainz", pk="test-artist-id")
+        artist.indexer_data.append(indexer_data)
+        self.music_list.commit(artist)
+        
+        # Mock get_albums_for_artist to return a new album
+        with mock.patch.object(self.music_list, 'get_albums_for_artist') as mock_get_albums:
+            album = music.Album(
+                name="New Album",
+                year=2025,
+                artist_pk=artist.pk,
+                tracks=10,
+                album_type="Album"
+            )
+            album_indexer = music.IndexerData(site="musicbrainz", pk="new-album-id")
+            album.indexer_data.append(album_indexer)
+            mock_get_albums.return_value = [album]
+            
+            # Enable auto search
+            settings.MUSIC_AUTO_SEARCH = True
+            
+            # Run search thread
+            self.music_list.search_thread()
+            
+            # Verify search_providers was called for the new album
+            mock_search_providers.assert_called_once_with(album)
+
+    @mock.patch('sickchill.oldbeard.clients.getClientInstance')
+    def test_snatch_album(self, mock_get_client):
+        """
+        Test snatching an album
+        """
+        # Create a test artist with an album
+        artist = music.Artist(name="Test Artist", sort_name="Artist, Test", country="US")
+        self.music_list.commit(artist)
+        
+        album = music.Album(
+            name="Test Album",
+            year=2020,
+            artist_pk=artist.pk,
+            tracks=10,
+            album_type="Album"
+        )
+        self.music_list.commit(album)
+        
+        # Create a mock result
+        mock_result = mock.MagicMock()
+        mock_result.album = album
+        mock_result.result.url = "http://example.com/test.torrent"
+        mock_result.result.name = "Test Album 2020"
+        mock_result.result.size = 100000
+        mock_result.provider.name = "Test Provider"
+        
+        # Mock the download client
+        mock_client = mock.MagicMock()
+        mock_client.sendTORRENT.return_value = True
+        mock_get_client.return_value.return_value = mock_client
+        
+        # Snatch the album
+        result = self.music_list.snatch_album(mock_result)
+        
+        # Verify the result
+        assert result is True
+        
+        # Verify the album status was updated
+        album = self.music_list.album_query.get(album.pk)
+        assert album.status == music.AlbumStatus.SNATCHED
+        assert album.provider == "Test Provider"
+        assert album.size == 100000
+        
+        # Verify a history entry was created
+        history = self.music_list.session.query(music.MusicHistory).filter_by(album_pk=album.pk).first()
+        assert history is not None
+        assert history.provider == "Test Provider"
+
+
+if __name__ == "__main__":
+    print("==================")
+    print("STARTING - MUSIC TESTS")
+    print("==================")
+    print("######################################################################")
+    SUITE = unittest.TestLoader().loadTestsFromTestCase(MusicListTests)
+    unittest.TextTestRunner(verbosity=2).run(SUITE)


### PR DESCRIPTION
Proposed changes in this pull request:
- support music download via MusicBrainz
- I couldn't find working options, including lidarr
- I know it's a big change, but it's mainly adding files, and not easy to break down

- [x] PR is based on the DEVELOP branch
- [ ] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read [contribution guide](https://github.com/SickChill/SickChill/blob/master/.github/CONTRIBUTING.md)

Tested adding artists, downloading and showing images and background

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced comprehensive music management, including artist and album tracking, powered by MusicBrainz integration.
  * Added web interface for browsing, searching, and managing music artists and albums.
  * Enabled configurable music root and download directories in settings.
  * Added support for album and artist metadata, cover art, and status management.
  * Implemented background music search and download queue.

* **User Interface**
  * New navigation menu for music with pages to list, search, and manage artists and albums.
  * Added UI components for managing music directories and MusicBrainz integration in settings.
  * Enhanced album and artist detail views with metadata and cover images.

* **Bug Fixes**
  * None.

* **Tests**
  * Added unit tests for music management features to ensure reliability and correctness.

* **Chores**
  * Added new dependencies required for MusicBrainz integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->