### PR TITLE
feat: Jackett with http local lans

### DIFF
--- a/sickchill/oldbeard/providers/jackett.py
+++ b/sickchill/oldbeard/providers/jackett.py
@@ -68,26 +68,52 @@ class Provider(TorrentProvider, tvcache.RSSTorrentMixin):
         return urlunsplit((parts.scheme, parts.netloc, path, "", ""))
 
     @classmethod
+    def _host_allows_cleartext_apikey(cls, host: str) -> bool:
+        """True when HTTP (cleartext) apikey transport is acceptable for ``host``.
+
+        Allows loopback, RFC1918/link-local/ULA addresses, and local/Docker-style
+        names (``jackett``, ``host.docker.internal``, ``*.local`` / ``*.lan``).
+        Public IPs and public-looking hostnames still require HTTPS — apikey is a
+        query param on the Torznab URL.
+        """
+        host = (host or "").lower().rstrip(".")
+        if not host:
+            return False
+        if host in ("localhost", "127.0.0.1", "::1", "host.docker.internal", "gateway.docker.internal"):
+            return True
+        if host.endswith((".localhost", ".local", ".lan", ".internal")):
+            return True
+        # Docker Compose / swarm service names are usually single-label.
+        if "." not in host and host.replace("-", "").replace("_", "").isalnum():
+            return True
+
+        try:
+            ip = ipaddress.ip_address(host)
+        except ValueError:
+            return False
+        # Prefer is_global so documentation/TEST-NET ranges stay non-public across Python versions.
+        return not ip.is_global
+
+    @classmethod
     def _url_allows_apikey_transport(cls, url: str) -> bool:
-        """Allow apikey query params over HTTPS, or HTTP only for loopback endpoints."""
+        """Allow apikey query params over HTTPS, or HTTP for local/private endpoints."""
         parts = urlsplit((url or "").strip())
         scheme = (parts.scheme or "").lower()
         if scheme == "https":
             return True
         if scheme != "http":
             return False
+        return cls._host_allows_cleartext_apikey(parts.hostname or "")
 
-        host = (parts.hostname or "").lower().rstrip(".")
-        if not host:
-            return False
-        if host in ("localhost", "127.0.0.1", "::1") or host.endswith(".localhost"):
+    @classmethod
+    def _is_usable_jackett_url(cls, url: str) -> bool:
+        """Like ``invalid_url``, but also accept Docker service names validators.url rejects."""
+        if not cls.invalid_url(url or ""):
             return True
-
-        try:
-            return bool(ipaddress.ip_address(host).is_loopback)
-        except ValueError:
-            # Any non-loopback hostname (LAN, docker, public) requires HTTPS
+        parts = urlsplit((url or "").strip())
+        if (parts.scheme or "").lower() not in ("http", "https"):
             return False
+        return cls._host_allows_cleartext_apikey(parts.hostname or "")
 
     @property
     def torznab_url(self) -> str:
@@ -118,15 +144,15 @@ class Provider(TorrentProvider, tvcache.RSSTorrentMixin):
         if not (self.api_key or "").strip():
             logger.warning(_("Jackett API key is not set. Check your provider settings."))
             return False
-        if self.invalid_url(self.custom_url or ""):
+        if not self._is_usable_jackett_url(self.custom_url or ""):
             logger.warning(_("Invalid Jackett URL. Check your provider settings."))
             return False
-        # apikey is sent as a query param — require HTTPS except for loopback HTTP
+        # apikey is sent as a query param — require HTTPS except for local/private HTTP
         if not self._url_allows_apikey_transport(self.torznab_url):
             logger.warning(
                 _(
-                    "Jackett URL must use HTTPS when the API key is sent in the query string. "
-                    "HTTP is only allowed for loopback addresses (localhost / 127.0.0.1 / ::1)."
+                    "Jackett URL must use HTTPS when the API key is sent public in the query string. "
+                    "HTTP allowed for loopback, private LAN IPs, and local/Docker hostnames "
                 )
             )
             return False

--- a/sickchill/oldbeard/providers/jackett.py
+++ b/sickchill/oldbeard/providers/jackett.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import ipaddress
+import socket
 import time
 from urllib.parse import urljoin, urlsplit, urlunsplit
 
@@ -67,32 +68,44 @@ class Provider(TorrentProvider, tvcache.RSSTorrentMixin):
         path = (parts.path or "").rstrip("/")
         return urlunsplit((parts.scheme, parts.netloc, path, "", ""))
 
+    @staticmethod
+    def _ip_allows_cleartext_apikey(ip) -> bool:
+        """Local/private peers may use HTTP; globally routable peers require HTTPS."""
+        return not ip.is_global
+
     @classmethod
     def _host_allows_cleartext_apikey(cls, host: str) -> bool:
         """True when HTTP (cleartext) apikey transport is acceptable for ``host``.
 
-        Allows loopback, RFC1918/link-local/ULA addresses, and local/Docker-style
-        names (``jackett``, ``host.docker.internal``, ``*.local`` / ``*.lan``).
-        Public IPs and public-looking hostnames still require HTTPS — apikey is a
-        query param on the Torznab URL.
+        Literal IPs are classified directly. Hostnames are resolved and every answer
+        must be non-global (loopback/private/link-local) — we do not trust
+        ``*.local`` / single-label name text alone (pin classification to peer addrs).
         """
         host = (host or "").lower().rstrip(".")
         if not host:
             return False
-        if host in ("localhost", "127.0.0.1", "::1", "host.docker.internal", "gateway.docker.internal"):
-            return True
-        if host.endswith((".localhost", ".local", ".lan", ".internal")):
-            return True
-        # Docker Compose / swarm service names are usually single-label.
-        if "." not in host and host.replace("-", "").replace("_", "").isalnum():
-            return True
 
         try:
-            ip = ipaddress.ip_address(host)
+            return cls._ip_allows_cleartext_apikey(ipaddress.ip_address(host))
         except ValueError:
+            pass
+
+        try:
+            addrinfo = socket.getaddrinfo(host, None)
+        except OSError:
             return False
-        # Prefer is_global so documentation/TEST-NET ranges stay non-public across Python versions.
-        return not ip.is_global
+
+        resolved = set()
+        for entry in addrinfo:
+            sockaddr = entry[4]
+            if not sockaddr:
+                continue
+            try:
+                resolved.add(ipaddress.ip_address(sockaddr[0]))
+            except ValueError:
+                continue
+
+        return bool(resolved) and all(cls._ip_allows_cleartext_apikey(ip) for ip in resolved)
 
     @classmethod
     def _url_allows_apikey_transport(cls, url: str) -> bool:
@@ -103,14 +116,24 @@ class Provider(TorrentProvider, tvcache.RSSTorrentMixin):
             return True
         if scheme != "http":
             return False
+        try:
+            # urlsplit.port raises ValueError on malformed ports (e.g. :99999 / :abc).
+            _ = parts.port
+        except ValueError:
+            return False
         return cls._host_allows_cleartext_apikey(parts.hostname or "")
 
     @classmethod
     def _is_usable_jackett_url(cls, url: str) -> bool:
         """Like ``invalid_url``, but also accept Docker service names validators.url rejects."""
+        parts = urlsplit((url or "").strip())
+        try:
+            _ = parts.port
+        except ValueError:
+            return False
+
         if not cls.invalid_url(url or ""):
             return True
-        parts = urlsplit((url or "").strip())
         if (parts.scheme or "").lower() not in ("http", "https"):
             return False
         return cls._host_allows_cleartext_apikey(parts.hostname or "")
@@ -147,12 +170,14 @@ class Provider(TorrentProvider, tvcache.RSSTorrentMixin):
         if not self._is_usable_jackett_url(self.custom_url or ""):
             logger.warning(_("Invalid Jackett URL. Check your provider settings."))
             return False
-        # apikey is sent as a query param — require HTTPS except for local/private HTTP
+        # apikey is a query param — HTTPS for public peers; HTTP only for local/private.
         if not self._url_allows_apikey_transport(self.torznab_url):
             logger.warning(
                 _(
-                    "Jackett URL must use HTTPS when the API key is sent public in the query string. "
-                    "HTTP allowed for loopback, private LAN IPs, and local/Docker hostnames "
+                    "Jackett URL must use HTTPS when the API key is sent in the query string to a "
+                    "public address. HTTP is allowed for loopback/private LAN IPs and hostnames "
+                    "that resolve only to local/private addresses "
+                    "(e.g. 127.0.0.1, 192.168.x.x, jackett, host.docker.internal)."
                 )
             )
             return False

--- a/sickchill/oldbeard/providers/jackett.py
+++ b/sickchill/oldbeard/providers/jackett.py
@@ -70,8 +70,12 @@ class Provider(TorrentProvider, tvcache.RSSTorrentMixin):
 
     @staticmethod
     def _ip_allows_cleartext_apikey(ip) -> bool:
-        """Local/private peers may use HTTP; globally routable peers require HTTPS."""
-        return not ip.is_global
+        """Loopback/private/link-local peers may use HTTP; all others require HTTPS.
+
+        Deliberately excludes CGNAT (100.64.0.0/10) and other non-global-but-not-private
+        ranges — those are not local Docker/LAN Jackett endpoints.
+        """
+        return bool(ip.is_loopback or ip.is_private or ip.is_link_local)
 
     @classmethod
     def _host_allows_cleartext_apikey(cls, host: str) -> bool:

--- a/tests/test_jackett_provider.py
+++ b/tests/test_jackett_provider.py
@@ -157,6 +157,9 @@ class JackettProviderTests(unittest.TestCase):
             self.assertFalse(allow("http://remote.example:9117"))
             self.assertFalse(allow("http://jackett.example.com:9117"))
         self.assertFalse(allow("http://8.8.8.8:9117"))
+        # CGNAT / RFC6598 is non-global but not private — require HTTPS
+        self.assertFalse(allow("http://100.64.0.1:9117"))
+        self.assertTrue(allow("https://100.64.0.1:9117"))
         self.assertFalse(allow("ftp://127.0.0.1:9117"))
         self.assertFalse(allow("http://127.0.0.1:99999"))
 

--- a/tests/test_jackett_provider.py
+++ b/tests/test_jackett_provider.py
@@ -100,26 +100,30 @@ class JackettProviderTests(unittest.TestCase):
         self.provider.api_key = "abc"
         self.assertTrue(self.provider._check_auth())
 
-    def test_check_auth_rejects_non_loopback_http_with_apikey(self):
+    def test_check_auth_http_local_vs_public(self):
+        # Public hostname over HTTP still rejected (apikey in query string)
         self.provider.custom_url = "http://jackett.example.com:9117"
         self.assertFalse(self.provider._check_auth())
-
         self.provider.custom_url = "https://jackett.example.com:9117"
         self.assertTrue(self.provider._check_auth())
 
-        # Loopback HTTP still allowed (bare "localhost" fails validators.url)
+        # Loopback HTTP allowed (bare "localhost" fails validators.url)
         self.provider.custom_url = "http://127.0.0.1:9117"
         self.assertTrue(self.provider._check_auth())
         self.provider.custom_url = "http://[::1]:9117"
         self.assertTrue(self.provider._check_auth())
 
-        # Private / LAN / hostname HTTP requires HTTPS (apikey in query string)
+        # Docker bridge → host LAN IP (Jackett published port) over HTTP
         self.provider.custom_url = "http://192.168.1.10:9117"
-        self.assertFalse(self.provider._check_auth())
+        self.assertTrue(self.provider._check_auth())
         self.provider.custom_url = "https://192.168.1.10:9117"
         self.assertTrue(self.provider._check_auth())
+
+        # Same Compose network by service name / .local over HTTP
+        self.provider.custom_url = "http://jackett:9117"
+        self.assertTrue(self.provider._check_auth())
         self.provider.custom_url = "http://jackett.local:9117"
-        self.assertFalse(self.provider._check_auth())
+        self.assertTrue(self.provider._check_auth())
         self.provider.custom_url = "https://jackett.local:9117"
         self.assertTrue(self.provider._check_auth())
 
@@ -131,11 +135,16 @@ class JackettProviderTests(unittest.TestCase):
         self.assertTrue(allow("http://[::1]:9117"))
         self.assertTrue(allow("https://192.168.1.10:9117"))
         self.assertTrue(allow("https://jackett.local:9117"))
-        self.assertFalse(allow("http://10.0.0.5:9117"))
-        self.assertFalse(allow("http://192.168.1.10:9117"))
-        self.assertFalse(allow("http://jackett:9117"))
-        self.assertFalse(allow("http://nas.local:9117"))
+        # Private / Docker-local HTTP (bridge → host IP, Compose service name)
+        self.assertTrue(allow("http://10.0.0.5:9117"))
+        self.assertTrue(allow("http://192.168.1.10:9117"))
+        self.assertTrue(allow("http://172.16.5.1:9117"))
+        self.assertTrue(allow("http://jackett:9117"))
+        self.assertTrue(allow("http://host.docker.internal:9117"))
+        self.assertTrue(allow("http://nas.local:9117"))
+        # Public cleartext still blocked
         self.assertFalse(allow("http://remote.example:9117"))
+        self.assertFalse(allow("http://8.8.8.8:9117"))
         self.assertFalse(allow("ftp://127.0.0.1:9117"))
 
     @patch("sickchill.oldbeard.providers.jackett.time.sleep", return_value=None)

--- a/tests/test_jackett_provider.py
+++ b/tests/test_jackett_provider.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import socket
 import unittest
 from datetime import date
 from unittest.mock import MagicMock, patch
@@ -100,52 +101,64 @@ class JackettProviderTests(unittest.TestCase):
         self.provider.api_key = "abc"
         self.assertTrue(self.provider._check_auth())
 
+    @staticmethod
+    def _addrinfo(ip: str):
+        """Minimal getaddrinfo-shaped tuple for mocking DNS."""
+        return [(socket.AF_INET, socket.SOCK_STREAM, 0, "", (ip, 0))]
+
     def test_check_auth_http_local_vs_public(self):
         # Public hostname over HTTP still rejected (apikey in query string)
-        self.provider.custom_url = "http://jackett.example.com:9117"
-        self.assertFalse(self.provider._check_auth())
+        with patch("sickchill.oldbeard.providers.jackett.socket.getaddrinfo", return_value=self._addrinfo("8.8.8.8")):
+            self.provider.custom_url = "http://jackett.example.com:9117"
+            self.assertFalse(self.provider._check_auth())
         self.provider.custom_url = "https://jackett.example.com:9117"
         self.assertTrue(self.provider._check_auth())
 
-        # Loopback HTTP allowed (bare "localhost" fails validators.url)
+        # Loopback / private literal IPs: HTTP or HTTPS
         self.provider.custom_url = "http://127.0.0.1:9117"
         self.assertTrue(self.provider._check_auth())
         self.provider.custom_url = "http://[::1]:9117"
         self.assertTrue(self.provider._check_auth())
-
-        # Docker bridge → host LAN IP (Jackett published port) over HTTP
         self.provider.custom_url = "http://192.168.1.10:9117"
         self.assertTrue(self.provider._check_auth())
         self.provider.custom_url = "https://192.168.1.10:9117"
         self.assertTrue(self.provider._check_auth())
 
-        # Same Compose network by service name / .local over HTTP
-        self.provider.custom_url = "http://jackett:9117"
-        self.assertTrue(self.provider._check_auth())
-        self.provider.custom_url = "http://jackett.local:9117"
-        self.assertTrue(self.provider._check_auth())
+        # Compose / .local hostnames: HTTP only when DNS pins to a local/private peer
+        with patch("sickchill.oldbeard.providers.jackett.socket.getaddrinfo", return_value=self._addrinfo("172.18.0.2")):
+            self.provider.custom_url = "http://jackett:9117"
+            self.assertTrue(self.provider._check_auth())
+            self.provider.custom_url = "http://jackett.local:9117"
+            self.assertTrue(self.provider._check_auth())
         self.provider.custom_url = "https://jackett.local:9117"
         self.assertTrue(self.provider._check_auth())
+
+        # Malformed port must not reach auth success via the Docker-name fallback
+        self.provider.custom_url = "http://jackett:notaport"
+        self.assertFalse(self.provider._check_auth())
 
     def test_url_allows_apikey_transport_helpers(self):
         allow = Provider._url_allows_apikey_transport
         self.assertTrue(allow("https://remote.example/jackett"))
         self.assertTrue(allow("http://127.0.0.1:9117"))
-        self.assertTrue(allow("http://localhost:9117"))
         self.assertTrue(allow("http://[::1]:9117"))
         self.assertTrue(allow("https://192.168.1.10:9117"))
-        self.assertTrue(allow("https://jackett.local:9117"))
-        # Private / Docker-local HTTP (bridge → host IP, Compose service name)
         self.assertTrue(allow("http://10.0.0.5:9117"))
         self.assertTrue(allow("http://192.168.1.10:9117"))
         self.assertTrue(allow("http://172.16.5.1:9117"))
-        self.assertTrue(allow("http://jackett:9117"))
-        self.assertTrue(allow("http://host.docker.internal:9117"))
-        self.assertTrue(allow("http://nas.local:9117"))
-        # Public cleartext still blocked
-        self.assertFalse(allow("http://remote.example:9117"))
+        with patch("sickchill.oldbeard.providers.jackett.socket.getaddrinfo", return_value=self._addrinfo("127.0.0.1")):
+            self.assertTrue(allow("http://localhost:9117"))
+        with patch("sickchill.oldbeard.providers.jackett.socket.getaddrinfo", return_value=self._addrinfo("172.18.0.2")):
+            self.assertTrue(allow("https://jackett.local:9117"))
+            self.assertTrue(allow("http://jackett:9117"))
+            self.assertTrue(allow("http://host.docker.internal:9117"))
+            self.assertTrue(allow("http://nas.local:9117"))
+        with patch("sickchill.oldbeard.providers.jackett.socket.getaddrinfo", return_value=self._addrinfo("8.8.8.8")):
+            self.assertFalse(allow("http://remote.example:9117"))
+            self.assertFalse(allow("http://jackett.example.com:9117"))
         self.assertFalse(allow("http://8.8.8.8:9117"))
         self.assertFalse(allow("ftp://127.0.0.1:9117"))
+        self.assertFalse(allow("http://127.0.0.1:99999"))
 
     @patch("sickchill.oldbeard.providers.jackett.time.sleep", return_value=None)
     @patch.object(Provider, "get_url")


### PR DESCRIPTION
Add local lan ip http

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Jackett connections now support HTTP with API keys for private-network and local destinations, including Docker services, LAN addresses, and `.local` hostnames.
  * Public hostnames and IP addresses, including shared address ranges, continue to require HTTPS.
  * Invalid ports and malformed addresses are rejected more reliably.
  * Authentication checks and transport warnings now accurately reflect these connection rules, improving compatibility with local and containerized Jackett deployments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->