### PR TITLE
Fix: cinemagoer pin to 2023.5.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -275,5 +275,5 @@ beekeeper-alt = ">=2022.9.3"
 
 stevedore = "^5.1.0"
 cachecontrol = ">=0.13.1,<0.15.0"
-cinemagoer = {version = "^2023.5.1", allow-prereleases = true}
+cinemagoer = "2023.5.1"
 appdirs = "^1.4.4"


### PR DESCRIPTION
Pin Cinemagoer to 2023.5.1 until code is changed for the 2026.6.27 version and IMDb interaction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a dependency version to a fixed release, making builds more predictable and reducing unexpected prerelease updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->