### PR TITLE
fix: fix CI and Docker healthcheck quoting, buildkitd typo, and YAML float coercion

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -176,9 +176,9 @@ jobs:
           docker run -d --rm -p 8081:8081 --name ${{ env.DOCKER_CONTAINER_NAME }} ${{ env.DOCKER_TEST_TAG }}
           echo "Waiting ${{ env.SLEEP }} seconds for the container to start..." && sleep ${{ env.SLEEP }}
           echo "Checking if container is alive..."
-          [ $(curl http://localhost:8081/ui/get_messages -s) == "{}" ] && echo "Success!" || (echo "Failed" && exit 1)
+          [ "$(curl http://localhost:8081/ui/get_messages -s)" == "{}" ] && echo "Success!" || (echo "Failed" && exit 1)
           echo "Checking if we have a working home page..."
-          $(curl http://localhost:8081/home/ -s | grep -q "site-notification-modal") && echo "Success!" || (echo "Failed" && exit 1)
+          curl http://localhost:8081/home/ -s | grep -q "site-notification-modal" && echo "Success!" || (echo "Failed" && exit 1)
           echo "Stopping and removing container..."
           docker stop ${{ env.DOCKER_CONTAINER_NAME }}
   Deploy:

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -46,7 +46,7 @@ jobs:
           key: ${{ github.workflow }}-environment
       - name: Create buildkitd config
         run: |
-          echo 'experimantal = true' > /tmp/buildkitd.toml
+          echo 'experimental = true' > /tmp/buildkitd.toml
           echo 'debug = true' >> /tmp/buildkitd.toml
           echo 'insecure-entitlements  = [ "security.insecure" ]' >> /tmp/buildkitd.toml
           # echo '[worker.oci]' >> /tmp/buildkitd.toml
@@ -80,7 +80,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest ]
-        python-version: [ 3.8, 3.9, "3.10", "3.11" ]
+        python-version: [ "3.8", "3.9", "3.10", "3.11" ]
         experimental: [ false ]
         include:
           - os: windows-latest

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -20,7 +20,7 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  SLEEP: 60
+  SLEEP: 120
   DOCKER_BUILDKIT: '1'
   DOCKER_TEST_TAG: sickchill/sickchill:test
   DOCKER_CONTAINER_NAME: sickchill_test
@@ -174,11 +174,30 @@ jobs:
       - name: Test Docker Image
         run: |
           docker run -d --rm -p 8081:8081 --name ${{ env.DOCKER_CONTAINER_NAME }} ${{ env.DOCKER_TEST_TAG }}
-          echo "Waiting ${{ env.SLEEP }} seconds for the container to start..." && sleep ${{ env.SLEEP }}
+
+          echo "Waiting for container to become ready (up to ${{ env.SLEEP }}s)..."
+          for i in $(seq 1 ${{ env.SLEEP }}); do
+            RESPONSE="$(curl -s http://localhost:8081/ui/get_messages 2>/dev/null || true)"
+            if [ "$RESPONSE" == "{}" ]; then
+              echo "Container ready after ${i}s"
+              break
+            fi
+            if [ "$i" -eq "${{ env.SLEEP }}" ]; then
+              echo "Container failed to become ready after ${{ env.SLEEP }}s"
+              echo "Last response: $RESPONSE"
+              docker logs ${{ env.DOCKER_CONTAINER_NAME }}
+              exit 1
+            fi
+            sleep 1
+          done
+
           echo "Checking if container is alive..."
-          [ "$(curl http://localhost:8081/ui/get_messages -s)" == "{}" ] && echo "Success!" || (echo "Failed" && exit 1)
+          RESPONSE="$(curl -s http://localhost:8081/ui/get_messages)"
+          [ "$RESPONSE" == "{}" ] && echo "Success!" || (echo "Failed - got: $RESPONSE" && docker logs ${{ env.DOCKER_CONTAINER_NAME }} && exit 1)
+
           echo "Checking if we have a working home page..."
-          curl http://localhost:8081/home/ -s | grep -q "site-notification-modal" && echo "Success!" || (echo "Failed" && exit 1)
+          curl http://localhost:8081/home/ -s | grep -q "site-notification-modal" && echo "Success!" || (echo "Failed" && docker logs ${{ env.DOCKER_CONTAINER_NAME }} && exit 1)
+
           echo "Stopping and removing container..."
           docker stop ${{ env.DOCKER_CONTAINER_NAME }}
   Deploy:

--- a/Dockerfile
+++ b/Dockerfile
@@ -116,4 +116,4 @@ CMD ["sickchill", "--nolaunch", "--datadir", "/data", "--port", "8081"]
 EXPOSE 8081
 
 HEALTHCHECK --interval=5m --timeout=3s \
- CMD bash -c 'if [ $(curl -f http://localhost:8081/ui/get_messages -s) == "{}" ]; then echo "sickchill is alive"; elif [ $(curl -f https://localhost:8081/ui/get_messages -s) == "{}" ]; then echo "sickchill is alive"; else echo 1; fi'
+ CMD bash -c 'if [ "$(curl -f http://localhost:8081/ui/get_messages -s)" == "{}" ]; then echo "sickchill is alive"; elif [ "$(curl -f https://localhost:8081/ui/get_messages -s)" == "{}" ]; then echo "sickchill is alive"; else echo 1; fi'

--- a/Dockerfile
+++ b/Dockerfile
@@ -116,4 +116,4 @@ CMD ["sickchill", "--nolaunch", "--datadir", "/data", "--port", "8081"]
 EXPOSE 8081
 
 HEALTHCHECK --interval=5m --timeout=3s \
- CMD bash -c 'if [ "$(curl -f http://localhost:8081/ui/get_messages -s)" == "{}" ]; then echo "sickchill is alive"; elif [ "$(curl -f https://localhost:8081/ui/get_messages -s)" == "{}" ]; then echo "sickchill is alive"; else echo 1; fi'
+ CMD bash -c 'if [ "$(curl -f http://localhost:8081/ui/get_messages -s)" == "{}" ]; then echo "sickchill is alive"; elif [ "$(curl -fk https://localhost:8081/ui/get_messages -s)" == "{}" ]; then echo "sickchill is alive"; else echo "sickchill is not responding" && exit 1; fi'


### PR DESCRIPTION
## Summary

- Quotes `$(curl ...)` in the workflow Docker healthcheck so an empty response produces `[ "" == "{}" ]` instead of `[ == "{}" ]`
- Removes the unnecessary `$(...)` wrapper around the `curl | grep -q` pipeline so the exit code is tested directly
- Fixes `experimantal` -> `experimental` typo in buildkitd.toml config (was silently ignored, preventing experimental mode from being enabled)
- Quotes Python `3.8` and `3.9` in the CI matrix to prevent YAML float coercion (`3.10` as a float is `3.1`)
- Quotes `$(curl ...)` in the Dockerfile HEALTHCHECK for the same unary operator bug

## Problem

The **Test Docker Image** step in the Python Packaging workflow fails with:

```
[: ==: unary operator expected
Failed
```

This happens when curl returns an empty response. See: https://github.com/SickChill/sickchill/actions/runs/24693241690/job/72245157607

The same quoting bug exists in the Dockerfile's own HEALTHCHECK directive.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved CI and container readiness checks to be more reliable and robust.
  * Hardened container health probes with clearer failure signaling and safer comparison logic; HTTPS probe now tolerates self-signed/invalid certs for readiness checks.
  * No user-facing changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->