### PR TITLE
fix: add typescript dependency and migrate xo config to flat config format

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-promise": "^7.0.0",
     "eslint-plugin-unicorn": "^59.0.0",
+    "globals": "^17.5.0",
     "grunt": "^1.6.1",
     "grunt-bower-concat": "git+https://github.com/miigotu/grunt-bower-concat.git",
     "grunt-bower-task": "^0.6.2",
@@ -67,6 +68,7 @@
     "stylelint": "^16.2.1",
     "stylelint-config-idiomatic-order": "^10.0.0",
     "toml": "^3.0.0",
+    "typescript": "^5.5.0",
     "webpack": "^5.90.2",
     "webpack-cli": "^5.1.4",
     "webpack-dev-server": "^5.0.2",
@@ -92,46 +94,5 @@
   },
   "stylelint": {
     "extends": "stylelint-config-idiomatic-order"
-  },
-  "xo": {
-    "space": 4,
-    "rules": {
-      "unicorn/filename-case": "off",
-      "unicorn/prefer-node-append": "off",
-      "unicorn/prefer-global-this": "off",
-      "unicorn/expiring-todo-comments": "off"
-    },
-    "esnext": true,
-    "envs": [
-      "browser"
-    ],
-    "globals": [
-      "_",
-      "scRoot",
-      "jQuery",
-      "$",
-      "metaToBool",
-      "getMeta",
-      "PNotify",
-      "themeSpinner",
-      "anonURL",
-      "Gettext",
-      "gt",
-      "_n",
-      "latinize"
-    ],
-    "ignores": [
-      "core.min.js",
-      "vendor.min.js",
-      "lib/**/*",
-      "Gruntfile.js",
-      "sickchill/gui/slick/js/lib/*",
-      "tests/js/index.js",
-      "frontend/static/*",
-      "frontend/movies/static/",
-      "frontend/shows/static/",
-      "frontend/config/static/",
-      "webpack.config.js"
-    ]
   }
 }

--- a/sickchill/gui/slick/js/browser.js
+++ b/sickchill/gui/slick/js/browser.js
@@ -222,14 +222,12 @@
         newOptions.field.addClass('fileBrowserField');
         if (newOptions.showBrowseButton) {
             // Append the browse button and give it a click behaviour
-            newOptions.field.after(
-                $('<input type="button" value="Browse&hellip;" class="btn btn-inline fileBrowser">').on('click', function () {
-                    const optionsWithInitialDirectory = $.extend({}, newOptions, {initialDirectory: newOptions.field.val() || (newOptions.key && path) || ''});
-                    $(this).nFileBrowser(callback, optionsWithInitialDirectory);
+            newOptions.field.after($('<input type="button" value="Browse&hellip;" class="btn btn-inline fileBrowser">').on('click', function () {
+                const optionsWithInitialDirectory = $.extend({}, newOptions, {initialDirectory: newOptions.field.val() || (newOptions.key && path) || ''});
+                $(this).nFileBrowser(callback, optionsWithInitialDirectory);
 
-                    return false;
-                }),
-            );
+                return false;
+            }));
         }
 
         return newOptions.field;

--- a/sickchill/gui/slick/js/core.js
+++ b/sickchill/gui/slick/js/core.js
@@ -2017,8 +2017,7 @@ const SICKCHILL = {
                         $('#torrent_paused_option').hide();
                         $('#torrent_host_option').hide();
                         $('#host_desc_torrent').text(_('URL to your putio client (e.g. http://localhost:8080)'));
-                        $('label[for="torrent_password"]').html(
-                            '<a href="' + anonURL + 'https://app.put.io/oauth/apps/new" target="_blank">'
+                        $('label[for="torrent_password"]').html('<a href="' + anonURL + 'https://app.put.io/oauth/apps/new" target="_blank">'
                             + _('Create a new OAuth app for put.io') + '</a>');
                         $('#username_title.component-title').text(_('Put.io Parent Folder'));
                         $('#password_title.component-title').text(_('Put.io OAuth Token'));
@@ -2456,7 +2455,7 @@ const SICKCHILL = {
                     getSortData: {
                         name(itemElement) {
                             const name = $(itemElement).attr('data-name') || '';
-                            const regex = new RegExp('^((?:' + getMeta('settings.GRAMMAR_ARTICLES') + ')\\s)', 'i');
+                            const regex = new RegExp('^((?:' + getMeta('settings.GRAMMAR_ARTICLES') + String.raw`)\s)`, 'i');
                             return latinize((metaToBool('settings.SORT_ARTICLE') ? name : name.replace(regex, '')).toLowerCase().normalize('NFC'));
                         },
                         network: '[data-network]',
@@ -2595,7 +2594,7 @@ const SICKCHILL = {
                     getSortData: {
                         name(itemElement) {
                             const name = $(itemElement).attr('data-name') || '';
-                            const regex = new RegExp('^((?:' + getMeta('settings.GRAMMAR_ARTICLES') + ')\\s)', 'i');
+                            const regex = new RegExp('^((?:' + getMeta('settings.GRAMMAR_ARTICLES') + String.raw`)\s)`, 'i');
                             return latinize((metaToBool('settings.SORT_ARTICLE') ? name : name.replace(regex, '')).toLowerCase().normalize('NFC'));
                         },
                         network: '[data-network]',
@@ -2628,7 +2627,7 @@ const SICKCHILL = {
                     getSortData: {
                         name(itemElement) {
                             const name = $(itemElement).attr('data-name') || '';
-                            const regex = new RegExp('^((?:' + getMeta('settings.GRAMMAR_ARTICLES') + ')\\s)', 'i');
+                            const regex = new RegExp('^((?:' + getMeta('settings.GRAMMAR_ARTICLES') + String.raw`)\s)`, 'i');
                             return latinize((metaToBool('settings.SORT_ARTICLE') ? name : name.replace(regex, '')).toLowerCase().normalize('NFC'));
                         },
                         network: '[data-network]',
@@ -3005,8 +3004,7 @@ const SICKCHILL = {
                     indexer,
                     forAbsolute,
                     sceneAbsolute: sceneAbsolute === '' ? null : sceneAbsolute,
-                },
-                data => {
+                }, data => {
                     // Set the values we get back
                     if (data.sceneAbsolute === null) {
                         $('#sceneAbsolute_' + showId + '_' + forAbsolute).val('');
@@ -3983,7 +3981,7 @@ const SICKCHILL = {
                     getSortData: {
                         name(itemElement) {
                             const name = $(itemElement).attr('data-name') || '';
-                            const regex = new RegExp('^((?:' + getMeta('settings.GRAMMAR_ARTICLES') + ')\\s)', 'i');
+                            const regex = new RegExp('^((?:' + getMeta('settings.GRAMMAR_ARTICLES') + String.raw`)\s)`, 'i');
                             return (metaToBool('settings.SORT_ARTICLE') ? name : name.replace(regex, '')).toLowerCase();
                         },
                         rating: '[data-rating] parseInt',
@@ -4144,47 +4142,47 @@ const SICKCHILL = {
             const buildTable = function (shows) {
                 let table
                     = '<div class="row">'
-                    + '<div class="col-lg-6 col-md-12">'
-                    + '<table class="sickchillTable new-show-table tablesorter">'
-                    + '<thead>'
-                    + '<tr>'
-                    + '<th></th>'
-                    + '<th>Show Name</th>'
-                    + '<th>Premiere</th>'
-                    + '<th>Indexer</th>'
-                    + '</tr>'
-                    + '</thead>'
-                    + '<tbody>';
+                        + '<div class="col-lg-6 col-md-12">'
+                        + '<table class="sickchillTable new-show-table tablesorter">'
+                        + '<thead>'
+                        + '<tr>'
+                        + '<th></th>'
+                        + '<th>Show Name</th>'
+                        + '<th>Premiere</th>'
+                        + '<th>Indexer</th>'
+                        + '</tr>'
+                        + '</thead>'
+                        + '<tbody>';
 
                 const selectedIndex = shows.indexOf(show => !show.inShowList);
 
                 for (const [index, show] of shows.entries()) {
                     table
                         += '<tr class="' + (show.inShowList ? 'in-list' : '') + '">'
-                        + '<td>'
-                        + '<input type="radio" class="whichSeries" name="whichSeries" value="' + show.obj + '" '
-                        + (selectedIndex === index ? 'checked ' : '') + (show.inShowList ? 'disabled' : '') + '/>'
-                        + '</td>'
-                        + '<td>'
-                        + (function () {
-                            let string = '<a href=';
-                            string += show.inShowList ? '"/home/displayShow?show=' + show.id + '"' : '"' + show.url + '" target="_blank"';
+                            + '<td>'
+                            + '<input type="radio" class="whichSeries" name="whichSeries" value="' + show.obj + '" '
+                            + (selectedIndex === index ? 'checked ' : '') + (show.inShowList ? 'disabled' : '') + '/>'
+                            + '</td>'
+                            + '<td>'
+                            + (function () {
+                                let string = '<a href=';
+                                string += show.inShowList ? '"/home/displayShow?show=' + show.id + '"' : '"' + show.url + '" target="_blank"';
 
-                            string += '>' + show.title + '</a>';
+                                string += '>' + show.title + '</a>';
 
-                            return string;
-                        })()
-                        + '</td>'
-                        + '<td>' + show.debut + '</td>'
-                        + '<td>' + show.indexer + '</td>'
-                        + '</tr>';
+                                return string;
+                            })()
+                            + '</td>'
+                            + '<td>' + show.debut + '</td>'
+                            + '<td>' + show.indexer + '</td>'
+                            + '</tr>';
                 }
 
                 table
                     += '</tbody>'
-                    + '</table>'
-                    + '</div>'
-                    + '</div>';
+                        + '</table>'
+                        + '</div>'
+                        + '</div>';
 
                 return table;
             };
@@ -4200,10 +4198,8 @@ const SICKCHILL = {
                 }
 
                 const searchingFor = _($('#show-name').val().trim() + ' on ' + $('#providedIndexer option:selected').text() + ' in ' + $('#indexerLangSelect option:selected').text());
-                $('#searchResults').empty().html(
-                    '<img id="searchingAnim" src="' + scRoot + '/images/loading32' + themeSpinner + '.gif" alt="loading" height="32" width="32" /> '
-                    + _('searching {searchingFor}...').replace(/{searchingFor}/, searchingFor),
-                );
+                $('#searchResults').empty().html('<img id="searchingAnim" src="' + scRoot + '/images/loading32' + themeSpinner + '.gif" alt="loading" height="32" width="32" /> '
+                    + _('searching {searchingFor}...').replace(/{searchingFor}/, searchingFor));
 
                 searchRequestXhr = $.post({
                     url: scRoot + '/addShows/searchIndexersForShowName',
@@ -4255,11 +4251,10 @@ const SICKCHILL = {
 
                         $('#searchResults').html(resultString);
                         updateSampleText();
-                        $('.new-show-table').tablesorter(
-                            {
-                                widgets: ['stickyHeaders', 'zebra', 'saveSort'],
-                                headers: {0: {sorter: false}},
-                            });
+                        $('.new-show-table').tablesorter({
+                            widgets: ['stickyHeaders', 'zebra', 'saveSort'],
+                            headers: {0: {sorter: false}},
+                        });
                     },
                 });
             };
@@ -4570,9 +4565,9 @@ const UTIL = {
         }
     },
     init() {
-        const body = document.body;
-        const controller = body.dataset.controller;
-        const action = body.dataset.action;
+        const {body} = document;
+        const {controller} = body.dataset;
+        const {action} = body.dataset;
 
         UTIL.exec('common');
         UTIL.exec(controller);

--- a/sickchill/gui/slick/js/parsers.js
+++ b/sickchill/gui/slick/js/parsers.js
@@ -8,7 +8,7 @@ $.tablesorter.addParser({
             return s.replace(_('Loading...'), '000');
         }
 
-        const regex = new RegExp('^((?:' + getMeta('settings.GRAMMAR_ARTICLES') + ')\\s)', 'i');
+        const regex = new RegExp('^((?:' + getMeta('settings.GRAMMAR_ARTICLES') + String.raw`)\s)`, 'i');
         return latinize(metaToBool('settings.SORT_ARTICLE') ? (s || '') : (s || '').replace(regex, '').normalize('NFC'));
     },
     type: 'text',

--- a/sickchill/gui/slick/js/rootDirs.js
+++ b/sickchill/gui/slick/js/rootDirs.js
@@ -27,7 +27,7 @@
         'trace',
         'warn',
     ];
-    let length = methods.length;
+    let {length} = methods;
     const console = window.console || {};
 
     while (length > 0) {

--- a/sickchill/gui/slick/js/trendingShows.js
+++ b/sickchill/gui/slick/js/trendingShows.js
@@ -12,7 +12,7 @@ $(document).ready(() => {
             getSortData: {
                 name(itemElement) {
                     const name = $(itemElement).attr('data-name') || '';
-                    const regex = new RegExp('^((?:' + getMeta('settings.GRAMMAR_ARTICLES') + ')\\s)', 'i');
+                    const regex = new RegExp('^((?:' + getMeta('settings.GRAMMAR_ARTICLES') + String.raw`)\s)`, 'i');
                     return (metaToBool('settings.SORT_ARTICLE') ? name : name.replace(regex, '')).toLowerCase();
                 },
                 rating: '[data-rating] parseInt',

--- a/xo.config.mjs
+++ b/xo.config.mjs
@@ -3,11 +3,11 @@ import globals from 'globals';
 const xoConfig = [
     {
         ignores: [
-            'core.min.js',
-            'vendor.min.js',
+            '**/core.min.js',
+            '**/vendor.min.js',
             'lib/**/*',
             'Gruntfile.js',
-            'sickchill/gui/slick/js/lib/*',
+            'sickchill/gui/slick/js/lib/**',
             'tests/js/index.js',
             'frontend/static/**',
             'frontend/movies/static/**',

--- a/xo.config.mjs
+++ b/xo.config.mjs
@@ -1,0 +1,49 @@
+import globals from 'globals';
+
+const xoConfig = [
+    {
+        ignores: [
+            'core.min.js',
+            'vendor.min.js',
+            'lib/**/*',
+            'Gruntfile.js',
+            'sickchill/gui/slick/js/lib/*',
+            'tests/js/index.js',
+            'frontend/static/**',
+            'frontend/movies/static/**',
+            'frontend/shows/static/**',
+            'frontend/config/static/**',
+            'frontend/*/src/**',
+            'webpack.config.js',
+        ],
+    },
+    {
+        space: 4,
+        rules: {
+            'unicorn/filename-case': 'off',
+            'unicorn/prefer-node-append': 'off',
+            'unicorn/prefer-global-this': 'off',
+            'unicorn/expiring-todo-comments': 'off',
+        },
+        languageOptions: {
+            globals: {
+                ...globals.browser,
+                _: 'readonly',
+                scRoot: 'readonly',
+                jQuery: 'readonly',
+                $: 'readonly',
+                metaToBool: 'readonly',
+                getMeta: 'readonly',
+                PNotify: 'readonly',
+                themeSpinner: 'readonly',
+                anonURL: 'readonly',
+                Gettext: 'readonly',
+                gt: 'readonly',
+                _n: 'readonly',
+                latinize: 'readonly',
+            },
+        },
+    },
+];
+
+export default xoConfig;

--- a/yarn.lock
+++ b/yarn.lock
@@ -6176,6 +6176,11 @@ globals@^16.0.0, globals@^16.3.0:
   resolved "https://registry.yarnpkg.com/globals/-/globals-16.5.0.tgz#ccf1594a437b97653b2be13ed4d8f5c9f850cac1"
   integrity sha512-c/c15i26VrJ4IRt5Z89DnIzCGDn9EcebibhAOjw5ibqEHsE1wLUgkPn9RDmNcUKyU87GeaL633nyJ+pplFR2ZQ==
 
+globals@^17.5.0:
+  version "17.5.0"
+  resolved "https://registry.yarnpkg.com/globals/-/globals-17.5.0.tgz#a82c641d898f8dfbe0e81f66fdff7d0de43f88c6"
+  integrity sha512-qoV+HK2yFl/366t2/Cb3+xxPUo5BuMynomoDmiaZBIdbs+0pYbjfZU+twLhGKp4uCZ/+NbtpVepH5bGCxRyy2g==
+
 globalthis@^1.0.1, globalthis@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/globalthis/-/globalthis-1.0.4.tgz#7430ed3a975d97bfb59bcce41f5cabbafa651236"
@@ -11411,6 +11416,11 @@ typescript-eslint@^8.3.0, typescript-eslint@^8.37.0:
     "@typescript-eslint/parser" "8.58.2"
     "@typescript-eslint/typescript-estree" "8.58.2"
     "@typescript-eslint/utils" "8.58.2"
+
+typescript@^5.5.0:
+  version "5.9.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.9.3.tgz#5b4f59e15310ab17a216f5d6cf53ee476ede670f"
+  integrity sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==
 
 uglify-js@^3.16.1:
   version "3.19.3"


### PR DESCRIPTION
## Summary

- Adds `typescript` as a devDependency — required by `@typescript-eslint` which is pulled in by `xo@^1.1.0`
- Adds `globals` as a devDependency for browser globals in flat config format
- Migrates xo config from legacy eslintrc format in `package.json` to flat config in `xo.config.mjs`
- Auto-fixes JS files for new stylistic rules from the updated xo/eslint

## Problem

The `yarn test` step (`xo --verbose && ava --verbose`) in the Python Packaging CI workflow has been failing continuously since at least late February 2026 with:

```
Error: Cannot find module 'typescript'
```

This happens because `xo@^1.1.0` (upgraded on `develop`) depends on `typescript-eslint`, which hard-requires `typescript` at load time. Additionally, the xo config in `package.json` used legacy eslintrc-format keys (`esnext`, `envs`, `globals`) that are not supported in xo 1.x flat config.

## Changes

1. **`package.json`**: Added `typescript` and `globals` to devDependencies. Removed the `xo` config section (moved to config file).
2. **`xo.config.mjs`**: New file with xo flat config — includes `space: 4`, rule overrides, ignores, browser globals, and project-specific globals (jQuery, $, PNotify, etc.).
3. **JS files**: Auto-fixed by `xo --fix` for updated indent and style rules.
4. **`yarn.lock`**: Updated with new dependencies.

## Testing

`yarn test` passes locally — xo reports 0 errors (7 warnings for pre-existing long lines) and ava tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Streamlined UI rendering and sorting behavior, simplified DOM/HTML assembly, and refined regex logic for more consistent title sorting and loading displays.

* **Chores**
  * Moved lint configuration to a dedicated config and updated development dependencies (added TypeScript and globals) to standardize tooling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->