### PR TITLE
fix: use inline buildkitd config instead of broken cross-job cache

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -39,19 +39,6 @@ jobs:
       docker_tags: ${{ steps.docker.outputs.tags }}
       docker_labels: ${{ steps.docker.outputs.labels }}
     steps:
-      - name: Cache environment files
-        uses: actions/cache@v4
-        with:
-          path: /tmp/buildkitd.toml
-          key: ${{ github.workflow }}-environment
-      - name: Create buildkitd config
-        run: |
-          echo 'experimental = true' > /tmp/buildkitd.toml
-          echo 'debug = true' >> /tmp/buildkitd.toml
-          echo 'insecure-entitlements  = [ "security.insecure" ]' >> /tmp/buildkitd.toml
-          # echo '[worker.oci]' >> /tmp/buildkitd.toml
-          # echo 'max-parallelism = 1' >> /tmp/buildkitd.toml
-          cat /tmp/buildkitd.toml
       - name: Docker meta
         id: docker
         uses: docker/metadata-action@v5
@@ -145,18 +132,15 @@ jobs:
     needs: [ Environment, Test ]
     runs-on: ubuntu-22.04
     steps:
-      - name: Restore environment files
-        uses: actions/cache@v4
-        with:
-          path: /tmp/buildkitd.toml
-          key: ${{ github.workflow }}-environment
-          restore-keys: ${{ github.workflow }}-environment
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:
-          config: /tmp/buildkitd.toml
+          buildkitd-config-inline: |
+            experimental = true
+            debug = true
+            insecure-entitlements = [ "security.insecure" ]
       - name: Test Docker Build
         uses: docker/build-push-action@v6
         with:
@@ -211,20 +195,18 @@ jobs:
           docker stop ${{ env.DOCKER_CONTAINER_NAME }} && docker rm ${{ env.DOCKER_CONTAINER_NAME }} 2>/dev/null || true
   Deploy:
     needs: [ Environment, Test, Test-Docker ]
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-22.04
     steps:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
-      - name: Cache environment files
-        uses: actions/cache@v4
-        with:
-          path: /tmp/buildkitd.toml
-          key: ${{ github.workflow }}-environment
-          restore-keys: ${{ github.workflow }}-environment
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:
-          config: /tmp/buildkitd.toml
+          buildkitd-config-inline: |
+            experimental = true
+            debug = true
+            insecure-entitlements = [ "security.insecure" ]
       - if: success() && !env.ACT
         name: Login to DockerHub
         uses: docker/login-action@v3
@@ -289,6 +271,9 @@ jobs:
   complete:
     name: Packaging tests completed
     runs-on: [ ubuntu-latest ]
+    if: always()
     needs: [ Environment, Test, Test-Docker, Deploy ]
     steps:
+      - if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: exit 1
       - run: echo "Success!"


### PR DESCRIPTION
## Summary

- Replace cross-job `actions/cache` of `/tmp/buildkitd.toml` with `buildkitd-config-inline` in `setup-buildx-action`
- Remove the `Cache environment files` / `Restore environment files` steps from Environment, Test-Docker, and Deploy jobs
- Remove the `Create buildkitd config` step from Environment job
- Fixes the deprecated `config` input warning (replaced by `buildkitd-config-inline` in v3)
- Skip Deploy job for fork PRs (no access to Docker Hub secrets)
- Make `Packaging tests completed` resilient to skipped Deploy (use `if: always()` with failure check)

## Root Cause

CI runs on `develop` fail at `Test-Docker → Set up Docker Buildx` with:

```
config file /tmp/buildkitd.toml not found
```

The buildkitd config was created in the `Environment` job and shared to `Test-Docker`/`Deploy` via `actions/cache`. The `refs/heads/develop` cache entry (created Feb 2025, 258 bytes) is permanently broken — cache key lookup succeeds but blob restore consistently fails:

```
Cache hit for: Python Packaging-environment
Failed to restore:
Cache not found for input keys: Python Packaging-environment
```

PR-scoped caches (e.g. `refs/pull/8893/merge`, 255 bytes) restore fine because they were freshly created. But `actions/cache` keys are immutable per ref, so the develop entry can't be overwritten. Only an admin cache deletion or a key name change would fix the current approach.

## Fix

Use `buildkitd-config-inline` to pass the config directly to `setup-buildx-action`, eliminating:
- The cross-job cache dependency (broken on develop, fragile by design)
- The deprecated `config` input (replaced by `buildkitd-config-inline` in v3)
- 3 cache steps across 3 jobs
- The `Create buildkitd config` shell step

Also skip Deploy for fork PRs since they lack Docker Hub secrets, and make the `Packaging tests completed` job handle skipped Deploy gracefully.

## Verification

Tested on fork CI (run 24995978101): Environment, all Tests, and Test-Docker pass. Deploy runs on the fork push (expected — `test-deploy` is a push event) and fails on Docker Hub login (no secrets on fork). On upstream fork PRs, Deploy will be skipped entirely via the `if` condition.