### PR TITLE
Fix: Edit Show artwork save (follow-up)

### DIFF
--- a/sickchill/oldbeard/helpers.py
+++ b/sickchill/oldbeard/helpers.py
@@ -1276,9 +1276,14 @@ def getURL(
             proxies=proxies,
             verify=verify,
         )
+        is_redirect = getattr(response, "is_redirect", False) or response.status_code in {301, 302, 303, 307, 308}
         # When callers disable redirects they must inspect 3xx themselves (e.g. SSRF-safe image fetch).
-        if allow_redirects or not (getattr(response, "is_redirect", False) or response.status_code in {301, 302, 303, 307, 308}):
+        if allow_redirects or not is_redirect:
             response.raise_for_status()
+        elif response_type not in ("response", None):
+            # Do not treat a redirect payload as successful text/json/content (e.g. Jackett with allow_redirects=False).
+            logger.debug(_("Ignoring redirect response for {url} because redirects are disabled").format(url=url))
+            return ""
     except Exception as error:
         handle_requests_exception(error)
         return ""

--- a/sickchill/providers/metadata/helpers.py
+++ b/sickchill/providers/metadata/helpers.py
@@ -1,4 +1,5 @@
 import re
+import time
 from urllib.parse import urljoin, urlparse
 
 import requests
@@ -70,21 +71,31 @@ def getShowImage(url, imgNum=None, timeout=30):
     return image_data
 
 
-def _fetch_allowed_image_content(url: str, timeout: int = 30):
-    """GET image bytes, re-validating every redirect target against the allowlist."""
+def _fetch_allowed_image_content(url: str, timeout: float = 30):
+    """GET image bytes, re-validating every redirect target against the allowlist.
+
+    ``timeout`` is a budget for the whole redirect chain, not per hop.
+    """
+    deadline = time.monotonic() + float(timeout)
     current = url
     for _ in range(_MAX_IMAGE_REDIRECTS + 1):
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            logger.warning(f"Timed out while fetching show image from {url}")
+            return None
+
         if not is_allowed_show_image_url(current):
             logger.warning(f"Blocked show image redirect to non-allowlisted URL: {current}")
             return None
 
+        # Pass only remaining budget — do not inflate past the cumulative deadline.
         response = helpers.getURL(
             current,
             session=meta_session,
             returns="response",
             allow_redirects=False,
             allow_proxy=settings.PROXY_INDEXERS,
-            timeout=timeout,
+            timeout=remaining,
         )
         if not response:
             return None

--- a/sickchill/providers/metadata/helpers.py
+++ b/sickchill/providers/metadata/helpers.py
@@ -25,6 +25,7 @@ _ALLOWED_SHOW_IMAGE_URL_RE = re.compile(
 )
 
 _MAX_IMAGE_REDIRECTS = 5
+_IMAGE_CHUNK_SIZE = 64 * 1024
 
 
 def is_allowed_show_image_url(url: str | None) -> bool:
@@ -71,10 +72,29 @@ def getShowImage(url, imgNum=None, timeout=30):
     return image_data
 
 
+def _read_response_until_deadline(response, deadline: float, url: str):
+    """Consume a streamed response in bounded chunks, aborting when the shared deadline expires."""
+    chunks = []
+    try:
+        for chunk in response.iter_content(_IMAGE_CHUNK_SIZE):
+            if deadline - time.monotonic() <= 0:
+                logger.warning(f"Timed out while reading show image from {url}")
+                return None
+            if chunk:
+                chunks.append(chunk)
+    finally:
+        try:
+            response.close()
+        except Exception:
+            pass
+    return b"".join(chunks) or None
+
+
 def _fetch_allowed_image_content(url: str, timeout: float = 30):
     """GET image bytes, re-validating every redirect target against the allowlist.
 
-    ``timeout`` is a budget for the whole redirect chain, not per hop.
+    ``timeout`` is a budget for the whole redirect chain and body download, not per hop.
+    Responses are streamed in bounded chunks so a slow body cannot overrun the deadline.
     """
     deadline = time.monotonic() + float(timeout)
     current = url
@@ -96,24 +116,34 @@ def _fetch_allowed_image_content(url: str, timeout: float = 30):
             allow_redirects=False,
             allow_proxy=settings.PROXY_INDEXERS,
             timeout=remaining,
+            stream=True,
         )
         if not response:
             return None
 
         if getattr(response, "is_redirect", False) or response.status_code in {301, 302, 303, 307, 308}:
             location = response.headers.get("Location") or ""
+            response_url = response.url or current
+            try:
+                response.close()
+            except Exception:
+                pass
             if not location:
                 logger.warning(f"Show image redirect missing Location from {current}")
                 return None
-            current = urljoin(response.url or current, location)
+            current = urljoin(response_url, location)
             continue
 
         try:
             response.raise_for_status()
         except requests.exceptions.RequestException:
+            try:
+                response.close()
+            except Exception:
+                pass
             return None
-        content = getattr(response, "content", None)
-        return content or None
+
+        return _read_response_until_deadline(response, deadline, url)
 
     logger.warning(f"Too many redirects while fetching show image from {url}")
     return None

--- a/sickchill/views/home.py
+++ b/sickchill/views/home.py
@@ -1442,14 +1442,15 @@ class Home(WebRoot):
                     remaining = _remaining_timeout()
                     if remaining <= 0:
                         return None, None
-                    _img_data = getShowImage(full_url, timeout=max(0.1, remaining))
+                    # Remaining budget is shared with streamed chunk reads inside getShowImage.
+                    _img_data = getShowImage(full_url, timeout=remaining)
                     if not _img_data:
                         return None, None
                     if thumb_url and thumb_url != full_url:
                         remaining = _remaining_timeout()
                         if remaining <= 0:
                             return _img_data, _img_data
-                        _thumb = getShowImage(thumb_url, timeout=max(0.1, remaining))
+                        _thumb = getShowImage(thumb_url, timeout=remaining)
                         return _img_data, _thumb or _img_data
                     return _img_data, _img_data
                 except Exception as e:  # getShowImage / CDN can raise various errors

--- a/sickchill/views/home.py
+++ b/sickchill/views/home.py
@@ -4,6 +4,7 @@ import binascii
 import datetime
 import json
 import os
+import time
 import urllib.parse
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -1420,7 +1421,7 @@ class Home(WebRoot):
             # Remote URL (TheTVDB, Fanart.tv, etc.) — optional "full|thumb" pipe form from the selector.
             # TVDB/TMDB often send the same URL for both; only fetch thumb when it differs.
             # SSRF: only allowlisted public artwork hosts (same set as imageSelector.url_wrap).
-            # Keep timeout short: this runs on the edit-save web request and must not stall the redirect.
+            # One shared deadline for full+thumb so edit-save cannot stall the redirect.
             elif isinstance(image, str) and image.strip():
                 try:
                     image_parts = image.split("|")
@@ -1432,11 +1433,23 @@ class Home(WebRoot):
                     if thumb_url and thumb_url != full_url and not is_allowed_show_image_url(thumb_url):
                         logger.warning(f"Rejected non-allowlisted thumb URL for show {show_obj.indexerid}: {thumb_url}")
                         thumb_url = ""
-                    _img_data = getShowImage(full_url, timeout=10)
+
+                    deadline = time.monotonic() + 10.0
+
+                    def _remaining_timeout():
+                        return max(0.0, deadline - time.monotonic())
+
+                    remaining = _remaining_timeout()
+                    if remaining <= 0:
+                        return None, None
+                    _img_data = getShowImage(full_url, timeout=max(0.1, remaining))
                     if not _img_data:
                         return None, None
                     if thumb_url and thumb_url != full_url:
-                        _thumb = getShowImage(thumb_url, timeout=10)
+                        remaining = _remaining_timeout()
+                        if remaining <= 0:
+                            return _img_data, _img_data
+                        _thumb = getShowImage(thumb_url, timeout=max(0.1, remaining))
                         return _img_data, _thumb or _img_data
                     return _img_data, _img_data
                 except Exception as e:  # getShowImage / CDN can raise various errors
@@ -1450,32 +1463,54 @@ class Home(WebRoot):
                 return False
             return metadata_generator._write_image(data, path, overwrite=True)
 
+        def _replace_artwork(kind, image_value, write_targets):
+            """Fetch/write one artwork kind; failures here must not skip other kinds.
+
+            write_targets: list of (image_data_key, path) where image_data_key is 'full' or 'thumb'
+            """
+            try:
+                img_data, img_thumb_data = get_images(image_value)
+                if not img_data:
+                    artwork_errors.append(_("Could not process the selected {kind} image.").format(kind=kind))
+                    return
+                payloads = {"full": img_data, "thumb": img_thumb_data or img_data}
+                for key, path in write_targets:
+                    if not _write_replaced_image(payloads[key], path):
+                        # Continue other targets for this kind (e.g. thumb after full) and other kinds.
+                        artwork_errors.append(_("Could not save the selected {kind} image.").format(kind=kind))
+            except Exception as error:
+                logger.warning(f"Error replacing {kind} for show {show_obj.indexerid}: {error}")
+                artwork_errors.append(_("Error replacing {kind} artwork: {error}").format(kind=kind, error=error))
+
         # Artwork replace must never prevent returning to displayShow after a successful settings save.
+        # Isolate each kind so one failure does not skip the others.
         artwork_errors = []
-        try:
-            if poster:
-                img_data, img_thumb_data = get_images(poster)
-                if not img_data:
-                    artwork_errors.append(_("Could not process the selected poster image."))
-                else:
-                    _write_replaced_image(img_data, settings.IMAGE_CACHE.poster_path(show_obj.indexerid))
-                    _write_replaced_image(img_thumb_data, settings.IMAGE_CACHE.poster_thumb_path(show_obj.indexerid))
-            if banner:
-                img_data, img_thumb_data = get_images(banner)
-                if not img_data:
-                    artwork_errors.append(_("Could not process the selected banner image."))
-                else:
-                    _write_replaced_image(img_data, settings.IMAGE_CACHE.banner_path(show_obj.indexerid))
-                    _write_replaced_image(img_thumb_data, settings.IMAGE_CACHE.banner_thumb_path(show_obj.indexerid))
-            if fanart:
-                img_data, img_thumb_data = get_images(fanart)
-                if not img_data:
-                    artwork_errors.append(_("Could not process the selected fanart image."))
-                else:
-                    _write_replaced_image(img_data, settings.IMAGE_CACHE.fanart_path(show_obj.indexerid))
-        except Exception as error:
-            logger.warning(f"Error replacing show artwork for {show_obj.indexerid}: {error}")
-            artwork_errors.append(_("Error replacing show artwork: {error}").format(error=error))
+        if poster:
+            _replace_artwork(
+                _("poster"),
+                poster,
+                [
+                    ("full", settings.IMAGE_CACHE.poster_path(show_obj.indexerid)),
+                    ("thumb", settings.IMAGE_CACHE.poster_thumb_path(show_obj.indexerid)),
+                ],
+            )
+        if banner:
+            _replace_artwork(
+                _("banner"),
+                banner,
+                [
+                    ("full", settings.IMAGE_CACHE.banner_path(show_obj.indexerid)),
+                    ("thumb", settings.IMAGE_CACHE.banner_thumb_path(show_obj.indexerid)),
+                ],
+            )
+        if fanart:
+            _replace_artwork(
+                _("fanart"),
+                fanart,
+                [
+                    ("full", settings.IMAGE_CACHE.fanart_path(show_obj.indexerid)),
+                ],
+            )
 
         # If direct_call from mass_edit_update no scene exceptions handling or blackandwhite list handling
         if not direct_call:

--- a/tests/test_show_image_url_allowlist.py
+++ b/tests/test_show_image_url_allowlist.py
@@ -2,10 +2,23 @@
 
 from __future__ import annotations
 
+import time
 import unittest
 from unittest.mock import MagicMock, patch
 
 from sickchill.providers.metadata.helpers import getShowImage, is_allowed_show_image_url
+
+
+def _ok_response(content: bytes = b"IMG"):
+    response = MagicMock()
+    response.is_redirect = False
+    response.status_code = 200
+    response.content = content
+    response.raise_for_status = MagicMock()
+    response.close = MagicMock()
+    response.iter_content = MagicMock(return_value=iter([content]))
+    response.url = "https://artworks.thetvdb.com/banners/x.jpg"
+    return response
 
 
 class AllowlistTests(unittest.TestCase):
@@ -32,18 +45,16 @@ class GetShowImageSSRFTests(unittest.TestCase):
 
     @patch("sickchill.providers.metadata.helpers.helpers.getURL")
     def test_fetches_allowlisted(self, get_url):
-        response = MagicMock()
-        response.is_redirect = False
-        response.status_code = 200
-        response.content = b"IMG"
-        response.raise_for_status = MagicMock()
+        response = _ok_response(b"IMG")
         get_url.return_value = response
 
         self.assertEqual(getShowImage("https://artworks.thetvdb.com/banners/x.jpg", timeout=10), b"IMG")
         get_url.assert_called_once()
         kwargs = get_url.call_args.kwargs
         self.assertFalse(kwargs.get("allow_redirects"))
+        self.assertTrue(kwargs.get("stream"))
         self.assertAlmostEqual(kwargs.get("timeout"), 10, delta=0.05)
+        response.close.assert_called()
 
     @patch("sickchill.providers.metadata.helpers.helpers.getURL")
     def test_revalidates_redirect_target(self, get_url):
@@ -53,10 +64,12 @@ class GetShowImageSSRFTests(unittest.TestCase):
         redirect.headers = {"Location": "https://127.0.0.1/internal"}
         redirect.url = "https://artworks.thetvdb.com/banners/x.jpg"
         redirect.raise_for_status = MagicMock()
+        redirect.close = MagicMock()
         get_url.return_value = redirect
 
         self.assertIsNone(getShowImage("https://artworks.thetvdb.com/banners/x.jpg"))
         get_url.assert_called_once()
+        redirect.close.assert_called()
 
     @patch("sickchill.providers.metadata.helpers.helpers.getURL")
     def test_follows_allowlisted_redirect(self, get_url):
@@ -66,12 +79,10 @@ class GetShowImageSSRFTests(unittest.TestCase):
         redirect.headers = {"Location": "https://artworks.thetvdb.com/banners/y.jpg"}
         redirect.url = "https://artworks.thetvdb.com/banners/x.jpg"
         redirect.raise_for_status = MagicMock()
+        redirect.close = MagicMock()
 
-        final = MagicMock()
-        final.is_redirect = False
-        final.status_code = 200
-        final.content = b"OK"
-        final.raise_for_status = MagicMock()
+        final = _ok_response(b"OK")
+        final.url = "https://artworks.thetvdb.com/banners/y.jpg"
 
         get_url.side_effect = [redirect, final]
         self.assertEqual(getShowImage("https://artworks.thetvdb.com/banners/x.jpg"), b"OK")
@@ -79,6 +90,37 @@ class GetShowImageSSRFTests(unittest.TestCase):
         # Second hop should receive a remaining timeout budget, not a fresh full timeout reset only
         self.assertIn("timeout", get_url.call_args_list[0].kwargs)
         self.assertIn("timeout", get_url.call_args_list[1].kwargs)
+        self.assertTrue(get_url.call_args_list[0].kwargs.get("stream"))
+        self.assertTrue(get_url.call_args_list[1].kwargs.get("stream"))
+        redirect.close.assert_called()
+        final.close.assert_called()
+
+    @patch("sickchill.providers.metadata.helpers.helpers.getURL")
+    def test_slow_chunks_cannot_exceed_deadline(self, get_url):
+        """Frequent slow chunks must abort once the shared deadline is exhausted."""
+
+        def slow_chunks(_chunk_size=0):
+            # Many small delays would exceed a short deadline if the body were read unbounded.
+            for _ in range(50):
+                time.sleep(0.05)
+                yield b"x" * 1024
+
+        response = MagicMock()
+        response.is_redirect = False
+        response.status_code = 200
+        response.raise_for_status = MagicMock()
+        response.close = MagicMock()
+        response.iter_content = MagicMock(side_effect=slow_chunks)
+        response.url = "https://artworks.thetvdb.com/banners/slow.jpg"
+        get_url.return_value = response
+
+        started = time.monotonic()
+        self.assertIsNone(getShowImage("https://artworks.thetvdb.com/banners/slow.jpg", timeout=0.2))
+        elapsed = time.monotonic() - started
+        # Should stop near the deadline, not after all 50*0.05s chunks (~2.5s)
+        self.assertLess(elapsed, 1.0)
+        response.close.assert_called()
+        self.assertTrue(get_url.call_args.kwargs.get("stream"))
 
 
 class GetURLRedirectHandlingTests(unittest.TestCase):

--- a/tests/test_show_image_url_allowlist.py
+++ b/tests/test_show_image_url_allowlist.py
@@ -43,7 +43,7 @@ class GetShowImageSSRFTests(unittest.TestCase):
         get_url.assert_called_once()
         kwargs = get_url.call_args.kwargs
         self.assertFalse(kwargs.get("allow_redirects"))
-        self.assertEqual(kwargs.get("timeout"), 10)
+        self.assertAlmostEqual(kwargs.get("timeout"), 10, delta=0.05)
 
     @patch("sickchill.providers.metadata.helpers.helpers.getURL")
     def test_revalidates_redirect_target(self, get_url):
@@ -76,7 +76,34 @@ class GetShowImageSSRFTests(unittest.TestCase):
         get_url.side_effect = [redirect, final]
         self.assertEqual(getShowImage("https://artworks.thetvdb.com/banners/x.jpg"), b"OK")
         self.assertEqual(get_url.call_count, 2)
+        # Second hop should receive a remaining timeout budget, not a fresh full timeout reset only
+        self.assertIn("timeout", get_url.call_args_list[0].kwargs)
+        self.assertIn("timeout", get_url.call_args_list[1].kwargs)
 
+
+class GetURLRedirectHandlingTests(unittest.TestCase):
+    def test_disabled_redirects_do_not_return_redirect_body_as_text(self):
+        """Jackett-style callers use returns=text with allow_redirects=False — must not parse 3xx bodies."""
+        from sickchill.oldbeard import helpers as oldbeard_helpers
+
+        session = MagicMock()
+        redirect = MagicMock()
+        redirect.is_redirect = True
+        redirect.status_code = 302
+        redirect.headers = {"Location": "https://example.invalid/next"}
+        redirect.text = "<html>redirect</html>"
+        redirect.raise_for_status = MagicMock()
+        session.request.return_value = redirect
+
+        result = oldbeard_helpers.getURL(
+            "http://127.0.0.1:9117/api",
+            session=session,
+            returns="text",
+            allow_redirects=False,
+            allow_proxy=False,
+        )
+        self.assertEqual(result, "")
+        redirect.raise_for_status.assert_not_called()
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_show_image_url_allowlist.py
+++ b/tests/test_show_image_url_allowlist.py
@@ -105,5 +105,6 @@ class GetURLRedirectHandlingTests(unittest.TestCase):
         self.assertEqual(result, "")
         redirect.raise_for_status.assert_not_called()
 
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
Follow-up to #9161 for Edit Show Customize banner/poster save freezes (`NS_BINDING_ABORTED` on `POST /home/editShow`).

- Cap remote artwork fetch to a **shared 10s deadline** for full+thumb (and across redirect hops)
- Isolate poster/banner/fanart replace so one failure does not skip the others; record write failures
- Do not treat HTTP redirect bodies as successful `text`/`json` when `allow_redirects=False` (also protects Jackett-style callers)

## Test plan
- [ ] Edit Show → Customize → select banner → Save Changes → returns to Display Show without abort
- [ ] Banner updates after refresh
- [ ] Same for poster/fanart when selected together
- [ ] `pytest tests/test_show_image_url_allowlist.py`

Supersedes the need for #9162 (revert of #9161); this keeps the fix and tightens the remaining review items.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of disabled redirects so redirect responses are no longer treated as successful content.
  * Kept image downloads within the configured overall timeout, including across redirects and slow responses.
  * Ensured remote image requests are properly closed after completion, errors, or redirects.
  * Artwork updates now continue processing other artwork types when one image fails.
  * Improved reliability when replacing posters, banners, and fanart from remote sources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->