### PR TITLE
Poster & Banner ratio tolerance and little ruff adjustments

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -154,7 +154,7 @@ combine-as-imports = true
 known-first-party = ["sickchill"]
 
 [tool.ruff.per-file-ignores]
-"__init__.py" = ["F401"]
+"**/__init__.py" = ["F401"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests", "sickchill", "SickChill.py"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -153,6 +153,9 @@ extend-select = ["F821", "I"]
 combine-as-imports = true
 known-first-party = ["sickchill"]
 
+[tool.ruff.per-file-ignores]
+"__init__.py" = ["F401"]
+
 [tool.pytest.ini_options]
 testpaths = ["tests", "sickchill", "SickChill.py"]
 addopts = "--cov=sickchill --cov-report xml --no-cov-on-fail -v --timeout=120"

--- a/sickchill/gui/slick/js/imageSelector.js
+++ b/sickchill/gui/slick/js/imageSelector.js
@@ -10,19 +10,19 @@
             errorMsg: 'The height of the poster can not be lower than 269 pixels and the aspect ratio should be 40:57.',
         },
         banner: {
-            targetRatio: 200 / 37,
             minHeight: 37,
-            tolerance: 0.03,              // 3% tolerance (very reasonable)
+            targetRatio: 200 / 37,
+            tolerance: 0.03,
 
             validate(img) {
                 if (img.height < this.minHeight) {
                     return false;
-                    }
+                }
 
-                    const actualRatio = img.width / img.height;
-                    const diff = Math.abs(actualRatio - this.targetRatio);
+                const actualRatio = img.width / img.height;
+                const diff = Math.abs(actualRatio - this.targetRatio);
 
-                    return diff <= this.tolerance
+                return diff <= this.tolerance;
             },
             errorMsg: 'Banner must have aspect ratio ≈ 200:37 (5.405:1) and height ≥ 37px.',
         },

--- a/sickchill/gui/slick/js/imageSelector.js
+++ b/sickchill/gui/slick/js/imageSelector.js
@@ -2,18 +2,8 @@
     const imageTypeSizes = {
         poster: {
             minHeight: 269,
-            ratio: 40 / 57,
-            validate(img) {
-                return img.height >= this.minHeight
-                    && img.width / img.height === this.ratio;
-            },
-            errorMsg: 'The height of the poster can not be lower than 269 pixels and the aspect ratio should be 40:57.',
-        },
-        banner: {
-            minHeight: 37,
-            targetRatio: 200 / 37,
-            tolerance: 0.03,
-
+            targetRatio: 40 / 57,
+            tolerance: 0.02,
             validate(img) {
                 if (img.height < this.minHeight) {
                     return false;
@@ -21,7 +11,21 @@
 
                 const actualRatio = img.width / img.height;
                 const diff = Math.abs(actualRatio - this.targetRatio);
+                return diff <= this.tolerance;
+            },
+            errorMsg: 'Poster must have aspect ratio ≈ 40:57 (≈0.7018) and height ≥ 269px.',
+        },
+        banner: {
+            minHeight: 37,
+            targetRatio: 200 / 37,
+            tolerance: 0.03,
+            validate(img) {
+                if (img.height < this.minHeight) {
+                    return false;
+                }
 
+                const actualRatio = img.width / img.height;
+                const diff = Math.abs(actualRatio - this.targetRatio);
                 return diff <= this.tolerance;
             },
             errorMsg: 'Banner must have aspect ratio ≈ 200:37 (5.405:1) and height ≥ 37px.',

--- a/sickchill/gui/slick/js/imageSelector.js
+++ b/sickchill/gui/slick/js/imageSelector.js
@@ -10,13 +10,21 @@
             errorMsg: 'The height of the poster can not be lower than 269 pixels and the aspect ratio should be 40:57.',
         },
         banner: {
+            targetRatio: 200 / 37,
             minHeight: 37,
-            ratio: 200 / 37,
+            tolerance: 0.03,              // 3% tolerance (very reasonable)
+
             validate(img) {
-                return img.height >= this.minHeight
-                    && img.width / img.height === this.ratio;
+                if (img.height < this.minHeight) {
+                    return false;
+                    }
+
+                    const actualRatio = img.width / img.height;
+                    const diff = Math.abs(actualRatio - this.targetRatio);
+
+                    return diff <= this.tolerance
             },
-            errorMsg: 'The height of the banner can not be lower than 37 pixels and the aspect ratio should be 200:37.',
+            errorMsg: 'Banner must have aspect ratio ≈ 200:37 (5.405:1) and height ≥ 37px.',
         },
         fanart: {
             minHeight: 200,


### PR DESCRIPTION
Fixes #

Proposed changes in this pull request:
Banner ratio - provide some tolerance than the strict 200:37

pop in a little ruff check to ignore __init__.py files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved poster and banner image validation to accept small aspect‑ratio deviations, enforce minimum height, and show clearer error messages.
* **Chores**
  * Updated lint configuration to suppress unused‑import warnings for package initializer files.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SickChill/sickchill/pull/8940?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->