### PR TITLE
Fix: cache, failed db. scene exceptions rectification.

### DIFF
--- a/sickchill/oldbeard/databases/cache.py
+++ b/sickchill/oldbeard/databases/cache.py
@@ -68,7 +68,7 @@ class ResultsTable(InitialSchema):
 
 class AddCacheIndexes(ResultsTable):
     def test(self):
-        return self.get_db_version() < 2
+        return self.get_db_version() >= 2
 
     def execute(self):
         self.connection.action("CREATE INDEX IF NOT EXISTS idx_scene_exceptions_lookup ON scene_exceptions (indexer_id, show_name, season);")

--- a/sickchill/oldbeard/databases/cache.py
+++ b/sickchill/oldbeard/databases/cache.py
@@ -24,13 +24,9 @@ class InitialSchema(db.SchemaUpgrade):
                 "failed INTEGER DEFAULT 0, added TEXT DEFAULT CURRENT_TIMESTAMP);",
             ),
             ("INSERT INTO db_version(db_version) VALUES (1);",),
-            # === Existing indexes ===
             ("CREATE UNIQUE INDEX IF NOT EXISTS idx_url ON results (url);",),
             ("CREATE INDEX IF NOT EXISTS provider ON results (provider);",),
             ("CREATE INDEX IF NOT EXISTS seeders ON results (seeders);",),
-            # === NEW indexes ===
-            ("CREATE INDEX IF NOT EXISTS idx_scene_exceptions_lookup ON scene_exceptions (indexer_id, show_name, season);",),
-            ("CREATE INDEX IF NOT EXISTS idx_results_name ON results (name);",),
         )
         for query in queries:
             self.connection.action(query[0])
@@ -68,3 +64,13 @@ class ResultsTable(InitialSchema):
                     [provider_id],
                 )
                 self.connection.action("DROP TABLE {}".format(provider_id))
+
+
+class AddCacheIndexes(ResultsTable):
+    def test(self):
+        return self.get_db_version() < 2
+
+    def execute(self):
+        self.connection.action("CREATE INDEX IF NOT EXISTS idx_scene_exceptions_lookup ON scene_exceptions (indexer_id, show_name, season);")
+        self.connection.action("CREATE INDEX IF NOT EXISTS idx_results_name ON results (name);")
+        self.increment_db_version()

--- a/sickchill/oldbeard/databases/cache.py
+++ b/sickchill/oldbeard/databases/cache.py
@@ -24,9 +24,13 @@ class InitialSchema(db.SchemaUpgrade):
                 "failed INTEGER DEFAULT 0, added TEXT DEFAULT CURRENT_TIMESTAMP);",
             ),
             ("INSERT INTO db_version(db_version) VALUES (1);",),
+            # === Existing indexes ===
             ("CREATE UNIQUE INDEX IF NOT EXISTS idx_url ON results (url);",),
             ("CREATE INDEX IF NOT EXISTS provider ON results (provider);",),
             ("CREATE INDEX IF NOT EXISTS seeders ON results (seeders);",),
+            # === NEW indexes ===
+            ("CREATE INDEX IF NOT EXISTS idx_scene_exceptions_lookup ON scene_exceptions (indexer_id, show_name, season);",),
+            ("CREATE INDEX IF NOT EXISTS idx_results_name ON results (name);",),
         )
         for query in queries:
             self.connection.action(query[0])

--- a/sickchill/oldbeard/scene_exceptions.py
+++ b/sickchill/oldbeard/scene_exceptions.py
@@ -226,19 +226,21 @@ def update_custom_scene_exceptions(indexer_id, scene_exceptions: dict) -> None:
 def retrieve_exceptions() -> None:
     """
     Looks up the exceptions on GitHub, parses them into a dict, and inserts them into the
-    scene_exceptions table in cache.db. Preserves custom=1 exceptions.
+    scene_exceptions table in cache.db. Removes stale official (custom=0) exceptions
+    while preserving user custom=1 entries.
     """
-    queries = []
-    updated_shows = set()
     cache_db_con = db.DBConnection("cache.db")
 
-    seen = set()
+    seen = set()  # (indexerid, name, season)
+    updated_shows = set()
+
     generators = (
         _sickchill_exceptions_generator(),
         _xem_exceptions_generator(),
         _anidb_exceptions_generator(),
     )
 
+    queries = []
     for gen in generators:
         if gen is None:
             continue
@@ -247,15 +249,17 @@ def retrieve_exceptions() -> None:
             if key in seen:
                 continue
             seen.add(key)
-
-            # Delete ONLY official versions (preserve user custom exceptions)
-            queries.append(["DELETE FROM scene_exceptions WHERE indexer_id = ? AND show_name = ? AND season = ? AND custom = 0;", [indexerid, name, season]])
-            queries.append(["INSERT OR IGNORE INTO scene_exceptions (indexer_id, show_name, season, custom) VALUES (?,?,?, 0);", [indexerid, name, season]])
             updated_shows.add(indexerid)
+
+            # Remove any old official version of this exact exception
+            queries.append(["DELETE FROM scene_exceptions WHERE indexer_id = ? AND show_name = ? AND season = ? AND custom = 0;", [indexerid, name, season]])
+            # Insert the current official version
+            queries.append(["INSERT OR IGNORE INTO scene_exceptions (indexer_id, show_name, season, custom) VALUES (?,?,?, 0);", [indexerid, name, season]])
 
     if queries:
         cache_db_con.mass_action(queries)
 
+        # Rebuild in-memory cache for affected shows
         for show in list(updated_shows):
             exceptions_cache.pop(show, None)
             rebuild_exception_cache(show)

--- a/sickchill/oldbeard/scene_exceptions.py
+++ b/sickchill/oldbeard/scene_exceptions.py
@@ -331,12 +331,8 @@ def _xem_exceptions_generator() -> Generator[tuple[int, str, int], None, None]:
 
         url = f"https://thexem.info/map/allNames?origin={instance.slug}&seasonNumbers=1"
 
-        try:
-            session = get_xem_session()
-            parsed_json = helpers.getURL(url, session=session, timeout=90, returns="json")
-        except Exception:
-            logger.debug(f"Check scene exceptions update failed for XEM: {url}")
-            continue
+        session = get_xem_session()
+        parsed_json = helpers.getURL(url, session=session, timeout=90, returns="json")
 
         if not parsed_json:
             logger.debug(f'Check scene exceptions update failed for "theTVDB", Unable to get URL: {url}')

--- a/sickchill/oldbeard/scene_exceptions.py
+++ b/sickchill/oldbeard/scene_exceptions.py
@@ -8,6 +8,11 @@ from sickchill import adba, logger, settings
 from sickchill.oldbeard import db, helpers
 from sickchill.show.Show import Show
 
+# Session for requests (created once)
+github_session = helpers.make_indexer_session()
+xem_session = helpers.make_indexer_session()
+
+# Cache for exceptions (used by rebuild_exception_cache, etc.)
 exceptions_cache = {}
 
 
@@ -96,17 +101,25 @@ def get_all_scene_exceptions(indexer_id: int) -> dict:
         del exceptions_cache[indexer_id]
 
     for cur_exception in exceptions:
-        if cur_exception["season"] not in all_exceptions_dict:
-            all_exceptions_dict[cur_exception["season"]] = []
-        all_exceptions_dict[cur_exception["season"]].append({"show_name": cur_exception["show_name"], "custom": bool(cur_exception["custom"])})
+        season = cur_exception["season"]
+        show_name = cur_exception["show_name"]
+        custom = bool(cur_exception["custom"])
 
+        if season not in all_exceptions_dict:
+            all_exceptions_dict[season] = []
+
+        # Deduplication: only add if this exact show_name hasn't been added yet for this season
+        if not any(e["show_name"] == show_name for e in all_exceptions_dict[season]):
+            all_exceptions_dict[season].append({"show_name": show_name, "custom": custom})
+
+        # Same deduplication for the in-memory cache
         if indexer_id not in exceptions_cache:
             exceptions_cache[indexer_id] = {}
+        if season not in exceptions_cache[indexer_id]:
+            exceptions_cache[indexer_id][season] = []
 
-        if cur_exception["season"] not in exceptions_cache[indexer_id]:
-            exceptions_cache[indexer_id][cur_exception["season"]] = []
-
-        exceptions_cache[indexer_id][cur_exception["season"]].append(cur_exception["show_name"])
+        if show_name not in exceptions_cache[indexer_id][season]:
+            exceptions_cache[indexer_id][season].append(show_name)
 
     show = Show.find(settings.show_list, indexer_id)
     if show:
@@ -123,18 +136,20 @@ def get_all_scene_exceptions(indexer_id: int) -> dict:
             if -1 not in exceptions_cache[indexer_id]:
                 exceptions_cache[indexer_id][-1] = []
 
-            if sanitized_name:
+            if sanitized_name and sanitized_name not in [e["show_name"] for e in all_exceptions_dict.get(-1, [])]:
                 all_exceptions_dict[-1].append({"show_name": sanitized_name, "custom": False})
                 if sanitized_name not in exceptions_cache[indexer_id][-1]:
                     exceptions_cache[indexer_id][-1].append(sanitized_name)
-            if sanitized_custom_name:
+
+            if sanitized_custom_name and sanitized_custom_name not in [e["show_name"] for e in all_exceptions_dict.get(-1, [])]:
                 all_exceptions_dict[-1].append({"show_name": sanitized_custom_name, "custom": False})
                 if sanitized_custom_name not in exceptions_cache[indexer_id][-1]:
                     exceptions_cache[indexer_id][-1].append(sanitized_custom_name)
 
-    # sort season in exceptions dict by "custom" then "show_name" so alphabetical and custom names are bottom of list
-    for ind, ele in enumerate(all_exceptions_dict):
-        all_exceptions_dict[ele] = sorted(all_exceptions_dict[ele], key=lambda x: (x["custom"], x["show_name"].lower()))
+        # sort season in exceptions dict by "custom" then "show_name" so alphabetical and custom names are bottom of list
+        # sort each season's list
+        for season in list(all_exceptions_dict.keys()):
+            all_exceptions_dict[season] = sorted(all_exceptions_dict[season], key=lambda x: (x["custom"], x["show_name"].lower()))
 
     logger.debug(f"get_all_scene_exceptions: {all_exceptions_dict}")
     logger.debug(f"exceptions_cache for {indexer_id}: {exceptions_cache.get(indexer_id)}")
@@ -206,6 +221,7 @@ def retrieve_exceptions() -> None:
     """
     Looks up the exceptions on GitHub, parses them into a dict, and inserts them into the
     scene_exceptions table in cache.db. Also clears the scene name cache.
+    Prevent duplicate entries.
     """
     queries = []
     updated_shows = set()
@@ -213,29 +229,41 @@ def retrieve_exceptions() -> None:
 
     seen = set()
     generators = (_sickchill_exceptions_generator(), _xem_exceptions_generator(), _anidb_exceptions_generator())
+
     for generator in generators:
         if generator is None:
             continue
+
         for indexerid, name, season in generator:
-            key = (indexerid, name, season)
+            if name is None:
+                continue
+
+            # Normalize for better duplicate detection
+            norm_name = name.strip().lower()
+            key = (indexerid, norm_name, season)
+
             if key in seen:
                 continue
             seen.add(key)
 
+            # Delete any existing (to handle updates/renames)
             queries.append(["DELETE FROM scene_exceptions WHERE indexer_id = ? AND show_name = ? AND season = ?;", [indexerid, name, season]])
+
+            # Insert fresh
             queries.append(["INSERT INTO scene_exceptions (indexer_id, show_name, season, custom) VALUES (?,?,?, 0);", [indexerid, name, season]])
+
             updated_shows.add(indexerid)
 
     if queries:
         cache_db_con.mass_action(queries)
 
+        # Rebuild cache for affected shows
         for show in updated_shows:
             rebuild_exception_cache(show)
 
-        logger.debug("Updated scene exceptions")
-
-
-github_session = helpers.make_indexer_session()
+        logger.debug(f"Updated scene exceptions for {len(updated_shows)} shows (total entries: {len(seen)})")
+    else:
+        logger.debug("No scene exceptions to update")
 
 
 def _sickchill_exceptions_generator() -> Generator[tuple[int, str, int], None, None]:
@@ -291,9 +319,6 @@ def _anidb_exceptions_generator() -> Generator[tuple[int, str, int], None, None]
                     yield int(show.indexerid), anime.name, -1
 
     set_last_refresh("anidb")
-
-
-xem_session = helpers.make_indexer_session()
 
 
 def _xem_exceptions_generator() -> Generator[tuple[int, str, int], None, None]:

--- a/sickchill/oldbeard/scene_exceptions.py
+++ b/sickchill/oldbeard/scene_exceptions.py
@@ -8,12 +8,18 @@ from sickchill import adba, logger, settings
 from sickchill.oldbeard import db, helpers
 from sickchill.show.Show import Show
 
-# Session for requests (created once)
-github_session = helpers.make_indexer_session()
-xem_session = helpers.make_indexer_session()
-
 # Cache for exceptions (used by rebuild_exception_cache, etc.)
 exceptions_cache = {}
+
+
+def _get_github_session():
+    """Return a fresh github session (lazy + respects current settings)."""
+    return helpers.make_indexer_session()
+
+
+def get_xem_session():
+    """Return a fresh xem session (lazy + respects current settings)."""
+    return helpers.make_indexer_session()
 
 
 def should_refresh(exception_provider: str) -> bool:
@@ -220,50 +226,47 @@ def update_custom_scene_exceptions(indexer_id, scene_exceptions: dict) -> None:
 def retrieve_exceptions() -> None:
     """
     Looks up the exceptions on GitHub, parses them into a dict, and inserts them into the
-    scene_exceptions table in cache.db. Also clears the scene name cache.
-    Prevent duplicate entries.
+    scene_exceptions table in cache.db. Preserves custom=1 exceptions.
     """
     queries = []
     updated_shows = set()
     cache_db_con = db.DBConnection("cache.db")
 
     seen = set()
-    generators = (_sickchill_exceptions_generator(), _xem_exceptions_generator(), _anidb_exceptions_generator())
+    generators = (
+        _sickchill_exceptions_generator(),
+        _xem_exceptions_generator(),
+        _anidb_exceptions_generator(),
+    )
 
-    for generator in generators:
-        if generator is None:
+    for gen in generators:
+        if gen is None:
             continue
-
-        for indexerid, name, season in generator:
-            if name is None:
-                continue
-
-            # Normalize for better duplicate detection
-            norm_name = name.strip().lower()
-            key = (indexerid, norm_name, season)
-
+        for indexerid, name, season in gen:
+            key = (indexerid, name, season)
             if key in seen:
                 continue
             seen.add(key)
 
-            # Delete any existing (to handle updates/renames)
-            queries.append(["DELETE FROM scene_exceptions WHERE indexer_id = ? AND show_name = ? AND season = ?;", [indexerid, name, season]])
-
-            # Insert fresh
-            queries.append(["INSERT INTO scene_exceptions (indexer_id, show_name, season, custom) VALUES (?,?,?, 0);", [indexerid, name, season]])
-
+            # Delete ONLY official versions (preserve user custom exceptions)
+            queries.append([
+                "DELETE FROM scene_exceptions WHERE indexer_id = ? AND show_name = ? AND season = ? AND custom = 0;",
+                [indexerid, name, season]
+            ])
+            queries.append([
+                "INSERT OR IGNORE INTO scene_exceptions (indexer_id, show_name, season, custom) VALUES (?,?,?, 0);",
+                [indexerid, name, season]
+            ])
             updated_shows.add(indexerid)
 
     if queries:
         cache_db_con.mass_action(queries)
 
-        # Rebuild cache for affected shows
-        for show in updated_shows:
+        for show in list(updated_shows):
+            exceptions_cache.pop(show, None)
             rebuild_exception_cache(show)
 
-        logger.debug(f"Updated scene exceptions for {len(updated_shows)} shows (total entries: {len(seen)})")
-    else:
-        logger.debug("No scene exceptions to update")
+        logger.debug("Updated scene exceptions")
 
 
 def _sickchill_exceptions_generator() -> Generator[tuple[int, str, int], None, None]:
@@ -275,17 +278,17 @@ def _sickchill_exceptions_generator() -> Generator[tuple[int, str, int], None, N
 
     # noinspection PyBroadException
     try:
-        jdata: dict = helpers.getURL(url, session=github_session, returns="json")
+        session = _get_github_session()
+        raw = helpers.getURL(url, session=session, returns="json")
+        jdata: dict = raw if isinstance(raw, dict) else {}
     except Exception:
         jdata = {}
 
     if not jdata:
-        # When jdata is None, trouble connecting to GitHub, or reading file failed
         logger.debug(f"Check scene exceptions update failed (no data). Unable to update from {url}")
         return
 
     for indexer, shows in jdata.items():
-        # noinspection PyBroadException
         try:
             for indexer_id, exceptions in shows.items():
                 for season, names in exceptions.items():
@@ -330,7 +333,13 @@ def _xem_exceptions_generator() -> Generator[tuple[int, str, int], None, None]:
 
         url = f"https://thexem.info/map/allNames?origin={instance.slug}&seasonNumbers=1"
 
-        parsed_json = helpers.getURL(url, session=xem_session, timeout=90, returns="json")
+        try:
+            session = get_xem_session()
+            parsed_json = helpers.getURL(url, session=session, timeout=90, returns="json")
+        except Exception:
+            logger.debug(f"Check scene exceptions update failed for XEM: {url}")
+            continue
+
         if not parsed_json:
             logger.debug(f'Check scene exceptions update failed for "theTVDB", Unable to get URL: {url}')
             continue

--- a/sickchill/oldbeard/scene_exceptions.py
+++ b/sickchill/oldbeard/scene_exceptions.py
@@ -249,14 +249,8 @@ def retrieve_exceptions() -> None:
             seen.add(key)
 
             # Delete ONLY official versions (preserve user custom exceptions)
-            queries.append([
-                "DELETE FROM scene_exceptions WHERE indexer_id = ? AND show_name = ? AND season = ? AND custom = 0;",
-                [indexerid, name, season]
-            ])
-            queries.append([
-                "INSERT OR IGNORE INTO scene_exceptions (indexer_id, show_name, season, custom) VALUES (?,?,?, 0);",
-                [indexerid, name, season]
-            ])
+            queries.append(["DELETE FROM scene_exceptions WHERE indexer_id = ? AND show_name = ? AND season = ? AND custom = 0;", [indexerid, name, season]])
+            queries.append(["INSERT OR IGNORE INTO scene_exceptions (indexer_id, show_name, season, custom) VALUES (?,?,?, 0);", [indexerid, name, season]])
             updated_shows.add(indexerid)
 
     if queries:

--- a/sickchill/oldbeard/scene_numbering.py
+++ b/sickchill/oldbeard/scene_numbering.py
@@ -10,7 +10,7 @@ import traceback
 import sickchill
 from sickchill import logger, settings
 from sickchill.oldbeard import db
-from sickchill.oldbeard.scene_exceptions import xem_session
+from sickchill.oldbeard.scene_exceptions import get_xem_session
 from sickchill.show.Show import Show
 
 
@@ -491,7 +491,8 @@ def xem_refresh(indexer_id, indexer, force=False):
         try:
             # XEM MAP URL
             url = f"https://thexem.info/map/havemap?origin={sickchill.indexer.slug(indexer)}"
-            parsed_json = sickchill.oldbeard.helpers.getURL(url, session=xem_session, returns="json")
+            parsed_json = sickchill.oldbeard.helpers.getURL(url, session=get_xem_session(), returns="json")
+
             if (
                 not parsed_json
                 or "result" not in parsed_json
@@ -504,7 +505,8 @@ def xem_refresh(indexer_id, indexer, force=False):
             # XEM API URL
             url = f"https://thexem.info/map/all?id={indexer_id}&origin={sickchill.indexer.slug(indexer)}&destination=scene"
 
-            parsed_json = sickchill.oldbeard.helpers.getURL(url, session=xem_session, returns="json")
+            parsed_json = sickchill.oldbeard.helpers.getURL(url, session=get_xem_session(), returns="json")
+
             if not parsed_json or "result" not in parsed_json or "success" not in parsed_json["result"]:
                 logger.info(f'No XEM data for show "{indexer_id} on {sickchill.indexer.name(indexer)}"')
                 return

--- a/sickchill/oldbeard/scene_numbering.py
+++ b/sickchill/oldbeard/scene_numbering.py
@@ -489,9 +489,10 @@ def xem_refresh(indexer_id, indexer, force=False):
         )
 
         try:
+            xem_session = get_xem_session()
             # XEM MAP URL
             url = f"https://thexem.info/map/havemap?origin={sickchill.indexer.slug(indexer)}"
-            parsed_json = sickchill.oldbeard.helpers.getURL(url, session=get_xem_session(), returns="json")
+            parsed_json = sickchill.oldbeard.helpers.getURL(url, session=xem_session(), returns="json")
 
             if (
                 not parsed_json
@@ -505,7 +506,7 @@ def xem_refresh(indexer_id, indexer, force=False):
             # XEM API URL
             url = f"https://thexem.info/map/all?id={indexer_id}&origin={sickchill.indexer.slug(indexer)}&destination=scene"
 
-            parsed_json = sickchill.oldbeard.helpers.getURL(url, session=get_xem_session(), returns="json")
+            parsed_json = sickchill.oldbeard.helpers.getURL(url, session=xem_session(), returns="json")
 
             if not parsed_json or "result" not in parsed_json or "success" not in parsed_json["result"]:
                 logger.info(f'No XEM data for show "{indexer_id} on {sickchill.indexer.name(indexer)}"')

--- a/sickchill/oldbeard/tvcache.py
+++ b/sickchill/oldbeard/tvcache.py
@@ -159,8 +159,8 @@ class CacheDBConnection(db.DBConnection):
     def __init__(self):
         super().__init__("cache.db")
         db.upgrade_database(self, cache.InitialSchema)
-        # self.action("DELETE from results WHERE added < datetime('now','-30 days')")
 
+        # self.action("DELETE from results WHERE added < datetime(settings.CACHE_RETENTION)")
         self.trim()
 
     def trim(self, provider: str = ""):

--- a/sickchill/oldbeard/tvcache.py
+++ b/sickchill/oldbeard/tvcache.py
@@ -159,6 +159,7 @@ class CacheDBConnection(db.DBConnection):
     def __init__(self):
         super().__init__("cache.db")
         db.upgrade_database(self, cache.InitialSchema)
+        db.upgrade_database(self, cache.AddCacheIndexes)
 
         # self.action("DELETE from results WHERE added < datetime(settings.CACHE_RETENTION)")
         self.trim()

--- a/sickchill/show_updater.py
+++ b/sickchill/show_updater.py
@@ -5,7 +5,6 @@ import time
 import sickchill
 from sickchill import logger, settings
 from sickchill.oldbeard import db, network_timezones, ui
-from sickchill.show.Show import Show
 
 
 class ShowUpdater(object):

--- a/sickchill/tv.py
+++ b/sickchill/tv.py
@@ -1099,7 +1099,6 @@ class TVShow(object):
         failed_db_con = db.DBConnection("failed.db")
         sql_l = [
             ["DELETE FROM history WHERE showid = ?", [self.indexerid]],
-            ["DELETE FROM failed WHERE showid = ?", [self.indexerid]],
         ]
 
         failed_db_con.mass_action(sql_l)

--- a/sickchill/tv.py
+++ b/sickchill/tv.py
@@ -1099,6 +1099,7 @@ class TVShow(object):
         failed_db_con = db.DBConnection("failed.db")
         sql_l = [
             ["DELETE FROM history WHERE showid = ?", [self.indexerid]],
+            ["DELETE FROM failed WHERE showid = ?", [self.indexerid]],
         ]
 
         failed_db_con.mass_action(sql_l)


### PR DESCRIPTION
Proposed changes in this pull request:
cache and failed db removal of deleted items
scene exceptions filtering
should resolve ever enlarging cache.db scene exceptions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Deduplicated scene-exception entries per season and enforced consistent deterministic sorting.
  * Preserved user custom exceptions during bulk exception refresh while updating official entries.
  * Improved remote exception refresh resilience by safely handling missing or empty remote payloads.
* **Refactor**
  * Updated remote exception fetch to use on-demand shared HTTP sessions for both GitHub and XEM.
* **Chores**
  * Added database indexes to speed up scene-exception and result lookups.
  * Updated cached-results expiration to use the configured retention setting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->