### PR TITLE
Fix: Find Propers

### DIFF
--- a/sickchill/oldbeard/scene_exceptions.py
+++ b/sickchill/oldbeard/scene_exceptions.py
@@ -84,8 +84,6 @@ def get_scene_exceptions(indexer_id: int, season: int = -1) -> list:
                 results.append(helpers.full_sanitizeSceneName(show.custom_name))
 
     response = list({result for result in results})
-    logger.debug(f"get_scene_exceptions: {response}")
-    logger.debug(f"exceptions_cache: {exceptions_cache.get(indexer_id)}")
     return response
 
 

--- a/sickchill/oldbeard/show_name_helpers.py
+++ b/sickchill/oldbeard/show_name_helpers.py
@@ -161,7 +161,10 @@ def all_possible_show_names(show, season=-1):
 
         show_names += new_show_names
 
-    return set(show_names)
+    show_names_clean = {n.lower() for n in show_names if n}
+    logger.debug(f"all_possible_show_names: {show_names_clean}")
+
+    return set(show_names_clean)
 
 
 def determine_release_name(directory=None, release_name=None):

--- a/sickchill/oldbeard/show_name_helpers.py
+++ b/sickchill/oldbeard/show_name_helpers.py
@@ -161,10 +161,19 @@ def all_possible_show_names(show, season=-1):
 
         show_names += new_show_names
 
-    show_names_clean = {n.lower() for n in show_names if n}
+    seen = {}
+    for name in show_names:
+        if not name:
+            continue
+        key = name.lower().strip()
+        # Prefer the original show.name when present
+        if key not in seen or name == show.name:
+            seen[key] = name
+
+    show_names_clean = set(seen.values())
     logger.debug(f"all_possible_show_names: {show_names_clean}")
 
-    return set(show_names_clean)
+    return show_names_clean
 
 
 def determine_release_name(directory=None, release_name=None):


### PR DESCRIPTION
Fixes duplicate call on Find Propers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved show-name matching by removing empty entries and eliminating duplicate variants while preserving the original show name.
  * Reduced unnecessary diagnostic output during scene exception processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->