### PR TITLE
Fix: DTZ min failure

### DIFF
--- a/sickchill/oldbeard/providers/thepiratebay.py
+++ b/sickchill/oldbeard/providers/thepiratebay.py
@@ -196,7 +196,7 @@ class TrackerCacheDBConnection(db.DBConnection):
         sql_result = self.select_one("SELECT * FROM trackers WHERE provider = ?", [self.provider_id])
 
         # Timezone-aware minimum sentinel (far in the past)
-        min_aware = datetime.datetime.min.replace(tzinfo=sc_timezone)
+        min_aware = datetime.datetime.min  # noqa: DTZ901
 
         if sql_result:
             last_time = datetime.datetime.fromtimestamp(sql_result["time"], tz=sc_timezone)

--- a/sickchill/oldbeard/subtitles.py
+++ b/sickchill/oldbeard/subtitles.py
@@ -421,7 +421,7 @@ class SubtitlesFinder(object):
             try:
                 lastsearched = datetime.datetime.strptime(ep_to_sub["lastsearch"], dateTimeFormat).replace(tzinfo=sc_timezone)
             except ValueError:
-                lastsearched = datetime.datetime.min.replace(tzinfo=sc_timezone)
+                lastsearched = datetime.datetime(1970, 1, 1, tzinfo=datetime.timezone.utc).astimezone(sc_timezone)
 
             try:
                 if not force:

--- a/sickchill/tv.py
+++ b/sickchill/tv.py
@@ -1213,7 +1213,7 @@ class TVShow(object):
                             episode_object.status = new_status
                             episode_object.subtitles = []
                             episode_object.subtitles_searchcount = 0
-                            episode_object.subtitles_lastsearch = str(datetime.datetime.min.replace(tzinfo=sc_timezone))
+                            episode_object.subtitles_lastsearch = str(datetime.datetime.min)  # noqa: DTZ901
                         episode_object.location = ""
                         episode_object.has_nfo = False
                         episode_object.has_tbn = False
@@ -1484,7 +1484,7 @@ class TVEpisode(object):
     description = DirtySetter("")
     subtitles = DirtySetter(list())
     subtitles_searchcount = DirtySetter(0)
-    subtitles_lastsearch = DirtySetter(str(datetime.datetime.min.replace(tzinfo=sc_timezone)))
+    subtitles_lastsearch = DirtySetter(str(datetime.datetime.min))  # noqa: DTZ901
     airdate = DirtySetter(datetime.date.min)
     has_nfo = DirtySetter(False)
     has_tbn = DirtySetter(False)
@@ -1693,7 +1693,7 @@ class TVEpisode(object):
             self.description = ""
             self.subtitles = []
             self.subtitles_searchcount = 0
-            self.subtitles_lastsearch = str(datetime.datetime.min.replace(tzinfo=sc_timezone))
+            self.subtitles_lastsearch = str(datetime.datetime.min)  # noqa: DTZ901
             existing_location = self._location
             self.location = ""
             self.file_size = 0


### PR DESCRIPTION
Fixes min dtz issue stopping start in docker


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when tracking provider and subtitle search timestamps.
  * Fixed timestamp handling for failed or unparseable subtitle searches.
  * Prevented potential timezone-related errors when resetting or loading episode subtitle search data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->