### PR TITLE
Fix status pill logic

### DIFF
--- a/sickchill/gui/slick/js/ajaxEpSearch.js
+++ b/sickchill/gui/slick/js/ajaxEpSearch.js
@@ -17,6 +17,54 @@ function disableLink(link) {
     link.fadeTo('fast', 0.5);
 }
 
+function buildStatusPill(statusText, quality) {
+    if (!statusText) {
+        return '';
+    }
+
+    let displayText = statusText.trim();
+    let cssClass = 'unknown';
+    const lower = displayText.toLowerCase();
+
+    // === Status Class Logic ===
+    if (lower === 'success' || lower === 'skipped' || lower.startsWith('skipped')) {
+        cssClass = 'archived'; // Grey for Skipped
+    } else if (lower.includes('downloaded')) {
+        cssClass = 'downloaded';
+    } else if (lower.includes('snatched')) {
+        cssClass = 'snatched';
+    } else if (lower.includes('wanted')) {
+        cssClass = 'wanted';
+    } else if (lower.includes('archived')) {
+        cssClass = 'archived';
+    } else if (lower.includes('failed')) {
+        cssClass = 'failed';
+    }
+
+    // === Clean up status text if it already includes quality ===
+    const qualityRegex = /\(([^)]+)\)/;
+    const match = displayText.match(qualityRegex);
+    let qualityInStatus = '';
+
+    if (match) {
+        qualityInStatus = match[1].trim(); // E.g. "1080p WEB-DL"
+        displayText = displayText.replace(qualityRegex, '').trim(); // Remove quality from status text
+    }
+
+    // Use provided quality if better
+    const finalQuality = quality && quality !== 'N/A' && quality !== '' ? quality : qualityInStatus;
+
+    let html = `<span class="status pill-${cssClass}">${displayText}</span>`;
+
+    // Add quality pill only if we have one
+    if (finalQuality) {
+        const qClass = finalQuality.toLowerCase().replaceAll(/\s+/g, '-');
+        html += ` <span class="quality ${qClass}">${finalQuality}</span>`;
+    }
+
+    return html;
+}
+
 function updateImages(data) {
     $.each(data.episodes, (name, ep) => {
         // Get td element for current ep
@@ -26,11 +74,10 @@ function updateImages(data) {
 
         // Try to get the <a> Element
         const link = $('a[id=' + ep.show + 'x' + ep.season + 'x' + ep.episode + ']');
-        if (link) {
+        if (link.length > 0) {
             const icon = link.children('span');
             const parent = link.parent();
 
-            let rSearchTerm = '';
             let htmlContent = '';
 
             if (ep.searchstatus.toLowerCase() === 'searching') {
@@ -39,7 +86,7 @@ function updateImages(data) {
                 icon.prop('alt', 'Searching');
 
                 disableLink(link);
-                htmlContent = ep.searchstatus.title;
+                htmlContent = '<span class="status pill-wanted">Searching...</span>'; // Optional nice pill
             } else if (ep.searchstatus.toLowerCase() === 'queued') {
                 icon.prop('class', queuedClass);
                 icon.prop('title', 'Queued');
@@ -55,13 +102,19 @@ function updateImages(data) {
 
                 icon.prop('title', 'Search');
                 icon.prop('alt', 'Search');
-
                 enableLink(link);
 
-                // Update Status and Quality
-                rSearchTerm = /(\w+)\s\((.+?)\)/;
-                htmlContent = ep.status.replace(rSearchTerm, '$1 <span class="quality ' + ep.quality + '">$2</span>');
-                parent.closest('tr').prop('class', ep.overview + ' season-' + ep.season + ' seasonstyle');
+                // Fixed status pill
+                htmlContent = buildStatusPill(ep.status, ep.quality);
+
+                // Improved row class - respect actual status
+                let rowClass = ep.overview || 'wanted';
+                const statusLower = (ep.status || '').toLowerCase().trim();
+                if (statusLower === 'skipped' || statusLower === 'success' || statusLower.startsWith('skipped')) {
+                    rowClass = 'skipped';
+                }
+
+                parent.closest('tr').prop('class', rowClass + ' season-' + ep.season + ' seasonstyle');
             }
 
             // Update the status column if it exists
@@ -73,40 +126,6 @@ function updateImages(data) {
             // And qtip location
             if (ep.location) {
                 parent.siblings('.episode').html('<span title="' + ep.location + '" class="addQTip">' + ep.episode + '</span>');
-            }
-        }
-
-        const elementCompleteEpisodes = $('a[id=forceUpdate-' + ep.show + 'x' + ep.season + 'x' + ep.episode + ']');
-        const spanCompleteEpisodes = elementCompleteEpisodes.children('span');
-        if (elementCompleteEpisodes) {
-            if (ep.searchstatus.toLowerCase() === 'searching') {
-                spanCompleteEpisodes.prop('class', loadingClass);
-                spanCompleteEpisodes.prop('title', 'Searching');
-                spanCompleteEpisodes.prop('alt', 'Searching');
-                disableLink(elementCompleteEpisodes);
-            } else if (ep.searchstatus.toLowerCase() === 'queued') {
-                spanCompleteEpisodes.prop('class', queuedClass);
-                spanCompleteEpisodes.prop('title', 'Queued');
-                spanCompleteEpisodes.prop('alt', 'Queued');
-                disableLink(elementCompleteEpisodes);
-            } else if (ep.searchstatus.toLowerCase() === 'finished') {
-                spanCompleteEpisodes.prop('class', searchClass);
-                spanCompleteEpisodes.prop('title', 'Search');
-                spanCompleteEpisodes.prop('alt', 'Search');
-                if (ep.overview.toLowerCase() === 'snatched') {
-                    // Find Banner or Poster
-                    let actionElement = elementCompleteEpisodes.closest('div.ep_listing');
-                    if (actionElement.length === 0 && elementCompleteEpisodes.closest('table.calendarTable').length === 0) {
-                        actionElement = elementCompleteEpisodes.closest('tr');
-                    }
-
-                    if (actionElement.length > 0) {
-                        // Remove any listing-* classes and add listing-snatched (keeping non listing-* classes)
-                        actionElement.attr('class', (i, value) => value.replaceAll(/(^|\s)listing-\S+/g, '')).addClass('listing-snatched');
-                    }
-                }
-
-                enableLink(elementCompleteEpisodes);
             }
         }
     });
@@ -174,10 +193,8 @@ $(document).ready(checkManualSearches);
                     parent.parent().removeClass('skipped wanted qual good unaired').addClass('snatched');
                 }
 
-                // Applying the quality class
-                const rSearchTerm = /(\w+)\s\((.+?)\)/;
-                const htmlContent = data.result.replace(rSearchTerm, '$1 <span class="quality ' + data.quality + '">$2</span>');
-                // Update the status column if it exists
+                // In the success callback (~line 178)
+                const htmlContent = buildStatusPill(data.result, data.quality);
                 parent.siblings('.col-status').html(htmlContent);
                 // Only if the queuing was successful, disable the onClick event of the loading image
                 disableLink(link);

--- a/sickchill/gui/slick/js/ajaxEpSearch.js
+++ b/sickchill/gui/slick/js/ajaxEpSearch.js
@@ -17,6 +17,7 @@ function disableLink(link) {
     link.fadeTo('fast', 0.5);
 }
 
+// Helper function for pill styling
 function buildStatusPill(statusText, quality) {
     if (!statusText) {
         return '';
@@ -28,7 +29,7 @@ function buildStatusPill(statusText, quality) {
 
     // === Status Class Logic ===
     if (lower === 'success' || lower === 'skipped' || lower.startsWith('skipped')) {
-        cssClass = 'archived'; // Grey for Skipped
+        cssClass = 'archived'; // Gray for Skipped
     } else if (lower.includes('downloaded')) {
         cssClass = 'downloaded';
     } else if (lower.includes('snatched')) {
@@ -104,7 +105,7 @@ function updateImages(data) {
                 icon.prop('alt', 'Search');
                 enableLink(link);
 
-                // Fixed status pill
+                // Update status and quality
                 htmlContent = buildStatusPill(ep.status, ep.quality);
 
                 // Improved row class - respect actual status
@@ -193,7 +194,7 @@ $(document).ready(checkManualSearches);
                     parent.parent().removeClass('skipped wanted qual good unaired').addClass('snatched');
                 }
 
-                // In the success callback (~line 178)
+                // In the success update the status with the result
                 const htmlContent = buildStatusPill(data.result, data.quality);
                 parent.siblings('.col-status').html(htmlContent);
                 // Only if the queuing was successful, disable the onClick event of the loading image

--- a/sickchill/gui/slick/js/ajaxEpSearch.js
+++ b/sickchill/gui/slick/js/ajaxEpSearch.js
@@ -23,22 +23,23 @@ function buildStatusPill(statusText, quality) {
         return statusText || '';
     }
 
-    let html = statusText; // Default to original text
+    let displayText = statusText; // Default to original text
 
     // If it already has quality in parentheses, wrap status part
     const match = statusText.match(/^(.+?)\s*\((.+?)\)$/);
     if (match) {
         const statusPart = match[1].trim();
         const qualityPart = match[2].trim();
-        html = `<span class="status pill-${getPillClass(statusPart)}">${statusPart}</span> <span class="quality ${quality}">${qualityPart}</span>`;
+        displayText = `<span class="status pill-${getPillClass(statusPart)}">${statusPart}</span> <span class="quality ${quality}">${qualityPart}</span>`;
     } else {
         // Plain status (like "Downloaded", "Skipped", etc.)
-        html = `<span class="status pill-${getPillClass(statusText)}">${statusText}</span>`;
+        displayText = `<span class="status pill-${getPillClass(statusText)}">${statusText}</span>`;
     }
 
-    return html;
+    return displayText;
 }
 
+// Helper function for pill class
 function getPillClass(status) {
     const lower = status.toLowerCase().trim();
     if (lower.includes('downloaded') || lower === 'success') {
@@ -50,6 +51,10 @@ function getPillClass(status) {
     }
 
     if (lower.includes('skipped') || lower.includes('ignored')) {
+        return 'archived';
+    }
+
+    if (lower.includes('archived')) {
         return 'archived';
     }
 
@@ -76,7 +81,6 @@ function updateImages(data) {
         if (link.length > 0) {
             const icon = link.children('span');
             const parent = link.parent();
-
             let htmlContent = '';
 
             if (ep.searchstatus.toLowerCase() === 'searching') {
@@ -130,7 +134,6 @@ function checkManualSearches() {
         url,
         success(data) {
             pollInterval = data.episodes ? 5000 : 15_000;
-
             updateImages(data);
         },
         error() {

--- a/sickchill/gui/slick/js/ajaxEpSearch.js
+++ b/sickchill/gui/slick/js/ajaxEpSearch.js
@@ -20,50 +20,48 @@ function disableLink(link) {
 // Helper function for pill styling
 function buildStatusPill(statusText, quality) {
     if (!statusText) {
-        return '';
+        return statusText || '';
     }
 
-    let displayText = statusText.trim();
-    let cssClass = 'unknown';
-    const lower = displayText.toLowerCase();
+    let html = statusText; // Default to original text
 
-    // === Status Class Logic ===
-    if (lower === 'success' || lower === 'skipped' || lower.startsWith('skipped')) {
-        cssClass = 'archived'; // Gray for Skipped
-    } else if (lower.includes('downloaded')) {
-        cssClass = 'downloaded';
-    } else if (lower.includes('snatched')) {
-        cssClass = 'snatched';
-    } else if (lower.includes('wanted')) {
-        cssClass = 'wanted';
-    } else if (lower.includes('archived')) {
-        cssClass = 'archived';
-    } else if (lower.includes('failed')) {
-        cssClass = 'failed';
-    }
-
-    // === Clean up status text if it already includes quality ===
-    const qualityRegex = /\(([^)]+)\)/;
-    const match = displayText.match(qualityRegex);
-    let qualityInStatus = '';
-
+    // If it already has quality in parentheses, wrap status part
+    const match = statusText.match(/^(.+?)\s*\((.+?)\)$/);
     if (match) {
-        qualityInStatus = match[1].trim(); // E.g. "1080p WEB-DL"
-        displayText = displayText.replace(qualityRegex, '').trim(); // Remove quality from status text
-    }
-
-    // Use provided quality if better
-    const finalQuality = quality && quality !== 'N/A' && quality !== '' ? quality : qualityInStatus;
-
-    let html = `<span class="status pill-${cssClass}">${displayText}</span>`;
-
-    // Add quality pill only if we have one
-    if (finalQuality) {
-        const qClass = finalQuality.toLowerCase().replaceAll(/\s+/g, '-');
-        html += ` <span class="quality ${qClass}">${finalQuality}</span>`;
+        const statusPart = match[1].trim();
+        const qualityPart = match[2].trim();
+        html = `<span class="status pill-${getPillClass(statusPart)}">${statusPart}</span> <span class="quality ${quality}">${qualityPart}</span>`;
+    } else {
+        // Plain status (like "Downloaded", "Skipped", etc.)
+        html = `<span class="status pill-${getPillClass(statusText)}">${statusText}</span>`;
     }
 
     return html;
+}
+
+function getPillClass(status) {
+    const lower = status.toLowerCase().trim();
+    if (lower.includes('downloaded') || lower === 'success') {
+        return 'downloaded';
+    }
+
+    if (lower.includes('snatched')) {
+        return 'snatched';
+    }
+
+    if (lower.includes('skipped') || lower.includes('ignored')) {
+        return 'archived';
+    }
+
+    if (lower.includes('wanted')) {
+        return 'wanted';
+    }
+
+    if (lower.includes('failed')) {
+        return 'failed';
+    }
+
+    return 'unknown';
 }
 
 function updateImages(data) {
@@ -107,15 +105,7 @@ function updateImages(data) {
 
                 // Update status and quality
                 htmlContent = buildStatusPill(ep.status, ep.quality);
-
-                // Improved row class - respect actual status
-                let rowClass = ep.overview || 'wanted';
-                const statusLower = (ep.status || '').toLowerCase().trim();
-                if (statusLower === 'skipped' || statusLower === 'success' || statusLower.startsWith('skipped')) {
-                    rowClass = 'skipped';
-                }
-
-                parent.closest('tr').prop('class', rowClass + ' season-' + ep.season + ' seasonstyle');
+                parent.closest('tr').prop('class', ep.overview + ' season-' + ep.season + ' seasonstyle');
             }
 
             // Update the status column if it exists
@@ -194,7 +184,7 @@ $(document).ready(checkManualSearches);
                     parent.parent().removeClass('skipped wanted qual good unaired').addClass('snatched');
                 }
 
-                // In the success update the status with the result
+                // With search success update the status with the result
                 const htmlContent = buildStatusPill(data.result, data.quality);
                 parent.siblings('.col-status').html(htmlContent);
                 // Only if the queuing was successful, disable the onClick event of the loading image


### PR DESCRIPTION
Fixes ticket #9 on discord
 - yes the blue pill
 - 
Proposed changes in this pull request:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed inconsistent status updates during manual and automatic episode searches; searching and finished states now render reliably.
  * Removed redundant status-update paths that caused stale or conflicting indicators; row updates now occur only when the episode link is present.
  * Disabled links during searching and re-enabled when finished to prevent inaccurate interactions.

* **UI Improvements**
  * Standardized status "pills" with separate status and quality display where applicable.
  * Improved row rendering so links and quality badges update consistently, enhancing clarity of search results.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SickChill/sickchill/pull/8946?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->