### PR TITLE
fix: add existing and search operations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,7 @@ optional = true
 
 [tool.poetry.group.types.dependencies]
 types-attrs = "^19.1.0"
-types-pyOpenSSL = ">=22.0.10,<26.0.0"
+types-pyOpenSSL = ">=22.0.10,<26.3.0"
 types-python-dateutil = "^2.8.19"
 types-python-slugify = ">=6.1,<9.0"
 types-requests = "^2.28.11"
@@ -239,7 +239,7 @@ greenlet = {version = ">=2.0.0", allow-prereleases = true}
 jsonrpclib-pelix = "^0.4.2"
 Mako = "^1.1.4"
 markdown2 = "^2.4.0"
-pyOpenSSL = ">=20.0.1,<27.0.0"
+pyOpenSSL = ">=20.0.1,<26.3.0"
 python-dateutil = "^2.8.1"
 python-twitter = "^3.5"
 rarfile = "^4.0"

--- a/sickchill/show/indexers/handler.py
+++ b/sickchill/show/indexers/handler.py
@@ -100,30 +100,30 @@ class ShowIndexer(object):
 
         assert bool(indexerid) or bool(name), "Must provide either a name or an indexer id to search indexers with"
 
-        for n in name or "X":
-            n = [re.sub("[. -]", " ", n)]
-            for i in indexer:
-                search = (name, indexerid)[bool(indexerid)]
+        for name_query in name or "X":
+            name_query = re.sub("[. -]", " ", name_query)
+            for indexer_num in indexer:
+                search = (name_query, indexerid)[bool(indexerid)]
                 # noinspection PyUnresolvedReferences
-                logger.debug("Trying to find {} on {}".format(search, self.name(i)))
+                logger.debug("Trying to find {} on {}".format(search, self.name(indexer_num)))
                 if indexerid:
-                    result = self.indexers[i].get_series_by_id(indexerid, language)
+                    result = self.indexers[indexer_num].get_series_by_id(indexerid, language)
                 else:
-                    result = self.indexers[i].get_series_by_name(n, indexerid, language)
+                    result = self.indexers[indexer_num].get_series_by_name(name_query, indexerid, language)
 
                 try:
                     # noinspection PyUnusedLocal
                     garbage = result.seriesName, result.id
                 except AttributeError:
                     # noinspection PyUnresolvedReferences
-                    logger.debug("Failed to find {} on {}".format(search, self.name(i)))
+                    logger.debug("Failed to find {} on {}".format(search, self.name(indexer_num)))
                     continue
 
                 show = Show.find(settings.show_list, result.id)
                 if indexerid and show and show.indexerid == result.id:
-                    return i, result
+                    return indexer_num, result
                 elif indexerid and indexerid == result.id:
-                    return i, result
+                    return indexer_num, result
 
         return None, None
 

--- a/sickchill/show/indexers/tvdb.py
+++ b/sickchill/show/indexers/tvdb.py
@@ -123,7 +123,7 @@ class TVDB(Indexer):
             names = [name]
             if not exact:
                 # Name without year and separator
-                test = re.match(r"^(.+?)[. -]+\(\d{4}\)?$", name)
+                test = re.match(r"^(.+?)[. _-]+\(\d{4}\)?$", name)
                 if test:
                     names.append(test.group(1).strip())
                 # Name with spaces

--- a/sickchill/show/indexers/tvdb.py
+++ b/sickchill/show/indexers/tvdb.py
@@ -127,11 +127,11 @@ class TVDB(Indexer):
                 if test:
                     names.append(test.group(1).strip())
                 # Name with spaces
-                if re.match(r"[. -_]", name):
-                    names.append(re.sub(r"[. -_]", " ", name).strip())
+                if re.search(r"[. _-]", name):
+                    names.append(re.sub(r"[. _-]", " ", name).strip())
                     if test:
                         # Name with spaces and without year
-                        names.append(re.sub(r"[. -_]", " ", test.group(1)).strip())
+                        names.append(re.sub(r"[. _-]", " ", test.group(1)).strip())
 
             for attempt in set(n for n in names if n.strip()):
                 try:

--- a/sickchill/views/manage/add_shows.py
+++ b/sickchill/views/manage/add_shows.py
@@ -173,8 +173,9 @@ class AddShows(Home):
         posts them to addNewShow
         """
         show_to_add = self.get_body_argument("show_to_add", show_to_add)
-        other_shows = self.get_body_arguments("other_shows") or other_shows
+        # other_shows = self.get_body_arguments("other_shows") or other_shows
         search_string = self.get_body_argument("search_string", search_string)
+        other_shows = other_shows if other_shows is not None else self.get_body_arguments("other_shows")
 
         t = PageTemplate(rh=self, filename="addShows_newShow.mako")
 
@@ -442,6 +443,9 @@ class AddShows(Home):
             # peel off the next one
             next_show = other_shows[0]
             remaining_shows = other_shows[1:]
+
+            if not remaining_shows:
+                return self.newShow(next_show, [])
 
             # go to add the next show
             return self.newShow(next_show, remaining_shows)

--- a/sickchill/views/manage/add_shows.py
+++ b/sickchill/views/manage/add_shows.py
@@ -173,9 +173,8 @@ class AddShows(Home):
         posts them to addNewShow
         """
         show_to_add = self.get_body_argument("show_to_add", show_to_add)
-        # other_shows = self.get_body_arguments("other_shows") or other_shows
-        search_string = self.get_body_argument("search_string", search_string)
         other_shows = other_shows if other_shows is not None else self.get_body_arguments("other_shows")
+        search_string = self.get_body_argument("search_string", search_string)
 
         t = PageTemplate(rh=self, filename="addShows_newShow.mako")
 


### PR DESCRIPTION
Fixes #
- iteration through add existing where no tvshow.nfo exists and each requires a search
- search regex instead of match to set as spaces.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved indexer series search query construction for more consistent name-based matching.
  * Updated TVDB show-name normalization to better handle dot/space/underscore/dash separator variations and year suffix parsing.
  * Fixed adding shows to correctly carry over “other shows” from the request and properly handle the case when no extra shows remain.
* **Maintenance**
  * Tightened OpenSSL-related dependency version constraints in the project configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->