### PR TITLE
Binary dump

### DIFF
--- a/sickchill/adba/__init__.py
+++ b/sickchill/adba/__init__.py
@@ -115,7 +115,7 @@ class Connection(threading.Thread):
 
     def handle_response(self, response):
         if response.rescode in ("501", "506") and response.req.command != "AUTH":
-            self.log("seams like the last command got a not authed error back tring to reconnect now")
+            self.log("seems like the last command got a not authed error back tring to reconnect now")
             if self._reauthenticate():
                 response.req.resp = None
                 self.handle(response.req, response.req.callback)
@@ -231,7 +231,7 @@ class Connection(threading.Thread):
                     self.start()
                     self._iamALIVE = True
                 else:
-                    self.log("not starting thread seams like it is already running. this must be a _reAuthenticate")
+                    self.log("not starting thread seems like it is already running. this must be a _reAuthenticate")
 
         self.lastAuth = time()
         return self.handle(AuthCommand(username, password, 3, self.client_name, self.client_version, nat, 1, "utf8", mtu), callback)

--- a/sickchill/oldbeard/providers/thepiratebay.py
+++ b/sickchill/oldbeard/providers/thepiratebay.py
@@ -55,10 +55,10 @@ class Provider(TorrentProvider):
         try:
             data = self.get_url(self.script_url)
 
-            # Lazy import – only when we actually need js2py
+            # Lazy import - only when we actually need js2py
             try:
                 import js2py
-            except (KeyError, ModuleNotFoundError, RuntimeError):
+            except (KeyError, ImportError, ModuleNotFoundError, RuntimeError):
                 js2py = None
 
             if js2py:

--- a/sickchill/oldbeard/providers/thepiratebay.py
+++ b/sickchill/oldbeard/providers/thepiratebay.py
@@ -4,11 +4,6 @@ import time
 import traceback
 from urllib.parse import urlencode, urljoin
 
-try:
-    import js2py
-except (KeyError, ModuleNotFoundError, RuntimeError):  # KeyError on python 3.12
-    js2py = None
-
 from sickchill import logger
 from sickchill.helper.common import try_int
 from sickchill.oldbeard import db, tvcache
@@ -59,6 +54,13 @@ class Provider(TorrentProvider):
     def get_tracker_list(self):
         try:
             data = self.get_url(self.script_url)
+
+            # Lazy import – only when we actually need js2py
+            try:
+                import js2py
+            except (KeyError, ModuleNotFoundError, RuntimeError):
+                js2py = None
+
             if js2py:
                 context = js2py.EvalJs()
                 context.execute(

--- a/sickchill/show/recommendations/imdb.py
+++ b/sickchill/show/recommendations/imdb.py
@@ -12,8 +12,8 @@ class imdbPopular(object):
     def __init__(self):
         """Gets a list of most popular TV series from IMDb via imdb-pie"""
         self.session = helpers.make_session()
-        self.client = Imdb()  # Low-level client
-        self.imdb = ImdbFacade(client=self.client)  # Higher-level facade (recommended)
+        self.client = Imdb()
+        self.imdb = ImdbFacade(client=self.client)
 
     def fetch_popular_shows(self):
         """Get popular show information from IMDB"""
@@ -41,7 +41,7 @@ class imdbPopular(object):
         try:
             return self.imdb.get_title(imdb_id=imdb_id)
         except ImdbAPIError as e:
-            print(f"Failed to get title {imdb_id}: {e}")
+            logger.warning(f"Failed to get title {imdb_id}: {e}")
             return None
 
     def imdb_url(self, result):


### PR DESCRIPTION
Fixes 
The binary dump at startup due to js2py load.
Switch a PRINT to logger.warning
Typo Seams to Seems.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected minor typos in connection and authentication log messages.
  * Improved IMDb API failure reporting by switching from console output to clearer warning logs that include the relevant IMDb identifier and error details.
  * Enhanced tracker list generation when the optional tracker-processing dependency is missing by relying on the existing fallback behavior without import-time interruption.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->