### PR TITLE
chore: batch dependency updates + replace black/isort with ruff

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -127,7 +127,7 @@ jobs:
         run: poetry run poe pytest
       - if: github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]'
         name: Coverage
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           env_vars: OS

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,9 +19,11 @@ repos:
     repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v2.3.0
   - hooks:
-      - id: black
-    repo: https://github.com/psf/black
-    rev: 22.10.0
+      - id: ruff-format
+      - id: ruff
+        args: [--select, "I,F821", --fix]
+    repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.12
 #  - hooks:
 #      - id: commitizen
 #      - id: commitizen-branch

--- a/frontend/app.py
+++ b/frontend/app.py
@@ -6,6 +6,7 @@ import threading
 from logging.config import dictConfig
 
 from flask import Flask
+
 from frontend.config import blueprint as config_blueprint
 from frontend.movies import blueprint as movies_blueprint
 from frontend.shows import blueprint as shows_blueprint

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "toml": "^4.1.1",
     "typescript": "^6.0.3",
     "webpack": "^5.90.2",
-    "webpack-cli": "^5.1.4",
+    "webpack-cli": "^7.0.2",
     "webpack-dev-server": "^5.0.2",
     "workbox-webpack-plugin": "^7.0.0",
     "xo": "^2.0.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,17 +53,14 @@ sickchill = "SickChill:main"
 optional = true
 
 [tool.poetry.group.dev.dependencies]
-black = ">=22.8,<25.0"
 coveralls = ">=4.0,<5.0"
 mock = ">=4.0.3,<6.0.0"
 Babel = "^2.9.0"
-pytest-cov = ">=3,<6"
+pytest-cov = ">=3,<8"
 pytest-timeout = ">=2.0,<3.0"
-pytest-isort = ">=3,<5"
 ruff = ">=0.4.0,<1.0"
-pytest = ">=7.0.1,<9.0.0,!=8.2.0"
-isort = "^5.10.1"
-poethepoet = ">=0.27.0,<0.31"
+pytest = ">=7.0.1,!=8.2.0,<10.0.0"
+poethepoet = ">=0.27.0,<0.46"
 po2json = "^0.2.2"
 pre-commit = ">=2.20,<4.0"
 
@@ -81,13 +78,13 @@ optional = true
 
 [tool.poetry.group.types.dependencies]
 types-attrs = "^19.1.0"
-types-pyOpenSSL = ">=22.0.10,<25.0.0"
+types-pyOpenSSL = ">=22.0.10,<26.0.0"
 types-python-dateutil = "^2.8.19"
 types-python-slugify = ">=6.1,<9.0"
 types-requests = "^2.28.11"
 types-chardet = "^5.0.4"
-types-pytz = ">=2022.2.1,<2025.0.0"
-types-setuptools = ">=65.3,<76.0"
+types-pytz = ">=2022.2.1,<2027.0.0"
+types-setuptools = ">=65.3,<83.0"
 types-six = "^1.16.20"
 
 [tool.poetry.group.experimental]
@@ -150,29 +147,16 @@ ignore = [
     "PT017",
     "S101",
 ]
+extend-select = ["F821", "I"]
+
+[tool.ruff.lint.isort]
+combine-as-imports = true
+known-first-party = ["sickchill"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests", "sickchill", "SickChill.py"]
 addopts = "--cov=sickchill --cov-report xml --no-cov-on-fail -v --timeout=120"
 filterwarnings = ['ignore:.*telnetlib.*is deprecated:DeprecationWarning']
-
-[tool.isort]
-profile = "black"
-multi_line_output = 3
-line_length = 160
-combine_as_imports = true
-order_by_type = false
-remove_imports = [ "from __future__ import absolute_import", "from __future__ import print_function", "from __future__ import unicode_literals" ]
-known_first_party = "sickchill"
-extra_standard_library = [ "posixpath", "ntpath" ]
-use_parentheses = true
-src_paths = [ "sickchill", "tests", "SickChill.py", "setup.py" ]
-
-[tool.black]
-line-length = 160
-target_version = ['py310']
-include = '\.pyi?$'
-exclude = 'contrib/scmaintools|\.venv|venv|\.git|\.hg|\.mypy_cache|\.tox|_build|buck-out|build|dist|node_modules|bower_components'
 
 [tool.poe.tasks]
 pytest = "pytest"
@@ -180,20 +164,19 @@ yarn = "yarn"
 xo = "xo"
 ava = "ava"
 
-_black = {cmd = "black . --check --diff", help = "Check code style using black"}
-_isort = {cmd = "isort . --check-only --diff", help = "Check import order"}
-flake8 = {cmd = "ruff check --select F821 sickchill tests SickChill.py", help = "Run Ruff lint checks"}
+_format_check = {cmd = "ruff format --check --diff .", help = "Check code formatting using ruff"}
+_isort_check = {cmd = "ruff check --select I .", help = "Check import order"}
+flake8 = {cmd = "ruff check --select F821 sickchill tests SickChill.py", help = "Check for undefined variables"}
 
-isort = {cmd = "isort .", help = "Fix import order"}
-black = {cmd = "black .", help = "Reformat code using black"}
+format = {cmd = "ruff format .", help = "Reformat code using ruff"}
+isort = {cmd = "ruff check --select I --fix .", help = "Fix import order"}
 
 test_providers = {cmd = "pytest tests/sickchill_tests/providers/torrent/test_parsing.py", help = "Run provider tests"}
 crowdin_upload = "crowdin-cli-py upload sources -c .github/crowdin.yml"
 crowdin_download = "crowdin-cli-py download -c .github/crowdin.yml"
 po2json = "po2json --format jed "
 
-lint = ["_black", "_isort", "flake8"]
-format = ["black", "isort", "flake8"]
+lint = ["_format_check", "_isort_check", "flake8"]
 
 _poetry_update = {shell = "poetry update", help = "update python dependancies"}
 _yarn_upgrade = {cmd = "yarn upgrade", help = "update yarn dependancies"}
@@ -253,7 +236,7 @@ greenlet = {version = ">=2.0.0", allow-prereleases = true}
 jsonrpclib-pelix = "^0.4.2"
 Mako = "^1.1.4"
 markdown2 = "^2.4.0"
-pyOpenSSL = ">=20.0.1,<26.0.0"
+pyOpenSSL = ">=20.0.1,<27.0.0"
 python-dateutil = "^2.8.1"
 python-twitter = "^3.5"
 rarfile = "^4.0"
@@ -262,7 +245,7 @@ tmdbsimple = "^2.8.0"
 tornado = "^6.3.2"
 tvdbsimple = "^1.0.6"
 Unidecode = "^1.2.0"
-validators = ">=0.30.0,<0.35.0"
+validators = ">=0.30.0,<0.36.0"
 enzyme = ">=0.5.0,<0.6.0"
 python3-fanart = "^2.0.0"
 gntp = "^1.0.3"
@@ -276,7 +259,7 @@ Send2Trash = ">=1.5.0"
 deluge-client = "^1.9.0"
 ifaddr = ">=0.1.7,<0.3.0"
 new-rtorrent-python = "^1.0.1-alpha.0"
-qbittorrent-api = ">=2021.3.18,<2025.0.0"
+qbittorrent-api = ">=2021.3.18,<2027.0.0"
 packaging = ">=24.2,<27.0"
 timeago = "^1.0.15"
 SQLAlchemy = ">=2.0.0,<3.0.0"

--- a/sickchill/__init__.py
+++ b/sickchill/__init__.py
@@ -2,4 +2,4 @@ from sickchill.init_helpers import maybe_daemonize
 
 maybe_daemonize()
 
-from sickchill.show.indexers import indexer, ShowIndexer
+from sickchill.show.indexers import ShowIndexer, indexer

--- a/sickchill/helper/__init__.py
+++ b/sickchill/helper/__init__.py
@@ -1,2 +1,2 @@
-from sickchill.helper.common import episode_num, HTTP_STATUS_CODES, MEDIA_EXTENSIONS, pretty_file_size, sanitize_filename, SUBTITLE_EXTENSIONS, try_int
+from sickchill.helper.common import HTTP_STATUS_CODES, MEDIA_EXTENSIONS, SUBTITLE_EXTENSIONS, episode_num, pretty_file_size, sanitize_filename, try_int
 from sickchill.helper.media_info import video_screen_size

--- a/sickchill/helper/argument_parser.py
+++ b/sickchill/helper/argument_parser.py
@@ -1,6 +1,6 @@
 import os
 import sys
-from argparse import ArgumentParser, SUPPRESS
+from argparse import SUPPRESS, ArgumentParser
 
 
 class SickChillArgumentParser:
@@ -19,8 +19,9 @@ class SickChillArgumentParser:
         self.parser.add_argument("-p", "--port", type=int, help="the port to listen on")
         self.parser.add_argument(
             "--datadir",
-            help="full path to a folder where the database, config, cache and log files should be stored. Default: {data_dir}"
-            "{sep}".format(data_dir=self.data_dir, sep=os.sep),
+            help="full path to a folder where the database, config, cache and log files should be stored. Default: {data_dir}{sep}".format(
+                data_dir=self.data_dir, sep=os.sep
+            ),
         )
         self.parser.add_argument(
             "--config",
@@ -35,7 +36,7 @@ class SickChillArgumentParser:
         self.parser.add_argument(
             "--force-update",
             action="store_true",
-            help="download the latest stable version and force an " "update (use when you're unable to do so using " "the web ui)",
+            help="download the latest stable version and force an update (use when you're unable to do so using the web ui)",
         )
         self.parser.add_argument(
             "--install-file",

--- a/sickchill/movies.py
+++ b/sickchill/movies.py
@@ -139,7 +139,7 @@ class MovieList:
         def add_tmdb_genres():
             for genre in tmdb_object["genres"]:
                 if genre["name"] not in imdb_genres:
-                    logger.debug(f'Adding tmdb genre {genre["name"]}')
+                    logger.debug(f"Adding tmdb genre {genre['name']}")
                     tmdb_data.genres.append(movie.Genres(pk=genre["name"]))
             instance.indexer_data.append(tmdb_data)
 

--- a/sickchill/oldbeard/databases/movie.py
+++ b/sickchill/oldbeard/databases/movie.py
@@ -4,7 +4,7 @@ from typing import List
 
 import guessit
 from slugify import slugify
-from sqlalchemy import ForeignKey, JSON
+from sqlalchemy import JSON, ForeignKey
 from sqlalchemy.event import listen
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship, sessionmaker

--- a/sickchill/oldbeard/helpers.py
+++ b/sickchill/oldbeard/helpers.py
@@ -35,8 +35,8 @@ from urllib3 import disable_warnings
 
 import sickchill
 from sickchill import adba, logger, settings
-from sickchill.helper import episode_num, pretty_file_size, SUBTITLE_EXTENSIONS
-from sickchill.helper.common import is_media_file, replace_extension, USER_AGENT
+from sickchill.helper import SUBTITLE_EXTENSIONS, episode_num, pretty_file_size
+from sickchill.helper.common import USER_AGENT, is_media_file, replace_extension
 from sickchill.oldbeard import db
 from sickchill.show.Show import Show
 
@@ -691,7 +691,7 @@ def create_https_certificates(ssl_cert, ssl_key):
     try:
         from OpenSSL import crypto
 
-        from sickchill.certgen import createCertificate, createCertRequest, createKeyPair, TYPE_RSA
+        from sickchill.certgen import TYPE_RSA, createCertificate, createCertRequest, createKeyPair
     except ModuleNotFoundError:
         logger.info(traceback.format_exc())
         logger.warning(_("pyopenssl module missing, please install for https access"))

--- a/sickchill/oldbeard/name_parser/parser.py
+++ b/sickchill/oldbeard/name_parser/parser.py
@@ -6,7 +6,7 @@ from collections import OrderedDict
 from datetime import date
 from operator import attrgetter
 from threading import Lock
-from typing import Any, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from dateutil.parser import parse
 

--- a/sickchill/oldbeard/notifiers/emailnotify.py
+++ b/sickchill/oldbeard/notifiers/emailnotify.py
@@ -41,9 +41,9 @@ class Notifier(object):
                     msg = MIMEMultipart("alternative")
                     msg.attach(
                         MIMEText(
-                            "SickChill Notification - Snatched\n"
-                            "Show: {0}\nEpisode Number: {1}\nEpisode: {2}\nQuality: {3}\n\n"
-                            "Powered by SickChill.".format(show[0], show[1], show[2], show[3])
+                            "SickChill Notification - Snatched\nShow: {0}\nEpisode Number: {1}\nEpisode: {2}\nQuality: {3}\n\nPowered by SickChill.".format(
+                                show[0], show[1], show[2], show[3]
+                            )
                         )
                     )
                     msg.attach(
@@ -95,9 +95,9 @@ class Notifier(object):
                     msg = MIMEMultipart("alternative")
                     msg.attach(
                         MIMEText(
-                            "SickChill Notification - Downloaded\n"
-                            "Show: {0}\nEpisode Number: {1}\nEpisode: {2}\nQuality: {3}\n\n"
-                            "Powered by SickChill.".format(show[0], show[1], show[2], show[3])
+                            "SickChill Notification - Downloaded\nShow: {0}\nEpisode Number: {1}\nEpisode: {2}\nQuality: {3}\n\nPowered by SickChill.".format(
+                                show[0], show[1], show[2], show[3]
+                            )
                         )
                     )
                     msg.attach(
@@ -252,7 +252,7 @@ class Notifier(object):
             else:
                 try:
                     msg = MIMEMultipart("alternative")
-                    msg.attach(MIMEText("SickChill Notification - Updated\n" "Version: {}\n\n" "Powered by SickChill.".format(new_version)))
+                    msg.attach(MIMEText("SickChill Notification - Updated\nVersion: {}\n\nPowered by SickChill.".format(new_version)))
                     msg.attach(
                         MIMEText(
                             '<body style="font-family:Helvetica, Arial, sans-serif;">'
@@ -294,7 +294,7 @@ class Notifier(object):
             else:
                 try:
                     msg = MIMEMultipart("alternative")
-                    msg.attach(MIMEText("SickChill Notification - Remote Login\n" "New login from IP: {0}\n\n" "Powered by SickChill.".format(ipaddress)))
+                    msg.attach(MIMEText("SickChill Notification - Remote Login\nNew login from IP: {0}\n\nPowered by SickChill.".format(ipaddress)))
                     msg.attach(
                         MIMEText(
                             '<body style="font-family:Helvetica, Arial, sans-serif;">'

--- a/sickchill/oldbeard/notifiers/matrix.py
+++ b/sickchill/oldbeard/notifiers/matrix.py
@@ -15,9 +15,7 @@ class Notifier(object):
             message = """<body>
                         <h3>SickChill Notification - Snatched</h3>
                         <p>Show: <b>{0}</b></p><p>Episode Number: <b>{1}</b></p><p>Episode: <b>{2}</b></p><p>Quality: <b>{3}</b></p>
-                        <h5>Powered by SickChill.</h5></body>""".format(
-                show[0], show[1], show[2], show[3]
-            )
+                        <h5>Powered by SickChill.</h5></body>""".format(show[0], show[1], show[2], show[3])
             self._notify_matrix(message)
 
     def notify_download(self, ep_name):
@@ -28,9 +26,7 @@ class Notifier(object):
                         <p>Show: <b>{0}</b></p><p>Episode Number: <b>{1}</b></p><p>Episode: <b>{2}</b></p><p>Quality: <b>{3}</b></p>
                         <h5 style="margin-top: 2.5em; padding: .7em 0;
                         color: #777; border-top: #BBB solid 1px;">
-                        Powered by SickChill.</h5></body>""".format(
-                show[0], show[1], show[2], show[3]
-            )
+                        Powered by SickChill.</h5></body>""".format(show[0], show[1], show[2], show[3])
             self._notify_matrix(message)
 
     def notify_subtitle_download(self, ep_name, lang):
@@ -40,9 +36,7 @@ class Notifier(object):
                         <h3>SickChill Notification - Subtitle Downloaded</h3>
                         <p>Show: <b>{0}</b></p><p>Episode Number: <b>{1}</b></p><p>Episode: <b>{2}</b></p></p>
                         <p>Language: <b>{3}</b></p>
-                        <h5>Powered by SickChill.</h5></body>""".format(
-                show[0], show[1], show[2], lang
-            )
+                        <h5>Powered by SickChill.</h5></body>""".format(show[0], show[1], show[2], lang)
             self._notify_matrix(message)
 
     def notify_update(self, new_version="??"):

--- a/sickchill/oldbeard/postProcessor.py
+++ b/sickchill/oldbeard/postProcessor.py
@@ -6,10 +6,11 @@ import stat
 import subprocess
 from datetime import datetime
 from pathlib import Path
-from typing import List, TYPE_CHECKING, Union
+from typing import TYPE_CHECKING, List, Union
 
 if TYPE_CHECKING:
     from processTV import ParseResult
+
     from sickchill.tv import TVShow
 
 from guessit import guessit
@@ -17,7 +18,7 @@ from guessit import guessit
 import sickchill.helper.common
 import sickchill.oldbeard.subtitles
 from sickchill import adba, logger, settings
-from sickchill.helper.common import episode_num, get_extension, is_rar_file, remove_extension, replace_extension, SUBTITLE_EXTENSIONS
+from sickchill.helper.common import SUBTITLE_EXTENSIONS, episode_num, get_extension, is_rar_file, remove_extension, replace_extension
 from sickchill.helper.exceptions import EpisodeNotFoundException, EpisodePostProcessingFailedException, ShowDirectoryNotFoundException
 from sickchill.oldbeard import common, db, helpers, notifiers, show_name_helpers
 from sickchill.oldbeard.helpers import verify_freespace

--- a/sickchill/oldbeard/properFinder.py
+++ b/sickchill/oldbeard/properFinder.py
@@ -8,7 +8,7 @@ import traceback
 from sickchill import logger, oldbeard, settings
 from sickchill.helper.exceptions import AuthException
 from sickchill.oldbeard import db, helpers
-from sickchill.oldbeard.common import cpu_presets, DOWNLOADED, Quality, SNATCHED, SNATCHED_PROPER
+from sickchill.oldbeard.common import DOWNLOADED, SNATCHED, SNATCHED_PROPER, Quality, cpu_presets
 from sickchill.oldbeard.name_parser.parser import InvalidNameException, InvalidShowException, NameParser
 from sickchill.oldbeard.scdatetime import sctimeago
 from sickchill.oldbeard.search import pick_best_result, snatch_episode

--- a/sickchill/oldbeard/providers/__init__.py
+++ b/sickchill/oldbeard/providers/__init__.py
@@ -209,7 +209,7 @@ def check_enabled_providers():
         if not (daily_enabled and backlog_enabled):
             searches = ((_("daily searches and backlog searches"), _("daily searches"))[backlog_enabled], _("backlog searches"))[daily_enabled]
             formatted_msg = _(
-                "No NZB/Torrent providers found or enabled for {searches}.<br/>" 'Please <a href="{web_root}/config/providers/">check your settings</a>.'
+                'No NZB/Torrent providers found or enabled for {searches}.<br/>Please <a href="{web_root}/config/providers/">check your settings</a>.'
             )
             sickchill.oldbeard.helpers.add_site_message(
                 formatted_msg.format(searches=searches, web_root=settings.WEB_ROOT), tag="no_providers_enabled", level="danger"

--- a/sickchill/oldbeard/providers/alpharatio.py
+++ b/sickchill/oldbeard/providers/alpharatio.py
@@ -129,8 +129,9 @@ class Provider(TorrentProvider):
                             if seeders < self.minseed or leechers < self.minleech:
                                 if mode != "RSS":
                                     logger.debug(
-                                        "Discarding torrent because it doesn't meet the"
-                                        " minimum seeders or leechers: {0} (S:{1} L:{2})".format(title, seeders, leechers)
+                                        "Discarding torrent because it doesn't meet the minimum seeders or leechers: {0} (S:{1} L:{2})".format(
+                                            title, seeders, leechers
+                                        )
                                     )
                                 continue
 

--- a/sickchill/oldbeard/providers/bitcannon.py
+++ b/sickchill/oldbeard/providers/bitcannon.py
@@ -71,8 +71,9 @@ class Provider(TorrentProvider):
                         if seeders < self.minseed or leechers < self.minleech:
                             if mode != "RSS":
                                 logger.debug(
-                                    "Discarding torrent because it doesn't meet the "
-                                    "minimum seeders or leechers: {0} (S:{1} L:{2})".format(title, seeders, leechers)
+                                    "Discarding torrent because it doesn't meet the minimum seeders or leechers: {0} (S:{1} L:{2})".format(
+                                        title, seeders, leechers
+                                    )
                                 )
                             continue
 

--- a/sickchill/oldbeard/providers/bjshare.py
+++ b/sickchill/oldbeard/providers/bjshare.py
@@ -190,8 +190,7 @@ class Provider(TorrentProvider):
                     if seeders < self.minseed or leechers < self.minleech:
                         if mode != "RSS":
                             logger.debug(
-                                "Discarding torrent because it doesn't meet the"
-                                " minimum seeders or leechers: {0} (S:{1} L:{2})".format(title, seeders, leechers)
+                                "Discarding torrent because it doesn't meet the minimum seeders or leechers: {0} (S:{1} L:{2})".format(title, seeders, leechers)
                             )
                         continue
 

--- a/sickchill/oldbeard/providers/btn.py
+++ b/sickchill/oldbeard/providers/btn.py
@@ -2,7 +2,7 @@ import math
 import socket
 import time
 from datetime import datetime
-from typing import Dict, Iterable, List, TYPE_CHECKING, Union
+from typing import TYPE_CHECKING, Dict, Iterable, List, Union
 
 import jsonrpclib
 

--- a/sickchill/oldbeard/providers/filelist.py
+++ b/sickchill/oldbeard/providers/filelist.py
@@ -124,8 +124,9 @@ class Provider(TorrentProvider):
                             if seeders < self.minseed or leechers < self.minleech:
                                 if mode != "RSS":
                                     logger.debug(
-                                        "Discarding torrent because it doesn't meet the"
-                                        " minimum seeders or leechers: {0} (S:{1} L:{2})".format(title, seeders, leechers)
+                                        "Discarding torrent because it doesn't meet the minimum seeders or leechers: {0} (S:{1} L:{2})".format(
+                                            title, seeders, leechers
+                                        )
                                     )
                                 continue
 

--- a/sickchill/oldbeard/providers/hdbits.py
+++ b/sickchill/oldbeard/providers/hdbits.py
@@ -1,6 +1,6 @@
 import datetime
 import json
-from typing import Dict, Iterable, List, TYPE_CHECKING, Union
+from typing import TYPE_CHECKING, Dict, Iterable, List, Union
 from urllib.parse import urlencode, urljoin
 
 from sickchill import logger

--- a/sickchill/oldbeard/providers/immortalseed.py
+++ b/sickchill/oldbeard/providers/immortalseed.py
@@ -132,8 +132,9 @@ class Provider(TorrentProvider):
                             if seeders < self.minseed or leechers < self.minleech:
                                 if mode != "RSS":
                                     logger.debug(
-                                        "Discarding torrent because it doesn't meet the"
-                                        " minimum seeders or leechers: {0} (S:{1} L:{2})".format(title, seeders, leechers)
+                                        "Discarding torrent because it doesn't meet the minimum seeders or leechers: {0} (S:{1} L:{2})".format(
+                                            title, seeders, leechers
+                                        )
                                     )
                                 continue
 

--- a/sickchill/oldbeard/providers/magnetdl.py
+++ b/sickchill/oldbeard/providers/magnetdl.py
@@ -81,8 +81,9 @@ class Provider(TorrentProvider):
                             if seeders < self.minseed or leechers < self.minleech:
                                 if mode != "RSS":
                                     logger.debug(
-                                        "Discarding torrent because it doesn't meet the"
-                                        " minimum seeders or leechers: {0} (S:{1} L:{2})".format(title, seeders, leechers)
+                                        "Discarding torrent because it doesn't meet the minimum seeders or leechers: {0} (S:{1} L:{2})".format(
+                                            title, seeders, leechers
+                                        )
                                     )
                                 continue
 

--- a/sickchill/oldbeard/providers/morethantv.py
+++ b/sickchill/oldbeard/providers/morethantv.py
@@ -1,5 +1,5 @@
 import re
-from typing import Dict, List, TYPE_CHECKING
+from typing import TYPE_CHECKING, Dict, List
 from urllib.parse import urljoin
 
 from requests.utils import dict_from_cookiejar
@@ -160,8 +160,9 @@ class Provider(TorrentProvider):
                             if seeders < self.minseed or leechers < self.minleech:
                                 if mode != "RSS":
                                     logger.debug(
-                                        "Discarding torrent because it doesn't meet the"
-                                        " minimum seeders or leechers: {0} (S:{1} L:{2})".format(title, seeders, leechers)
+                                        "Discarding torrent because it doesn't meet the minimum seeders or leechers: {0} (S:{1} L:{2})".format(
+                                            title, seeders, leechers
+                                        )
                                     )
                                 continue
 

--- a/sickchill/oldbeard/providers/nebulance.py
+++ b/sickchill/oldbeard/providers/nebulance.py
@@ -138,8 +138,9 @@ class Provider(TorrentProvider):
                             if seeders < self.minseed or leechers < self.minleech:
                                 if mode != "RSS":
                                     logger.debug(
-                                        "Discarding torrent because it doesn't meet the"
-                                        " minimum seeders or leechers: {0} (S:{1} L:{2})".format(title, seeders, leechers)
+                                        "Discarding torrent because it doesn't meet the minimum seeders or leechers: {0} (S:{1} L:{2})".format(
+                                            title, seeders, leechers
+                                        )
                                     )
                                 continue
 

--- a/sickchill/oldbeard/providers/norbits.py
+++ b/sickchill/oldbeard/providers/norbits.py
@@ -69,7 +69,7 @@ class Provider(TorrentProvider):
                 if self.check_auth_from_data(parsed_json):
                     json_items = parsed_json.get("data", "")
                     if not json_items:
-                        logger.exception(_("Resulting JSON from provider is not correct, " "not parsing it"))
+                        logger.exception(_("Resulting JSON from provider is not correct, not parsing it"))
 
                     for item in json_items.get("torrents", []):
                         title = item.pop("name", "")
@@ -83,8 +83,9 @@ class Provider(TorrentProvider):
 
                         if seeders < self.minseed or leechers < self.minleech:
                             logger.debug(
-                                "Discarding torrent because it does not meet "
-                                "the minimum seeders or leechers: {0} (S:{1} L:{2})".format(title, seeders, leechers)
+                                "Discarding torrent because it does not meet the minimum seeders or leechers: {0} (S:{1} L:{2})".format(
+                                    title, seeders, leechers
+                                )
                             )
                             continue
 

--- a/sickchill/oldbeard/providers/omgwtfnzbs.py
+++ b/sickchill/oldbeard/providers/omgwtfnzbs.py
@@ -82,7 +82,7 @@ class Provider(NZBProvider):
                     if not self._get_title_and_url(item):
                         continue
 
-                    logger.debug(_("Found result: ") + f'{item.get("release")}')
+                    logger.debug(_("Found result: ") + f"{item.get('release')}")
                     items.append(item)
 
             results += items

--- a/sickchill/oldbeard/providers/rarbg.py
+++ b/sickchill/oldbeard/providers/rarbg.py
@@ -1,7 +1,7 @@
 import datetime
 import re
 import time
-from typing import Dict, List, TYPE_CHECKING
+from typing import TYPE_CHECKING, Dict, List
 
 from sickchill import logger, settings
 from sickchill.helper.common import convert_size, try_int
@@ -131,8 +131,9 @@ class Provider(TorrentProvider):
                         if seeders < self.minseed or leechers < self.minleech:
                             if mode != "RSS":
                                 logger.debug(
-                                    "Discarding torrent because it doesn't meet the"
-                                    " minimum seeders or leechers: {0} (S:{1} L:{2})".format(title, seeders, leechers)
+                                    "Discarding torrent because it doesn't meet the minimum seeders or leechers: {0} (S:{1} L:{2})".format(
+                                        title, seeders, leechers
+                                    )
                                 )
                             continue
 

--- a/sickchill/oldbeard/providers/torrentleech.py
+++ b/sickchill/oldbeard/providers/torrentleech.py
@@ -109,8 +109,9 @@ class Provider(TorrentProvider):
                         if seeders < self.minseed or leechers < self.minleech:
                             if mode != "RSS":
                                 logger.debug(
-                                    "Discarding torrent because it doesn't meet the"
-                                    " minimum seeders or leechers: {0} (S:{1} L:{2})".format(title, seeders, leechers)
+                                    "Discarding torrent because it doesn't meet the minimum seeders or leechers: {0} (S:{1} L:{2})".format(
+                                        title, seeders, leechers
+                                    )
                                 )
                                 continue
 

--- a/sickchill/oldbeard/providers/tvchaosuk.py
+++ b/sickchill/oldbeard/providers/tvchaosuk.py
@@ -99,8 +99,9 @@ class Provider(TorrentProvider):
                             if seeders < self.minseed or leechers < self.minleech:
                                 if mode != "RSS":
                                     logger.debug(
-                                        "Discarding torrent because it doesn't meet the"
-                                        " minimum seeders or leechers: {0} (S:{1} L:{2})".format(title, seeders, leechers)
+                                        "Discarding torrent because it doesn't meet the minimum seeders or leechers: {0} (S:{1} L:{2})".format(
+                                            title, seeders, leechers
+                                        )
                                     )
                                 continue
 

--- a/sickchill/oldbeard/search.py
+++ b/sickchill/oldbeard/search.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:  # pragma: no cover
     from sickchill.providers.result_classes import SearchResult
 
 from sickchill.oldbeard import clients, common, db, helpers, notifiers, nzbget, nzbSplitter, sab, show_name_helpers, ui
-from sickchill.oldbeard.common import MULTI_EP_RESULT, Quality, SEASON_RESULT, SNATCHED, SNATCHED_BEST, SNATCHED_PROPER
+from sickchill.oldbeard.common import MULTI_EP_RESULT, SEASON_RESULT, SNATCHED, SNATCHED_BEST, SNATCHED_PROPER, Quality
 
 
 def _download_result(result: "SearchResult"):

--- a/sickchill/oldbeard/subtitles.py
+++ b/sickchill/oldbeard/subtitles.py
@@ -365,7 +365,7 @@ class SubtitlesFinder(object):
             return
 
         if not enabled_service_list():
-            logger.warning("Not enough services selected. At least 1 service is required to " "search subtitles in the background")
+            logger.warning("Not enough services selected. At least 1 service is required to search subtitles in the background")
             return
 
         self.amActive = True

--- a/sickchill/oldbeard/traktChecker.py
+++ b/sickchill/oldbeard/traktChecker.py
@@ -6,7 +6,7 @@ import sickchill
 from sickchill import logger, settings
 from sickchill.helper.common import episode_num, sanitize_filename
 from sickchill.oldbeard import db, helpers, search_queue
-from sickchill.oldbeard.common import Quality, SKIPPED, UNKNOWN, WANTED
+from sickchill.oldbeard.common import SKIPPED, UNKNOWN, WANTED, Quality
 from sickchill.oldbeard.trakt_api import TraktAPI, traktException
 from sickchill.show.Show import Show
 

--- a/sickchill/providers/GenericProvider.py
+++ b/sickchill/providers/GenericProvider.py
@@ -5,7 +5,7 @@ from datetime import datetime
 from itertools import chain
 from os.path import join
 from random import shuffle
-from typing import Callable, Dict, Iterable, List, TYPE_CHECKING, Union
+from typing import TYPE_CHECKING, Callable, Dict, Iterable, List, Union
 from urllib.parse import urljoin
 
 from requests.structures import CaseInsensitiveDict
@@ -15,7 +15,7 @@ import sickchill.oldbeard
 from sickchill import logger
 from sickchill.helper.common import sanitize_filename, valid_url
 from sickchill.oldbeard import filters
-from sickchill.oldbeard.common import MULTI_EP_RESULT, Quality, SEASON_RESULT
+from sickchill.oldbeard.common import MULTI_EP_RESULT, SEASON_RESULT, Quality
 from sickchill.oldbeard.db import DBConnection
 from sickchill.oldbeard.helpers import download_file, getURL, make_session, remove_file_failed
 from sickchill.oldbeard.name_parser.parser import InvalidNameException, InvalidShowException, NameParser

--- a/sickchill/providers/metadata/generic.py
+++ b/sickchill/providers/metadata/generic.py
@@ -736,9 +736,9 @@ class GenericMetadata(object):
 
         def fix_xml():
             logger.info(
-                _(
-                    "There was an error loading {0}, trying to repair it by fixing & symbols. If it still has problems, please check the file " "manually"
-                ).format(metadata_path)
+                _("There was an error loading {0}, trying to repair it by fixing & symbols. If it still has problems, please check the file manually").format(
+                    metadata_path
+                )
             )
             with open(metadata_path) as __xml_file:
                 output = __xml_file.read()

--- a/sickchill/providers/metadata/kodi.py
+++ b/sickchill/providers/metadata/kodi.py
@@ -195,8 +195,7 @@ class KODIMetadata(generic.GenericMetadata):
             indexer_episode = current_episode.idxr.episode(current_episode)
             if not indexer_episode:
                 logger.info(
-                    "Metadata writer is unable to find episode {0:d}x{1:d} of {2} on {3}..."
-                    "has it been removed? Should I delete from db?".format(
+                    "Metadata writer is unable to find episode {0:d}x{1:d} of {2} on {3}...has it been removed? Should I delete from db?".format(
                         current_episode.season, current_episode.episode, current_episode.show.name, episode_object.idxr.name
                     )
                 )

--- a/sickchill/providers/metadata/mede8er.py
+++ b/sickchill/providers/metadata/mede8er.py
@@ -194,8 +194,7 @@ class Mede8erMetadata(mediabrowser.MediaBrowserMetadata):
             indexer_episode = current_episode.idxr.episode(current_episode)
             if not indexer_episode:
                 logger.info(
-                    "Metadata writer is unable to find episode {0:d}x{1:d} of {2} on {3}..."
-                    "has it been removed? Should I delete from db?".format(
+                    "Metadata writer is unable to find episode {0:d}x{1:d} of {2} on {3}...has it been removed? Should I delete from db?".format(
                         current_episode.season, current_episode.episode, current_episode.show.name, episode_object.idxr.name
                     )
                 )

--- a/sickchill/providers/metadata/wdtv.py
+++ b/sickchill/providers/metadata/wdtv.py
@@ -157,8 +157,7 @@ class WDTVMetadata(generic.GenericMetadata):
             indexer_episode = current_episode.idxr.episode(current_episode)
             if not indexer_episode:
                 logger.info(
-                    "Metadata writer is unable to find episode {0:d}x{1:d} of {2} on {3}..."
-                    "has it been removed? Should I delete from db?".format(
+                    "Metadata writer is unable to find episode {0:d}x{1:d} of {2} on {3}...has it been removed? Should I delete from db?".format(
                         current_episode.season, current_episode.episode, current_episode.show.name, episode_object.idxr.name
                     )
                 )

--- a/sickchill/providers/result_classes.py
+++ b/sickchill/providers/result_classes.py
@@ -1,5 +1,5 @@
 import re
-from typing import List, TYPE_CHECKING, Union
+from typing import TYPE_CHECKING, List, Union
 
 import sickchill
 from sickchill.oldbeard.common import Quality

--- a/sickchill/providers/subtitle/bsplayer.py
+++ b/sickchill/providers/subtitle/bsplayer.py
@@ -17,7 +17,7 @@ from babelfish import Language, language_converters
 from requests.structures import CaseInsensitiveDict
 from subliminal import __short_version__
 from subliminal.providers import Provider, TimeoutSafeTransport
-from subliminal.subtitle import fix_line_ending, Subtitle
+from subliminal.subtitle import Subtitle, fix_line_ending
 
 from sickchill import settings
 from sickchill.oldbeard.helpers import make_context
@@ -151,7 +151,7 @@ class BSPlayerProvider(Provider):
         logger.error("[BSPlayer] ERROR: Too many tries (%d)..." % tries)
 
     def initialize(self):
-        root = self._api_request(func_name="logIn", params=("<username></username>" "<password></password>" "<AppID>BSPlayer v2.67</AppID>"))
+        root = self._api_request(func_name="logIn", params=("<username></username><password></password><AppID>BSPlayer v2.67</AppID>"))
         res = root.find(".//return")
         if res.find("status").text == "OK":
             self.token = res.find("data").text

--- a/sickchill/providers/subtitle/itasa.py
+++ b/sickchill/providers/subtitle/itasa.py
@@ -3,17 +3,17 @@ import io
 import logging
 import re
 from xml.etree import ElementTree
-from zipfile import is_zipfile, ZipFile
+from zipfile import ZipFile, is_zipfile
 
 from babelfish import Language
 from guessit import guessit
 from requests import Session
 from subliminal import __version__
-from subliminal.cache import EPISODE_EXPIRATION_TIME, region, SHOW_EXPIRATION_TIME
+from subliminal.cache import EPISODE_EXPIRATION_TIME, SHOW_EXPIRATION_TIME, region
 from subliminal.exceptions import AuthenticationError, ConfigurationError, DownloadLimitExceeded
 from subliminal.matches import guess_matches, sanitize
 from subliminal.providers import Provider
-from subliminal.subtitle import fix_line_ending, Subtitle
+from subliminal.subtitle import Subtitle, fix_line_ending
 from subliminal.video import Episode
 
 logger = logging.getLogger(__name__)

--- a/sickchill/providers/subtitle/subscenter.py
+++ b/sickchill/providers/subtitle/subscenter.py
@@ -9,11 +9,11 @@ from babelfish import Language
 from guessit import guessit
 from requests import Session
 from subliminal import __short_version__
-from subliminal.cache import region, SHOW_EXPIRATION_TIME
+from subliminal.cache import SHOW_EXPIRATION_TIME, region
 from subliminal.exceptions import AuthenticationError, ConfigurationError, ProviderError
 from subliminal.matches import guess_matches
 from subliminal.providers import ParserBeautifulSoup, Provider
-from subliminal.subtitle import fix_line_ending, Subtitle
+from subliminal.subtitle import Subtitle, fix_line_ending
 from subliminal.utils import sanitize
 from subliminal.video import Episode, Movie
 

--- a/sickchill/providers/subtitle/subtitulamos.py
+++ b/sickchill/providers/subtitle/subtitulamos.py
@@ -2,16 +2,16 @@ import json
 import logging
 import re
 
-from babelfish import Language, language_converters, LanguageReverseConverter
+from babelfish import Language, LanguageReverseConverter, language_converters
 from guessit import guessit
 from requests import Session
 from subliminal import __short_version__
-from subliminal.cache import region, SHOW_EXPIRATION_TIME
+from subliminal.cache import SHOW_EXPIRATION_TIME, region
 from subliminal.exceptions import ProviderError
 from subliminal.matches import guess_matches
 from subliminal.providers import ParserBeautifulSoup, Provider
 from subliminal.score import get_equivalent_release_groups
-from subliminal.subtitle import fix_line_ending, Subtitle
+from subliminal.subtitle import Subtitle, fix_line_ending
 from subliminal.utils import sanitize, sanitize_release_group
 from subliminal.video import Episode
 

--- a/sickchill/providers/subtitle/tusubtitulo.py
+++ b/sickchill/providers/subtitle/tusubtitulo.py
@@ -1,16 +1,16 @@
 import logging
 import re
 
-from babelfish import Language, language_converters, LanguageReverseConverter
+from babelfish import Language, LanguageReverseConverter, language_converters
 from guessit import guessit
 from requests import Session
 from subliminal import __short_version__
-from subliminal.cache import region, SHOW_EXPIRATION_TIME
+from subliminal.cache import SHOW_EXPIRATION_TIME, region
 from subliminal.exceptions import ProviderError
 from subliminal.matches import guess_matches
 from subliminal.providers import ParserBeautifulSoup, Provider
 from subliminal.score import get_equivalent_release_groups
-from subliminal.subtitle import fix_line_ending, Subtitle
+from subliminal.subtitle import Subtitle, fix_line_ending
 from subliminal.utils import sanitize, sanitize_release_group
 from subliminal.video import Episode
 

--- a/sickchill/providers/subtitle/wizdom.py
+++ b/sickchill/providers/subtitle/wizdom.py
@@ -7,11 +7,11 @@ import zipfile
 from babelfish import Language
 from guessit import guessit
 from requests import Session
-from subliminal.cache import region, SHOW_EXPIRATION_TIME
+from subliminal.cache import SHOW_EXPIRATION_TIME, region
 from subliminal.exceptions import ProviderError
 from subliminal.matches import guess_matches
 from subliminal.providers import Provider
-from subliminal.subtitle import fix_line_ending, Subtitle
+from subliminal.subtitle import Subtitle, fix_line_ending
 from subliminal.utils import sanitize
 from subliminal.video import Episode, Movie
 

--- a/sickchill/providers/torrent/FrenchProvider.py
+++ b/sickchill/providers/torrent/FrenchProvider.py
@@ -1,5 +1,5 @@
 import re
-from typing import Dict, List, TYPE_CHECKING
+from typing import TYPE_CHECKING, Dict, List
 from urllib.parse import urljoin
 
 from sickchill import logger, settings

--- a/sickchill/show/ComingEpisodes.py
+++ b/sickchill/show/ComingEpisodes.py
@@ -4,7 +4,7 @@ from operator import itemgetter
 from sickchill import settings
 from sickchill.helper.common import dateFormat, timeFormat
 from sickchill.helper.quality import get_quality_string
-from sickchill.oldbeard.common import Quality, UNAIRED, WANTED
+from sickchill.oldbeard.common import UNAIRED, WANTED, Quality
 from sickchill.oldbeard.db import DBConnection
 from sickchill.oldbeard.network_timezones import parse_date_time
 from sickchill.oldbeard.scdatetime import scdatetime

--- a/sickchill/show/History.py
+++ b/sickchill/show/History.py
@@ -10,13 +10,13 @@ from sickchill.helper.metaclasses import Singleton
 from sickchill.providers.result_classes import SearchResult
 
 if TYPE_CHECKING:
-    from sickchill.tv import TVEpisode, TVShow
     from sickchill.oldbeard.subtitles import Scores
     from sickchill.providers.GenericProvider import GenericProvider
+    from sickchill.tv import TVEpisode, TVShow
 
 from sickchill.helper.common import remove_extension, try_int
 from sickchill.helper.exceptions import EpisodeNotFoundException
-from sickchill.oldbeard.common import FAILED, Quality, SNATCHED, SUBTITLED, WANTED
+from sickchill.oldbeard.common import FAILED, SNATCHED, SUBTITLED, WANTED, Quality
 from sickchill.oldbeard.db import DBConnection
 
 

--- a/sickchill/show/Show.py
+++ b/sickchill/show/Show.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING, Union
 
 from sickchill import settings
 from sickchill.helper.exceptions import CantRefreshShowException, CantRemoveShowException, CantUpdateShowException, MultipleShowObjectsException
-from sickchill.oldbeard.common import Quality, SKIPPED, WANTED
+from sickchill.oldbeard.common import SKIPPED, WANTED, Quality
 from sickchill.oldbeard.db import DBConnection
 
 if TYPE_CHECKING:

--- a/sickchill/show/indexers/tvdb.py
+++ b/sickchill/show/indexers/tvdb.py
@@ -111,7 +111,7 @@ class TVDB(Indexer):
         if re.match(r"^t?t?\d{7,8}$", name) or re.match(r"^\d{6}$", name):
             try:
                 if re.match(r"^t?t?\d{7,8}$", name):
-                    result = self._search(imdbId=f'tt{name.strip("t")}', language=language)
+                    result = self._search(imdbId=f"tt{name.strip('t')}", language=language)
                 elif re.match(r"^\d{6}$", name):
                     series = self._series(name, language=language)
                     if series:
@@ -180,7 +180,7 @@ class TVDB(Indexer):
         location = location.strip()
         if not location:
             return location
-        return f'https://artworks.thetvdb.com/banners/{re.sub(r"^_cache/", "", location)}'
+        return f"https://artworks.thetvdb.com/banners/{re.sub(r'^_cache/', '', location)}"
 
     @ExceptionDecorator(default_return="", catch=(requests.exceptions.RequestException, requests.exceptions.HTTPError, KeyError, Exception), image_api=True)
     def __call_images_api(self, show, thumb, keyType, subKey=None, lang=None, multiple=False):

--- a/sickchill/sickchill-service.py
+++ b/sickchill/sickchill-service.py
@@ -3,9 +3,10 @@ import os.path
 import sys
 
 import servicemanager
-import SickChill
 import win32service
 import win32serviceutil
+
+import SickChill
 
 
 class SickChillService(win32serviceutil.ServiceFramework):

--- a/sickchill/start.py
+++ b/sickchill/start.py
@@ -32,7 +32,7 @@ from sickchill.oldbeard import (
     traktChecker,
 )
 from sickchill.oldbeard.common import ARCHIVED, IGNORED, MULTI_EP_STRINGS, SD, SKIPPED, WANTED
-from sickchill.oldbeard.config import check_section, check_setting_bool, check_setting_float, check_setting_int, check_setting_str, ConfigMigrator
+from sickchill.oldbeard.config import ConfigMigrator, check_section, check_setting_bool, check_setting_float, check_setting_int, check_setting_str
 from sickchill.oldbeard.databases import cache, failed, main
 from sickchill.oldbeard.providers.newznab import NewznabProvider
 from sickchill.oldbeard.providers.rsstorrent import TorrentRssProvider

--- a/sickchill/tv.py
+++ b/sickchill/tv.py
@@ -45,15 +45,15 @@ from sickchill.oldbeard.common import (
     NAMING_LIMITED_EXTEND,
     NAMING_LIMITED_EXTEND_E_PREFIXED,
     NAMING_SEPARATED_REPEAT,
-    Overview,
-    Quality,
     SKIPPED,
     SNATCHED,
     SNATCHED_PROPER,
-    statusStrings,
     UNAIRED,
     UNKNOWN,
     WANTED,
+    Overview,
+    Quality,
+    statusStrings,
 )
 from sickchill.oldbeard.name_parser.parser import InvalidNameException, InvalidShowException, NameParser
 from sickchill.show.Show import Show
@@ -664,8 +664,7 @@ class TVShow(object):
                 # if there is a new file associated with this ep then re-check the quality
                 if episode.location and os.path.normpath(episode.location) != os.path.normpath(filepath):
                     logger.debug(
-                        f"{self.indexerid}: The old episode had a different file associated with it, "
-                        f"re-checking the quality using the new filename {filepath}"
+                        f"{self.indexerid}: The old episode had a different file associated with it, re-checking the quality using the new filename {filepath}"
                     )
                     check_quality_again = True
 
@@ -1317,8 +1316,7 @@ class TVShow(object):
         elif manual_search:
             if (down_cur_quality and quality >= cur_quality) or (not down_cur_quality and quality != cur_quality):
                 logger.debug(
-                    "Usually ignoring found result, but forced search allows the quality,"
-                    " getting found result for {name} {ep} with quality {quality}".format(
+                    "Usually ignoring found result, but forced search allows the quality, getting found result for {name} {ep} with quality {quality}".format(
                         name=self.name, ep=episode_num(season, episode), quality=Quality.qualityStrings[quality]
                     )
                 )

--- a/sickchill/views/__init__.py
+++ b/sickchill/views/__init__.py
@@ -1,4 +1,4 @@
-from sickchill.views.api import ApiCall, ApiHandler, function_mapper, KeyHandler
+from sickchill.views.api import ApiCall, ApiHandler, KeyHandler, function_mapper
 from sickchill.views.authentication import LoginHandler, LogoutHandler
 from sickchill.views.browser import WebFileBrowser
 from sickchill.views.calendar import CalendarHandler

--- a/sickchill/views/api/__init__.py
+++ b/sickchill/views/api/__init__.py
@@ -57,6 +57,6 @@ from sickchill.views.api.webapi import (
     CMDSickChillShutdown,
     CMDSickChillUpdate,
     CMDSubtitleSearch,
-    function_mapper,
     TVDBShorthandWrapper,
+    function_mapper,
 )

--- a/sickchill/views/api/webapi.py
+++ b/sickchill/views/api/webapi.py
@@ -24,15 +24,15 @@ from sickchill.oldbeard.common import (
     DOWNLOADED,
     FAILED,
     IGNORED,
-    Overview,
-    Quality,
     SKIPPED,
     SNATCHED,
     SNATCHED_PROPER,
-    statusStrings_bare,
     UNAIRED,
     UNKNOWN,
     WANTED,
+    Overview,
+    Quality,
+    statusStrings_bare,
 )
 from sickchill.oldbeard.postProcessor import PROCESS_METHODS
 from sickchill.show.ComingEpisodes import ComingEpisodes
@@ -837,9 +837,7 @@ class AbstractStartScheduler(ApiCall):
         if self.scheduler.forceRun():
             cycle_time = self.scheduler.cycleTime
             next_run = datetime.datetime.now() + cycle_time
-            result_str = "Force run successful: {0} search underway. Time Remaining: {1}. " "Next Run: {2}".format(
-                self.scheduler_class_str, time_remain, next_run
-            )
+            result_str = "Force run successful: {0} search underway. Time Remaining: {1}. Next Run: {2}".format(self.scheduler_class_str, time_remain, next_run)
             return _responds(RESULT_SUCCESS, msg=result_str)
 
         # Scheduler is currently active
@@ -1228,7 +1226,7 @@ class CMDLogs(ApiCall):
         "desc": "Get the logs",
         "optionalParameters": {
             "min_level": {
-                "desc": "The minimum level classification of log entries to return. " "Each level inherits its above levels: debug < info < warning < error"
+                "desc": "The minimum level classification of log entries to return. Each level inherits its above levels: debug < info < warning < error"
             },
         },
     }
@@ -1715,7 +1713,7 @@ class CMDSickChillSearchTVRAGE(CMDSickChillSearchIndexers):
     """
 
     _help = {
-        "desc": "Search for a show with a given name on TVRage, in a specific language. " "This command should not longer be used, as TVRage was shut down.",
+        "desc": "Search for a show with a given name on TVRage, in a specific language. This command should not longer be used, as TVRage was shut down.",
         "optionalParameters": {
             "name": {"desc": "The name of the show you want to search for"},
             "lang": {"desc": "The 2-letter language code of the desired show"},

--- a/sickchill/views/calendar.py
+++ b/sickchill/views/calendar.py
@@ -62,16 +62,16 @@ class CalendarHandler(BaseHandler):
 
                 # Create event for episode
                 ical += "BEGIN:VEVENT\r\n"
-                ical += f'DTSTART:{air_date_time.strftime("%Y%m%d")}T{air_date_time.strftime("%H%M%S")}Z\r\n'
-                ical += f'DTEND:{air_date_time_end.strftime("%Y%m%d")}T{air_date_time_end.strftime("%H%M%S")}Z\r\n'
+                ical += f"DTSTART:{air_date_time.strftime('%Y%m%d')}T{air_date_time.strftime('%H%M%S')}Z\r\n"
+                ical += f"DTEND:{air_date_time_end.strftime('%Y%m%d')}T{air_date_time_end.strftime('%H%M%S')}Z\r\n"
                 if settings.CALENDAR_ICONS:
                     ical += "X-GOOGLE-CALENDAR-CONTENT-ICON:https://sickchill.github.io/images/ico/favicon-16.png\r\n"
                     ical += "X-GOOGLE-CALENDAR-CONTENT-DISPLAY:CHIP\r\n"
-                ical += f'SUMMARY: {show["show_name"]} - {episode["season"]}x{episode["episode"]} - {episode["name"]}\r\n'
-                ical += f'UID:SickChill-{datetime.date.today().isoformat()}-{show["show_name"].replace(" ", "-")}-S{episode["season"]}E{episode["episode"]}\r\n'
-                ical += f'DESCRIPTION:{show["airs"] or "(Unknown airs)"} on {show["network"] or "Unknown network"}'
+                ical += f"SUMMARY: {show['show_name']} - {episode['season']}x{episode['episode']} - {episode['name']}\r\n"
+                ical += f"UID:SickChill-{datetime.date.today().isoformat()}-{show['show_name'].replace(' ', '-')}-S{episode['season']}E{episode['episode']}\r\n"
+                ical += f"DESCRIPTION:{show['airs'] or '(Unknown airs)'} on {show['network'] or 'Unknown network'}"
                 if episode["description"]:
-                    ical += f' \\n\\n {episode["description"].splitlines()[0]}'
+                    ical += f" \\n\\n {episode['description'].splitlines()[0]}"
                 ical += "\r\nEND:VEVENT\r\n"
 
         # Ending the iCal

--- a/sickchill/views/home.py
+++ b/sickchill/views/home.py
@@ -17,7 +17,7 @@ from sickchill.helper.common import episode_num, pretty_file_size
 from sickchill.helper.exceptions import CantUpdateShowException, NoNFOException, ShowDirectoryNotFoundException
 from sickchill.oldbeard import clients, config, db, filters, helpers, notifiers, sab, search_queue, subtitles as subtitle_module, ui
 from sickchill.oldbeard.blackandwhitelist import BlackAndWhiteList, short_group_names
-from sickchill.oldbeard.common import cpu_presets, FAILED, IGNORED, Overview, Quality, SKIPPED, SNATCHED_BEST, statusStrings, UNAIRED, WANTED
+from sickchill.oldbeard.common import FAILED, IGNORED, SKIPPED, SNATCHED_BEST, UNAIRED, WANTED, Overview, Quality, cpu_presets, statusStrings
 from sickchill.oldbeard.scene_numbering import (
     get_scene_absolute_numbering,
     get_scene_absolute_numbering_for_show,

--- a/sickchill/views/index.py
+++ b/sickchill/views/index.py
@@ -11,7 +11,7 @@ from urllib.parse import urljoin
 
 from mako.exceptions import RichTraceback
 from tornado.concurrent import run_on_executor
-from tornado.web import authenticated, HTTPError, RequestHandler
+from tornado.web import HTTPError, RequestHandler, authenticated
 
 import sickchill.start
 from sickchill import logger, settings
@@ -74,9 +74,7 @@ class BaseHandler(RequestHandler):
                         <p>{3}</p>
                         <button onclick="window.location='{4}/errorlogs/';">View Log(Errors)</button>
                     </body>
-                    </html>""".format(
-                    error, error, trace_info, request_info, settings.WEB_ROOT
-                )
+                    </html>""".format(error, error, trace_info, request_info, settings.WEB_ROOT)
             )
 
     def redirect(self, url, permanent=False, status=None):
@@ -241,7 +239,7 @@ class WebRoot(WebHandler):
 
         episodes = {}
 
-        results = main_db_con.select("SELECT episode, season, showid " "FROM tv_episodes " "ORDER BY season, episode")
+        results = main_db_con.select("SELECT episode, season, showid FROM tv_episodes ORDER BY season, episode")
 
         for result in results:
             if result["showid"] not in episodes:

--- a/sickchill/views/manage/index.py
+++ b/sickchill/views/manage/index.py
@@ -7,7 +7,7 @@ from sickchill import logger, settings
 from sickchill.helper import episode_num, try_int
 from sickchill.helper.exceptions import CantRefreshShowException, CantUpdateShowException
 from sickchill.oldbeard import db, subtitles as subtitle_module, ui
-from sickchill.oldbeard.common import Overview, Quality, SNATCHED
+from sickchill.oldbeard.common import SNATCHED, Overview, Quality
 from sickchill.show.Show import Show
 from sickchill.views.common import PageTemplate
 from sickchill.views.home import Home, WebRoot

--- a/sickchill/views/server_settings.py
+++ b/sickchill/views/server_settings.py
@@ -110,9 +110,9 @@ class SCWebServer(threading.Thread):
             autoreload=True,
             gzip=settings.WEB_USE_GZIP,
             cookie_secret=settings.WEB_COOKIE_SECRET,
-            login_url=f'{self.options["web_root"]}/login/',
+            login_url=f"{self.options['web_root']}/login/",
             static_path=self.options["data_root"],
-            static_url_prefix=f'{self.options["web_root"]}/',
+            static_url_prefix=f"{self.options['web_root']}/",
             static_handler_class=SickChillStaticFileHandler,
         )
 
@@ -121,27 +121,27 @@ class SCWebServer(threading.Thread):
             ".*$",
             [
                 url(
-                    rf'{self.options["web_root"]}/(favicon\.ico)',
+                    rf"{self.options['web_root']}/(favicon\.ico)",
                     SickChillStaticFileHandler,
                     {"path": os.path.join(self.options["data_root"], "images/ico")},
                     name="favicon",
                 ),
                 url(
-                    rf'{self.options["web_root"]}/images/(.*)',
+                    rf"{self.options['web_root']}/images/(.*)",
                     SickChillStaticFileHandler,
                     {"path": os.path.join(self.options["data_root"], "images")},
                     name="images",
                 ),
                 url(
-                    rf'{self.options["web_root"]}/cache/images/(.*)',
+                    rf"{self.options['web_root']}/cache/images/(.*)",
                     SickChillStaticFileHandler,
                     {"path": os.path.join(settings.CACHE_DIR, "images")},
                     name="image_cache",
                 ),
-                url(rf'{self.options["web_root"]}/css/(.*)', SickChillStaticFileHandler, {"path": os.path.join(self.options["data_root"], "css")}, name="css"),
-                url(rf'{self.options["web_root"]}/js/(.*)', SickChillStaticFileHandler, {"path": os.path.join(self.options["data_root"], "js")}, name="js"),
+                url(rf"{self.options['web_root']}/css/(.*)", SickChillStaticFileHandler, {"path": os.path.join(self.options["data_root"], "css")}, name="css"),
+                url(rf"{self.options['web_root']}/js/(.*)", SickChillStaticFileHandler, {"path": os.path.join(self.options["data_root"], "js")}, name="js"),
                 url(
-                    rf'{self.options["web_root"]}/fonts/(.*)',
+                    rf"{self.options['web_root']}/fonts/(.*)",
                     SickChillStaticFileHandler,
                     {"path": os.path.join(self.options["data_root"], "fonts")},
                     name="fonts",
@@ -153,18 +153,18 @@ class SCWebServer(threading.Thread):
         self.app.add_handlers(
             ".*$",
             [
-                url(rf'{self.options["api_root"]}(/?.*)', ApiHandler, name="api"),
-                url(rf'{self.options["web_root"]}/getkey(/?.*)', KeyHandler, name="get_api_key"),
-                url(rf'{self.options["web_root"]}/api/builder', RedirectHandler, {"url": self.options["web_root"] + "/apibuilder/"}, name="apibuilder"),
-                url(rf'{self.options["web_root"]}/login(/?)', LoginHandler, name="login"),
-                url(rf'{self.options["web_root"]}/logout(/?)', LogoutHandler, name="logout"),
-                url(rf'{self.options["web_root"]}/calendar/?', CalendarHandler, name="calendar"),
-                url(rf'{self.options["web_root"]}/movies/(?P<route>details)/(?P<slug>.*)/', MoviesHandler, name="movies-details"),
-                url(rf'{self.options["web_root"]}/movies/(?P<route>remove)/(?P<pk>.*)/', MoviesHandler, name="movies-remove"),
-                url(rf'{self.options["web_root"]}/movies/(?P<route>add)/', MoviesHandler, name="movies-add"),
-                url(rf'{self.options["web_root"]}/movies/(?P<route>search)/', MoviesHandler, name="movies-search"),
-                url(rf'{self.options["web_root"]}/movies/(?P<route>list)/', MoviesHandler, name="movies-list"),
-                url(rf'{self.options["web_root"]}/movies/(.*)', MoviesHandler, name="movies"),
+                url(rf"{self.options['api_root']}(/?.*)", ApiHandler, name="api"),
+                url(rf"{self.options['web_root']}/getkey(/?.*)", KeyHandler, name="get_api_key"),
+                url(rf"{self.options['web_root']}/api/builder", RedirectHandler, {"url": self.options["web_root"] + "/apibuilder/"}, name="apibuilder"),
+                url(rf"{self.options['web_root']}/login(/?)", LoginHandler, name="login"),
+                url(rf"{self.options['web_root']}/logout(/?)", LogoutHandler, name="logout"),
+                url(rf"{self.options['web_root']}/calendar/?", CalendarHandler, name="calendar"),
+                url(rf"{self.options['web_root']}/movies/(?P<route>details)/(?P<slug>.*)/", MoviesHandler, name="movies-details"),
+                url(rf"{self.options['web_root']}/movies/(?P<route>remove)/(?P<pk>.*)/", MoviesHandler, name="movies-remove"),
+                url(rf"{self.options['web_root']}/movies/(?P<route>add)/", MoviesHandler, name="movies-add"),
+                url(rf"{self.options['web_root']}/movies/(?P<route>search)/", MoviesHandler, name="movies-search"),
+                url(rf"{self.options['web_root']}/movies/(?P<route>list)/", MoviesHandler, name="movies-list"),
+                url(rf"{self.options['web_root']}/movies/(.*)", MoviesHandler, name="movies"),
                 # routes added by @route decorator
                 # Plus naked index with missing web_root prefix
             ]

--- a/tests/sickchill_tests/helper/test_common.py
+++ b/tests/sickchill_tests/helper/test_common.py
@@ -9,6 +9,8 @@ from pathlib import Path
 
 from sickchill import settings
 from sickchill.helper.common import (
+    MEDIA_EXTENSIONS,
+    SUBTITLE_EXTENSIONS,
     convert_size,
     episode_num,
     http_code_description,
@@ -16,12 +18,10 @@ from sickchill.helper.common import (
     is_rar_file,
     is_sync_file,
     is_torrent_or_nzb_file,
-    MEDIA_EXTENSIONS,
     pretty_file_size,
     remove_extension,
     replace_extension,
     sanitize_filename,
-    SUBTITLE_EXTENSIONS,
     try_int,
 )
 

--- a/tests/sickchill_tests/helper/test_quality.py
+++ b/tests/sickchill_tests/helper/test_quality.py
@@ -5,7 +5,7 @@ Test qualities
 import unittest
 
 from sickchill.helper.quality import get_quality_string
-from sickchill.oldbeard.common import ANY, HD, HD720p, HD1080p, Quality, SD
+from sickchill.oldbeard.common import ANY, HD, SD, HD720p, HD1080p, Quality
 
 
 class QualityTests(unittest.TestCase):

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -93,7 +93,7 @@ class QualityStringTests(unittest.TestCase):
             "Test.Show.S01E02.1080p.iTunes.H.264.AAC-GROUP",
             "Test Show S01E02 1080p iTunes H 264 AAC-GROUP",
             "Test_Show_S01E02_1080p_iTunes_H_264_AAC-GROUP",
-            "Test.Show.S01E02.Episode.Name.1080p.Itunes.WEB-DL.x264" "Test.Show.S01E02.Episode.Name.1080p.ItunesHD.WEB-DL.x264",
+            "Test.Show.S01E02.Episode.Name.1080p.Itunes.WEB-DL.x264Test.Show.S01E02.Episode.Name.1080p.ItunesHD.WEB-DL.x264",
             "Test.Show.S01E02.Episode.Name.1080p.ItunesUHD.WEB-DL.x264",
             "Test.Show.S01E02.Episode.Name.1080p.AMZN.WEB-DL.x264",
             "Test.Show.S01E02.Episode.Name.1080p.Amazon.WEB-DL.x264",

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -46,9 +46,7 @@ class ConfigTestBasic(unittest.TestCase):
         """
         Test clean_hosts
         """
-        dirty_hosts = (
-            "http://127.0.0.1:8080,https://mail.google.com/mail," "http://localhost:8081/home/displayShow?show=80379#season-10," "www.google.com/search,"
-        )
+        dirty_hosts = "http://127.0.0.1:8080,https://mail.google.com/mail,http://localhost:8081/home/displayShow?show=80379#season-10,www.google.com/search,"
         clean_result = "127.0.0.1:8080,mail.google.com:5050,localhost:8081,www.google.com:5050"
         assert config.clean_hosts(dirty_hosts, "5050") == clean_result
 

--- a/tests/test_rootdirs.py
+++ b/tests/test_rootdirs.py
@@ -1,7 +1,7 @@
 import logging
 import tempfile
 from pathlib import Path
-from unittest import skip, TestCase
+from unittest import TestCase, skip
 from unittest.mock import patch
 
 from sickchill.helper.rootdirs import RootDirectories

--- a/yarn.lock
+++ b/yarn.lock
@@ -849,10 +849,10 @@
   resolved "https://registry.yarnpkg.com/@csstools/selector-specificity/-/selector-specificity-5.0.0.tgz#037817b574262134cabd68fc4ec1a454f168407b"
   integrity sha512-PCqQV3c4CoVm3kdPhyeZ07VmBRdH2EpMFA/pd9OASpOEC3aXNGoqPDAZ80D0cLpMBxnmk0+yNhGsEx31hq7Gtw==
 
-"@discoveryjs/json-ext@^0.5.0":
-  version "0.5.7"
-  resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz#1d572bfbbe14b7704e0ba0f39b74815b84870d70"
-  integrity sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==
+"@discoveryjs/json-ext@^1.0.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-1.1.0.tgz#44b5ce3485e95235aca06e628eeaaa3c816bc4cc"
+  integrity sha512-Xc3VhU02wqZ1HvHRJUwL09HkZSTvidqY5Ya0NXBSYOxAp+Ln9dcJr9fySI+CkONzP3PekQo9WdzCv0PGER/mOA==
 
 "@dual-bundle/import-meta-resolve@^4.2.1":
   version "4.2.1"
@@ -2347,21 +2347,6 @@
     "@webassemblyjs/ast" "1.14.1"
     "@xtuc/long" "4.2.2"
 
-"@webpack-cli/configtest@^2.1.1":
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/@webpack-cli/configtest/-/configtest-2.1.1.tgz#3b2f852e91dac6e3b85fb2a314fb8bef46d94646"
-  integrity sha512-wy0mglZpDSiSS0XHrVR+BAdId2+yxPSoJW8fsna3ZpYSlufjvxnP4YbKTCBZnNIcGN4r6ZPXV55X4mYExOfLmw==
-
-"@webpack-cli/info@^2.0.2":
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/@webpack-cli/info/-/info-2.0.2.tgz#cc3fbf22efeb88ff62310cf885c5b09f44ae0fdd"
-  integrity sha512-zLHQdI/Qs1UyT5UBdWNqsARasIA+AaF8t+4u2aS2nEpBQh2mWIVb8qAklq0eUENnC5mOItrIB4LiS9xMtph18A==
-
-"@webpack-cli/serve@^2.0.5":
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/@webpack-cli/serve/-/serve-2.0.5.tgz#325db42395cd49fe6c14057f9a900e427df8810e"
-  integrity sha512-lqaoKnRYBdo1UgDX8uF24AfGMifWK19TxPmM5FHc2vAGxrJ/qtyUyFBWoY1tISZdelsQ5fBcOusifo5o5wSJxQ==
-
 "@xtuc/ieee754@^1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@xtuc/ieee754/-/ieee754-1.2.0.tgz#eef014a3145ae477a1cbc00cd1e552336dceb790"
@@ -3236,7 +3221,7 @@ colord@^2.9.3:
   resolved "https://registry.yarnpkg.com/colord/-/colord-2.9.3.tgz#4f8ce919de456f1d5c1c368c307fe20f3e59fb43"
   integrity sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw==
 
-colorette@^2.0.10, colorette@^2.0.14:
+colorette@^2.0.10:
   version "2.0.20"
   resolved "https://registry.yarnpkg.com/colorette/-/colorette-2.0.20.tgz#9eb793e6833067f7235902fcd3b09917a000a95a"
   integrity sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==
@@ -3258,10 +3243,10 @@ combined-stream@^1.0.6, combined-stream@~1.0.6:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@^10.0.1:
-  version "10.0.1"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-10.0.1.tgz#881ee46b4f77d1c1dccc5823433aa39b022cbe06"
-  integrity sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==
+commander@^14.0.3:
+  version "14.0.3"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-14.0.3.tgz#425d79b48f9af82fcd9e4fc1ea8af6c5ec07bbc2"
+  integrity sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==
 
 commander@^2.20.0:
   version "2.20.3"
@@ -3396,7 +3381,7 @@ cosmiconfig@^9.0.0:
     js-yaml "^4.1.0"
     parse-json "^5.2.0"
 
-cross-spawn@^7.0.3, cross-spawn@^7.0.6:
+cross-spawn@^7.0.6:
   version "7.0.6"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.6.tgz#8a58fe78f00dcd70c370451759dfbfaf03e8ee9f"
   integrity sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==
@@ -3753,7 +3738,7 @@ env-paths@^2.2.1:
   resolved "https://registry.yarnpkg.com/env-paths/-/env-paths-2.2.1.tgz#420399d416ce1fbe9bc0a07c62fa68d67fd0f8f2"
   integrity sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==
 
-envinfo@^7.7.3:
+envinfo@^7.14.0:
   version "7.21.0"
   resolved "https://registry.yarnpkg.com/envinfo/-/envinfo-7.21.0.tgz#04a251be79f92548541f37d13c8b6f22940c3bae"
   integrity sha512-Lw7I8Zp5YKHFCXL7+Dz95g4CcbMEpgvqZNNq3AmlT5XAV6CgAAk6gyAMqn2zjw08K9BHfcNuKrMiCPLByGafow==
@@ -8788,24 +8773,20 @@ webidl-conversions@^4.0.2:
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-4.0.2.tgz#a855980b1f0b6b359ba1d5d9fb39ae941faa63ad"
   integrity sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==
 
-webpack-cli@^5.1.4:
-  version "5.1.4"
-  resolved "https://registry.yarnpkg.com/webpack-cli/-/webpack-cli-5.1.4.tgz#c8e046ba7eaae4911d7e71e2b25b776fcc35759b"
-  integrity sha512-pIDJHIEI9LR0yxHXQ+Qh95k2EvXpWzZ5l+d+jIo+RdSm9MiHfzazIxwwni/p7+x4eJZuvG1AJwgC4TNQ7NRgsg==
+webpack-cli@^7.0.2:
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/webpack-cli/-/webpack-cli-7.0.2.tgz#c916e324acc7c14f895226ed351020924900db12"
+  integrity sha512-dB0R4T+C/8YuvM+fabdvil6QE44/ChDXikV5lOOkrUeCkW5hTJv2pGLE3keh+D5hjYw8icBaJkZzpFoaHV4T+g==
   dependencies:
-    "@discoveryjs/json-ext" "^0.5.0"
-    "@webpack-cli/configtest" "^2.1.1"
-    "@webpack-cli/info" "^2.0.2"
-    "@webpack-cli/serve" "^2.0.5"
-    colorette "^2.0.14"
-    commander "^10.0.1"
-    cross-spawn "^7.0.3"
-    envinfo "^7.7.3"
+    "@discoveryjs/json-ext" "^1.0.0"
+    commander "^14.0.3"
+    cross-spawn "^7.0.6"
+    envinfo "^7.14.0"
     fastest-levenshtein "^1.0.12"
     import-local "^3.0.2"
     interpret "^3.1.1"
     rechoir "^0.8.0"
-    webpack-merge "^5.7.3"
+    webpack-merge "^6.0.1"
 
 webpack-dev-middleware@^7.4.2:
   version "7.4.5"
@@ -8853,14 +8834,14 @@ webpack-dev-server@^5.0.2:
     webpack-dev-middleware "^7.4.2"
     ws "^8.18.0"
 
-webpack-merge@^5.7.3:
-  version "5.10.0"
-  resolved "https://registry.yarnpkg.com/webpack-merge/-/webpack-merge-5.10.0.tgz#a3ad5d773241e9c682803abf628d4cd62b8a4177"
-  integrity sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==
+webpack-merge@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/webpack-merge/-/webpack-merge-6.0.1.tgz#50c776868e080574725abc5869bd6e4ef0a16c6a"
+  integrity sha512-hXXvrjtx2PLYx4qruKl+kyRSLc52V+cCvMxRjmKwoA+CBbbF5GfIBtR6kCvl0fYGqTUPKB+1ktVmTHqMOzgCBg==
   dependencies:
     clone-deep "^4.0.1"
     flat "^5.0.2"
-    wildcard "^2.0.0"
+    wildcard "^2.0.1"
 
 webpack-sources@^1.4.3:
   version "1.4.3"
@@ -9020,7 +9001,7 @@ which@^2.0.1, which@~2.0.2:
   dependencies:
     isexe "^2.0.0"
 
-wildcard@^2.0.0:
+wildcard@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/wildcard/-/wildcard-2.0.1.tgz#5ab10d02487198954836b6349f74fff961e10f67"
   integrity sha512-CC1bOL87PIWSBhDcTrdeLo6eGT7mCFtrg0uIJtqJUFyK+eJnzl8A1niH56uu7KMa5XFrtiV+AQuHO3n7DsHnLQ==


### PR DESCRIPTION
## Summary

- Widen version ranges for 9 Python dependencies (dev, types, and runtime)
- Bump webpack-cli from 5.x to 7.x (experimental frontend only)
- Bump codecov/codecov-action from v4 to v6
- **Replace black + isort + pytest-isort with ruff** (format + import sorting)
  - Removes 3 dev dependencies
  - Updates poe tasks to use `ruff format` and `ruff check --select I`
  - Reformats 32 files to match ruff format output (minor style differences vs black 24.x)

## Rationale for dropping black/isort

ruff format is a drop-in replacement for black (same style, same `line-length = 160` config) and ruff's isort rules replace the standalone isort tool. This eliminates version pinning headaches (black 25+ reformats differently) and consolidates all Python linting/formatting into a single tool.

## Notable exclusions

- **ava 7→8**: Requires ESM migration (handled in #8922)
- **xo 1→2**: Handled in #8907 (merged)

## Supersedes

#8908, #8909, #8910, #8912, #8913, #8914, #8915, #8916, #8917, #8918, #8919, #8920

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Codecov integration and build tooling dependencies, including webpack-cli and Poetry dependency version constraints
  * Replaced Black with Ruff for code formatting and style enforcement
  * Refactored internal code organization, imports, and formatting for improved consistency and maintainability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->