### PR TITLE
Show images and display

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -153,7 +153,7 @@ extend-select = ["F821", "I"]
 combine-as-imports = true
 known-first-party = ["sickchill"]
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 "**/__init__.py" = ["F401"]
 
 [tool.pytest.ini_options]

--- a/sickchill/gui/slick/js/imageSelector.js
+++ b/sickchill/gui/slick/js/imageSelector.js
@@ -131,15 +131,10 @@
                     const thumb = selectedImage.data('thumb');
                     const source = selectedImage.attr('src');
 
-                    let finalValue = '';
-
                     // Special handling for uploaded images
-                    if (source && source.startsWith('data:image')) {
-                        finalValue = source;
-                    } else {
-                        // Original behavior for web sources
-                        finalValue = (image ? image + '|' : '') + thumb;
-                    }
+                    const finalValue = source && source.startsWith('data:image')
+                        ? source
+                        : (image ? image + '|' : '') + thumb;
 
                     // Update hidden field and main preview
                     $('[name=' + imageType + ']').val(finalValue);
@@ -193,7 +188,7 @@
                 console.log('📤 File selected:', file.name);
 
                 const reader = new FileReader();
-                reader.onload = function (event_) {
+                reader.addEventListener('load', event_ => {
                     const dataUrl = event_.target.result;
 
                     if (typeof dataUrl !== 'string' || !dataUrl.startsWith('data:image')) {
@@ -204,7 +199,7 @@
                     console.log('📸 Data URL length:', dataUrl.length);
 
                     const img = new Image();
-                    img.onload = function () {
+                    img.addEventListener('load', () => {
                         if (imageTypeSizes[imageType].validate(img)) {
                             console.log('✅ Image validated for', imageType);
 
@@ -213,15 +208,17 @@
                             const selectors = [
                                 'input[name="' + imageType + '"]',
                                 '#' + imageType,
-                                'input[type="hidden"][name="' + imageType + '"]'
+                                'input[type="hidden"][name="' + imageType + '"]',
                             ];
 
                             for (const sel of selectors) {
                                 hiddenInput = $(sel);
-                                if (hiddenInput.length > 0) break;
+                                if (hiddenInput.length > 0) {
+                                    break;
+                                }
                             }
 
-                            if (hiddenInput && hiddenInput.length) {
+                            if (hiddenInput && hiddenInput.length > 0) {
                                 hiddenInput.val(dataUrl);
                                 console.log('✅ SUCCESS: Hidden field updated using selector');
                             } else {
@@ -229,21 +226,20 @@
                             }
 
                             // Update preview
-                            $('.image-selector-dialog .images').empty().append(
-                                $('<img>')
-                                    .attr('src', dataUrl)
-                                    .css({
-                                        'max-width': '100%',
-                                        'max-height': '320px',
-                                        'object-fit': 'contain'
-                                    })
-                            );
+                            $('.image-selector-dialog .images').empty().append($('<img alt="Selector preview">')
+                                .attr('src', dataUrl)
+                                .css({
+                                    'max-width': '100%',
+                                    'max-height': '320px',
+                                    'object-fit': 'contain',
+                                }));
                         } else {
                             imageSelectorElement.children('.error').text(imageTypeSizes[imageType].errorMsg).show();
                         }
-                    };
+                    });
+
                     img.src = dataUrl;
-                };
+                });
 
                 reader.readAsDataURL(file);
             }

--- a/sickchill/gui/slick/js/imageSelector.js
+++ b/sickchill/gui/slick/js/imageSelector.js
@@ -130,7 +130,19 @@
                     const image = selectedImage.data('image');
                     const thumb = selectedImage.data('thumb');
                     const source = selectedImage.attr('src');
-                    $('[name=' + imageType + ']').val((image ? image + '|' : '') + thumb);
+
+                    let finalValue = '';
+
+                    // Special handling for uploaded images
+                    if (source && source.startsWith('data:image')) {
+                        finalValue = source;
+                    } else {
+                        // Original behavior for web sources
+                        finalValue = (image ? image + '|' : '') + thumb;
+                    }
+
+                    // Update hidden field and main preview
+                    $('[name=' + imageType + ']').val(finalValue);
                     field.attr('src', source).addClass('modified');
                 }
 
@@ -176,25 +188,64 @@
         $('.upload #upload-image-input').on('change', function () {
             imageSelectorElement.children('.error').hide();
 
-            if (this.files) {
-                const loadFunction = event_ => {
+            if (this.files && this.files.length > 0) {
+                const file = this.files[0];
+                console.log('📤 File selected:', file.name);
+
+                const reader = new FileReader();
+                reader.onload = function (event_) {
+                    const dataUrl = event_.target.result;
+
+                    if (typeof dataUrl !== 'string' || !dataUrl.startsWith('data:image')) {
+                        console.error('❌ Invalid data URL');
+                        return;
+                    }
+
+                    console.log('📸 Data URL length:', dataUrl.length);
+
                     const img = new Image();
-                    img.addEventListener('load', () => {
+                    img.onload = function () {
                         if (imageTypeSizes[imageType].validate(img)) {
-                            createImage(img.src);
+                            console.log('✅ Image validated for', imageType);
+
+                            // === MULTIPLE FALLBACK SELECTORS FOR HIDDEN FIELD ===
+                            let hiddenInput = null;
+                            const selectors = [
+                                'input[name="' + imageType + '"]',
+                                '#' + imageType,
+                                'input[type="hidden"][name="' + imageType + '"]'
+                            ];
+
+                            for (const sel of selectors) {
+                                hiddenInput = $(sel);
+                                if (hiddenInput.length > 0) break;
+                            }
+
+                            if (hiddenInput && hiddenInput.length) {
+                                hiddenInput.val(dataUrl);
+                                console.log('✅ SUCCESS: Hidden field updated using selector');
+                            } else {
+                                console.error('❌ Could not find hidden input for', imageType);
+                            }
+
+                            // Update preview
+                            $('.image-selector-dialog .images').empty().append(
+                                $('<img>')
+                                    .attr('src', dataUrl)
+                                    .css({
+                                        'max-width': '100%',
+                                        'max-height': '320px',
+                                        'object-fit': 'contain'
+                                    })
+                            );
                         } else {
-                            imageSelectorElement.children('.error').text(imageTypeSizes[imageType].errorMsg);
-                            imageSelectorElement.children('.error').show();
+                            imageSelectorElement.children('.error').text(imageTypeSizes[imageType].errorMsg).show();
                         }
-                    });
-                    img.src = event_.target.result;
+                    };
+                    img.src = dataUrl;
                 };
 
-                for (const file of this.files) {
-                    const reader = new FileReader();
-                    reader.addEventListener('load', loadFunction);
-                    reader.readAsDataURL(file);
-                }
+                reader.readAsDataURL(file);
             }
         });
 

--- a/sickchill/gui/slick/js/imageSelector.js
+++ b/sickchill/gui/slick/js/imageSelector.js
@@ -134,7 +134,7 @@
                     // Special handling for uploaded images
                     const finalValue = source && source.startsWith('data:image')
                         ? source
-                        : (image ? image + '|' : '') + thumb;
+                        : (image ? image + '|' : '') + (thumb || '');
 
                     // Update hidden field and main preview
                     $('[name=' + imageType + ']').val(finalValue);
@@ -220,13 +220,15 @@
 
                             if (hiddenInput && hiddenInput.length > 0) {
                                 hiddenInput.val(dataUrl);
-                                console.log('✅ SUCCESS: Hidden field updated using selector');
+                                console.log('SUCCESS: Hidden field updated using selector');
                             } else {
-                                console.error('❌ Could not find hidden input for', imageType);
+                                console.error('Could not find hidden input for', imageType);
                             }
 
-                            // Update preview
+                            // Keep selection in dialog; commit on OK
                             $('.image-selector-dialog .images').empty().append($('<img alt="Selector preview">')
+                                .addClass('image-selector-item image-selector-item-selected')
+                                .attr('data-image', dataUrl)
                                 .attr('src', dataUrl)
                                 .css({
                                     'max-width': '100%',

--- a/sickchill/gui/slick/views/displayShow.mako
+++ b/sickchill/gui/slick/views/displayShow.mako
@@ -11,7 +11,7 @@
     from sickchill.helper.common import pretty_file_size, try_int
 %>
 <%block name="metas">
-    <meta data-var="showBackgroundImage" data-content="${static_url(show.show_image_url('fanart'))}${ '?nocache=1' if from_edit else '' }">
+    <meta data-var="showBackgroundImage" data-content="${static_url(show.show_image_url('fanart'))}?t=${int(datetime.datetime.now().timestamp())}">
 </%block>
 <%block name="scripts">
     <script type="text/javascript" src="${static_url('js/lib/jquery.bookmarkscroll.js')}"></script>
@@ -112,7 +112,7 @@
                 <div class="col-md-12">
                     <div class="poster-container">
                         <a href="${static_url(show.show_image_url('poster_thumb'))}">
-                            <img src="${static_url(show.show_image_url('poster_thumb'))}${ '?nocache=1' if from_edit else '' }"
+                            <img src="${static_url(show.show_image_url('poster_thumb'))}?t=${int(datetime.datetime.now().timestamp())}"
                                  class="tvshowImg" alt="${_('Poster for')} ${show.name}"
                             />
                         </a>
@@ -121,8 +121,10 @@
                     <div class="info-container">
                         <div class="row">
                             <div class="pull-right col-lg-4 col-md-4 hidden-sm hidden-xs">
-                                <img src="${static_url(show.show_image_url('banner'))}${ '?nocache=1' if from_edit else '' }"
-                                     style="max-height:50px;border:1px solid black;" class="pull-right">
+                                <img src="${static_url(show.show_image_url('banner'))}?t=${int(datetime.datetime.now().timestamp())}"
+                                    alt="Banner"
+                                    style="max-height:50px;border:1px solid black;"
+                                    class="pull-right">
                             </div>
                             <div class="pull-left col-lg-8 col-md-8 col-sm-12 col-xs-12">
                                 % if 'rating' in show.imdb_info and 'votes' in show.imdb_info:

--- a/sickchill/gui/slick/views/displayShow.mako
+++ b/sickchill/gui/slick/views/displayShow.mako
@@ -11,7 +11,7 @@
     from sickchill.helper.common import pretty_file_size, try_int
 %>
 <%block name="metas">
-    <meta data-var="showBackgroundImage" data-content="${static_url(show.show_image_url('fanart'))}">
+    <meta data-var="showBackgroundImage" data-content="${static_url(show.show_image_url('fanart'))}${ '?nocache=1' if from_edit else '' }">
 </%block>
 <%block name="scripts">
     <script type="text/javascript" src="${static_url('js/lib/jquery.bookmarkscroll.js')}"></script>
@@ -112,7 +112,7 @@
                 <div class="col-md-12">
                     <div class="poster-container">
                         <a href="${static_url(show.show_image_url('poster_thumb'))}">
-                            <img src="${static_url(show.show_image_url('poster_thumb'))}"
+                            <img src="${static_url(show.show_image_url('poster_thumb'))}${ '?nocache=1' if from_edit else '' }"
                                  class="tvshowImg" alt="${_('Poster for')} ${show.name}"
                             />
                         </a>
@@ -121,7 +121,7 @@
                     <div class="info-container">
                         <div class="row">
                             <div class="pull-right col-lg-4 col-md-4 hidden-sm hidden-xs">
-                                <img src="${static_url(show.show_image_url('banner'))}"
+                                <img src="${static_url(show.show_image_url('banner'))}${ '?nocache=1' if from_edit else '' }"
                                      style="max-height:50px;border:1px solid black;" class="pull-right">
                             </div>
                             <div class="pull-left col-lg-8 col-md-8 col-sm-12 col-xs-12">

--- a/sickchill/gui/slick/views/editShow.mako
+++ b/sickchill/gui/slick/views/editShow.mako
@@ -1,5 +1,6 @@
 <%inherit file="/layouts/main.mako" />
 <%!
+    import datetime
     from sickchill import settings
     from sickchill.oldbeard import common
     from sickchill.oldbeard.common import SKIPPED, WANTED, IGNORED
@@ -486,7 +487,7 @@
                                             <div class="col-md-12">
                                                 <div class="poster-container">
                                                     <input type="hidden" name="poster" />
-                                                    <img src="${static_url(show.show_image_url('poster'))}"
+                                                    <img src="${static_url(show.show_image_url('poster'))}?t=${int(datetime.datetime.now().timestamp())}"
                                                         data-image-type="poster"
                                                         class="custom-image tvshowImg" alt="${_('Poster for')} ${show.name}"
                                                     />
@@ -506,9 +507,9 @@
                                             <div class="col-md-12">
                                                 <div class="banner-container">
                                                     <input type="hidden" name="banner" />
-                                                    <img src="${static_url(show.show_image_url('banner'))}"
-                                                        data-image-type="banner"
-                                                        class="custom-image banner" alt="${_('Banner for')} ${show.name}"
+                                                    <img src="${static_url(show.show_image_url('banner'))}?t=${int(datetime.datetime.now().timestamp())}"
+                                                         data-image-type="banner"
+                                                         class="custom-image banner" alt="${_('Banner for')} ${show.name}"
                                                     />
                                                 </div>
                                             </div>
@@ -526,7 +527,7 @@
                                             <div class="col-md-12">
                                                 <div class="fanart-container">
                                                     <input type="hidden" name="fanart" />
-                                                    <img src="${static_url(show.show_image_url('fanart'))}"
+                                                    <img src="${static_url(show.show_image_url('fanart'))}?t=${int(datetime.datetime.now().timestamp())}"
                                                         data-image-type="fanart"
                                                         class="custom-image tvshowImg" alt="${_('Fanart for')} ${show.name}"
                                                     />

--- a/sickchill/views/home.py
+++ b/sickchill/views/home.py
@@ -1,5 +1,6 @@
 import ast
 import base64
+import binascii
 import datetime
 import json
 import os
@@ -63,6 +64,7 @@ class Home(WebRoot):
         self.new_anime = None
         self.new_scene = None
         self.new_air_by_date = None
+        self.from_edit = None
 
     def _genericMessage(self, subject=None, message=None):
         t = PageTemplate(rh=self, filename="genericMessage.mako")
@@ -867,6 +869,14 @@ class Home(WebRoot):
     def displayShow(self):
         show = self.get_query_argument("show")
 
+        from_edit = self.get_query_argument("from_edit", default="0") == "1"
+
+        if from_edit:
+            # Force fresh page + images
+            self.set_header("Cache-Control", "no-store, no-cache, must-revalidate, max-age=0")
+            self.set_header("Pragma", "no-cache")
+            self.set_header("Expires", "0")
+
         # todo: add more comprehensive show validation
         try:
             show_obj = Show.find(settings.show_list, int(show))
@@ -1064,6 +1074,7 @@ class Home(WebRoot):
             title=show_obj.name,
             controller="home",
             action="displayShow",
+            from_edit=from_edit,
         )
 
     def plotDetails(self):
@@ -1249,9 +1260,35 @@ class Home(WebRoot):
         metadata_generator = GenericMetadata()
 
         def get_images(image):
+            def unwrap_image_selector_url(value):
+                parsed_url = urllib.parse.urlparse(value)
+                if parsed_url.path.endswith("/imageSelector/url_wrap/"):
+                    wrapped_urls = urllib.parse.parse_qs(parsed_url.query).get("url")
+                    if wrapped_urls:
+                        return wrapped_urls[0]
+
+                return value
+
+            image = unwrap_image_selector_url(image)
+
             if image.startswith("data:image"):
-                start = image.index("base64,") + 7
-                _img_data = base64.b64decode(image[start:])
+                try:
+                    header, image_data = image.split(",", 1)
+                except ValueError:
+                    raise ValueError("Invalid image data URL")
+
+                if ";base64" not in header.lower():
+                    raise ValueError("Image data URL is not base64 encoded")
+
+                image_data = image_data.strip().replace(" ", "+")
+                image_data = "".join(image_data.split())
+                image_data += "=" * (-len(image_data) % 4)
+
+                try:
+                    _img_data = base64.b64decode(image_data, validate=True)
+                except binascii.Error as error:
+                    raise ValueError("Invalid base64 image data") from error
+
                 return _img_data, _img_data
 
             image_parts = image.split("|")
@@ -1389,9 +1426,9 @@ class Home(WebRoot):
             ui.notifications.error(
                 _("{num_errors:d} error{plural} while saving changes:").format(num_errors=len(errors), plural="" if len(errors) == 1 else "s"),
                 "<ul>" + "\n".join([f"<li>{error}</li>" for error in errors]) + "</ul>",
-            )
+                )
 
-        return self.redirect("/home/displayShow?show=" + show_id)
+        return self.redirect("/home/displayShow?show=" + show_id + "&from_edit=1")
 
     def togglePause(self):
         show = self.get_query_argument("show")

--- a/sickchill/views/home.py
+++ b/sickchill/views/home.py
@@ -1101,7 +1101,7 @@ class Home(WebRoot):
         return "<br>".join(out)
 
     # noinspection PyUnboundLocalVariable
-    def editShow(self, direct_call=False, **kwargs):
+    def editShow(self, direct_call=False):
         """Edit show settings"""
         if direct_call is False:
             # Original + safe image handling
@@ -1221,9 +1221,13 @@ class Home(WebRoot):
                 action="editShow",
             )
 
-        banner = self.get_body_argument("banner", default=None)
-        fanart = self.get_body_argument("fanart", default=None)
-        poster = self.get_body_argument("poster", default=None)
+        # Read from body if not already set
+        if banner is None:
+            banner = self.get_body_argument("banner", default=None)
+        if fanart is None:
+            fanart = self.get_body_argument("fanart", default=None)
+        if poster is None:
+            poster = self.get_body_argument("poster", default=None)
         indexer_lang = self.get_body_argument("indexerLang", default=None)
         custom_name = self.get_body_argument("custom_name", default="")
         subtitles_sc_metadata = config.checkbox_to_value(self.get_body_argument("subtitles_sc_metadata", default="False"))

--- a/sickchill/views/home.py
+++ b/sickchill/views/home.py
@@ -1134,11 +1134,11 @@ class Home(WebRoot):
             poster = self.get_body_argument("poster", default=None)
 
             if "banner" in self.request.files:
-                banner = self.request.files["banner"][0]
+                banner = self.request.files["banner"][0].get("body")
             if "fanart" in self.request.files:
-                fanart = self.request.files["fanart"][0]
+                fanart = self.request.files["fanart"][0].get("body")
             if "poster" in self.request.files:
-                poster = self.request.files["poster"][0]
+                poster = self.request.files["poster"][0].get("body")
 
         else:
             show_id = self.current_show
@@ -1277,8 +1277,9 @@ class Home(WebRoot):
 
         def get_images(image):
             """Handle both uploaded images (data URL) and remote URLs"""
-            if not image:
-                return None, None
+            if isinstance(image, (bytes, bytearray)):
+                data = bytes(image)
+                return data, data
 
             # 1. Upload from imageSelector (data:image;base64...)
             if isinstance(image, str) and image.startswith("data:image"):

--- a/sickchill/views/home.py
+++ b/sickchill/views/home.py
@@ -1101,13 +1101,16 @@ class Home(WebRoot):
         return "<br>".join(out)
 
     # noinspection PyUnboundLocalVariable
-    def editShow(self, direct_call=False):
+    def editShow(self, direct_call=False, **kwargs):
+        """Edit show settings"""
         if direct_call is False:
+            # Original + safe image handling
             show_id = self.get_query_argument("show", default=None)
             location = self.get_body_argument("location", default=None)
             any_qualities = self.get_body_arguments("anyQualities")
             best_qualities = self.get_body_arguments("bestQualities")
             season_folders = config.checkbox_to_value(self.get_body_argument("season_folders", default="False"))
+
             if show_id is None:
                 show_id = self.get_body_argument("show")
                 blacklist = self.get_body_argument("blacklist", default=None)
@@ -1124,6 +1127,19 @@ class Home(WebRoot):
                 sports = config.checkbox_to_value(self.get_body_argument("sports", default="False"))
                 anime = config.checkbox_to_value(self.get_body_argument("anime", default="False"))
                 subtitles = config.checkbox_to_value(self.get_body_argument("subtitles", default="False"))
+
+            # === IMAGE UPLOAD SUPPORT ===
+            banner = self.get_body_argument("banner", default=None)
+            fanart = self.get_body_argument("fanart", default=None)
+            poster = self.get_body_argument("poster", default=None)
+
+            if "banner" in self.request.files:
+                banner = self.request.files["banner"][0]
+            if "fanart" in self.request.files:
+                fanart = self.request.files["fanart"][0]
+            if "poster" in self.request.files:
+                poster = self.request.files["poster"][0]
+
         else:
             show_id = self.current_show
             location = self.new_show_dir
@@ -1260,43 +1276,40 @@ class Home(WebRoot):
         metadata_generator = GenericMetadata()
 
         def get_images(image):
-            def unwrap_image_selector_url(value):
-                parsed_url = urllib.parse.urlparse(value)
-                if parsed_url.path.endswith("/imageSelector/url_wrap/"):
-                    wrapped_urls = urllib.parse.parse_qs(parsed_url.query).get("url")
-                    if wrapped_urls:
-                        return wrapped_urls[0]
+            """Handle both uploaded images (data URL) and remote URLs"""
+            if not image:
+                return None, None
 
-                return value
-
-            image = unwrap_image_selector_url(image)
-
-            if image.startswith("data:image"):
+            # 1. Upload from imageSelector (data:image;base64...)
+            if isinstance(image, str) and image.startswith("data:image"):
                 try:
                     header, image_data = image.split(",", 1)
-                except ValueError:
-                    raise ValueError("Invalid image data URL")
+                    if ";base64" not in header.lower():
+                        return None, None
 
-                if ";base64" not in header.lower():
-                    raise ValueError("Image data URL is not base64 encoded")
+                    image_data = "".join(image_data.split())
+                    image_data += "=" * (-len(image_data) % 4)
 
-                image_data = image_data.strip().replace(" ", "+")
-                image_data = "".join(image_data.split())
-                image_data += "=" * (-len(image_data) % 4)
-
-                try:
                     _img_data = base64.b64decode(image_data, validate=True)
-                except binascii.Error as error:
-                    raise ValueError("Invalid base64 image data") from error
+                    return _img_data, _img_data
 
-                return _img_data, _img_data
+                except (ValueError, binascii.Error, TypeError) as e:
+                    logger.warning(f"Failed to decode uploaded image: {e}")
+                    return None, None
 
-            image_parts = image.split("|")
-            _img_data = getShowImage(image_parts[0])
-            if len(image_parts) > 1:
-                return _img_data, getShowImage(image_parts[1])
+            # 2. Remote URL (TheTVDB, Fanart.tv, etc.)
+            elif isinstance(image, str):
+                try:
+                    image_parts = image.split("|")
+                    _img_data = getShowImage(image_parts[0])
+                    if len(image_parts) > 1:
+                        return _img_data, getShowImage(image_parts[1])
+                    return _img_data, _img_data
+                except Exception as e:  # Keep this one broader as getShowImage can raise various errors
+                    logger.warning(f"Failed to fetch remote image: {e}")
+                    return None, None
 
-            return _img_data, _img_data
+            return None, None
 
         if poster:
             img_data, img_thumb_data = get_images(poster)
@@ -1426,7 +1439,7 @@ class Home(WebRoot):
             ui.notifications.error(
                 _("{num_errors:d} error{plural} while saving changes:").format(num_errors=len(errors), plural="" if len(errors) == 1 else "s"),
                 "<ul>" + "\n".join([f"<li>{error}</li>" for error in errors]) + "</ul>",
-                )
+            )
 
         return self.redirect("/home/displayShow?show=" + show_id + "&from_edit=1")
 

--- a/sickchill/views/imageSelector.py
+++ b/sickchill/views/imageSelector.py
@@ -28,7 +28,17 @@ class ImageSelector(Home):
         self.set_header("Cache-Control", "max-age=0,no-cache,no-store")
         self.set_header("Content-Type", "application/json")
 
-        provider = int(provider)
+        # Handle Upload option (-1)
+        if provider == -1 or provider is None or str(provider) == "-1":
+            # For upload, we don't return external images — just an empty list
+            # The frontend handles the upload locally
+            return json.dumps([])
+
+        try:
+            provider = int(provider)
+        except (TypeError, ValueError):
+            provider = None
+
         if provider == ShowIndexer.FANART:
             metadata_generator = GenericMetadata()
             images = metadata_generator._retrieve_show_image_urls_from_fanart(show_obj, imageType, multiple=True)


### PR DESCRIPTION
Proposed changes in this pull request:
- update images after changing in editShow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Images now bypass cache after edits (timestamped URLs + no-cache response headers) so updated artwork appears immediately.
  * Returning from edit forces fresh content.
  * Upload-mode image listings return immediately instead of performing external lookups.

* **New Features**
  * Edit flow accepts direct image uploads with stricter base64 validation and safer handling of malformed input.
  * Image selector validates uploads, updates preview, enforces single-file selection, and writes data URLs for uploaded images.

* **Chores**
  * Lint configuration key corrected.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SickChill/sickchill/pull/8945?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->