### PR TITLE
Update: Restore browser show zip

### DIFF
--- a/sickchill/gui/slick/js/browser.js
+++ b/sickchill/gui/slick/js/browser.js
@@ -74,8 +74,7 @@
 
                     const isZipRequested
                         = fileTypes.includes('zip')
-                            || fileTypes.includes('archives')
-                            || fileTypes.includes('*');
+                            || fileTypes.includes('archives');
 
                     const isAllowed
                         = entry.isAllowed

--- a/sickchill/gui/slick/js/browser.js
+++ b/sickchill/gui/slick/js/browser.js
@@ -69,8 +69,16 @@
                  * @param entry.isAllowed
                  */
                 // noinspection OverlyComplexBooleanExpressionJS
-                if (entry.isFile && fileTypes) {
-                    const isAllowed = (entry.isAllowed || (fileTypes.includes('images') && entry.isImage));
+                if (entry.isFile && fileTypes && fileTypes.length > 0) {
+                    const ext = entry.name.split('.').pop().toLowerCase();
+                    const allowedExts = ['zip', 'rar'];
+
+                    const isAllowed = (entry.isAllowed
+                        || (fileTypes.includes('images') && entry.isImage)
+                        || allowedExts.includes(ext)
+                        || fileTypes.includes('*')
+                        || fileTypes.includes('archives'));
+
                     if (!isAllowed) {
                         return true;
                     }

--- a/sickchill/gui/slick/js/browser.js
+++ b/sickchill/gui/slick/js/browser.js
@@ -71,13 +71,17 @@
                 // noinspection OverlyComplexBooleanExpressionJS
                 if (entry.isFile && fileTypes && fileTypes.length > 0) {
                     const ext = entry.name.split('.').pop().toLowerCase();
-                    const allowedExts = ['zip', 'rar'];
 
-                    const isAllowed = (entry.isAllowed
-                        || (fileTypes.includes('images') && entry.isImage)
-                        || allowedExts.includes(ext)
-                        || fileTypes.includes('*')
-                        || fileTypes.includes('archives'));
+                    const isZipRequested
+                        = fileTypes.includes('zip')
+                            || fileTypes.includes('archives')
+                            || fileTypes.includes('*');
+
+                    const isAllowed
+                        = entry.isAllowed
+                            || (fileTypes.includes('images') && entry.isImage)
+                            || (ext === 'zip' && isZipRequested)
+                            || fileTypes.includes(ext);
 
                     if (!isAllowed) {
                         return true;


### PR DESCRIPTION
Update to make visible the zip files in the restore function


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file browsing filtering so results better match the selected file type options, using each file’s extension for more accurate inclusion decisions.
  * Expanded support for common selections (including images and ZIP/archives) and reduced filtering when no file types are selected, preserving “show all” behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->