### PR TITLE
fix: subliminal 2.x compatibility for subtitle scoring, paths, and metadata

### DIFF
--- a/sickchill/oldbeard/subtitles.py
+++ b/sickchill/oldbeard/subtitles.py
@@ -5,7 +5,6 @@ import subprocess
 import threading
 import traceback
 from collections import namedtuple
-from typing import Union
 
 import subliminal
 from babelfish import Language, language_converters
@@ -55,13 +54,15 @@ max_score = {}
 Scores = namedtuple("Scores", "res percent min min_percent")
 
 
-def log_scores(subtitle: Union[subliminal.Episode, subliminal.Movie], video: subliminal.Video, user_score: int = None) -> Scores:
+def log_scores(subtitle: subliminal.subtitle.Subtitle, video: subliminal.Video, user_score: int | None = None) -> Scores:
     if not max_score:
         max_score[subliminal.Episode] = sum(subliminal.score.episode_scores.values())
         max_score[subliminal.Movie] = sum(subliminal.score.movie_scores.values())
 
-    score = subliminal.score.compute_score(subtitle, video, hearing_impaired=settings.SUBTITLES_HEARING_IMPAIRED)
-    return Scores(score, round(score / max_score[type(video)] * 100), user_score, round(user_score / max_score[type(video)] * 100))
+    score = subliminal.score.compute_score(subtitle, video)
+    max_s = max_score[type(video)]
+    min_percent = round(user_score / max_s * 100) if user_score is not None else 0
+    return Scores(score, round(score / max_s * 100), user_score, min_percent)
 
 
 class SubtitleProviderPool(object):
@@ -203,15 +204,14 @@ def download_subtitles(episode, force_lang=None):
     subtitles_path = get_subtitles_path(episode.location)
     video_path = episode.location
 
-    # Perfect match = hash score - hearing impaired score - resolution score
-    # (subtitle for 720p is the same as for 1080p)
-    # Perfect match = 215 - 1 - 1 = 213
+    # Compute score thresholds dynamically from subliminal's current scoring tables.
+    # Perfect match = hash - resolution - video_codec (subtitle for 720p is the same as for 1080p)
     # Non-perfect match = series + year + season + episode
-    # Non-perfect match = 108 + 54 + 18 + 18 = 198
-    # From latest subliminal code:
-    # episode_scores = {'hash': 215, 'series': 108, 'year': 54, 'season': 18, 'episode': 18, 'release_group': 9,
-    #                   'source': 4, 'audio_codec': 2, 'resolution': 1, 'hearing_impaired': 1, 'video_codec': 1}
-    user_score = 213 if settings.SUBTITLES_PERFECT_MATCH else 198
+    scores = subliminal.score.episode_scores
+    if settings.SUBTITLES_PERFECT_MATCH:
+        user_score = scores["hash"] - scores.get("resolution", 0) - scores.get("video_codec", 0)
+    else:
+        user_score = scores.get("series", 0) + scores.get("year", 0) + scores.get("season", 0) + scores.get("episode", 0)
 
     video = get_video(video_path, subtitles_path=subtitles_path, episode=episode)
     if not video:
@@ -260,7 +260,7 @@ def download_subtitles(episode, force_lang=None):
         return existing_subtitles, None
 
     for subtitle in found_subtitles:
-        subtitle_path = subliminal.subtitle.get_subtitle_path(video.name, None if not settings.SUBTITLES_MULTI else subtitle.language)
+        subtitle_path = subliminal.subtitle.get_subtitle_path(video.name, "" if not settings.SUBTITLES_MULTI else f".{subtitle.language.alpha2}")
         if subtitles_path is not None:
             subtitle_path = os.path.join(subtitles_path, os.path.split(subtitle_path)[1])
 
@@ -307,7 +307,7 @@ def get_video(video_path, subtitles_path=None, subtitles=True, embedded_subtitle
 
         # external subtitles
         if subtitles:
-            video.subtitle_languages |= set(subliminal.core.search_external_subtitles(video_path, directory=subtitles_path).values())
+            video.subtitles.extend(subliminal.core.search_external_subtitles(video_path, directory=subtitles_path).values())
 
         if embedded_subtitles is None:
             embedded_subtitles = bool(not settings.EMBEDDED_SUBTITLES_ALL and video_path.endswith(".mkv"))
@@ -472,7 +472,7 @@ def run_subs_extra_scripts(episode, subtitle, video, single=False):
         script_cmd[0] = os.path.abspath(script_cmd[0])
         logger.debug(f"Absolute path to script: {script_cmd[0]}")
 
-        subtitle_path = subliminal.subtitle.get_subtitle_path(video.name, None if single else subtitle.language)
+        subtitle_path = subliminal.subtitle.get_subtitle_path(video.name, "" if single else f".{subtitle.language.alpha2}")
 
         inner_cmd = script_cmd + [
             video.name,
@@ -503,14 +503,19 @@ def run_subs_extra_scripts(episode, subtitle, video, single=False):
 def refine_video(video, episode):
     # try to enrich video object using information in original filename
     if episode.release_name:
-        guess_ep = subliminal.Episode.fromguess(episode.release_name, guessit(episode.release_name))
-        for name in vars(guess_ep):
-            if getattr(guess_ep, name) and not getattr(video, name):
-                setattr(video, name, getattr(guess_ep, name))
+        try:
+            guess_ep = subliminal.Episode.fromguess(episode.release_name, guessit(episode.release_name))
+        except ValueError as error:
+            logger.debug(f"Unable to guess episode from release name {episode.release_name!r}: {error}")
+            guess_ep = None
+
+        if guess_ep:
+            for name in vars(guess_ep):
+                if getattr(guess_ep, name) and not getattr(video, name):
+                    setattr(video, name, getattr(guess_ep, name))
 
     # Use oldbeard metadata
     metadata_mapping = {
-        "episode": "episode",
         "release_group": "release_group",
         "season": "season",
         "series": "show.name",
@@ -540,6 +545,14 @@ def refine_video(video, episode):
                 setattr(video, name, get_attr_value(episode, metadata_mapping[name]))
         except AttributeError:
             logger.debug("Unable to set {}.{} from episode.{} attribute".format(type(video), name, metadata_mapping[name]))
+
+    # Set episode separately — video.episode is a read-only property in subliminal 2.x,
+    # so we must set video.episodes (a list) instead.
+    try:
+        if episode.episode and (not video.episodes or episode.show.subtitles_sc_metadata):
+            video.episodes = [episode.episode]
+    except AttributeError:
+        logger.debug("Unable to set {}.episodes from episode.episode attribute".format(type(video)))
 
     # Set quality from metadata
     status, quality = Quality.splitCompositeStatus(episode.status)

--- a/tests/test_subtitles.py
+++ b/tests/test_subtitles.py
@@ -1,0 +1,204 @@
+"""Tests for subliminal 2.x compatibility in the subtitles module."""
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+import subliminal
+import subliminal.score
+import subliminal.subtitle
+from babelfish import Language
+
+from sickchill import settings
+from sickchill.oldbeard import subtitles as subtitle_module
+
+
+class TestGetVideo(unittest.TestCase):
+    """Test the get_video function."""
+
+    @patch("sickchill.oldbeard.subtitles.get_subtitles_path")
+    @patch("sickchill.oldbeard.subtitles.subliminal")
+    def test_external_subtitles_added_to_video_subtitles(self, mock_subliminal, mock_get_path):
+        """External subtitles should be added to video.subtitles, not subtitle_languages."""
+        mock_get_path.return_value = "/fake/subs"
+
+        mock_video = MagicMock()
+        mock_video.subtitles = []
+        mock_video.name = "video.mkv"
+        mock_subliminal.scan_video.return_value = mock_video
+
+        fake_external_sub = MagicMock(name="ExternalSubtitle")
+        mock_subliminal.core.search_external_subtitles.return_value = {
+            "video.en.srt": fake_external_sub,
+        }
+
+        result = subtitle_module.get_video("/fake/path/video.mkv")
+
+        self.assertIs(result, mock_video)
+        self.assertIn(fake_external_sub, result.subtitles)
+
+    @patch("sickchill.oldbeard.subtitles.get_subtitles_path")
+    @patch("sickchill.oldbeard.subtitles.subliminal")
+    def test_external_subtitles_multiple(self, mock_subliminal, mock_get_path):
+        """Multiple external subtitles should all be added."""
+        mock_get_path.return_value = "/fake/subs"
+
+        mock_video = MagicMock()
+        mock_video.subtitles = []
+        mock_video.name = "video.mkv"
+        mock_subliminal.scan_video.return_value = mock_video
+
+        sub_en = MagicMock(name="ExternalSubtitle-en")
+        sub_fr = MagicMock(name="ExternalSubtitle-fr")
+        mock_subliminal.core.search_external_subtitles.return_value = {
+            "video.en.srt": sub_en,
+            "video.fr.srt": sub_fr,
+        }
+
+        result = subtitle_module.get_video("/fake/path/video.mkv")
+
+        self.assertEqual(len(result.subtitles), 2)
+        self.assertIn(sub_en, result.subtitles)
+        self.assertIn(sub_fr, result.subtitles)
+
+    @patch("sickchill.oldbeard.subtitles.get_subtitles_path")
+    @patch("sickchill.oldbeard.subtitles.subliminal")
+    def test_no_external_subtitles_when_disabled(self, mock_subliminal, mock_get_path):
+        """When subtitles=False, search_external_subtitles should not be called."""
+        mock_get_path.return_value = "/fake/subs"
+
+        mock_video = MagicMock()
+        mock_video.subtitles = []
+        mock_video.name = "video.mkv"
+        mock_subliminal.scan_video.return_value = mock_video
+
+        subtitle_module.get_video("/fake/path/video.mkv", subtitles=False)
+
+        mock_subliminal.core.search_external_subtitles.assert_not_called()
+
+
+class TestScoreThresholds(unittest.TestCase):
+    """Test that score thresholds use subliminal's actual scoring tables."""
+
+    def test_perfect_match_score_uses_hash(self):
+        """Perfect match score should be derived from the hash score, not hardcoded."""
+        scores = subliminal.score.episode_scores
+        perfect = scores["hash"] - scores.get("resolution", 0) - scores.get("video_codec", 0)
+        non_perfect = scores.get("series", 0) + scores.get("year", 0) + scores.get("season", 0) + scores.get("episode", 0)
+        # Must not be the old hardcoded value
+        self.assertNotEqual(perfect, 213)
+        # Must be positive and greater than non-perfect threshold
+        self.assertGreater(perfect, 0)
+        self.assertGreater(perfect, non_perfect)
+
+    def test_non_perfect_match_score(self):
+        """Non-perfect match score should sum series+year+season+episode."""
+        scores = subliminal.score.episode_scores
+        expected = scores.get("series", 0) + scores.get("year", 0) + scores.get("season", 0) + scores.get("episode", 0)
+        # Must not be the old hardcoded value
+        self.assertNotEqual(expected, 198)
+        # Must be positive
+        self.assertGreater(expected, 0)
+
+
+class TestGetSubtitlePath(unittest.TestCase):
+    """Test that get_subtitle_path receives correct string arguments."""
+
+    def test_single_subtitle_path(self):
+        """Single subtitle mode should pass empty string suffix."""
+        result = subliminal.subtitle.get_subtitle_path("/path/to/video.mkv", "")
+        self.assertEqual(result, "/path/to/video.srt")
+
+    def test_multi_subtitle_path_with_language(self):
+        """Multi subtitle mode should pass language code as string suffix."""
+        lang = Language("eng")
+        result = subliminal.subtitle.get_subtitle_path("/path/to/video.mkv", f".{lang.alpha2}")
+        self.assertEqual(result, "/path/to/video.en.srt")
+
+    def test_none_suffix_crashes(self):
+        """Passing None as suffix should raise TypeError (the old bug)."""
+        with self.assertRaises(TypeError):
+            subliminal.subtitle.get_subtitle_path("/path/to/video.mkv", None)
+
+    def test_language_object_suffix_crashes(self):
+        """Passing a Language object as suffix should raise TypeError (the old bug)."""
+        lang = Language("eng")
+        with self.assertRaises(TypeError):
+            subliminal.subtitle.get_subtitle_path("/path/to/video.mkv", lang)
+
+
+class TestRefineVideo(unittest.TestCase):
+    """Test refine_video for subliminal 2.x compatibility."""
+
+    def test_episode_attribute_is_readonly_property(self):
+        """video.episode should be a read-only property in subliminal 2.x."""
+        ep = subliminal.Episode("test.mkv", series="Test", season=1, episodes=[5])
+        self.assertEqual(ep.episode, 5)
+        with self.assertRaises(AttributeError):
+            ep.episode = 10  # noqa: B009
+
+    def test_episodes_attribute_is_settable(self):
+        """video.episodes should be settable."""
+        ep = subliminal.Episode("test.mkv", series="Test", season=1, episodes=[5])
+        ep.episodes = [10]
+        self.assertEqual(ep.episode, 10)
+
+    @patch("sickchill.oldbeard.subtitles.guessit")
+    @patch("sickchill.oldbeard.subtitles.subliminal")
+    def test_refine_video_sets_episodes_not_episode(self, mock_subliminal, mock_guessit):
+        """refine_video should set video.episodes (list) not video.episode (property)."""
+        mock_video = MagicMock(spec=[])  # no spec so setattr works freely
+        mock_video.episodes = None
+        mock_video.release_group = "TestGroup"
+        mock_video.season = 1
+        mock_video.series = "TestShow"
+        mock_video.series_imdb_id = None
+        mock_video.size = None
+        mock_video.title = None
+        mock_video.year = None
+        mock_video.series_tvdb_id = None
+        mock_video.tvdb_id = None
+        mock_video.source = None
+        mock_video.resolution = None
+
+        mock_episode = MagicMock()
+        mock_episode.release_name = None
+        mock_episode.episode = 5
+        mock_episode.show.subtitles_sc_metadata = False
+
+        subtitle_module.refine_video(mock_video, mock_episode)
+
+        # Should have set episodes to [5], not tried to set episode
+        self.assertEqual(mock_video.episodes, [5])
+
+    @patch("sickchill.oldbeard.subtitles.guessit")
+    @patch("sickchill.oldbeard.subtitles.subliminal")
+    def test_refine_video_handles_guessing_error(self, mock_subliminal, mock_guessit):
+        """refine_video should handle GuessingError from Episode.fromguess gracefully."""
+        mock_video = MagicMock()
+        mock_video.episodes = [5]
+
+        mock_episode = MagicMock()
+        mock_episode.release_name = "Some.Bad.Release.Name"
+        mock_episode.episode = 5
+        mock_episode.show.subtitles_sc_metadata = False
+
+        mock_guessit.return_value = {"type": "episode"}  # Missing 'title' and 'episode'
+        mock_subliminal.Episode.fromguess.side_effect = ValueError("Insufficient data")
+
+        # Should not raise
+        subtitle_module.refine_video(mock_video, mock_episode)
+
+
+class TestComputeScore(unittest.TestCase):
+    """Test that compute_score is called correctly."""
+
+    def test_compute_score_signature(self):
+        """compute_score should accept subtitle and video without hearing_impaired."""
+        import inspect
+
+        sig = inspect.signature(subliminal.score.compute_score)
+        params = list(sig.parameters.keys())
+        self.assertEqual(params[0], "subtitle")
+        self.assertEqual(params[1], "video")
+        # hearing_impaired should NOT be a named parameter (only **kwargs)
+        self.assertNotIn("hearing_impaired", params)


### PR DESCRIPTION
## Summary
Fixes multiple subliminal 2.x API breaking changes that cause runtime crashes and incorrect subtitle matching behavior. Supersedes #8926 (which only fixed the external subtitles issue).

## Issues Fixed

### Crashes (3)
1. **`get_subtitle_path` TypeError** — subliminal 2.x changed the `suffix` parameter from accepting `Language`/`None` to requiring a `str`. Both download and extra-scripts paths crashed at runtime.
2. **`video.subtitle_languages |=` AttributeError** — `subtitle_languages` is now a read-only property. External subtitle discovery crashed.
3. **`video.episode` AttributeError** — `episode` is now a read-only property on `Episode`. `refine_video` metadata mapping crashed when trying to `setattr`.

### Wrong Results (1)
4. **Hardcoded score thresholds (213/198)** — subliminal 2.x changed episode scores from max 215 to max 971. The old thresholds made `min_score` filtering effectively disabled (every subtitle passed). Now computed dynamically.

### Robustness (2)
5. **`Episode.fromguess` GuessingError** — 2.x raises on incomplete guesses instead of returning partial objects. Now caught gracefully.
6. **`compute_score` hearing_impaired kwarg** — silently swallowed via `**kwargs` in 2.x. Removed (filtering is handled by `download_best_subtitles`).

## Score Threshold Details
| | Old (subliminal 1.x) | New (subliminal 2.x) |
|---|---|---|
| Max episode score | 215 | 971 |
| Perfect match threshold | 213 | 969 (hash - resolution - video_codec) |
| Non-perfect threshold | 198 | 756 (series + year + season + episode) |

## Testing
- 14 new regression tests covering all fixes
- Full test suite: 274 passed, 0 failed
- Tests verify both the fix AND that the old code would have crashed (e.g., `test_none_suffix_crashes`, `test_episode_attribute_is_readonly_property`)

## Context
Reported via [Discord](https://discord.com/channels/502612977271439372/1132477941436125256), flagged by @BKSteve on #8924.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated subtitle scoring to use dynamic thresholds for more accurate matches
  * Corrected single vs. multi-language subtitle file naming/suffix handling
  * External subtitles now attach to videos and support multiple results
  * Metadata refinement is more robust: skips failed guessing and writes to writable episode fields

* **Tests**
  * Added tests covering scoring thresholds, subtitle paths, external subtitle integration, and refinement resilience

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SickChill/sickchill/pull/8927)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->