### PR TITLE
Upgrade_dependencies.yml schedule

### DIFF
--- a/.github/workflows/upgrade_dependencies.yml
+++ b/.github/workflows/upgrade_dependencies.yml
@@ -1,7 +1,7 @@
 name: "Upgrade poetry and yarn dependencies"
 on:
   schedule:
-    - cron: "30 2 * * *"
+    - cron: "30 2 * * 1"
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
change from daily to weekly (Monday) per other updaters to develop.

Fixes too many updates.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency upgrade workflow schedule to run on Mondays only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->