### PR TITLE
fix: replace dead flake9 with ruff for Python 3.12+ compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,11 +58,7 @@ mock = ">=4.0.3,<6.0.0"
 Babel = "^2.9.0"
 pytest-cov = ">=3,<6"
 pytest-isort = ">=3,<5"
-flake8-pytest-style = "^1.5.1"
-flake8-commas = "^2.0.0"
-flake8-quotes = "^3.3.0"
-flake8-docstrings = "^1.6.0"
-flake9 = "^3.8.3"
+ruff = ">=0.4.0,<1.0"
 pytest = ">=7.0.1,<9.0.0,!=8.2.0"
 isort = "^5.10.1"
 poethepoet = ">=0.27.0,<0.31"
@@ -116,43 +112,13 @@ frontend = ["frontend"]
 requires = ["poetry-core>=1.2.0"]
 build-backend = "poetry.core.masonry.api"
 
-[tool.flake8]
-exclude = [
-    ".eggs",
-    ".git",
-    "__pycache__",
-    "docs/source/conf.py",
-    "build",
-    "dist",
-]
-inline-quotes = "double"
-docstring-convention = "numpy"
-ignore = [
-    "C812",
-    "D4",
-    "D400",
-    "D401",
-    "D403",
-    "D406",
-    "D407",
-    "D200",
-    "D202",
-    "D205",
-    "D100",
-    "D101",
-    "D102",
-    "D103",
-    "D104",
-    "D106",
-    "S101",
-    "PT009",
-    "PT017"
-]
-
-max_line_length = 160
-show_source = "True"
+[tool.ruff]
+line-length = 160
 builtins = ["_"]
-#select = 'C103'
+target-version = "py310"
+
+[tool.ruff.lint]
+select = ["F821"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests", "sickchill", "SickChill.py"]
@@ -177,11 +143,6 @@ target_version = ['py310']
 include = '\.pyi?$'
 exclude = 'contrib/scmaintools|\.venv|venv|\.git|\.hg|\.mypy_cache|\.tox|_build|buck-out|build|dist|node_modules|bower_components'
 
-[tool.ruff]
-line-length = 160
-builtins = ["_"]
-target-version = 'py310'
-
 [tool.poe.tasks]
 pytest = "pytest"
 yarn = "yarn"
@@ -190,7 +151,7 @@ ava = "ava"
 
 _black = {cmd = "black . --check --diff", help = "Check code style using black"}
 _isort = {cmd = "isort . --check-only --diff", help = "Check import order"}
-flake8 = {cmd = "flake8 --select C103 sickchill tests SickChill.py", help = "Check for undefined variables"}
+flake8 = {cmd = "ruff check --select F821 sickchill tests SickChill.py", help = "Check for undefined variables"}
 
 isort = {cmd = "isort .", help = "Fix import order"}
 black = {cmd = "black .", help = "Reformat code using black"}

--- a/sickchill/oldbeard/providers/kat.py
+++ b/sickchill/oldbeard/providers/kat.py
@@ -102,6 +102,7 @@ class Provider(TorrentProvider):
 
                             seeders = try_int(result.find(class_="green").get_text(strip=True))
                             leechers = try_int(result.find(class_="red").get_text(strip=True))
+                            size = -1
 
                             # Filter unseeded torrent
                             if seeders < self.minseed or leechers < self.minleech:


### PR DESCRIPTION
## Summary

- Replace flake9 (dead since 2021, crashes on Python 3.12+ with `AttributeError: 'EntryPoints' object has no attribute 'get'`) with ruff
- Unblocks #8900 (drop Python 3.8/3.9, add 3.12/3.13)

## Changes

- **Remove** from dev deps: `flake9`, `flake8-pytest-style`, `flake8-commas`, `flake8-quotes`, `flake8-docstrings`
- **Add**: `ruff = ">=0.4.0,<1.0"`
- **Replace** `[tool.flake8]` config section (30 lines) with `[tool.ruff]` + `[tool.ruff.lint]` (7 lines)
- **Update** poe `flake8` task: `flake8 --select C103` → `ruff check --select F821` (same check: undefined variables)
- **Fix** pre-existing bug in `kat.py`: `size` variable was never assigned (undefined name that flake9 never caught despite being configured for exactly this)

## Testing

- `poe lint` passes (black ✓, isort ✓, ruff ✓)
- `pytest`: 269 passed, 143 skipped, 5 xfailed (same as baseline)

## Context

@BKSteve — this aligns with your comment on #8900 about moving to ruff. This is a minimal migration that only replaces the linting function flake9 was actually performing (undefined variable detection). A broader ruff adoption (replacing black, isort, adding more lint rules) can be done incrementally in follow-up PRs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a data consistency issue in torrent provider results where size information could be missing. Result entries now always include size data with appropriate fallback values when unavailable from the source, ensuring complete and consistent search results.

* **Chores**
  * Updated development dependencies by replacing flake8 with Ruff for improved code linting efficiency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->