### PR TITLE
Update LimeTorrents URLs to new domain

### DIFF
--- a/sickchill/oldbeard/providers/limetorrents.py
+++ b/sickchill/oldbeard/providers/limetorrents.py
@@ -13,9 +13,9 @@ class Provider(TorrentProvider):
         super().__init__("LimeTorrents")
 
         self.urls = {
-            "index": "https://www.limetorrents.info/",
-            "search": "https://www.limetorrents.info/searchrss/",
-            "rss": "https://www.limetorrents.info/rss/tv/",
+            "index": "https://www.limetorrents.fun/",
+            "search": "https://www.limetorrents.fun/searchrss/",
+            "rss": "https://www.limetorrents.fun/rss/tv/",
         }
 
         self.url = self.urls["index"]


### PR DESCRIPTION
The existing LimeTorrents provider uses the outdated `limetorrents.info` domain.

In testing, search results returned through that endpoint consistently resolved to torrents whose payloads were `.exe` files rather than the expected video files. The corresponding releases on the current LimeTorrents site (`limetorrents.fun`) returned normal video torrents instead.

This means the outdated provider endpoint is currently serving malicious/malware torrent results and should no longer be used.

Proposed changes in this pull request:

* Update LimeTorrents index URL from `limetorrents.info` to `limetorrents.fun`
* Update the search RSS endpoint to `limetorrents.fun/searchrss/`
* Update the RSS endpoint to `limetorrents.fun/rss/`

Testing:

* Verified `limetorrents.fun/searchrss/` returns valid search results

* Verified matching releases on `limetorrents.fun` return the expected video torrents

* Verified the old `limetorrents.info` endpoint was returning different torrent hashes whose payloads were `.exe` files

* [ ] PR is based on the DEVELOP branch

* [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review

* [x] Read [[contribution guide](https://github.com/SickChill/SickChill/blob/master/.github/CONTRIBUTING.md)](https://github.com/SickChill/SickChill/blob/master/.github/CONTRIBUTING.md)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated LimeTorrents provider endpoints to use the current `.fun` domain for browsing, searching, and RSS feeds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->