### PR TITLE
imdb, provider tweaks

### DIFF
--- a/sickchill/adba/aniDBfileInfo.py
+++ b/sickchill/adba/aniDBfileInfo.py
@@ -37,18 +37,24 @@ def get_file_hash(filePath: Path):
 
 
 def download_file(url, filename: Path):
+    """Download ``url`` to ``filename``.
+
+    Writes via a temp file and only replaces the destination on success, so a
+    failed refresh never deletes a previously good cache file.
+    """
+    tmp_path = filename.with_suffix(filename.suffix + ".tmp")
     try:
-        r = requests.get(url, stream=True, verify=False)
+        r = requests.get(url, stream=True, verify=False, timeout=120)
         r.raise_for_status()
-        with filename.open("wb") as fp:
+        with tmp_path.open("wb") as fp:
             for chunk in r.iter_content(chunk_size=1024):
                 if chunk:
                     fp.write(chunk)
                     fp.flush()
-
+        tmp_path.replace(filename)
     except requests.exceptions.RequestException:
-        if filename.is_file():
-            filename.unlink()
+        if tmp_path.is_file():
+            tmp_path.unlink()
         return False
 
     return True
@@ -67,12 +73,15 @@ def read_anidb_xml(cache_dir: Path):
 
     if not file_path.exists():
         if not get_anime_titles_xml(file_path):
-            return
+            return None
     else:
         mtime = os.path.getmtime(file_path)
-        if time.time() > mtime + 24 * 60 * 60 and not get_anime_titles_xml(file_path):
-            return
+        # Best-effort daily refresh; keep the stale file if the download fails.
+        if time.time() > mtime + 24 * 60 * 60:
+            get_anime_titles_xml(file_path)
 
+    if not file_path.exists():
+        return None
     return read_xml_into_etree(file_path)
 
 
@@ -80,12 +89,15 @@ def read_tvdb_map_xml(cache_dir: Path):
     file_path = cache_dir / "anime-list.xml"
     if not file_path.is_file():
         if not get_anime_list_xml(file_path):
-            return
+            return None
     else:
         mtime = os.path.getmtime(file_path)
-        if time.time() > mtime + 24 * 60 * 60 and not get_anime_list_xml(file_path):
-            return
+        # Best-effort daily refresh; keep the stale file if the download fails.
+        if time.time() > mtime + 24 * 60 * 60:
+            get_anime_list_xml(file_path)
 
+    if not file_path.is_file():
+        return None
     return read_xml_into_etree(file_path)
 
 

--- a/sickchill/adba/aniDBfileInfo.py
+++ b/sickchill/adba/aniDBfileInfo.py
@@ -102,5 +102,4 @@ def read_tvdb_map_xml(cache_dir: Path):
 
 
 def read_xml_into_etree(file_path):
-    with file_path.open("r") as f:
-        return ElementTree.ElementTree(file=f)
+    return ElementTree.parse(file_path)

--- a/sickchill/oldbeard/helpers.py
+++ b/sickchill/oldbeard/helpers.py
@@ -1727,6 +1727,58 @@ def imdb_from_tvdbid_on_tvmaze(indexer_id: Union[str, int]) -> str:
     return imdb_id
 
 
+def normalize_imdb_id(imdb_id: Union[str, None]) -> str:
+    """Return a normalized ``tt`` IMDb title id, or empty string if invalid."""
+    if not imdb_id:
+        return ""
+    digits = re.sub(r"\D", "", str(imdb_id))
+    return f"tt{digits}" if digits else ""
+
+
+def resolve_imdb_title_id(imdb_id: Union[str, None], client=None) -> str:
+    """Normalize an IMDb title id and follow IMDb redirections to the canonical id.
+
+    IMDb sometimes keeps duplicate/legacy ids that redirect to a canonical ``tt`` id.
+    ``imdbpie`` refuses those with ``Title not found. … is a redirection imdb id``.
+    """
+    normalized = normalize_imdb_id(imdb_id)
+    if not normalized:
+        return ""
+
+    try:
+        from imdbpie import Imdb
+        from imdbpie.imdbpie import BASE_URI
+    except Exception as error:
+        logger.debug(f"IMDb redirect resolve unavailable: {error}")
+        return normalized
+
+    imdb_client = client or Imdb()
+    try:
+        path = "/template/imdb-ios-writable/title-auxiliary-v31.jstl/render"
+        resource = imdb_client._get(
+            url=urljoin(BASE_URI, path),
+            params={
+                "tconst": normalized,
+                "today": datetime.datetime.now(datetime.timezone.utc).date().strftime("%Y-%m-%d"),
+                "region": getattr(imdb_client, "region", None),
+            },
+        )
+    except Exception as error:
+        logger.debug(f"IMDb redirect lookup failed for {normalized}: {error}")
+        return normalized
+
+    if not isinstance(resource, dict):
+        return normalized
+
+    returned_id = resource.get("id") or ""
+    # IMDb title ids were historically 7 digits and are now commonly 7–8+ digits.
+    match = re.search(r"tt\d{7,}", str(returned_id))
+    if match and match.group() != normalized:
+        logger.debug(f"IMDb id {normalized} redirects to {match.group()}")
+        return match.group()
+    return normalized
+
+
 def is_ip_local(ip):
     request_ip = ipaddress.ip_address(ip)
     if request_ip.is_private:

--- a/sickchill/oldbeard/providers/jackett.py
+++ b/sickchill/oldbeard/providers/jackett.py
@@ -46,6 +46,11 @@ class Provider(TorrentProvider, tvcache.RSSTorrentMixin):
         self.url = self.custom_url
         self.cache = tvcache.TVCache(self, min_time=30)
 
+    @property
+    def uses_configurable_categories(self) -> bool:
+        """Persist Torznab category ids via the generic provider config keys."""
+        return True
+
     def image_name(self):
         import os
 

--- a/sickchill/oldbeard/providers/newznab.py
+++ b/sickchill/oldbeard/providers/newznab.py
@@ -45,6 +45,11 @@ class NewznabProvider(NZBProvider, tvcache.RSSTorrentMixin):
 
         self.cache = tvcache.TVCache(self, min_time=30)  # only poll newznab providers every 30 minutes max
 
+    @property
+    def uses_configurable_categories(self) -> bool:
+        """Newznab category ids (also via config_string); not torrent hardcoded categories."""
+        return True
+
     def config_string(self):
         """
         Generates a '|' delimited string of instance attributes, for saving to config.ini

--- a/sickchill/oldbeard/scene_exceptions.py
+++ b/sickchill/oldbeard/scene_exceptions.py
@@ -329,14 +329,54 @@ def _sickchill_exceptions_generator() -> Generator[tuple[int, str, int], None, N
     set_last_refresh("sickchill")
 
 
+def _parse_defaulttvdbseason(raw) -> int:
+    """ScudLee defaulttvdbseason → scene-exception season.
+
+    ``a`` means absolute / whole-series numbering → generic season -1.
+    Missing or non-numeric values default to 1 (ScudLee one-off convention).
+    """
+    if raw is None:
+        return 1
+    value = str(raw).strip().lower()
+    if not value:
+        return 1
+    if value == "a":
+        return -1
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 1
+
+
+def _show_applicable_tvdb_seasons(show) -> set[int] | None:
+    """Seasons that should select among multiple AniDB mappings.
+
+    Optional ``show.default_tvdb_season`` (tests / callers) wins; otherwise
+    regular seasons already on the show. ``None`` means “accept all mappings”.
+    """
+    explicit = getattr(show, "default_tvdb_season", None)
+    if explicit is not None:
+        try:
+            return {int(explicit)}
+        except (TypeError, ValueError):
+            pass
+
+    episodes = getattr(show, "episodes", None)
+    if isinstance(episodes, dict) and episodes:
+        seasons = {int(season) for season in episodes if str(season).lstrip("-").isdigit()}
+        seasons.discard(0)
+        if seasons:
+            return seasons
+    return None
+
+
 def _anidb_exceptions_generator() -> Generator[tuple[int, str, int], None, None]:
     """Yield AniDB main titles for local anime shows via ScudLee mapping XMLs.
 
     This does **not** use the AniDB UDP API. It downloads/parses local caches of
     ``anime-list.xml`` / ``animetitles.xml`` once per refresh, then looks up each
-    show. The previous per-show ``adba.Anime(...)`` path re-parsed multi‑MB XML for
-    every title (minutes of MAIN/SHOWQUEUE blocking) and swallowed missing-map
-    ``ValueError``s without detail.
+    show. Multiple AniDB ids can share one TVDB id (e.g. 72025 → aid 1 season 1
+    and aid 4 season 2); those rows are kept and selected by ``defaulttvdbseason``.
     """
     if not should_refresh("anidb"):
         return
@@ -358,16 +398,21 @@ def _anidb_exceptions_generator() -> Generator[tuple[int, str, int], None, None]
         logger.warning("AniDB scene exceptions skipped: anime-list/animetitles XML unavailable")
         return
 
-    tvdb_to_aid: dict[int, int] = {}
+    # tvdb_id -> [(aid, defaulttvdbseason), ...]  — all rows, not first-wins
+    tvdb_to_mappings: dict[int, list[tuple[int, int]]] = {}
     for anime in anime_list.findall("anime"):
         try:
             tvdb_id = int(anime.get("tvdbid") or 0)
             aid = int(anime.get("anidbid") or 0)
         except (TypeError, ValueError):
             continue
-        if tvdb_id > 0 and aid > 0:
-            # First mapping wins; list order is stable enough for scene-name use.
-            tvdb_to_aid.setdefault(tvdb_id, aid)
+        if tvdb_id <= 0 or aid <= 0:
+            continue
+        mapped_season = _parse_defaulttvdbseason(anime.get("defaulttvdbseason"))
+        mappings = tvdb_to_mappings.setdefault(tvdb_id, [])
+        pair = (aid, mapped_season)
+        if pair not in mappings:
+            mappings.append(pair)
 
     aid_to_main_name: dict[int, str] = {}
     xml_lang = "{http://www.w3.org/XML/1998/namespace}lang"
@@ -400,22 +445,35 @@ def _anidb_exceptions_generator() -> Generator[tuple[int, str, int], None, None]
             continue
 
         try:
-            aid = tvdb_to_aid.get(int(show.indexerid), 0)
-            if not aid:
+            mappings = tvdb_to_mappings.get(int(show.indexerid), [])
+            if not mappings:
                 skipped += 1
                 logger.debug(f"AniDB: no TVDB mapping for {show.name} (tvdb={show.indexerid})")
                 continue
 
-            anidb_name = aid_to_main_name.get(aid)
-            if not anidb_name:
-                skipped += 1
-                logger.debug(f"AniDB: no title for aid={aid} ({show.name}, tvdb={show.indexerid})")
-                continue
-
-            if anidb_name != show.name:
-                updated += 1
-                yield int(show.indexerid), anidb_name, -1
+            applicable = _show_applicable_tvdb_seasons(show)
+            selected: list[tuple[int, int]] = []
+            if applicable is None:
+                selected = list(mappings)
             else:
+                selected = [(aid, season) for aid, season in mappings if season in applicable or season == -1]
+                # Absolute/"a" rows already included; if nothing matched, fall back to season 1 then first row
+                if not selected:
+                    selected = [(aid, season) for aid, season in mappings if season == 1] or mappings[:1]
+
+            yielded = False
+            for aid, mapped_season in selected:
+                anidb_name = aid_to_main_name.get(aid)
+                if not anidb_name:
+                    logger.debug(f"AniDB: no title for aid={aid} ({show.name}, tvdb={show.indexerid})")
+                    continue
+                if anidb_name == show.name:
+                    continue
+                updated += 1
+                yielded = True
+                yield int(show.indexerid), anidb_name, mapped_season
+
+            if not yielded:
                 skipped += 1
         except Exception as error:
             failed += 1

--- a/sickchill/oldbeard/scene_exceptions.py
+++ b/sickchill/oldbeard/scene_exceptions.py
@@ -1,10 +1,9 @@
-import datetime
 import time
 from pathlib import Path
 from typing import Generator
 
 import sickchill
-from sickchill import adba, logger, settings
+from sickchill import logger, settings
 from sickchill.oldbeard import db, helpers
 from sickchill.oldbeard.network_timezones import sc_now
 from sickchill.show.Show import Show
@@ -331,25 +330,98 @@ def _sickchill_exceptions_generator() -> Generator[tuple[int, str, int], None, N
 
 
 def _anidb_exceptions_generator() -> Generator[tuple[int, str, int], None, None]:
+    """Yield AniDB main titles for local anime shows via ScudLee mapping XMLs.
+
+    This does **not** use the AniDB UDP API. It downloads/parses local caches of
+    ``anime-list.xml`` / ``animetitles.xml`` once per refresh, then looks up each
+    show. The previous per-show ``adba.Anime(...)`` path re-parsed multi‑MB XML for
+    every title (minutes of MAIN/SHOWQUEUE blocking) and swallowed missing-map
+    ``ValueError``s without detail.
+    """
     if not should_refresh("anidb"):
         return
 
     logger.info("Checking for scene exception updates for AniDB")
+
+    cache_dir = Path(settings.CACHE_DIR) / "anime"
+    try:
+        cache_dir.mkdir(parents=True, exist_ok=True)
+    except OSError as error:
+        logger.warning(f"AniDB scene exceptions skipped: cannot create cache dir {cache_dir}: {error}")
+        return
+
+    from sickchill.adba import aniDBfileInfo as anidb_files
+
+    anime_list = anidb_files.read_tvdb_map_xml(cache_dir)
+    titles_xml = anidb_files.read_anidb_xml(cache_dir)
+    if anime_list is None or titles_xml is None:
+        logger.warning("AniDB scene exceptions skipped: anime-list/animetitles XML unavailable")
+        return
+
+    tvdb_to_aid: dict[int, int] = {}
+    for anime in anime_list.findall("anime"):
+        try:
+            tvdb_id = int(anime.get("tvdbid") or 0)
+            aid = int(anime.get("anidbid") or 0)
+        except (TypeError, ValueError):
+            continue
+        if tvdb_id > 0 and aid > 0:
+            # First mapping wins; list order is stable enough for scene-name use.
+            tvdb_to_aid.setdefault(tvdb_id, aid)
+
+    aid_to_main_name: dict[int, str] = {}
+    xml_lang = "{http://www.w3.org/XML/1998/namespace}lang"
+    for anime in titles_xml.findall("anime"):
+        try:
+            aid = int(anime.get("aid") or 0)
+        except (TypeError, ValueError):
+            continue
+        if not aid:
+            continue
+        main_name = ""
+        for title in anime.findall("title"):
+            if title.get("type") == "main" and title.text:
+                main_name = title.text
+                break
+        if not main_name:
+            for title in anime.findall("title"):
+                if title.get(xml_lang) == "en" and title.text:
+                    main_name = title.text
+                    break
+        if main_name:
+            aid_to_main_name[aid] = main_name
+
+    updated = skipped = failed = 0
     for show in settings.show_list:
         if settings.stopping or settings.restarting:
             return
 
-        if show.is_anime and show.indexer == 1:
-            # noinspection PyBroadException
-            try:
-                anime = adba.Anime(None, name=show.name, tvdbid=show.indexerid, autoCorrectName=True, cache_dir=Path(settings.CACHE_DIR))
-            except Exception:
-                logger.debug(f"Could not update anime exceptions from anidb for {show.name}")
-                continue
-            else:
-                if anime.name and anime.name != show.name:
-                    yield int(show.indexerid), anime.name, -1
+        if not (show.is_anime and show.indexer == 1):
+            continue
 
+        try:
+            aid = tvdb_to_aid.get(int(show.indexerid), 0)
+            if not aid:
+                skipped += 1
+                logger.debug(f"AniDB: no TVDB mapping for {show.name} (tvdb={show.indexerid})")
+                continue
+
+            anidb_name = aid_to_main_name.get(aid)
+            if not anidb_name:
+                skipped += 1
+                logger.debug(f"AniDB: no title for aid={aid} ({show.name}, tvdb={show.indexerid})")
+                continue
+
+            if anidb_name != show.name:
+                updated += 1
+                yield int(show.indexerid), anidb_name, -1
+            else:
+                skipped += 1
+        except Exception as error:
+            failed += 1
+            logger.debug(f"Could not update anime exceptions from anidb for {show.name}: {error}")
+
+    logger.info(f"AniDB scene exceptions finished: updated={updated}, skipped={skipped}, failed={failed}")
     set_last_refresh("anidb")
 
 

--- a/sickchill/providers/GenericProvider.py
+++ b/sickchill/providers/GenericProvider.py
@@ -348,6 +348,16 @@ class GenericProvider(object):
     def get_id(self, suffix=""):
         return GenericProvider.make_id(self.name) + str(suffix)
 
+    @property
+    def uses_configurable_categories(self) -> bool:
+        """True for Newznab and Jackett-SC (user-editable category id lists).
+
+        Torrent providers other than Jackett-SC reuse ``categories`` for hardcoded
+        ints/lists/dicts or query strings and must not be overwritten with
+        Newznab-style string defaults (#9148 TorrentDay regression).
+        """
+        return False
+
     def get_quality(self, item, anime=False):
         (title, url_) = self._get_title_and_url(item)
         quality = Quality.scene_quality(title, anime)

--- a/sickchill/start.py
+++ b/sickchill/start.py
@@ -893,9 +893,14 @@ def initialize(console_logging: bool = True, debug: bool = False, dbdebug: bool 
                 curProvider.cookies = check_setting_str(settings.CFG, curProvider.get_id().upper(), curProvider.get_id("_cookies"), censor_log=True)
             if hasattr(curProvider, "indexer"):
                 curProvider.indexer = check_setting_str(settings.CFG, curProvider.get_id().upper(), curProvider.get_id("_indexer"), "all")
-            if hasattr(curProvider, "categories"):
+            # Newznab + Jackett-SC only. Other torrent providers keep hardcoded
+            # categories (ints/lists/dicts/query strings) — #9148 TorrentDay regression.
+            if getattr(curProvider, "uses_configurable_categories", False):
                 curProvider.categories = check_setting_str(
-                    settings.CFG, curProvider.get_id().upper(), curProvider.get_id("_categories"), "5000,5030,5040,5045,5050,5060,5070"
+                    settings.CFG,
+                    curProvider.get_id().upper(),
+                    curProvider.get_id("_categories"),
+                    getattr(curProvider, "categories", "") or "5000,5030,5040,5045,5050,5060,5070",
                 )
 
         try:
@@ -1189,7 +1194,7 @@ def save_config():
             new_config[curProvider.get_id().upper()][curProvider.get_id("_custom_url")] = curProvider.custom_url
         if hasattr(curProvider, "indexer"):
             new_config[curProvider.get_id().upper()][curProvider.get_id("_indexer")] = curProvider.indexer
-        if hasattr(curProvider, "categories"):
+        if getattr(curProvider, "uses_configurable_categories", False):
             new_config[curProvider.get_id().upper()][curProvider.get_id("_categories")] = curProvider.categories
         if hasattr(curProvider, "digest"):
             new_config[curProvider.get_id().upper()][curProvider.get_id("_digest")] = curProvider.digest

--- a/sickchill/tv.py
+++ b/sickchill/tv.py
@@ -1168,27 +1168,27 @@ class TVShow(object):
                 logger.debug(f"Search failed: {e}")
 
         self.check_imdb_id()
-    
+
         if not self.imdb_id:
             logger.debug(f"{self.indexerid}: No IMDb ID")
             return
-    
+
         logger.debug(f"{self.indexerid}: Refreshing IMDb info")
-    
+
         executor = ThreadPoolExecutor(max_workers=1)
         future = None
-    
+
         try:
             future = executor.submit(self._fetch_imdb_title, self.imdb_id)
             title = future.result(timeout=25)  # raises FuturesTimeoutError on timeout
-    
+
             if title:
                 new_title = getattr(title, "title", self.name)
                 new_imdb_id = helpers.normalize_imdb_id(getattr(title, "imdb_id", None)) or self.imdb_id
                 if new_imdb_id != self.imdb_id:
                     logger.info(f"{self.indexerid}: IMDb id {self.imdb_id} redirects to {new_imdb_id}")
                     self.imdb_id = new_imdb_id
-    
+
                 self.imdb_info.update(
                     {
                         "indexer_id": self.indexerid,
@@ -1208,7 +1208,7 @@ class TVShow(object):
                 )
                 self.dirty = True
                 self.save_to_db()
-    
+
                 logger.debug(f"{self.indexerid}: IMDb info refreshed → {new_title} ({new_imdb_id})")
             else:
                 logger.warning(f"{self.indexerid}: No live IMDb data for {self.imdb_id}")

--- a/sickchill/tv.py
+++ b/sickchill/tv.py
@@ -1173,6 +1173,17 @@ class TVShow(object):
             logger.debug(f"{self.indexerid}: No IMDb ID")
             return
 
+        # Follow IMDb redirect/legacy ids before refresh (imdbpie raises on those).
+        try:
+            resolved_id = helpers.resolve_imdb_title_id(self.imdb_id)
+        except Exception as error:
+            logger.debug(f"{self.indexerid}: IMDb redirect resolve failed: {error}")
+            resolved_id = self.imdb_id
+
+        if resolved_id and resolved_id != self.imdb_id:
+            logger.info(f"{self.indexerid}: IMDb id {self.imdb_id} redirects to {resolved_id}")
+            self.imdb_id = resolved_id
+
         logger.debug(f"{self.indexerid}: Refreshing IMDb info")
 
         executor = ThreadPoolExecutor(max_workers=1)
@@ -1184,7 +1195,9 @@ class TVShow(object):
 
             if title:
                 new_title = getattr(title, "title", self.name)
-                new_imdb_id = getattr(title, "imdb_id", self.imdb_id)
+                new_imdb_id = helpers.normalize_imdb_id(getattr(title, "imdb_id", None)) or self.imdb_id
+                if new_imdb_id != self.imdb_id:
+                    self.imdb_id = new_imdb_id
 
                 self.imdb_info.update(
                     {
@@ -1194,7 +1207,7 @@ class TVShow(object):
                         "year": getattr(title, "year", self.startyear),
                         "akas": self.imdb_info.get("akas", ""),
                         "runtimes": getattr(title, "runtime", self.runtime),
-                        "genres": "|".join(getattr(title, "genres", [])),
+                        "genres": "|".join(getattr(title, "genres", []) or []),
                         "countries": getattr(title, "countries", "") or self.imdb_info.get("countries", ""),
                         "country_codes": self.imdb_info.get("country_codes", ""),
                         "certificates": getattr(title, "certification", "") or "",
@@ -1221,9 +1234,22 @@ class TVShow(object):
             executor.shutdown(wait=False, cancel_futures=True)
 
     def _fetch_imdb_title(self, imdb_id):
-        """Isolated so it can be run in a thread with a timeout"""
-        facade = ImdbFacade()
-        return facade.get_title(imdb_id)
+        """Isolated so it can be run in a thread with a timeout.
+
+        Resolves redirected/legacy IMDb ids before calling imdbpie, which otherwise
+        raises ``Title not found. … is a redirection imdb id``.
+        """
+        client = Imdb()
+        resolved_id = helpers.resolve_imdb_title_id(imdb_id, client=client) or imdb_id
+        facade = ImdbFacade(client=client)
+        title = facade.get_title(resolved_id)
+        # Ensure callers persist the canonical id even if facade omits it.
+        if title is not None and resolved_id and getattr(title, "imdb_id", None) != resolved_id:
+            try:
+                title.imdb_id = resolved_id
+            except Exception:
+                pass
+        return title
 
     def next_episode(self):
         current_date = sc_today().toordinal()

--- a/sickchill/tv.py
+++ b/sickchill/tv.py
@@ -1168,37 +1168,27 @@ class TVShow(object):
                 logger.debug(f"Search failed: {e}")
 
         self.check_imdb_id()
-
+    
         if not self.imdb_id:
             logger.debug(f"{self.indexerid}: No IMDb ID")
             return
-
-        # Follow IMDb redirect/legacy ids before refresh (imdbpie raises on those).
-        try:
-            resolved_id = helpers.resolve_imdb_title_id(self.imdb_id)
-        except Exception as error:
-            logger.debug(f"{self.indexerid}: IMDb redirect resolve failed: {error}")
-            resolved_id = self.imdb_id
-
-        if resolved_id and resolved_id != self.imdb_id:
-            logger.info(f"{self.indexerid}: IMDb id {self.imdb_id} redirects to {resolved_id}")
-            self.imdb_id = resolved_id
-
+    
         logger.debug(f"{self.indexerid}: Refreshing IMDb info")
-
+    
         executor = ThreadPoolExecutor(max_workers=1)
         future = None
-
+    
         try:
             future = executor.submit(self._fetch_imdb_title, self.imdb_id)
             title = future.result(timeout=25)  # raises FuturesTimeoutError on timeout
-
+    
             if title:
                 new_title = getattr(title, "title", self.name)
                 new_imdb_id = helpers.normalize_imdb_id(getattr(title, "imdb_id", None)) or self.imdb_id
                 if new_imdb_id != self.imdb_id:
+                    logger.info(f"{self.indexerid}: IMDb id {self.imdb_id} redirects to {new_imdb_id}")
                     self.imdb_id = new_imdb_id
-
+    
                 self.imdb_info.update(
                     {
                         "indexer_id": self.indexerid,
@@ -1218,7 +1208,7 @@ class TVShow(object):
                 )
                 self.dirty = True
                 self.save_to_db()
-
+    
                 logger.debug(f"{self.indexerid}: IMDb info refreshed → {new_title} ({new_imdb_id})")
             else:
                 logger.warning(f"{self.indexerid}: No live IMDb data for {self.imdb_id}")

--- a/sickchill/views/config/providers.py
+++ b/sickchill/views/config/providers.py
@@ -259,7 +259,9 @@ class ConfigProviders(Config):
             provider.check_set_option(self, "custom_url")
             provider.check_set_option(self, "cookies")
             provider.check_set_option(self, "indexer", "all")
-            provider.check_set_option(self, "categories", "5000,5030,5040,5045,5050,5060,5070")
+            # Newznab + Jackett-SC only — leave other torrent categories alone (#9148).
+            if getattr(provider, "uses_configurable_categories", False):
+                provider.check_set_option(self, "categories", "5000,5030,5040,5045,5050,5060,5070")
 
             provider.check_set_option(self, "minseed", 0, int)
             provider.check_set_option(self, "minleech", 0, int)

--- a/tests/test_anidb_scene_exceptions.py
+++ b/tests/test_anidb_scene_exceptions.py
@@ -13,10 +13,14 @@ from sickchill.adba import aniDBfileInfo as anidb_files
 from sickchill.oldbeard import scene_exceptions
 
 
-def _write_map_xml(path: Path, entries: list[tuple[str, str, str]]) -> None:
+def _write_map_xml(path: Path, entries: list[tuple]) -> None:
     root = ElementTree.Element("anime-list")
-    for anidb, tvdb, name in entries:
-        anime = ElementTree.SubElement(root, "anime", anidbid=anidb, tvdbid=tvdb)
+    for entry in entries:
+        anidb, tvdb, name = entry[0], entry[1], entry[2]
+        attrs = {"anidbid": anidb, "tvdbid": tvdb}
+        if len(entry) > 3 and entry[3] is not None:
+            attrs["defaulttvdbseason"] = str(entry[3])
+        anime = ElementTree.SubElement(root, "anime", **attrs)
         ElementTree.SubElement(anime, "name").text = name
     ElementTree.ElementTree(root).write(path, encoding="utf-8", xml_declaration=True)
 
@@ -47,13 +51,10 @@ class DownloadFileSafetyTests(unittest.TestCase):
 
 class AnidbExceptionsGeneratorTests(unittest.TestCase):
     def setUp(self):
-        self._saved = {
-            "show_list": settings.show_list,
-            "CACHE_DIR": settings.CACHE_DIR,
-            "stopping": settings.stopping,
-            "restarting": settings.restarting,
-        }
-        # Other tests can leave these True and abort the generator early (CI flake).
+        self._saved_show_list = settings.show_list
+        self._saved_cache_dir = settings.CACHE_DIR
+        self._saved_stopping = settings.stopping
+        self._saved_restarting = settings.restarting
         settings.stopping = False
         settings.restarting = False
 
@@ -66,8 +67,9 @@ class AnidbExceptionsGeneratorTests(unittest.TestCase):
         _write_map_xml(
             self.anime_dir / "anime-list.xml",
             [
-                ("12385", "329820", "Isekai Shokudou"),
-                ("1", "72025", "Seikai no Monshou"),
+                ("12385", "329820", "Isekai Shokudou", "1"),
+                ("1", "72025", "Seikai no Monshou", "1"),
+                ("4", "72025", "Seikai no Senki", "2"),
             ],
         )
         _write_titles_xml(
@@ -75,48 +77,46 @@ class AnidbExceptionsGeneratorTests(unittest.TestCase):
             [
                 ("12385", "Isekai Shokudou"),
                 ("1", "Seikai no Monshou"),
+                ("4", "Seikai no Senki"),
             ],
         )
 
     def tearDown(self):
-        settings.show_list = self._saved["show_list"]
-        settings.CACHE_DIR = self._saved["CACHE_DIR"]
-        settings.stopping = self._saved["stopping"]
-        settings.restarting = self._saved["restarting"]
+        settings.show_list = self._saved_show_list
+        settings.CACHE_DIR = self._saved_cache_dir
+        settings.stopping = self._saved_stopping
+        settings.restarting = self._saved_restarting
         self._tmp.cleanup()
 
-    def _show(self, name: str, indexerid: int, is_anime: bool = True, indexer: int = 1):
+    def _show(self, name: str, indexerid: int, is_anime: bool = True, indexer: int = 1, default_tvdb_season=None, episodes=None):
         show = MagicMock()
         show.name = name
         show.indexerid = indexerid
         show.is_anime = is_anime
         show.indexer = indexer
+        show.default_tvdb_season = default_tvdb_season
+        show.episodes = episodes if episodes is not None else {}
         return show
 
     @patch("sickchill.oldbeard.scene_exceptions.should_refresh", return_value=True)
     @patch("sickchill.oldbeard.scene_exceptions.set_last_refresh")
-    def test_yields_anidb_main_name_when_different(self, set_refresh, _should):
-        settings.show_list = [
-            self._show("Restaurant to Another World", 329820),
-            self._show("4 Cut Hero", 462598),  # unmapped → skipped, not raised
-            self._show("Not Anime", 1, is_anime=False),
-        ]
-
+    def test_tvdb_72025_selects_season_specific_anidb_title(self, set_refresh, _should):
+        # Whole series: both AniDB titles, tagged with defaulttvdbseason
+        settings.show_list = [self._show("Crest of the Stars", 72025)]
         results = list(scene_exceptions._anidb_exceptions_generator())
-        self.assertEqual(results, [(329820, "Isekai Shokudou", -1)])
-        set_refresh.assert_called_once_with("anidb")
+        self.assertEqual(
+            sorted(results),
+            [
+                (72025, "Seikai no Monshou", 1),
+                (72025, "Seikai no Senki", 2),
+            ],
+        )
 
-    @patch("sickchill.adba.aniDBfileInfo.get_anime_titles_xml", return_value=False)
-    @patch("sickchill.adba.aniDBfileInfo.get_anime_list_xml", return_value=False)
-    @patch("sickchill.oldbeard.scene_exceptions.should_refresh", return_value=True)
-    @patch("sickchill.oldbeard.scene_exceptions.set_last_refresh")
-    def test_skips_when_xml_missing(self, set_refresh, _should, _list_dl, _titles_dl):
-        for path in self.anime_dir.glob("*.xml"):
-            path.unlink()
-        settings.show_list = [self._show("Restaurant to Another World", 329820)]
-
-        self.assertEqual(list(scene_exceptions._anidb_exceptions_generator()), [])
-        set_refresh.assert_not_called()
+        # Season-2-only show must not first-wins onto aid 1
+        settings.show_list = [self._show("Banner of the Stars", 72025, default_tvdb_season=2)]
+        results = list(scene_exceptions._anidb_exceptions_generator())
+        self.assertEqual(results, [(72025, "Seikai no Senki", 2)])
+        set_refresh.assert_called_with("anidb")
 
 
 if __name__ == "__main__":

--- a/tests/test_anidb_scene_exceptions.py
+++ b/tests/test_anidb_scene_exceptions.py
@@ -47,7 +47,16 @@ class DownloadFileSafetyTests(unittest.TestCase):
 
 class AnidbExceptionsGeneratorTests(unittest.TestCase):
     def setUp(self):
-        self._saved_show_list = settings.show_list
+        self._saved = {
+            "show_list": settings.show_list,
+            "CACHE_DIR": settings.CACHE_DIR,
+            "stopping": settings.stopping,
+            "restarting": settings.restarting,
+        }
+        # Other tests can leave these True and abort the generator early (CI flake).
+        settings.stopping = False
+        settings.restarting = False
+
         self._tmp = TemporaryDirectory()
         self.cache_root = Path(self._tmp.name)
         self.anime_dir = self.cache_root / "anime"
@@ -70,7 +79,10 @@ class AnidbExceptionsGeneratorTests(unittest.TestCase):
         )
 
     def tearDown(self):
-        settings.show_list = self._saved_show_list
+        settings.show_list = self._saved["show_list"]
+        settings.CACHE_DIR = self._saved["CACHE_DIR"]
+        settings.stopping = self._saved["stopping"]
+        settings.restarting = self._saved["restarting"]
         self._tmp.cleanup()
 
     def _show(self, name: str, indexerid: int, is_anime: bool = True, indexer: int = 1):

--- a/tests/test_anidb_scene_exceptions.py
+++ b/tests/test_anidb_scene_exceptions.py
@@ -1,0 +1,111 @@
+"""AniDB scene-exception refresh (ScudLee XML) — no UDP API."""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest.mock import MagicMock, patch
+from xml.etree import ElementTree
+
+from sickchill import settings
+from sickchill.adba import aniDBfileInfo as anidb_files
+from sickchill.oldbeard import scene_exceptions
+
+
+def _write_map_xml(path: Path, entries: list[tuple[str, str, str]]) -> None:
+    root = ElementTree.Element("anime-list")
+    for anidb, tvdb, name in entries:
+        anime = ElementTree.SubElement(root, "anime", anidbid=anidb, tvdbid=tvdb)
+        ElementTree.SubElement(anime, "name").text = name
+    ElementTree.ElementTree(root).write(path, encoding="utf-8", xml_declaration=True)
+
+
+def _write_titles_xml(path: Path, entries: list[tuple[str, str]]) -> None:
+    root = ElementTree.Element("animetitles")
+    for aid, main_name in entries:
+        anime = ElementTree.SubElement(root, "anime", aid=aid)
+        title = ElementTree.SubElement(anime, "title", type="main")
+        title.set("{http://www.w3.org/XML/1998/namespace}lang", "x-jat")
+        title.text = main_name
+    ElementTree.ElementTree(root).write(path, encoding="utf-8", xml_declaration=True)
+
+
+class DownloadFileSafetyTests(unittest.TestCase):
+    def test_failed_download_keeps_existing_file(self):
+        with TemporaryDirectory() as tmp:
+            target = Path(tmp) / "anime-list.xml"
+            target.write_text("<anime-list/>", encoding="utf-8")
+
+            with patch("sickchill.adba.aniDBfileInfo.requests.get", side_effect=anidb_files.requests.exceptions.RequestException("boom")):
+                self.assertFalse(anidb_files.download_file("https://example.test/x.xml", target))
+
+            self.assertTrue(target.is_file())
+            self.assertEqual(target.read_text(encoding="utf-8"), "<anime-list/>")
+            self.assertFalse(list(Path(tmp).glob("*.tmp")))
+
+
+class AnidbExceptionsGeneratorTests(unittest.TestCase):
+    def setUp(self):
+        self._saved_show_list = settings.show_list
+        self._tmp = TemporaryDirectory()
+        self.cache_root = Path(self._tmp.name)
+        self.anime_dir = self.cache_root / "anime"
+        self.anime_dir.mkdir()
+        settings.CACHE_DIR = str(self.cache_root)
+
+        _write_map_xml(
+            self.anime_dir / "anime-list.xml",
+            [
+                ("12385", "329820", "Isekai Shokudou"),
+                ("1", "72025", "Seikai no Monshou"),
+            ],
+        )
+        _write_titles_xml(
+            self.anime_dir / "animetitles.xml",
+            [
+                ("12385", "Isekai Shokudou"),
+                ("1", "Seikai no Monshou"),
+            ],
+        )
+
+    def tearDown(self):
+        settings.show_list = self._saved_show_list
+        self._tmp.cleanup()
+
+    def _show(self, name: str, indexerid: int, is_anime: bool = True, indexer: int = 1):
+        show = MagicMock()
+        show.name = name
+        show.indexerid = indexerid
+        show.is_anime = is_anime
+        show.indexer = indexer
+        return show
+
+    @patch("sickchill.oldbeard.scene_exceptions.should_refresh", return_value=True)
+    @patch("sickchill.oldbeard.scene_exceptions.set_last_refresh")
+    def test_yields_anidb_main_name_when_different(self, set_refresh, _should):
+        settings.show_list = [
+            self._show("Restaurant to Another World", 329820),
+            self._show("4 Cut Hero", 462598),  # unmapped → skipped, not raised
+            self._show("Not Anime", 1, is_anime=False),
+        ]
+
+        results = list(scene_exceptions._anidb_exceptions_generator())
+        self.assertEqual(results, [(329820, "Isekai Shokudou", -1)])
+        set_refresh.assert_called_once_with("anidb")
+
+    @patch("sickchill.adba.aniDBfileInfo.get_anime_titles_xml", return_value=False)
+    @patch("sickchill.adba.aniDBfileInfo.get_anime_list_xml", return_value=False)
+    @patch("sickchill.oldbeard.scene_exceptions.should_refresh", return_value=True)
+    @patch("sickchill.oldbeard.scene_exceptions.set_last_refresh")
+    def test_skips_when_xml_missing(self, set_refresh, _should, _list_dl, _titles_dl):
+        for path in self.anime_dir.glob("*.xml"):
+            path.unlink()
+        settings.show_list = [self._show("Restaurant to Another World", 329820)]
+
+        self.assertEqual(list(scene_exceptions._anidb_exceptions_generator()), [])
+        set_refresh.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_imdb_redirect_id.py
+++ b/tests/test_imdb_redirect_id.py
@@ -1,0 +1,86 @@
+"""IMDb redirect/legacy title id resolution."""
+
+from __future__ import annotations
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from sickchill.oldbeard import helpers
+
+
+class NormalizeImdbIdTests(unittest.TestCase):
+    def test_normalizes_digits_and_prefixed(self):
+        self.assertEqual(helpers.normalize_imdb_id("41154853"), "tt41154853")
+        self.assertEqual(helpers.normalize_imdb_id("tt41154853"), "tt41154853")
+        self.assertEqual(helpers.normalize_imdb_id("IMDB tt38840807"), "tt38840807")
+
+    def test_empty_and_invalid(self):
+        self.assertEqual(helpers.normalize_imdb_id(None), "")
+        self.assertEqual(helpers.normalize_imdb_id(""), "")
+        self.assertEqual(helpers.normalize_imdb_id("not-an-id"), "")
+
+
+class ResolveImdbTitleIdTests(unittest.TestCase):
+    def test_empty_returns_empty(self):
+        self.assertEqual(helpers.resolve_imdb_title_id(None), "")
+        self.assertEqual(helpers.resolve_imdb_title_id(""), "")
+
+    def test_follows_redirect_from_auxiliary_id(self):
+        client = MagicMock()
+        client.region = None
+        client._get.return_value = {"id": "/title/tt38840807/"}
+
+        self.assertEqual(helpers.resolve_imdb_title_id("tt41154853", client=client), "tt38840807")
+        client._get.assert_called_once()
+        params = client._get.call_args.kwargs["params"]
+        self.assertEqual(params["tconst"], "tt41154853")
+
+    def test_canonical_id_unchanged(self):
+        client = MagicMock()
+        client.region = None
+        client._get.return_value = {"id": "/title/tt38840807/"}
+
+        self.assertEqual(helpers.resolve_imdb_title_id("tt38840807", client=client), "tt38840807")
+
+    def test_lookup_failure_returns_normalized(self):
+        client = MagicMock()
+        client.region = None
+        client._get.side_effect = Exception("boom")
+
+        self.assertEqual(helpers.resolve_imdb_title_id("41154853", client=client), "tt41154853")
+
+    def test_non_dict_response_returns_normalized(self):
+        client = MagicMock()
+        client.region = None
+        client._get.return_value = None
+
+        self.assertEqual(helpers.resolve_imdb_title_id("tt41154853", client=client), "tt41154853")
+
+
+class FetchImdbTitleRedirectTests(unittest.TestCase):
+    @patch("sickchill.tv.ImdbFacade")
+    @patch("sickchill.tv.helpers.resolve_imdb_title_id", return_value="tt38840807")
+    @patch("sickchill.tv.Imdb")
+    def test_fetch_uses_resolved_id(self, imdb_cls, resolve_id, facade_cls):
+        from sickchill.tv import TVShow
+
+        client = MagicMock()
+        imdb_cls.return_value = client
+        title = SimpleNamespace(imdb_id="tt41154853", title="Resolved Show")
+        facade = MagicMock()
+        facade.get_title.return_value = title
+        facade_cls.return_value = facade
+
+        show = object.__new__(TVShow)
+        result = TVShow._fetch_imdb_title(show, "tt41154853")
+
+        resolve_id.assert_called_once_with("tt41154853", client=client)
+        facade_cls.assert_called_once_with(client=client)
+        facade.get_title.assert_called_once_with("tt38840807")
+        self.assertIs(result, title)
+        self.assertEqual(result.imdb_id, "tt38840807")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes broken provider str int issue.
imdb redirect

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved IMDb title handling by resolving redirected or legacy IDs and preserving canonical IDs.
  - Failed metadata refreshes no longer discard valid cached data.
  - Safer downloads prevent incomplete files from replacing existing caches.
  - Prevented torrent provider categories from being overwritten by Newznab defaults.

- **Improvements**
  - Newznab and Jackett-SC category settings are now preserved and configurable.
  - AniDB scene-exception processing is more efficient and handles unavailable data gracefully.
  - Season-specific AniDB mappings now select the appropriate titles more accurately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->