### PR TITLE
fix: provider rename

### DIFF
--- a/sickchill/gui/slick/js/configProviders.js
+++ b/sickchill/gui/slick/js/configProviders.js
@@ -30,6 +30,16 @@ $(document).ready(function () {
     const providerRenameTokens = {};
     const providerRenameXhrs = {};
 
+    const invalidateProviderRename = function (providerId) {
+        providerRenameTokens[providerId] = (providerRenameTokens[providerId] || 0) + 1;
+        if (providerRenameXhrs[providerId]) {
+            providerRenameXhrs[providerId].abort();
+            delete providerRenameXhrs[providerId];
+        }
+
+        return providerRenameTokens[providerId];
+    };
+
     /**
      * Gets categories for the provided newznab provider.
      * @param {String} isDefault
@@ -185,16 +195,12 @@ $(document).ready(function () {
             $(this).refreshProviderList();
         }.bind(this);
 
+        // Always invalidate first: reverting A→B back to A must not let A→B apply.
+        const renameToken = invalidateProviderRename(id);
+
         if (newId === id) {
             applyUpdate(id);
             return;
-        }
-
-        // Invalidate any in-flight rename validation for this provider id.
-        const renameToken = (providerRenameTokens[id] || 0) + 1;
-        providerRenameTokens[id] = renameToken;
-        if (providerRenameXhrs[id]) {
-            providerRenameXhrs[id].abort();
         }
 
         // Name change → new id. Confirm it does not collide with customs or built-ins.
@@ -263,6 +269,9 @@ $(document).ready(function () {
             $(this).refreshProviderList();
         }.bind(this);
 
+        // Always invalidate first: reverting A→B back to A must not let A→B apply.
+        const renameToken = invalidateProviderRename(id);
+
         if (newId === id) {
             applyUpdate(id);
             const $li = $('#provider_order_list > #' + id);
@@ -274,12 +283,6 @@ $(document).ready(function () {
             }
 
             return;
-        }
-
-        const renameToken = (providerRenameTokens[id] || 0) + 1;
-        providerRenameTokens[id] = renameToken;
-        if (providerRenameXhrs[id]) {
-            providerRenameXhrs[id].abort();
         }
 
         const request = $.getJSON(scRoot + '/config/providers/canAddTorrentRssProvider', {

--- a/sickchill/gui/slick/js/configProviders.js
+++ b/sickchill/gui/slick/js/configProviders.js
@@ -26,6 +26,10 @@ $(document).ready(function () {
         return found;
     };
 
+    // Monotonic tokens + in-flight XHRs so stale rename callbacks cannot mutate providers.
+    const providerRenameTokens = {};
+    const providerRenameXhrs = {};
+
     /**
      * Gets categories for the provided newznab provider.
      * @param {String} isDefault
@@ -123,12 +127,28 @@ $(document).ready(function () {
         }
 
         const checked = $('#enable_' + oldId).is(':checked');
-        const providerItem = '<li class="ui-state-default" id="' + newId + '">'
-            + ' <input type="checkbox" id="enable_' + newId + '" class="provider_enabler"' + (checked ? ' checked' : '') + '>'
-            + ' <a href="' + anonURL + url + '" class="imgLink" target="_new">'
-            + '<img src="' + scRoot + '/images/providers/' + image + '" alt="' + name + '" width="16" height="16">'
-            + '</a> ' + name + '</li>';
-        $li.replaceWith(providerItem);
+        const $checkbox = $('<input>', {
+            type: 'checkbox',
+            id: 'enable_' + newId,
+            class: 'provider_enabler',
+        }).prop('checked', checked);
+        const $img = $('<img>', {
+            src: scRoot + '/images/providers/' + image,
+            alt: name,
+            width: 16,
+            height: 16,
+        });
+        const $link = $('<a>', {
+            href: anonURL + url,
+            class: 'imgLink',
+            target: '_new',
+        }).append($img);
+        const $item = $('<li>', {
+            class: 'ui-state-default',
+            id: newId,
+        }).append(' ', $checkbox, ' ', $link, document.createTextNode(' ' + name));
+
+        $li.replaceWith($item);
         $('#provider_order_list').sortable('refresh');
         $(this).refreshProviderList();
     };
@@ -170,23 +190,46 @@ $(document).ready(function () {
             return;
         }
 
+        // Invalidate any in-flight rename validation for this provider id.
+        const renameToken = (providerRenameTokens[id] || 0) + 1;
+        providerRenameTokens[id] = renameToken;
+        if (providerRenameXhrs[id]) {
+            providerRenameXhrs[id].abort();
+        }
+
         // Name change → new id. Confirm it does not collide with customs or built-ins.
         // exclude_id matches the Tornado/Python query argument name.
-        $.getJSON(scRoot + '/config/providers/canAddNewznabProvider', {
+        const request = $.getJSON(scRoot + '/config/providers/canAddNewznabProvider', {
             name,
             exclude_id: id, // eslint-disable-line camelcase
-        }, data => {
+        });
+        providerRenameXhrs[id] = request;
+        request.done(data => {
+            if (providerRenameTokens[id] !== renameToken) {
+                return;
+            }
+
             if (data.error !== undefined) {
                 alert(data.error); // eslint-disable-line no-alert
                 $(this).populateNewznabSection();
                 return;
             }
 
+            const renamedId = data.success;
+            if (!renamedId) {
+                $(this).populateNewznabSection();
+                return;
+            }
+
             delete newznabProviders[id];
             $('#editANewznabProvider').removeOption(id);
-            $('#editANewznabProvider').addOption(newId, name);
-            $(this).migrateProviderOrderItem(id, newId, name, url, 'newznab.png');
-            applyUpdate(newId);
+            $('#editANewznabProvider').addOption(renamedId, name);
+            $(this).migrateProviderOrderItem(id, renamedId, name, url, 'newznab.png');
+            applyUpdate(renamedId);
+        }).always(() => {
+            if (providerRenameXhrs[id] === request) {
+                delete providerRenameXhrs[id];
+            }
         });
     };
 
@@ -233,24 +276,46 @@ $(document).ready(function () {
             return;
         }
 
-        $.getJSON(scRoot + '/config/providers/canAddTorrentRssProvider', {
+        const renameToken = (providerRenameTokens[id] || 0) + 1;
+        providerRenameTokens[id] = renameToken;
+        if (providerRenameXhrs[id]) {
+            providerRenameXhrs[id].abort();
+        }
+
+        const request = $.getJSON(scRoot + '/config/providers/canAddTorrentRssProvider', {
             name,
             url,
             cookies,
             titleTAG,
             exclude_id: id, // eslint-disable-line camelcase
-        }, data => {
+        });
+        providerRenameXhrs[id] = request;
+        request.done(data => {
+            if (providerRenameTokens[id] !== renameToken) {
+                return;
+            }
+
             if (data.error !== undefined) {
                 alert(data.error); // eslint-disable-line no-alert
                 $(this).populateTorrentRssSection();
                 return;
             }
 
+            const renamedId = data.success;
+            if (!renamedId) {
+                $(this).populateTorrentRssSection();
+                return;
+            }
+
             delete torrentRssProviders[id];
             $('#editATorrentRssProvider').removeOption(id);
-            $('#editATorrentRssProvider').addOption(newId, name);
-            $(this).migrateProviderOrderItem(id, newId, name, url, 'torrentrss.png');
-            applyUpdate(newId);
+            $('#editATorrentRssProvider').addOption(renamedId, name);
+            $(this).migrateProviderOrderItem(id, renamedId, name, url, 'torrentrss.png');
+            applyUpdate(renamedId);
+        }).always(() => {
+            if (providerRenameXhrs[id] === request) {
+                delete providerRenameXhrs[id];
+            }
         });
     };
 

--- a/sickchill/gui/slick/js/configProviders.js
+++ b/sickchill/gui/slick/js/configProviders.js
@@ -27,8 +27,9 @@ $(document).ready(function () {
     };
 
     // Monotonic tokens + in-flight XHRs so stale rename callbacks cannot mutate providers.
-    const providerRenameTokens = {};
-    const providerRenameXhrs = {};
+    // Prototype-free maps so a provider id of "__proto__" is a normal key.
+    const providerRenameTokens = Object.create(null);
+    const providerRenameXhrs = Object.create(null);
 
     const invalidateProviderRename = function (providerId) {
         providerRenameTokens[providerId] = (providerRenameTokens[providerId] || 0) + 1;
@@ -67,8 +68,9 @@ $(document).ready(function () {
         });
     };
 
-    const newznabProviders = [];
-    const torrentRssProviders = [];
+    // Prototype-free maps (keyed by provider id); not arrays despite historical [].
+    const newznabProviders = Object.create(null);
+    const torrentRssProviders = Object.create(null);
 
     const newznabProvidersCapabilities = [];
 

--- a/sickchill/gui/slick/js/configProviders.js
+++ b/sickchill/gui/slick/js/configProviders.js
@@ -111,12 +111,83 @@ $(document).ready(function () {
         $(this).makeTorrentRssProviderString();
     };
 
-    $.fn.updateProvider = function (id, url, key, cat) {
-        newznabProviders[id][1][1] = url;
-        newznabProviders[id][1][2] = key;
-        newznabProviders[id][1][3] = cat;
-        $(this).populateNewznabSection();
-        $(this).makeNewznabProviderString();
+    $.fn.makeProviderId = function (name) {
+        return $.trim(String(name || '')).toLowerCase().replaceAll(/\W/g, '_');
+    };
+
+    // eslint-disable-next-line max-params
+    $.fn.migrateProviderOrderItem = function (oldId, newId, name, url, image) {
+        const $li = $('#provider_order_list > #' + oldId);
+        if ($li.length === 0) {
+            return;
+        }
+
+        const checked = $('#enable_' + oldId).is(':checked');
+        const providerItem = '<li class="ui-state-default" id="' + newId + '">'
+            + ' <input type="checkbox" id="enable_' + newId + '" class="provider_enabler"' + (checked ? ' checked' : '') + '>'
+            + ' <a href="' + anonURL + url + '" class="imgLink" target="_new">'
+            + '<img src="' + scRoot + '/images/providers/' + image + '" alt="' + name + '" width="16" height="16">'
+            + '</a> ' + name + '</li>';
+        $li.replaceWith(providerItem);
+        $('#provider_order_list').sortable('refresh');
+        $(this).refreshProviderList();
+    };
+
+    $.fn.updateProvider = function (id, name, url, key, cat) { // eslint-disable-line max-params
+        const row = newznabProviders[id];
+        if (!row) {
+            return;
+        }
+
+        const isDefault = row[0];
+        name = $.trim(name || row[1][0]);
+        const newId = $(this).makeProviderId(name);
+        if (!newId) {
+            alert(_('No Provider Name specified')); // eslint-disable-line no-alert
+            $(this).populateNewznabSection();
+            return;
+        }
+
+        const applyUpdate = function (providerId) {
+            newznabProviders[providerId] = [isDefault, [name, url, key, cat]];
+            $('#editANewznabProvider option[value="' + providerId + '"]').text(name);
+            const $li = $('#provider_order_list > #' + providerId);
+            if ($li.length > 0) {
+                $li.contents().filter(function () {
+                    return this.nodeType === 3;
+                }).remove();
+                $li.append(document.createTextNode(' ' + name));
+            }
+
+            $('#editANewznabProvider').val(providerId);
+            $(this).populateNewznabSection();
+            $(this).makeNewznabProviderString();
+            $(this).refreshProviderList();
+        }.bind(this);
+
+        if (newId === id) {
+            applyUpdate(id);
+            return;
+        }
+
+        // Name change → new id. Confirm it does not collide with customs or built-ins.
+        // exclude_id matches the Tornado/Python query argument name.
+        $.getJSON(scRoot + '/config/providers/canAddNewznabProvider', {
+            name,
+            exclude_id: id, // eslint-disable-line camelcase
+        }, data => {
+            if (data.error !== undefined) {
+                alert(data.error); // eslint-disable-line no-alert
+                $(this).populateNewznabSection();
+                return;
+            }
+
+            delete newznabProviders[id];
+            $('#editANewznabProvider').removeOption(id);
+            $('#editANewznabProvider').addOption(newId, name);
+            $(this).migrateProviderOrderItem(id, newId, name, url, 'newznab.png');
+            applyUpdate(newId);
+        });
     };
 
     $.fn.deleteProvider = function (id) {
@@ -127,12 +198,60 @@ $(document).ready(function () {
         $(this).makeNewznabProviderString();
     };
 
-    $.fn.updateTorrentRssProvider = function (id, url, cookies, titleTAG) {
-        torrentRssProviders[id][1] = url;
-        torrentRssProviders[id][2] = cookies;
-        torrentRssProviders[id][3] = titleTAG;
-        $(this).populateTorrentRssSection();
-        $(this).makeTorrentRssProviderString();
+    $.fn.updateTorrentRssProvider = function (id, name, url, cookies, titleTAG) { // eslint-disable-line max-params
+        if (!torrentRssProviders[id]) {
+            return;
+        }
+
+        name = $.trim(name || torrentRssProviders[id][0]);
+        const newId = $(this).makeProviderId(name);
+        if (!newId) {
+            alert(_('Invalid name specified')); // eslint-disable-line no-alert
+            $(this).populateTorrentRssSection();
+            return;
+        }
+
+        const applyUpdate = function (providerId) {
+            torrentRssProviders[providerId] = [name, url, cookies, titleTAG];
+            $('#editATorrentRssProvider option[value="' + providerId + '"]').text(name);
+            $('#editATorrentRssProvider').val(providerId);
+            $(this).populateTorrentRssSection();
+            $(this).makeTorrentRssProviderString();
+            $(this).refreshProviderList();
+        }.bind(this);
+
+        if (newId === id) {
+            applyUpdate(id);
+            const $li = $('#provider_order_list > #' + id);
+            if ($li.length > 0) {
+                $li.contents().filter(function () {
+                    return this.nodeType === 3;
+                }).remove();
+                $li.append(document.createTextNode(' ' + name));
+            }
+
+            return;
+        }
+
+        $.getJSON(scRoot + '/config/providers/canAddTorrentRssProvider', {
+            name,
+            url,
+            cookies,
+            titleTAG,
+            exclude_id: id, // eslint-disable-line camelcase
+        }, data => {
+            if (data.error !== undefined) {
+                alert(data.error); // eslint-disable-line no-alert
+                $(this).populateTorrentRssSection();
+                return;
+            }
+
+            delete torrentRssProviders[id];
+            $('#editATorrentRssProvider').removeOption(id);
+            $('#editATorrentRssProvider').addOption(newId, name);
+            $(this).migrateProviderOrderItem(id, newId, name, url, 'torrentrss.png');
+            applyUpdate(newId);
+        });
     };
 
     $.fn.deleteTorrentRssProvider = function (id) {
@@ -199,16 +318,23 @@ $(document).ready(function () {
         if (selectedProvider === 'addNewznab') {
             $('#newznab_name').removeAttr('disabled');
             $('#newznab_url').removeAttr('disabled');
-        } else {
+        } else if (isDefault) {
+            // Stock/default Newznab rows keep a fixed name/url
             $('#newznab_name').attr('disabled', 'disabled');
+            $('#newznab_url').attr('disabled', 'disabled');
+            $('#newznab_delete').attr('disabled', 'disabled');
 
-            if (isDefault) {
-                $('#newznab_url').attr('disabled', 'disabled');
-                $('#newznab_delete').attr('disabled', 'disabled');
-            } else {
-                $('#newznab_url').removeAttr('disabled');
-                $('#newznab_delete').removeAttr('disabled');
+            // Get Categories Capabilities
+            if (data[0] && data[1] && data[2] && !ifExists(newznabProvidersCapabilities, data[0])) {
+                $(this).getCategories(isDefault, data);
             }
+
+            $(this).updateNewznabCaps(null, data);
+        } else {
+            // Custom Newznab: allow rename (needed when id collides with a built-in e.g. Jackett-SC)
+            $('#newznab_name').removeAttr('disabled');
+            $('#newznab_url').removeAttr('disabled');
+            $('#newznab_delete').removeAttr('disabled');
 
             // Get Categories Capabilities
             if (data[0] && data[1] && data[2] && !ifExists(newznabProvidersCapabilities, data[0])) {
@@ -288,7 +414,8 @@ $(document).ready(function () {
             $('#torrentrss_cookies').removeAttr('disabled');
             $('#torrentrss_titleTAG').removeAttr('disabled');
         } else {
-            $('#torrentrss_name').attr('disabled', 'disabled');
+            // Allow renaming customs (same built-in id collision issue as Newznab)
+            $('#torrentrss_name').removeAttr('disabled');
             $('#torrentrss_url').removeAttr('disabled');
             $('#torrentrss_cookies').removeAttr('disabled');
             $('#torrentrss_titleTAG').removeAttr('disabled');
@@ -353,36 +480,39 @@ $(document).ready(function () {
         const cat = $('#' + providerId + '_cat').val();
         const key = $(this).val();
 
-        $(this).updateProvider(providerId, url, key, cat);
+        const name = newznabProviders[providerId] ? newznabProviders[providerId][1][0] : providerId;
+        $(this).updateProvider(providerId, name, url, key, cat);
     });
 
-    $('#newznab_key,#newznab_url').on('change', function () {
+    $('#newznab_key,#newznab_url,#newznab_name').on('change', function () {
         const selectedProvider = $('#editANewznabProvider :selected').val();
 
         if (selectedProvider === 'addNewznab') {
             return;
         }
 
+        const name = $('#newznab_name').val();
         const url = $('#newznab_url').val();
         const key = $('#newznab_key').val();
 
         const cat = $('#newznab_cat option').map((i, opt) => $(opt).text()).toArray().join(',');
 
-        $(this).updateProvider(selectedProvider, url, key, cat);
+        $(this).updateProvider(selectedProvider, name, url, key, cat);
     });
 
-    $('#torrentrss_url,#torrentrss_cookies,#torrentrss_titleTAG').on('change', function () {
+    $('#torrentrss_url,#torrentrss_cookies,#torrentrss_titleTAG,#torrentrss_name').on('change', function () {
         const selectedProvider = $('#editATorrentRssProvider :selected').val();
 
         if (selectedProvider === 'addTorrentRss') {
             return;
         }
 
+        const name = $('#torrentrss_name').val();
         const url = $('#torrentrss_url').val();
         const cookies = $('#torrentrss_cookies').val();
         const titleTAG = $('#torrentrss_titleTAG').val();
 
-        $(this).updateTorrentRssProvider(selectedProvider, url, cookies, titleTAG);
+        $(this).updateTorrentRssProvider(selectedProvider, name, url, cookies, titleTAG);
     });
 
     $.fn.populateJackettSelectedCategories = function () {
@@ -494,6 +624,7 @@ $(document).ready(function () {
             return;
         }
 
+        const name = $('#newznab_name').val();
         const url = $('#newznab_url').val();
         const key = $('#newznab_key').val();
 
@@ -501,7 +632,7 @@ $(document).ready(function () {
 
         $('#newznab_cat option:not([value])').remove();
 
-        $(this).updateProvider(selectedProvider, url, key, cat);
+        $(this).updateProvider(selectedProvider, name, url, key, cat);
     });
 
     $('#newznab_add').on('click', () => {

--- a/sickchill/views/config/providers.py
+++ b/sickchill/views/config/providers.py
@@ -31,16 +31,38 @@ class ConfigProviders(Config):
         )
 
     @staticmethod
-    def canAddNewznabProvider(name):
+    def canAddNewznabProvider(name, exclude_id=""):
+        """Return whether ``name`` can be used for a custom Newznab provider.
+
+        ``exclude_id`` is the current provider id when renaming — that id is ignored
+        so a no-op / case-only rename that normalizes to the same id still succeeds.
+        Also rejects ids that collide with built-in or torrent-rss providers.
+        """
         if not name:
             return json.dumps({"error": "No Provider Name specified"})
 
-        provider_dict = {x.get_id(): x for x in settings.newznab_provider_list}
-
         provider_id = GenericProvider.make_id(name)
+        if not provider_id:
+            return json.dumps({"error": "No Provider Name specified"})
 
-        if provider_id in provider_dict:
-            return json.dumps({"error": "Provider Name already exists as " + name})
+        exclude_id = GenericProvider.make_id(exclude_id) if exclude_id else ""
+        if exclude_id and provider_id == exclude_id:
+            return json.dumps({"success": provider_id})
+
+        taken = {x.get_id() for x in settings.newznab_provider_list}
+        taken.update(x.get_id() for x in settings.torrent_rss_provider_list)
+        taken.update(x.get_id() for x in (settings.providerList or []))
+        if exclude_id:
+            taken.discard(exclude_id)
+
+        if provider_id in taken:
+            return json.dumps(
+                {
+                    "error": _(
+                        "Provider Name already exists as '{name}' (id '{provider_id}'). Choose a different name that does not match a built-in provider."
+                    ).format(name=name, provider_id=provider_id)
+                }
+            )
 
         return json.dumps({"success": provider_id})
 
@@ -106,19 +128,35 @@ class ConfigProviders(Config):
         return "1"
 
     @staticmethod
-    def canAddTorrentRssProvider(name, url, cookies, titleTAG):
+    def canAddTorrentRssProvider(name, url, cookies, titleTAG, exclude_id=""):
         if not name:
             return json.dumps({"error": "Invalid name specified"})
 
         url = config.clean_url(url)
         temp_provider = TorrentRssProvider(name, url, cookies, titleTAG)
+        provider_id = temp_provider.get_id()
+        exclude_id = GenericProvider.make_id(exclude_id) if exclude_id else ""
+        if exclude_id and provider_id == exclude_id:
+            return json.dumps({"success": provider_id})
 
-        if temp_provider.get_id() in (x.get_id() for x in settings.torrent_rss_provider_list):
-            return json.dumps({"error": "Exists as " + temp_provider.name})
+        taken = {x.get_id() for x in settings.torrent_rss_provider_list}
+        taken.update(x.get_id() for x in settings.newznab_provider_list)
+        taken.update(x.get_id() for x in (settings.providerList or []))
+        if exclude_id:
+            taken.discard(exclude_id)
+
+        if provider_id in taken:
+            return json.dumps(
+                {
+                    "error": _(
+                        "Provider Name already exists as '{name}' (id '{provider_id}'). Choose a different name that does not match a built-in provider."
+                    ).format(name=name, provider_id=provider_id)
+                }
+            )
 
         (succ, errMsg) = temp_provider.validateRSS()
         if succ:
-            return json.dumps({"success": temp_provider.get_id()})
+            return json.dumps({"success": provider_id})
 
         return json.dumps({"error": errMsg})
 

--- a/tests/test_provider_rename.py
+++ b/tests/test_provider_rename.py
@@ -1,0 +1,77 @@
+"""Custom Newznab/TorrentRSS rename vs built-in provider id collisions."""
+
+from __future__ import annotations
+
+import json
+import unittest
+
+from sickchill import settings
+from sickchill.oldbeard.providers.newznab import NewznabProvider
+from sickchill.oldbeard.providers.rsstorrent import TorrentRssProvider
+from sickchill.providers.GenericProvider import GenericProvider
+from sickchill.views.config.providers import ConfigProviders
+
+
+class _Builtin:
+    def __init__(self, name: str):
+        self.name = name
+
+    def get_id(self, suffix=""):
+        return GenericProvider.make_id(self.name) + str(suffix)
+
+
+class CanAddProviderRenameTests(unittest.TestCase):
+    def setUp(self):
+        self._saved = {
+            "newznab_provider_list": settings.newznab_provider_list,
+            "torrent_rss_provider_list": settings.torrent_rss_provider_list,
+            "providerList": settings.providerList,
+        }
+        settings.providerList = [_Builtin("Jackett-SC"), _Builtin("TorrentLeech")]
+        settings.newznab_provider_list = [
+            NewznabProvider("Jackett-SC", "http://127.0.0.1:9117/", key="secret", categories="5000"),
+            NewznabProvider("KeepMe", "https://keep.example/", key="k1", categories="5030"),
+        ]
+        settings.torrent_rss_provider_list = [
+            TorrentRssProvider("RssKeep", "https://rss.example/feed", "", "title"),
+        ]
+
+    def tearDown(self):
+        settings.newznab_provider_list = self._saved["newznab_provider_list"]
+        settings.torrent_rss_provider_list = self._saved["torrent_rss_provider_list"]
+        settings.providerList = self._saved["providerList"]
+
+    def test_make_id_jackett_sc_collides_with_builtin(self):
+        self.assertEqual(GenericProvider.make_id("Jackett-SC"), "jackett_sc")
+        self.assertEqual(GenericProvider.make_id("Jackett SC"), "jackett_sc")
+
+    def test_can_add_rejects_builtin_id(self):
+        result = json.loads(ConfigProviders.canAddNewznabProvider("TorrentLeech"))
+        self.assertIn("error", result)
+        self.assertIn("torrentleech", result["error"])
+
+    def test_can_add_rejects_existing_custom(self):
+        result = json.loads(ConfigProviders.canAddNewznabProvider("KeepMe"))
+        self.assertIn("error", result)
+
+    def test_rename_exclude_allows_same_id(self):
+        # Renaming Jackett-SC → Jackett SC still normalizes to jackett_sc; exclude current id
+        result = json.loads(ConfigProviders.canAddNewznabProvider("Jackett SC", exclude_id="jackett_sc"))
+        self.assertEqual(result.get("success"), "jackett_sc")
+
+    def test_rename_to_free_name_succeeds(self):
+        result = json.loads(ConfigProviders.canAddNewznabProvider("My Jackett", exclude_id="jackett_sc"))
+        self.assertEqual(result.get("success"), "my_jackett")
+
+    def test_rename_onto_builtin_still_rejected(self):
+        # Even with exclude of a different custom, cannot take torrentleech
+        result = json.loads(ConfigProviders.canAddNewznabProvider("TorrentLeech", exclude_id="jackett_sc"))
+        self.assertIn("error", result)
+
+    def test_torrent_rss_rejects_builtin(self):
+        result = json.loads(ConfigProviders.canAddTorrentRssProvider("Jackett-SC", "https://rss.example/x", "", "title"))
+        self.assertIn("error", result)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
fix provider rename when identical to built in.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Custom Newznab and TorrentRSS providers can now be renamed.
  * Provider ordering is preserved after renaming.
  * Provider names are normalized and checked against built-in and existing providers to prevent conflicts.
  * Name fields are available when creating or editing eligible providers.

* **Bug Fixes**
  * Validation messages now identify conflicting provider names and IDs.
  * Renaming a provider no longer incorrectly conflicts with its current ID.
  * Provider IDs with special names are handled correctly.

* **Tests**
  * Added coverage for provider renaming, ID normalization, and collision handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->