### PR TITLE
fix show refresh pause and force failure

### DIFF
--- a/sickchill/show_updater.py
+++ b/sickchill/show_updater.py
@@ -66,10 +66,10 @@ class ShowUpdater(object):
 
                         # When last_update is not set from the cache or the show was in the tvdb updated list we update the show
                         if not last_update or (cur_show.indexerid in updated_shows and not skip_update):
-                            pi_list.append(Show.update(cur_show, force))
+                            pi_list.append(cur_show.update(force))
                         elif not skip_update:
                             # Temporarily use the same duration for paused as ended
-                            pi_list.append(Show.refresh(cur_show, force=True))
+                            pi_list.append(cur_show.refresh(force))
 
                     except Exception as error:
                         logger.info(_("Automatic update failed: {error}").format(error=error))


### PR DESCRIPTION
Fixes a force update failure condition of #8965


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved show update and refresh handling to use the correct show-specific actions during library processing.
  * Refresh behavior now respects the selected refresh setting more consistently, which should reduce unexpected results when updating shows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->