### PR TITLE
Fix: Image changer

### DIFF
--- a/sickchill/providers/metadata/helpers.py
+++ b/sickchill/providers/metadata/helpers.py
@@ -1,9 +1,45 @@
+import re
+from urllib.parse import urljoin, urlparse
+
 import requests
 
 from sickchill import logger, settings
 from sickchill.oldbeard import helpers
 
 meta_session = helpers.make_session()
+
+# Public artwork CDNs used by the image selector / edit-show replace flow.
+# Keep in sync with sickchill.views.imageSelector.url_wrap allowlist.
+ALLOWED_SHOW_IMAGE_HOSTS = frozenset(
+    {
+        "artworks.thetvdb.com",
+        "assets.fanart.tv",
+        "image.tmdb.org",
+    }
+)
+
+_ALLOWED_SHOW_IMAGE_URL_RE = re.compile(
+    r"^https?://(artworks\.thetvdb\.com|assets\.fanart\.tv|image\.tmdb\.org)/.*",
+    re.IGNORECASE,
+)
+
+_MAX_IMAGE_REDIRECTS = 5
+
+
+def is_allowed_show_image_url(url: str | None) -> bool:
+    """Return True if url is http(s) to an approved public artwork host (SSRF guard)."""
+    if not url or not isinstance(url, str):
+        return False
+    candidate = url.strip()
+    if not candidate or not _ALLOWED_SHOW_IMAGE_URL_RE.match(candidate):
+        return False
+    parsed = urlparse(candidate)
+    if parsed.scheme not in ("http", "https"):
+        return False
+    if parsed.username is not None or parsed.password is not None:
+        return False
+    host = (parsed.hostname or "").lower()
+    return host in ALLOWED_SHOW_IMAGE_HOSTS
 
 
 def getShowImage(url, imgNum=None):
@@ -16,10 +52,14 @@ def getShowImage(url, imgNum=None):
     else:
         temp_url = url
 
+    if not is_allowed_show_image_url(temp_url):
+        logger.warning(f"Blocked show image fetch from non-allowlisted URL: {temp_url}")
+        return None
+
     logger.debug("Fetching image from " + temp_url)
 
     try:
-        image_data = helpers.getURL(temp_url, session=meta_session, returns="content", allow_proxy=settings.PROXY_INDEXERS)
+        image_data = _fetch_allowed_image_content(temp_url)
     except requests.exceptions.RequestException:
         image_data = None
 
@@ -28,3 +68,37 @@ def getShowImage(url, imgNum=None):
         return
 
     return image_data
+
+
+def _fetch_allowed_image_content(url: str):
+    """GET image bytes, re-validating every redirect target against the allowlist."""
+    current = url
+    for _ in range(_MAX_IMAGE_REDIRECTS + 1):
+        if not is_allowed_show_image_url(current):
+            logger.warning(f"Blocked show image redirect to non-allowlisted URL: {current}")
+            return None
+
+        response = helpers.getURL(
+            current,
+            session=meta_session,
+            returns="response",
+            allow_redirects=False,
+            allow_proxy=settings.PROXY_INDEXERS,
+        )
+        if not response:
+            return None
+
+        if getattr(response, "is_redirect", False) or response.status_code in {301, 302, 303, 307, 308}:
+            location = response.headers.get("Location") or ""
+            if not location:
+                logger.warning(f"Show image redirect missing Location from {current}")
+                return None
+            current = urljoin(response.url or current, location)
+            continue
+
+        response.raise_for_status()
+        content = getattr(response, "content", None)
+        return content or None
+
+    logger.warning(f"Too many redirects while fetching show image from {url}")
+    return None

--- a/sickchill/views/home.py
+++ b/sickchill/views/home.py
@@ -33,6 +33,7 @@ from sickchill.oldbeard.trakt_api import TraktAPI
 from sickchill.providers import result_classes
 from sickchill.providers.GenericProvider import GenericProvider
 from sickchill.providers.metadata.generic import GenericMetadata
+from sickchill.providers.metadata.helpers import getShowImage
 from sickchill.show.Show import Show
 from sickchill.system.Restart import Restart
 from sickchill.system.Shutdown import Shutdown
@@ -749,7 +750,6 @@ class Home(WebRoot):
 
     def getPushbulletDevices(self):
         api = self.get_body_argument("api")
-        # self.set_header('Cache-Control', 'max-age=0,no-cache,no-store')
 
         result = notifiers.pushbullet_notifier.get_devices(api)
         if result:
@@ -876,7 +876,6 @@ class Home(WebRoot):
             self.set_header("Pragma", "no-cache")
             self.set_header("Expires", "0")
 
-        # todo: add more comprehensive show validation
         try:
             show_obj = Show.find(settings.show_list, int(show))
         except (ValueError, TypeError):
@@ -1131,7 +1130,6 @@ class Home(WebRoot):
     def editShow(self, direct_call=False):
         """Edit show settings"""
 
-        # Initialize image variables for ALL call paths
         banner = None
         fanart = None
         poster = None
@@ -1344,7 +1342,7 @@ class Home(WebRoot):
                 data = bytes(image)
                 return data, data
 
-            # 1. Upload from imageSelector (data:image;base64...)
+            # Upload from imageSelector (data:image;base64...)
             if isinstance(image, str) and image.startswith("data:image"):
                 try:
                     header, image_data = image.split(",", 1)
@@ -1361,35 +1359,42 @@ class Home(WebRoot):
                     logger.warning(f"Failed to decode uploaded image: {e}")
                     return None, None
 
-            # 2. Remote URL (TheTVDB, Fanart.tv, etc.) — do not block edit save on CDN fetch.
-            # Queued show update/refresh can refresh artwork later; uploaded bytes still write below.
-            elif isinstance(image, str) and image.startswith(("http://", "https://")):
-                logger.debug(f"Skipping remote image fetch on edit save for show {show_obj.indexerid}")
-                return None, None
+            # Remote URL (TheTVDB, Fanart.tv, etc.) — optional "full|thumb" pipe form from the selector.
+            # TVDB/TMDB often send the same URL for both; only fetch thumb when it differs.
+            elif isinstance(image, str) and image.strip():
+                try:
+                    image_parts = image.split("|")
+                    full_url = (image_parts[0] or "").strip()
+                    thumb_url = (image_parts[1] if len(image_parts) > 1 else "").strip()
+                    _img_data = getShowImage(full_url)
+                    if not _img_data:
+                        return None, None
+                    if thumb_url and thumb_url != full_url:
+                        _thumb = getShowImage(thumb_url)
+                        return _img_data, _thumb or _img_data
+                    return _img_data, _img_data
+                except Exception as e:  # getShowImage / CDN can raise various errors
+                    logger.warning(f"Failed to fetch remote image for show {show_obj.indexerid}: {e}")
+                    return None, None
 
             return None, None
 
+        def _write_replaced_image(data, path):
+            if not data:
+                return False
+            return metadata_generator._write_image(data, path, overwrite=True)
+
         if poster:
             img_data, img_thumb_data = get_images(poster)
-            dest_path = settings.IMAGE_CACHE.poster_path(show_obj.indexerid)
-            dest_thumb_path = settings.IMAGE_CACHE.poster_thumb_path(show_obj.indexerid)
-            # noinspection PyProtectedMember
-            metadata_generator._write_image(img_data, dest_path, overwrite=True)
-            # noinspection PyProtectedMember
-            metadata_generator._write_image(img_thumb_data, dest_thumb_path, overwrite=True)
+            _write_replaced_image(img_data, settings.IMAGE_CACHE.poster_path(show_obj.indexerid))
+            _write_replaced_image(img_thumb_data, settings.IMAGE_CACHE.poster_thumb_path(show_obj.indexerid))
         if banner:
             img_data, img_thumb_data = get_images(banner)
-            dest_path = settings.IMAGE_CACHE.banner_path(show_obj.indexerid)
-            dest_thumb_path = settings.IMAGE_CACHE.banner_thumb_path(show_obj.indexerid)
-            # noinspection PyProtectedMember
-            metadata_generator._write_image(img_data, dest_path, overwrite=True)
-            # noinspection PyProtectedMember
-            metadata_generator._write_image(img_thumb_data, dest_thumb_path, overwrite=True)
+            _write_replaced_image(img_data, settings.IMAGE_CACHE.banner_path(show_obj.indexerid))
+            _write_replaced_image(img_thumb_data, settings.IMAGE_CACHE.banner_thumb_path(show_obj.indexerid))
         if fanart:
             img_data, img_thumb_data = get_images(fanart)
-            dest_path = settings.IMAGE_CACHE.fanart_path(show_obj.indexerid)
-            # noinspection PyProtectedMember
-            metadata_generator._write_image(img_data, dest_path, overwrite=True)
+            _write_replaced_image(img_data, settings.IMAGE_CACHE.fanart_path(show_obj.indexerid))
 
         # If direct_call from mass_edit_update no scene exceptions handling or blackandwhite list handling
         if not direct_call:

--- a/sickchill/views/home.py
+++ b/sickchill/views/home.py
@@ -33,7 +33,7 @@ from sickchill.oldbeard.trakt_api import TraktAPI
 from sickchill.providers import result_classes
 from sickchill.providers.GenericProvider import GenericProvider
 from sickchill.providers.metadata.generic import GenericMetadata
-from sickchill.providers.metadata.helpers import getShowImage
+from sickchill.providers.metadata.helpers import getShowImage, is_allowed_show_image_url
 from sickchill.show.Show import Show
 from sickchill.system.Restart import Restart
 from sickchill.system.Shutdown import Shutdown
@@ -1361,11 +1361,18 @@ class Home(WebRoot):
 
             # Remote URL (TheTVDB, Fanart.tv, etc.) — optional "full|thumb" pipe form from the selector.
             # TVDB/TMDB often send the same URL for both; only fetch thumb when it differs.
+            # SSRF: only allowlisted public artwork hosts (same set as imageSelector.url_wrap).
             elif isinstance(image, str) and image.strip():
                 try:
                     image_parts = image.split("|")
                     full_url = (image_parts[0] or "").strip()
                     thumb_url = (image_parts[1] if len(image_parts) > 1 else "").strip()
+                    if not is_allowed_show_image_url(full_url):
+                        logger.warning(f"Rejected non-allowlisted image URL for show {show_obj.indexerid}: {full_url}")
+                        return None, None
+                    if thumb_url and thumb_url != full_url and not is_allowed_show_image_url(thumb_url):
+                        logger.warning(f"Rejected non-allowlisted thumb URL for show {show_obj.indexerid}: {thumb_url}")
+                        thumb_url = ""
                     _img_data = getShowImage(full_url)
                     if not _img_data:
                         return None, None

--- a/sickchill/views/imageSelector.py
+++ b/sickchill/views/imageSelector.py
@@ -66,9 +66,10 @@ class ImageSelector(Home):
         Wrap Image URL so it has our host and does not trigger ADBlock.
         @return: redirect
         """
+        from sickchill.providers.metadata.helpers import is_allowed_show_image_url
+
         url = self.get_query_argument("url")
-        regex = r"^https?://(artworks\.thetvdb\.com|assets\.fanart\.tv|image\.tmdb\.org)/.*"
-        if not re.match(regex, url):
+        if not is_allowed_show_image_url(url):
             return self.write_error(404)
 
         request = self.indexer_session.get(url, stream=True)

--- a/tests/test_show_image_url_allowlist.py
+++ b/tests/test_show_image_url_allowlist.py
@@ -1,0 +1,81 @@
+"""SSRF guards for show artwork URL fetching."""
+
+from __future__ import annotations
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from sickchill.providers.metadata.helpers import getShowImage, is_allowed_show_image_url
+
+
+class AllowlistTests(unittest.TestCase):
+    def test_allows_known_hosts(self):
+        self.assertTrue(is_allowed_show_image_url("https://artworks.thetvdb.com/banners/graphical/1.jpg"))
+        self.assertTrue(is_allowed_show_image_url("https://assets.fanart.tv/fanart/tv/1/tvposter.jpg"))
+        self.assertTrue(is_allowed_show_image_url("http://image.tmdb.org/t/p/original/x.jpg"))
+
+    def test_blocks_other_hosts_and_schemes(self):
+        self.assertFalse(is_allowed_show_image_url("https://evil.example/pwn.jpg"))
+        self.assertFalse(is_allowed_show_image_url("https://127.0.0.1/secret"))
+        self.assertFalse(is_allowed_show_image_url("https://artworks.thetvdb.com.evil.example/x.jpg"))
+        self.assertFalse(is_allowed_show_image_url("file:///etc/passwd"))
+        self.assertFalse(is_allowed_show_image_url("https://user:pass@artworks.thetvdb.com/banners/x.jpg"))
+        self.assertFalse(is_allowed_show_image_url(""))
+        self.assertFalse(is_allowed_show_image_url(None))
+
+
+class GetShowImageSSRFTests(unittest.TestCase):
+    @patch("sickchill.providers.metadata.helpers.helpers.getURL")
+    def test_blocks_before_fetch(self, get_url):
+        self.assertIsNone(getShowImage("https://127.0.0.1/admin"))
+        get_url.assert_not_called()
+
+    @patch("sickchill.providers.metadata.helpers.helpers.getURL")
+    def test_fetches_allowlisted(self, get_url):
+        response = MagicMock()
+        response.is_redirect = False
+        response.status_code = 200
+        response.content = b"IMG"
+        response.raise_for_status = MagicMock()
+        get_url.return_value = response
+
+        self.assertEqual(getShowImage("https://artworks.thetvdb.com/banners/x.jpg"), b"IMG")
+        get_url.assert_called_once()
+        kwargs = get_url.call_args.kwargs
+        self.assertFalse(kwargs.get("allow_redirects"))
+
+    @patch("sickchill.providers.metadata.helpers.helpers.getURL")
+    def test_revalidates_redirect_target(self, get_url):
+        redirect = MagicMock()
+        redirect.is_redirect = True
+        redirect.status_code = 302
+        redirect.headers = {"Location": "https://127.0.0.1/internal"}
+        redirect.url = "https://artworks.thetvdb.com/banners/x.jpg"
+        redirect.raise_for_status = MagicMock()
+        get_url.return_value = redirect
+
+        self.assertIsNone(getShowImage("https://artworks.thetvdb.com/banners/x.jpg"))
+        get_url.assert_called_once()
+
+    @patch("sickchill.providers.metadata.helpers.helpers.getURL")
+    def test_follows_allowlisted_redirect(self, get_url):
+        redirect = MagicMock()
+        redirect.is_redirect = True
+        redirect.status_code = 302
+        redirect.headers = {"Location": "https://artworks.thetvdb.com/banners/y.jpg"}
+        redirect.url = "https://artworks.thetvdb.com/banners/x.jpg"
+        redirect.raise_for_status = MagicMock()
+
+        final = MagicMock()
+        final.is_redirect = False
+        final.status_code = 200
+        final.content = b"OK"
+        final.raise_for_status = MagicMock()
+
+        get_url.side_effect = [redirect, final]
+        self.assertEqual(getShowImage("https://artworks.thetvdb.com/banners/x.jpg"), b"OK")
+        self.assertEqual(get_url.call_count, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes broken image changer in EditShow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Remote show images are now downloaded and displayed instead of being skipped.
  - Image URLs supporting full-size or thumbnail variants are handled correctly.
  - Replaced show images are saved more reliably when updating show details.
  - Show artwork downloads now support redirects only to approved artwork hosts, helping block unsafe or invalid image URLs.
  - Image selection requests use the same URL validation rules for consistent handling of permitted artwork sources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->