### PR TITLE
update: ensure revision when git@dev

### DIFF
--- a/sickchill/init_helpers.py
+++ b/sickchill/init_helpers.py
@@ -260,6 +260,10 @@ def _revision_from_direct_url() -> tuple[str, str] | None:
         # Missing dist, missing file, bad JSON, etc. — never fail Help/startup
         return None
 
+    # Valid non-object JSON (array, string, …) must not raise — fall through to env
+    if not isinstance(data, dict):
+        return None
+
     vcs = data.get("vcs_info")
     if not isinstance(vcs, dict):
         return None

--- a/sickchill/init_helpers.py
+++ b/sickchill/init_helpers.py
@@ -226,11 +226,57 @@ def _revision_from_env() -> tuple[str, str]:
     return _normalize_revision(branch, sha)
 
 
+def _branch_from_requested_revision(requested: str, commit_id: str) -> str:
+    """Use requested_revision as branch unless it is clearly a commit-ish."""
+    req = (requested or "").strip()
+    if not req:
+        return ""
+    # pip records the ref the user asked for; when that is a SHA, do not show "sha@sha"
+    if commit_id and (req == commit_id or commit_id.startswith(req)):
+        return ""
+    return req
+
+
+def _revision_from_direct_url() -> tuple[str, str] | None:
+    """
+    PEP 610 ``direct_url.json`` written by pip for VCS installs, e.g.::
+
+        pip install "git+https://github.com/SickChill/SickChill.git@develop"
+
+    Yields ``vcs_info.commit_id`` and optional ``requested_revision`` (branch/tag).
+    Editable local checkouts use ``dir_info`` only — those return None here.
+    """
+    import json
+
+    try:
+        dist = get_distribution()
+        if dist is None:
+            return None
+        text = dist.read_text("direct_url.json")
+        if not text:
+            return None
+        data = json.loads(text)
+    except Exception:
+        # Missing dist, missing file, bad JSON, etc. — never fail Help/startup
+        return None
+
+    vcs = data.get("vcs_info")
+    if not isinstance(vcs, dict):
+        return None
+    sha = (vcs.get("commit_id") or "").strip()
+    branch = _branch_from_requested_revision(vcs.get("requested_revision") or "", sha)
+    normalized = _normalize_revision(branch, sha)
+    if not normalized[1]:
+        return None
+    return normalized
+
+
 def get_git_revision() -> tuple[str, str]:
     """
     Return ``(branch, sha)`` for the running code.
 
-    Resolution order: live git checkout → ``sickchill/_revision.txt`` → env
+    Resolution order: live git checkout → ``sickchill/_revision.txt`` →
+    PEP 610 ``direct_url.json`` (pip ``git+https://…@branch``) → env
     (``SICKCHILL_SHA`` / ``GIT_SHA``, ``SICKCHILL_BRANCH`` / ``GIT_BRANCH``).
     Result is cached for the process lifetime.
     """
@@ -243,6 +289,8 @@ def get_git_revision() -> tuple[str, str]:
         result = _parse_revision_file(_revision_file)
         if result == ("", ""):
             result = None
+    if result is None:
+        result = _revision_from_direct_url()
     if result is None:
         result = _revision_from_env()
         if result == ("", ""):

--- a/tests/test_git_revision.py
+++ b/tests/test_git_revision.py
@@ -55,8 +55,9 @@ class TestGetGitRevision(unittest.TestCase):
             with mock.patch.object(init_helpers, "_git_output") as git_out:
                 with mock.patch.object(init_helpers, "_revision_file") as rev_file:
                     rev_file.is_file.return_value = False
-                    self.assertEqual(init_helpers.get_git_revision(), ("", ""))
-                    git_out.assert_not_called()
+                    with mock.patch.object(init_helpers, "_revision_from_direct_url", return_value=None):
+                        self.assertEqual(init_helpers.get_git_revision(), ("", ""))
+                        git_out.assert_not_called()
 
     def test_worktree_git_file_still_looked_up(self):
         """Worktrees use a .git *file*; exists() is enough (not is_dir())."""
@@ -121,7 +122,8 @@ class TestGetGitRevision(unittest.TestCase):
         with mock.patch.object(init_helpers, "_revision_from_git", return_value=None):
             with mock.patch.object(init_helpers, "_revision_file") as rev_file:
                 rev_file.is_file.return_value = False
-                branch, got_sha = init_helpers.get_git_revision()
+                with mock.patch.object(init_helpers, "_revision_from_direct_url", return_value=None):
+                    branch, got_sha = init_helpers.get_git_revision()
         self.assertEqual(branch, "feature/x")
         self.assertEqual(got_sha, sha)
 
@@ -131,13 +133,71 @@ class TestGetGitRevision(unittest.TestCase):
         with mock.patch.object(init_helpers, "_revision_from_git", return_value=None):
             with mock.patch.object(init_helpers, "_revision_file") as rev_file:
                 rev_file.is_file.return_value = False
-                self.assertEqual(init_helpers.get_git_revision(), ("", ""))
+                with mock.patch.object(init_helpers, "_revision_from_direct_url", return_value=None):
+                    self.assertEqual(init_helpers.get_git_revision(), ("", ""))
 
     def test_all_missing_returns_empty(self):
         with mock.patch.object(init_helpers, "_revision_from_git", return_value=None):
             with mock.patch.object(init_helpers, "_revision_file") as rev_file:
                 rev_file.is_file.return_value = False
-                self.assertEqual(init_helpers.get_git_revision(), ("", ""))
+                with mock.patch.object(init_helpers, "_revision_from_direct_url", return_value=None):
+                    self.assertEqual(init_helpers.get_git_revision(), ("", ""))
+
+    def test_from_direct_url_pip_git_install(self):
+        """pip install git+https://…@develop → PEP 610 direct_url.json."""
+        sha = "a00b0e1e8482408ffbace149cfe59573d078034d"
+        payload = {
+            "url": "https://github.com/SickChill/SickChill.git",
+            "vcs_info": {
+                "vcs": "git",
+                "requested_revision": "develop",
+                "commit_id": sha,
+            },
+        }
+        dist = mock.Mock()
+        dist.read_text.return_value = __import__("json").dumps(payload)
+        with mock.patch.object(init_helpers, "_revision_from_git", return_value=None):
+            with mock.patch.object(init_helpers, "_revision_file") as rev_file:
+                rev_file.is_file.return_value = False
+                with mock.patch.object(init_helpers, "get_distribution", return_value=dist):
+                    branch, got_sha = init_helpers.get_git_revision()
+        self.assertEqual(branch, "develop")
+        self.assertEqual(got_sha, sha)
+        dist.read_text.assert_called_with("direct_url.json")
+
+    def test_direct_url_commitish_omits_branch(self):
+        sha = "a00b0e1e8482408ffbace149cfe59573d078034d"
+        payload = {
+            "url": "https://github.com/SickChill/SickChill.git",
+            "vcs_info": {
+                "vcs": "git",
+                "requested_revision": sha,
+                "commit_id": sha,
+            },
+        }
+        self.assertEqual(
+            init_helpers._branch_from_requested_revision(sha, sha),
+            "",
+        )
+        dist = mock.Mock()
+        dist.read_text.return_value = __import__("json").dumps(payload)
+        with mock.patch.object(init_helpers, "_revision_from_git", return_value=None):
+            with mock.patch.object(init_helpers, "_revision_file") as rev_file:
+                rev_file.is_file.return_value = False
+                with mock.patch.object(init_helpers, "get_distribution", return_value=dist):
+                    branch, got_sha = init_helpers.get_git_revision()
+        self.assertEqual(branch, "")
+        self.assertEqual(got_sha, sha)
+
+    def test_direct_url_editable_without_vcs_ignored(self):
+        """Editable local installs have dir_info only — fall through."""
+        dist = mock.Mock()
+        dist.read_text.return_value = '{"dir_info": {"editable": true}, "url": "file:///tmp/sickchill"}'
+        with mock.patch.object(init_helpers, "_revision_from_git", return_value=None):
+            with mock.patch.object(init_helpers, "_revision_file") as rev_file:
+                rev_file.is_file.return_value = False
+                with mock.patch.object(init_helpers, "get_distribution", return_value=dist):
+                    self.assertEqual(init_helpers.get_git_revision(), ("", ""))
 
 
 class TestFormatGitRevision(unittest.TestCase):

--- a/tests/test_git_revision.py
+++ b/tests/test_git_revision.py
@@ -199,6 +199,23 @@ class TestGetGitRevision(unittest.TestCase):
                 with mock.patch.object(init_helpers, "get_distribution", return_value=dist):
                     self.assertEqual(init_helpers.get_git_revision(), ("", ""))
 
+    def test_direct_url_json_array_falls_through_to_env(self):
+        """Top-level JSON array is valid JSON but not PEP 610 — do not crash; use env."""
+        sha = "dddddddddddddddddddddddddddddddddddddddd"
+        os.environ["SICKCHILL_SHA"] = sha
+        os.environ["SICKCHILL_BRANCH"] = "develop"
+        dist = mock.Mock()
+        dist.read_text.return_value = '[{"url": "https://example.com"}]'
+        with mock.patch.object(init_helpers, "_revision_from_git", return_value=None):
+            with mock.patch.object(init_helpers, "_revision_file") as rev_file:
+                rev_file.is_file.return_value = False
+                with mock.patch.object(init_helpers, "get_distribution", return_value=dist):
+                    self.assertEqual(init_helpers.get_git_revision(), ("develop", sha))
+        # Helper itself returns None for non-object JSON
+        _clear_revision_cache()
+        with mock.patch.object(init_helpers, "get_distribution", return_value=dist):
+            self.assertIsNone(init_helpers._revision_from_direct_url())
+
 
 class TestFormatGitRevision(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
Fixes missing display of info


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved version information detection for installations made directly from Git repositories.
  * Version details can now be identified from package installation metadata when live repository information and revision files are unavailable.
  * Added fallback handling for branch-based and commit-based installations.
  * Improved handling of installations without version-control metadata, allowing the application to use other available version information when possible.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->