### PR TITLE
Revert "Fix: Image replacer"

### DIFF
--- a/sickchill/oldbeard/helpers.py
+++ b/sickchill/oldbeard/helpers.py
@@ -1276,9 +1276,7 @@ def getURL(
             proxies=proxies,
             verify=verify,
         )
-        # When callers disable redirects they must inspect 3xx themselves (e.g. SSRF-safe image fetch).
-        if allow_redirects or not (getattr(response, "is_redirect", False) or response.status_code in {301, 302, 303, 307, 308}):
-            response.raise_for_status()
+        response.raise_for_status()
     except Exception as error:
         handle_requests_exception(error)
         return ""

--- a/sickchill/providers/metadata/helpers.py
+++ b/sickchill/providers/metadata/helpers.py
@@ -42,7 +42,7 @@ def is_allowed_show_image_url(url: str | None) -> bool:
     return host in ALLOWED_SHOW_IMAGE_HOSTS
 
 
-def getShowImage(url, imgNum=None, timeout=30):
+def getShowImage(url, imgNum=None):
     if not url:
         return None
 
@@ -59,7 +59,7 @@ def getShowImage(url, imgNum=None, timeout=30):
     logger.debug("Fetching image from " + temp_url)
 
     try:
-        image_data = _fetch_allowed_image_content(temp_url, timeout=timeout)
+        image_data = _fetch_allowed_image_content(temp_url)
     except requests.exceptions.RequestException:
         image_data = None
 
@@ -70,7 +70,7 @@ def getShowImage(url, imgNum=None, timeout=30):
     return image_data
 
 
-def _fetch_allowed_image_content(url: str, timeout: int = 30):
+def _fetch_allowed_image_content(url: str):
     """GET image bytes, re-validating every redirect target against the allowlist."""
     current = url
     for _ in range(_MAX_IMAGE_REDIRECTS + 1):
@@ -84,7 +84,6 @@ def _fetch_allowed_image_content(url: str, timeout: int = 30):
             returns="response",
             allow_redirects=False,
             allow_proxy=settings.PROXY_INDEXERS,
-            timeout=timeout,
         )
         if not response:
             return None
@@ -97,10 +96,7 @@ def _fetch_allowed_image_content(url: str, timeout: int = 30):
             current = urljoin(response.url or current, location)
             continue
 
-        try:
-            response.raise_for_status()
-        except requests.exceptions.RequestException:
-            return None
+        response.raise_for_status()
         content = getattr(response, "content", None)
         return content or None
 

--- a/sickchill/views/home.py
+++ b/sickchill/views/home.py
@@ -1420,7 +1420,6 @@ class Home(WebRoot):
             # Remote URL (TheTVDB, Fanart.tv, etc.) — optional "full|thumb" pipe form from the selector.
             # TVDB/TMDB often send the same URL for both; only fetch thumb when it differs.
             # SSRF: only allowlisted public artwork hosts (same set as imageSelector.url_wrap).
-            # Keep timeout short: this runs on the edit-save web request and must not stall the redirect.
             elif isinstance(image, str) and image.strip():
                 try:
                     image_parts = image.split("|")
@@ -1432,11 +1431,11 @@ class Home(WebRoot):
                     if thumb_url and thumb_url != full_url and not is_allowed_show_image_url(thumb_url):
                         logger.warning(f"Rejected non-allowlisted thumb URL for show {show_obj.indexerid}: {thumb_url}")
                         thumb_url = ""
-                    _img_data = getShowImage(full_url, timeout=10)
+                    _img_data = getShowImage(full_url)
                     if not _img_data:
                         return None, None
                     if thumb_url and thumb_url != full_url:
-                        _thumb = getShowImage(thumb_url, timeout=10)
+                        _thumb = getShowImage(thumb_url)
                         return _img_data, _thumb or _img_data
                     return _img_data, _img_data
                 except Exception as e:  # getShowImage / CDN can raise various errors
@@ -1450,32 +1449,17 @@ class Home(WebRoot):
                 return False
             return metadata_generator._write_image(data, path, overwrite=True)
 
-        # Artwork replace must never prevent returning to displayShow after a successful settings save.
-        artwork_errors = []
-        try:
-            if poster:
-                img_data, img_thumb_data = get_images(poster)
-                if not img_data:
-                    artwork_errors.append(_("Could not process the selected poster image."))
-                else:
-                    _write_replaced_image(img_data, settings.IMAGE_CACHE.poster_path(show_obj.indexerid))
-                    _write_replaced_image(img_thumb_data, settings.IMAGE_CACHE.poster_thumb_path(show_obj.indexerid))
-            if banner:
-                img_data, img_thumb_data = get_images(banner)
-                if not img_data:
-                    artwork_errors.append(_("Could not process the selected banner image."))
-                else:
-                    _write_replaced_image(img_data, settings.IMAGE_CACHE.banner_path(show_obj.indexerid))
-                    _write_replaced_image(img_thumb_data, settings.IMAGE_CACHE.banner_thumb_path(show_obj.indexerid))
-            if fanart:
-                img_data, img_thumb_data = get_images(fanart)
-                if not img_data:
-                    artwork_errors.append(_("Could not process the selected fanart image."))
-                else:
-                    _write_replaced_image(img_data, settings.IMAGE_CACHE.fanart_path(show_obj.indexerid))
-        except Exception as error:
-            logger.warning(f"Error replacing show artwork for {show_obj.indexerid}: {error}")
-            artwork_errors.append(_("Error replacing show artwork: {error}").format(error=error))
+        if poster:
+            img_data, img_thumb_data = get_images(poster)
+            _write_replaced_image(img_data, settings.IMAGE_CACHE.poster_path(show_obj.indexerid))
+            _write_replaced_image(img_thumb_data, settings.IMAGE_CACHE.poster_thumb_path(show_obj.indexerid))
+        if banner:
+            img_data, img_thumb_data = get_images(banner)
+            _write_replaced_image(img_data, settings.IMAGE_CACHE.banner_path(show_obj.indexerid))
+            _write_replaced_image(img_thumb_data, settings.IMAGE_CACHE.banner_thumb_path(show_obj.indexerid))
+        if fanart:
+            img_data, img_thumb_data = get_images(fanart)
+            _write_replaced_image(img_data, settings.IMAGE_CACHE.fanart_path(show_obj.indexerid))
 
         # If direct_call from mass_edit_update no scene exceptions handling or blackandwhite list handling
         if not direct_call:
@@ -1496,7 +1480,7 @@ class Home(WebRoot):
                     else:
                         show_obj.release_groups.set_black_keywords([])
 
-        errors = list(artwork_errors)
+        errors = []
         with show_obj.lock:
             new_quality = Quality.combineQualities([int(q) for q in any_qualities], [int(q) for q in best_qualities])
             show_obj.quality = new_quality

--- a/tests/test_show_image_url_allowlist.py
+++ b/tests/test_show_image_url_allowlist.py
@@ -39,11 +39,10 @@ class GetShowImageSSRFTests(unittest.TestCase):
         response.raise_for_status = MagicMock()
         get_url.return_value = response
 
-        self.assertEqual(getShowImage("https://artworks.thetvdb.com/banners/x.jpg", timeout=10), b"IMG")
+        self.assertEqual(getShowImage("https://artworks.thetvdb.com/banners/x.jpg"), b"IMG")
         get_url.assert_called_once()
         kwargs = get_url.call_args.kwargs
         self.assertFalse(kwargs.get("allow_redirects"))
-        self.assertEqual(kwargs.get("timeout"), 10)
 
     @patch("sickchill.providers.metadata.helpers.helpers.getURL")
     def test_revalidates_redirect_target(self, get_url):


### PR DESCRIPTION
Reverts SickChill/sickchill#9161

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Image requests now consistently treat unsuccessful and redirected responses as errors, preventing invalid artwork from being used.
  - Failed show artwork downloads are skipped instead of being saved.
  - Artwork replacement errors are no longer displayed in the show editing workflow.
  - Image allowlisting and redirect-prevention behavior remain enforced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->