### PR TITLE
Feat: SHA tag of install

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -185,10 +185,11 @@ jobs:
           target: sickchill-final
           cache-from: type=gha
           cache-to: type=gha,mode=max  # Added for better reuse
+          # GIT_BRANCH: PR head_ref, or branch ref_name; empty on tag pushes (sha-only bake)
           build-args: |
             SOURCE=1
             GIT_SHA=${{ github.sha }}
-            GIT_BRANCH=${{ github.head_ref || github.ref_name }}
+            GIT_BRANCH=${{ github.head_ref || (startsWith(github.ref, 'refs/heads/') && github.ref_name) || '' }}
           allow: |
             security.insecure
 
@@ -274,10 +275,11 @@ jobs:
           target: sickchill-final
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          # GIT_BRANCH: PR head_ref, or branch ref_name; empty on tag pushes (sha-only bake)
           build-args: |
             SOURCE=1
             GIT_SHA=${{ github.sha }}
-            GIT_BRANCH=${{ github.head_ref || github.ref_name }}
+            GIT_BRANCH=${{ github.head_ref || (startsWith(github.ref, 'refs/heads/') && github.ref_name) || '' }}
           allow: |
             security.insecure
 
@@ -291,10 +293,11 @@ jobs:
           outputs: type=local,dest=/tmp/sickchill-wheels
           target: sickchill-wheels
           cache-from: type=gha
+          # GIT_BRANCH: PR head_ref, or branch ref_name; empty on tag pushes (sha-only bake)
           build-args: |
             SOURCE=1
             GIT_SHA=${{ github.sha }}
-            GIT_BRANCH=${{ github.head_ref || github.ref_name }}
+            GIT_BRANCH=${{ github.head_ref || (startsWith(github.ref, 'refs/heads/') && github.ref_name) || '' }}
           allow: |
             security.insecure
 

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -187,6 +187,8 @@ jobs:
           cache-to: type=gha,mode=max  # Added for better reuse
           build-args: |
             SOURCE=1
+            GIT_SHA=${{ github.sha }}
+            GIT_BRANCH=${{ github.head_ref || github.ref_name }}
           allow: |
             security.insecure
 
@@ -274,6 +276,8 @@ jobs:
           cache-to: type=gha,mode=max
           build-args: |
             SOURCE=1
+            GIT_SHA=${{ github.sha }}
+            GIT_BRANCH=${{ github.head_ref || github.ref_name }}
           allow: |
             security.insecure
 
@@ -289,6 +293,8 @@ jobs:
           cache-from: type=gha
           build-args: |
             SOURCE=1
+            GIT_SHA=${{ github.sha }}
+            GIT_BRANCH=${{ github.head_ref || github.ref_name }}
           allow: |
             security.insecure
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 #  SC User Related   #
 ######################
+sickchill/_revision.txt
 /cache/
 /gui/slick/cache
 /sickchill/gui/slick/cache

--- a/Dockerfile
+++ b/Dockerfile
@@ -102,10 +102,14 @@ else \
   poetry build --no-interaction --no-ansi && pip install --upgrade "$(ls ./dist/sickchill-*.whl)[speedups]"; \
 fi
 
-# Ensure installed package has _revision.txt (wheel may omit gitignored file)
+# Ensure installed package has _revision.txt (wheel may omit gitignored file).
+# Run python from /tmp so cwd (/sickchill) is not on sys.path — otherwise
+# `import sickchill` resolves to the source tree and cp is same-file.
 RUN if [ -f sickchill/_revision.txt ]; then \
-  REV_DST="$(python -c 'import pathlib, sickchill; print(pathlib.Path(sickchill.__file__).parent)')" && \
-  cp sickchill/_revision.txt "$REV_DST/_revision.txt"; \
+  REV_DST="$(cd /tmp && python -c 'import pathlib, sickchill; print(pathlib.Path(sickchill.__file__).parent)')" && \
+  SRC="$(realpath sickchill/_revision.txt)" && \
+  DST="$(realpath -m "$REV_DST/_revision.txt")" && \
+  if [ "$SRC" != "$DST" ]; then cp sickchill/_revision.txt "$REV_DST/_revision.txt"; fi; \
 fi
 
 RUN mkdir -m 777 /sickchill-wheels && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,9 @@ ENV PYTHONUNBUFFERED=1
 ARG SOURCE
 ARG PIP_EXTRA_INDEX_URL="https://www.piwheels.org/simple"
 ARG HOME=${HOME:-}
+# Neutral defaults — never invent "develop" (master/local builds omit or pass real ref)
+ARG GIT_SHA=unknown
+ARG GIT_BRANCH=unknown
 
 ENV POETRY_INSTALLER_PARALLEL=false
 ENV POETRY_VIRTUALENVS_CREATE=false
@@ -79,6 +82,17 @@ RUN pip install -U wheel setuptools-rust
 WORKDIR /sickchill
 COPY . /sickchill/
 
+# Bake git revision for Help & Info. Skip placeholder "unknown" so pip-only
+ARG GIT_SHA
+ARG GIT_BRANCH
+RUN if [ -n "$GIT_SHA" ] && [ "$GIT_SHA" != "unknown" ]; then \
+  if [ -n "$GIT_BRANCH" ] && [ "$GIT_BRANCH" != "unknown" ]; then \
+    printf '%s %s\n' "$GIT_BRANCH" "$GIT_SHA" > sickchill/_revision.txt; \
+  else \
+    printf '%s\n' "$GIT_SHA" > sickchill/_revision.txt; \
+  fi; \
+fi
+
 # https://github.com/rust-lang/cargo/issues/8719#issuecomment-1253575253
 # hadolint ignore=SC2215,SC1089
 RUN --mount=type=tmpfs,target="$CARGO_HOME" if [ -z "$SOURCE" ]; then \
@@ -86,6 +100,12 @@ RUN --mount=type=tmpfs,target="$CARGO_HOME" if [ -z "$SOURCE" ]; then \
 else \
   pip install --upgrade poetry && poetry run pip install -U setuptools-rust pycparser && \
   poetry build --no-interaction --no-ansi && pip install --upgrade "$(ls ./dist/sickchill-*.whl)[speedups]"; \
+fi
+
+# Ensure installed package has _revision.txt (wheel may omit gitignored file)
+RUN if [ -f sickchill/_revision.txt ]; then \
+  REV_DST="$(python -c 'import pathlib, sickchill; print(pathlib.Path(sickchill.__file__).parent)')" && \
+  cp sickchill/_revision.txt "$REV_DST/_revision.txt"; \
 fi
 
 RUN mkdir -m 777 /sickchill-wheels && \
@@ -104,6 +124,14 @@ COPY --from=builder /sickchill-wheels /
 FROM base AS sickchill-final
 
 COPY --from=builder "$POETRY_VIRTUALENVS_PATH" "$POETRY_VIRTUALENVS_PATH"
+
+# Runtime env + OCI label (builder-stage ENV/LABEL do not reach this image).
+# Defaults are "unknown" (filtered at runtime); CI passes the real ref_name.
+ARG GIT_SHA=unknown
+ARG GIT_BRANCH=unknown
+ENV SICKCHILL_SHA=$GIT_SHA
+ENV SICKCHILL_BRANCH=$GIT_BRANCH
+LABEL org.opencontainers.image.revision=$GIT_SHA
 
 # When you docker exec, show the config files in the container
 ENV HOME=/data

--- a/SickChill.py
+++ b/SickChill.py
@@ -26,7 +26,7 @@ except (ModuleNotFoundError, ImportError):
 
 from sickchill import logger, settings
 from sickchill.helper.common import choose_data_dir
-from sickchill.init_helpers import check_installed, get_current_version, remove_pid_file, setup_gettext
+from sickchill.init_helpers import check_installed, format_git_revision, get_current_version, remove_pid_file, setup_gettext
 from sickchill.movies import MovieList
 from sickchill.oldbeard.name_parser.parser import NameParser, ParseResult
 
@@ -208,7 +208,12 @@ class SickChill:
         # Build from the DB to start with
         self.load_shows_from_db()
 
-        logger.info("Starting SickChill [{version}] using '{config}'".format(version=get_current_version(), config=settings.CONFIG_FILE))
+        _rev = format_git_revision()
+        _ver = get_current_version()
+        if _rev:
+            logger.info(f"Starting SickChill [{_ver} {_rev}] using '{settings.CONFIG_FILE}'")
+        else:
+            logger.info(f"Starting SickChill [{_ver}] using '{settings.CONFIG_FILE}'")
 
         self.clear_cache()
 

--- a/sickchill/gui/slick/views/config.mako
+++ b/sickchill/gui/slick/views/config.mako
@@ -1,5 +1,7 @@
 <%inherit file="/layouts/main.mako" />
 <%!
+    from urllib.parse import quote
+
     from sickchill import settings
     from sickchill.oldbeard import db
     from sickchill.oldbeard.helpers import anon_url
@@ -47,12 +49,12 @@
                             <div class="col-md-12">
                                 ${_('Revision')}:
                                 % if sc_branch and sc_branch != 'HEAD':
-                                    <a href="${anon_url('https://github.com/SickChill/sickchill/tree/%s' % sc_branch)}">${sc_branch}</a>@
+                                    <a href="${anon_url('https://github.com/SickChill/sickchill/tree/%s' % quote(sc_branch, safe=''))}">${sc_branch}</a>@
                                 % elif sc_branch:
                                     ${sc_branch}@
                                 % endif
                                 % if sc_revision:
-                                    <a href="${anon_url('https://github.com/SickChill/sickchill/commit/%s' % sc_revision)}">${sc_revision[:12]}</a>
+                                    ${sc_revision[:12]}
                                 % endif
                             </div>
                         </div>

--- a/sickchill/gui/slick/views/config.mako
+++ b/sickchill/gui/slick/views/config.mako
@@ -42,6 +42,21 @@
                             </div>
                         </div>
                     % endif
+                    % if sc_branch or sc_revision:
+                        <div class="row">
+                            <div class="col-md-12">
+                                ${_('Revision')}:
+                                % if sc_branch and sc_branch != 'HEAD':
+                                    <a href="${anon_url('https://github.com/SickChill/sickchill/tree/%s' % sc_branch)}">${sc_branch}</a>@
+                                % elif sc_branch:
+                                    ${sc_branch}@
+                                % endif
+                                % if sc_revision:
+                                    <a href="${anon_url('https://github.com/SickChill/sickchill/commit/%s' % sc_revision)}">${sc_revision[:12]}</a>
+                                % endif
+                            </div>
+                        </div>
+                    % endif
                     <div class="row">
                         <div class="col-md-12">
                             Database Version: ${'{}.{}'.format(*db.DBConnection().version)}

--- a/sickchill/init_helpers.py
+++ b/sickchill/init_helpers.py
@@ -151,3 +151,107 @@ def get_current_version() -> str:
         return get_distribution().version
     except PackageNotFoundError:
         return fallback_version
+
+
+_revision_cache: tuple[str, str] | None = None
+_revision_file = sickchill_dir / "_revision.txt"
+
+
+def _git_output(*args: str, cwd: Path | None = None) -> str | None:
+    """Run a git command; return stripped stdout or None on any failure."""
+    import subprocess
+
+    try:
+        return (
+            subprocess.check_output(
+                ["git", *args],
+                cwd=str(cwd) if cwd else None,
+                stderr=subprocess.DEVNULL,
+                timeout=5,
+                text=True,
+            ).strip()
+            or None
+        )
+    except (OSError, subprocess.CalledProcessError, subprocess.TimeoutExpired):
+        return None
+
+
+def _normalize_revision(branch: str, sha: str) -> tuple[str, str]:
+    """Drop placeholder values so Help does not show a fake revision."""
+    branch = (branch or "").strip()
+    sha = (sha or "").strip()
+    if branch in ("", "unknown"):
+        branch = ""
+    if sha in ("", "unknown"):
+        # No real commit → hide the whole Revision row (do not show "develop@")
+        return "", ""
+    return branch, sha
+
+
+def _parse_revision_file(path: Path) -> tuple[str, str]:
+    """Parse ``branch sha`` or a single ``sha`` from a bake file."""
+    try:
+        text = path.read_text(encoding="utf-8").strip()
+    except OSError:
+        return "", ""
+    if not text:
+        return "", ""
+    parts = text.split()
+    if len(parts) >= 2:
+        return _normalize_revision(parts[0], parts[1])
+    return _normalize_revision("", parts[0])
+
+
+def _revision_from_git() -> tuple[str, str] | None:
+    """Return (branch, sha) from a live checkout, or None if not a git tree."""
+    repo_root = git_folder.parent
+    if _git_output("-C", str(repo_root), "rev-parse", "--git-dir") is None:
+        return None
+    sha = _git_output("-C", str(repo_root), "rev-parse", "HEAD")
+    if not sha:
+        return None
+    branch = _git_output("-C", str(repo_root), "rev-parse", "--abbrev-ref", "HEAD") or "HEAD"
+    return branch, sha
+
+
+def _revision_from_env() -> tuple[str, str]:
+    sha = os.environ.get("SICKCHILL_SHA") or os.environ.get("GIT_SHA") or ""
+    branch = os.environ.get("SICKCHILL_BRANCH") or os.environ.get("GIT_BRANCH") or ""
+    return _normalize_revision(branch, sha)
+
+
+def get_git_revision() -> tuple[str, str]:
+    """
+    Return ``(branch, sha)`` for the running code.
+
+    Resolution order: live git checkout → ``sickchill/_revision.txt`` → env
+    (``SICKCHILL_SHA`` / ``GIT_SHA``, ``SICKCHILL_BRANCH`` / ``GIT_BRANCH``).
+    Result is cached for the process lifetime.
+    """
+    global _revision_cache
+    if _revision_cache is not None:
+        return _revision_cache
+
+    result = _revision_from_git()
+    if result is None and _revision_file.is_file():
+        result = _parse_revision_file(_revision_file)
+        if result == ("", ""):
+            result = None
+    if result is None:
+        result = _revision_from_env()
+        if result == ("", ""):
+            result = ("", "")
+
+    _revision_cache = result
+    return _revision_cache
+
+
+def format_git_revision(short: int = 12) -> str:
+    """Return ``branch@sha12`` or ``sha12`` or empty string for logs/UI helpers."""
+    branch, sha = get_git_revision()
+    if not sha:
+        return f"{branch}@" if branch else ""
+    short_sha = sha[:short] if short else sha
+    if branch and branch != "HEAD":
+        return f"{branch}@{short_sha}"
+    return short_sha

--- a/sickchill/init_helpers.py
+++ b/sickchill/init_helpers.py
@@ -203,7 +203,13 @@ def _parse_revision_file(path: Path) -> tuple[str, str]:
 
 
 def _revision_from_git() -> tuple[str, str] | None:
-    """Return (branch, sha) from a live checkout, or None if not a git tree."""
+    """Return (branch, sha) from a live checkout, or None if not a git tree.
+
+    ``git_folder`` may be a directory *or* a file (worktree / ``gitdir:``
+    pointer). Only ``exists()`` is required — do not use ``is_dir()``.
+    """
+    if not git_folder.exists():
+        return None
     repo_root = git_folder.parent
     if _git_output("-C", str(repo_root), "rev-parse", "--git-dir") is None:
         return None

--- a/sickchill/views/config/index.py
+++ b/sickchill/views/config/index.py
@@ -3,7 +3,7 @@ import os
 from tornado.web import addslash
 
 from sickchill import logger
-from sickchill.init_helpers import get_current_version
+from sickchill.init_helpers import get_current_version, get_git_revision
 from sickchill.views.common import PageTemplate
 from sickchill.views.index import WebRoot
 from sickchill.views.routes import Route
@@ -55,6 +55,7 @@ class Config(WebRoot):
         except Exception:
             ssl_version = "Unknown"
 
+        sc_branch, sc_revision = get_git_revision()
         return t.render(
             submenu=self.ConfigMenu(),
             title=_("SickChill Configuration"),
@@ -64,4 +65,6 @@ class Config(WebRoot):
             sc_locale=sc_locale,
             ssl_version=ssl_version,
             sc_version=get_current_version(),
+            sc_branch=sc_branch,
+            sc_revision=sc_revision,
         )

--- a/tests/test_git_revision.py
+++ b/tests/test_git_revision.py
@@ -1,0 +1,145 @@
+"""Unit tests for get_git_revision / format_git_revision (Help & Info SHA)."""
+
+from __future__ import annotations
+
+import os
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from sickchill import init_helpers
+
+
+def _clear_revision_cache() -> None:
+    init_helpers._revision_cache = None
+
+
+class TestGetGitRevision(unittest.TestCase):
+    def setUp(self):
+        _clear_revision_cache()
+        self._env_backup = {key: os.environ.get(key) for key in ("SICKCHILL_SHA", "SICKCHILL_BRANCH", "GIT_SHA", "GIT_BRANCH")}
+        for key in self._env_backup:
+            os.environ.pop(key, None)
+
+    def tearDown(self):
+        _clear_revision_cache()
+        for key, value in self._env_backup.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+
+    def test_from_git_checkout(self):
+        sha = "e1f8475ded8dabcdef0123456789abcdef012345"
+        with mock.patch.object(init_helpers, "_git_output") as git_out:
+            git_out.side_effect = [
+                ".git",  # rev-parse --git-dir
+                sha,  # rev-parse HEAD
+                "develop",  # rev-parse --abbrev-ref HEAD
+            ]
+            branch, got_sha = init_helpers.get_git_revision()
+        self.assertEqual(branch, "develop")
+        self.assertEqual(got_sha, sha)
+        # Cached: second call does not hit git again
+        with mock.patch.object(init_helpers, "_git_output") as git_out2:
+            self.assertEqual(init_helpers.get_git_revision(), ("develop", sha))
+            git_out2.assert_not_called()
+
+    def test_from_revision_file_when_no_git(self):
+        sha = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        with mock.patch.object(init_helpers, "_revision_from_git", return_value=None):
+            with mock.patch.object(init_helpers, "_revision_file") as rev_file:
+                rev_file.is_file.return_value = True
+                with mock.patch.object(
+                    init_helpers,
+                    "_parse_revision_file",
+                    return_value=("SHA-tag", sha),
+                ):
+                    branch, got_sha = init_helpers.get_git_revision()
+        self.assertEqual(branch, "SHA-tag")
+        self.assertEqual(got_sha, sha)
+
+    def test_parse_revision_file_formats(self):
+        with self.subTest("branch and sha"):
+            path = mock.Mock(spec=Path)
+            path.read_text.return_value = "develop deadbeefdeadbeefdeadbeefdeadbeefdeadbeef\n"
+            self.assertEqual(
+                init_helpers._parse_revision_file(path),
+                ("develop", "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"),
+            )
+        with self.subTest("sha only"):
+            path = mock.Mock(spec=Path)
+            path.read_text.return_value = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef\n"
+            self.assertEqual(
+                init_helpers._parse_revision_file(path),
+                ("", "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"),
+            )
+        with self.subTest("unknown placeholder ignored"):
+            path = mock.Mock(spec=Path)
+            path.read_text.return_value = "develop unknown\n"
+            self.assertEqual(init_helpers._parse_revision_file(path), ("", ""))
+        with self.subTest("empty"):
+            path = mock.Mock(spec=Path)
+            path.read_text.return_value = "\n"
+            self.assertEqual(init_helpers._parse_revision_file(path), ("", ""))
+        with self.subTest("missing file"):
+            path = mock.Mock(spec=Path)
+            path.read_text.side_effect = OSError("nope")
+            self.assertEqual(init_helpers._parse_revision_file(path), ("", ""))
+
+    def test_from_env_when_git_and_file_absent(self):
+        sha = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        os.environ["SICKCHILL_SHA"] = sha
+        os.environ["SICKCHILL_BRANCH"] = "feature/x"
+        with mock.patch.object(init_helpers, "_revision_from_git", return_value=None):
+            with mock.patch.object(init_helpers, "_revision_file") as rev_file:
+                rev_file.is_file.return_value = False
+                branch, got_sha = init_helpers.get_git_revision()
+        self.assertEqual(branch, "feature/x")
+        self.assertEqual(got_sha, sha)
+
+    def test_env_unknown_treated_as_empty(self):
+        os.environ["GIT_SHA"] = "unknown"
+        os.environ["GIT_BRANCH"] = "unknown"
+        with mock.patch.object(init_helpers, "_revision_from_git", return_value=None):
+            with mock.patch.object(init_helpers, "_revision_file") as rev_file:
+                rev_file.is_file.return_value = False
+                self.assertEqual(init_helpers.get_git_revision(), ("", ""))
+
+    def test_all_missing_returns_empty(self):
+        with mock.patch.object(init_helpers, "_revision_from_git", return_value=None):
+            with mock.patch.object(init_helpers, "_revision_file") as rev_file:
+                rev_file.is_file.return_value = False
+                self.assertEqual(init_helpers.get_git_revision(), ("", ""))
+
+
+class TestFormatGitRevision(unittest.TestCase):
+    def setUp(self):
+        _clear_revision_cache()
+
+    def tearDown(self):
+        _clear_revision_cache()
+
+    def test_branch_and_short_sha(self):
+        with mock.patch.object(
+            init_helpers,
+            "get_git_revision",
+            return_value=("develop", "e1f8475ded8dabcdef0123456789abcdef012345"),
+        ):
+            self.assertEqual(init_helpers.format_git_revision(), "develop@e1f8475ded8d")
+
+    def test_detached_head_omits_branch(self):
+        with mock.patch.object(
+            init_helpers,
+            "get_git_revision",
+            return_value=("HEAD", "e1f8475ded8dabcdef0123456789abcdef012345"),
+        ):
+            self.assertEqual(init_helpers.format_git_revision(), "e1f8475ded8d")
+
+    def test_empty(self):
+        with mock.patch.object(init_helpers, "get_git_revision", return_value=("", "")):
+            self.assertEqual(init_helpers.format_git_revision(), "")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_git_revision.py
+++ b/tests/test_git_revision.py
@@ -31,19 +31,46 @@ class TestGetGitRevision(unittest.TestCase):
 
     def test_from_git_checkout(self):
         sha = "e1f8475ded8dabcdef0123456789abcdef012345"
-        with mock.patch.object(init_helpers, "_git_output") as git_out:
-            git_out.side_effect = [
-                ".git",  # rev-parse --git-dir
-                sha,  # rev-parse HEAD
-                "develop",  # rev-parse --abbrev-ref HEAD
-            ]
-            branch, got_sha = init_helpers.get_git_revision()
+        with mock.patch.object(init_helpers, "git_folder") as gf:
+            gf.exists.return_value = True
+            gf.parent = Path("/repo")
+            with mock.patch.object(init_helpers, "_git_output") as git_out:
+                git_out.side_effect = [
+                    ".git",  # rev-parse --git-dir
+                    sha,  # rev-parse HEAD
+                    "develop",  # rev-parse --abbrev-ref HEAD
+                ]
+                branch, got_sha = init_helpers.get_git_revision()
         self.assertEqual(branch, "develop")
         self.assertEqual(got_sha, sha)
         # Cached: second call does not hit git again
         with mock.patch.object(init_helpers, "_git_output") as git_out2:
             self.assertEqual(init_helpers.get_git_revision(), ("develop", sha))
             git_out2.assert_not_called()
+
+    def test_skips_git_when_dot_git_missing(self):
+        """No .git file/dir → do not spawn git (pip install / bare tree)."""
+        with mock.patch.object(init_helpers, "git_folder") as gf:
+            gf.exists.return_value = False
+            with mock.patch.object(init_helpers, "_git_output") as git_out:
+                with mock.patch.object(init_helpers, "_revision_file") as rev_file:
+                    rev_file.is_file.return_value = False
+                    self.assertEqual(init_helpers.get_git_revision(), ("", ""))
+                    git_out.assert_not_called()
+
+    def test_worktree_git_file_still_looked_up(self):
+        """Worktrees use a .git *file*; exists() is enough (not is_dir())."""
+        sha = "cccccccccccccccccccccccccccccccccccccccc"
+        with mock.patch.object(init_helpers, "git_folder") as gf:
+            gf.exists.return_value = True
+            gf.is_dir.return_value = False  # file pointer
+            gf.parent = Path("/repo")
+            with mock.patch.object(init_helpers, "_git_output") as git_out:
+                git_out.side_effect = [".git", sha, "HEAD"]
+                branch, got_sha = init_helpers.get_git_revision()
+        self.assertEqual(branch, "HEAD")
+        self.assertEqual(got_sha, sha)
+        gf.is_dir.assert_not_called()
 
     def test_from_revision_file_when_no_git(self):
         sha = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"


### PR DESCRIPTION
Add feature of SHA tag in help&info

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Git branch and revision information to the SickChill startup log.
  * Added a Revision row to the configuration information page, showing the branch and shortened revision when available.
  * Docker builds now preserve revision metadata for installed SickChill packages and expose it through container metadata.

* **Bug Fixes**
  * Revision information now resolves reliably across source checkouts, packaged builds, containers, and worktrees.
  * Unavailable or placeholder values are omitted instead of displayed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->