### PR TITLE
fix: use video.subtitles.extend for external subtitle discovery

### DIFF
--- a/sickchill/oldbeard/subtitles.py
+++ b/sickchill/oldbeard/subtitles.py
@@ -303,7 +303,7 @@ def get_video(video_path, subtitles_path=None, subtitles=True, embedded_subtitle
 
         # external subtitles
         if subtitles:
-            video.subtitle_languages |= set(subliminal.core.search_external_subtitles(video_path, directory=subtitles_path).values())
+            video.subtitles.extend(subliminal.core.search_external_subtitles(video_path, directory=subtitles_path).values())
 
         if embedded_subtitles is None:
             embedded_subtitles = bool(not settings.EMBEDDED_SUBTITLES_ALL and video_path.endswith(".mkv"))

--- a/tests/test_subtitles.py
+++ b/tests/test_subtitles.py
@@ -1,0 +1,73 @@
+"""Tests for subtitle scanning and external subtitle discovery."""
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from sickchill.oldbeard import subtitles as subtitle_module
+
+
+class TestGetVideo(unittest.TestCase):
+    """Test the get_video function."""
+
+    @patch("sickchill.oldbeard.subtitles.get_subtitles_path")
+    @patch("sickchill.oldbeard.subtitles.subliminal")
+    def test_external_subtitles_added_to_video_subtitles(self, mock_subliminal, mock_get_path):
+        """External subtitles should be added to video.subtitles (not subtitle_languages)."""
+        mock_get_path.return_value = "/fake/subs"
+
+        mock_video = MagicMock()
+        mock_video.subtitles = []
+        mock_video.name = "video.mkv"
+        mock_subliminal.scan_video.return_value = mock_video
+
+        fake_external_sub = MagicMock(name="ExternalSubtitle")
+        mock_subliminal.core.search_external_subtitles.return_value = {
+            "video.en.srt": fake_external_sub,
+        }
+
+        result = subtitle_module.get_video("/fake/path/video.mkv")
+
+        self.assertIs(result, mock_video)
+        self.assertIn(fake_external_sub, result.subtitles)
+        mock_subliminal.core.search_external_subtitles.assert_called_once_with(
+            "/fake/path/video.mkv", directory="/fake/subs"
+        )
+
+    @patch("sickchill.oldbeard.subtitles.get_subtitles_path")
+    @patch("sickchill.oldbeard.subtitles.subliminal")
+    def test_external_subtitles_multiple(self, mock_subliminal, mock_get_path):
+        """Multiple external subtitles should all be added."""
+        mock_get_path.return_value = "/fake/subs"
+
+        mock_video = MagicMock()
+        mock_video.subtitles = []
+        mock_video.name = "video.mkv"
+        mock_subliminal.scan_video.return_value = mock_video
+
+        sub_en = MagicMock(name="ExternalSubtitle-en")
+        sub_fr = MagicMock(name="ExternalSubtitle-fr")
+        mock_subliminal.core.search_external_subtitles.return_value = {
+            "video.en.srt": sub_en,
+            "video.fr.srt": sub_fr,
+        }
+
+        result = subtitle_module.get_video("/fake/path/video.mkv")
+
+        self.assertEqual(len(result.subtitles), 2)
+        self.assertIn(sub_en, result.subtitles)
+        self.assertIn(sub_fr, result.subtitles)
+
+    @patch("sickchill.oldbeard.subtitles.get_subtitles_path")
+    @patch("sickchill.oldbeard.subtitles.subliminal")
+    def test_no_external_subtitles_when_disabled(self, mock_subliminal, mock_get_path):
+        """When subtitles=False, search_external_subtitles should not be called."""
+        mock_get_path.return_value = "/fake/subs"
+
+        mock_video = MagicMock()
+        mock_video.subtitles = []
+        mock_video.name = "video.mkv"
+        mock_subliminal.scan_video.return_value = mock_video
+
+        subtitle_module.get_video("/fake/path/video.mkv", subtitles=False)
+
+        mock_subliminal.core.search_external_subtitles.assert_not_called()


### PR DESCRIPTION
## Summary
- Fix `AttributeError` when scanning external subtitles with subliminal 2.x

## Problem
`subliminal.core.search_external_subtitles()` changed its return type in subliminal 2.x:
- **Old** (subliminal 1.x): returns `dict[str, Language]`
- **New** (subliminal 2.x): returns `dict[str, ExternalSubtitle]`

Additionally, `video.subtitle_languages` changed from a mutable `set` attribute to a **read-only property** computed from `video.subtitles`. The old code:

```python
video.subtitle_languages |= set(search_external_subtitles(...).values())
```

fails with `AttributeError` because you can't `|=` into a property, and the values are `ExternalSubtitle` objects not `Language` objects.

## Fix
```python
video.subtitles.extend(search_external_subtitles(...).values())
```

This adds the `ExternalSubtitle` objects to `video.subtitles` (a mutable list), and the `subtitle_languages` property correctly derives the `Language` set from them.

## Context
Reported via [Discord](https://discord.com/channels/502612977271439372/1132477941436125256), flagged by @BKSteve on #8924.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * External subtitle discovery now correctly registers discovered subtitle files so they appear alongside a video's existing subtitles.

* **Tests**
  * Added unit tests to verify external subtitles are detected and attached, support multiple matches, and are skipped when external subtitle scanning is disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->