### PR TITLE
Fix: images in massEdit

### DIFF
--- a/sickchill/views/home.py
+++ b/sickchill/views/home.py
@@ -1103,6 +1103,12 @@ class Home(WebRoot):
     # noinspection PyUnboundLocalVariable
     def editShow(self, direct_call=False):
         """Edit show settings"""
+
+        # Initialize image variables for ALL call paths
+        banner = None
+        fanart = None
+        poster = None
+
         if direct_call is False:
             # Original + safe image handling
             show_id = self.get_query_argument("show", default=None)


### PR DESCRIPTION
Fixes #

After banner fanart and poster fix the massEdit function was broken, this fixes that issue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability when editing show details by ensuring proper initialization of image-related variables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->