### PR TITLE
fix: Multi episode file PP

### DIFF
--- a/sickchill/oldbeard/name_parser/parser.py
+++ b/sickchill/oldbeard/name_parser/parser.py
@@ -43,6 +43,14 @@ class NameParser(object):
             self._compile_regexes(self.ALL_REGEX)
 
     @staticmethod
+    def _is_contiguous(episodes):
+        """True when episode numbers form an unbroken inclusive range."""
+        if not episodes:
+            return False
+        ordered = sorted(episodes)
+        return ordered == list(range(ordered[0], ordered[-1] + 1))
+
+    @staticmethod
     def clean_series_name(series_name):
         """Cleans up series name by removing any . and _
         characters, along with any trailing hyphens.
@@ -276,6 +284,10 @@ class NameParser(object):
                     new_season_numbers.append(s)
 
             elif best_result.season_number and best_result.episode_numbers:
+                # Preserve pre-scene list for multi-ep sanity (e.g. S01E01-E03 → [1,2,3]).
+                release_episode_numbers = list(best_result.episode_numbers)
+                release_season_number = best_result.season_number
+
                 for epNo in best_result.episode_numbers:
                     s = best_result.season_number
                     e = epNo
@@ -289,6 +301,27 @@ class NameParser(object):
 
                     new_episode_numbers.append(e)
                     new_season_numbers.append(s)
+
+                # Contiguous multi-ep in the release (E01-E03) that scene-maps to a gapped
+                # set (E01,E04,E07) almost always means the filename already used indexer
+                # numbering (e.g. Official shorts), not scene/DVD pack numbers.
+                if (
+                    best_result.show.is_scene
+                    and not skip_scene_detection
+                    and len(release_episode_numbers) > 1
+                    and self._is_contiguous(release_episode_numbers)
+                    and new_episode_numbers
+                    and not self._is_contiguous(new_episode_numbers)
+                ):
+                    logger.debug(
+                        "Scene numbering mapped contiguous multi-ep {release} to non-contiguous "
+                        "{converted}; keeping release episode numbers (likely already indexer order)".format(
+                            release=release_episode_numbers, converted=sorted(set(new_episode_numbers))
+                        )
+                    )
+                    new_episode_numbers = list(release_episode_numbers)
+                    new_season_numbers = [release_season_number]
+                    new_absolute_numbers = []
 
             # need to do a quick sanity check regex.  It's possible that we now have episodes
             # from more than one season (by tvdb numbering), and this is just too much

--- a/sickchill/oldbeard/postProcessor.py
+++ b/sickchill/oldbeard/postProcessor.py
@@ -87,6 +87,9 @@ class PostProcessor(object):
 
         self.history = History()
 
+        # Set before every soft failure (``return False``) so processTV can surface it.
+        self.failure_reason = ""
+
     def _log(self, message, level=logging.INFO):
         """
         A wrapper for the internal logger which also keeps track of messages and saves them to a string for later.
@@ -96,6 +99,12 @@ class PostProcessor(object):
         """
         logger.log(level, message)
         self.log += message + "\n"
+
+    def _fail(self, message, level=logging.WARNING):
+        """Log a post-process failure reason and return False for ``process()``."""
+        self.failure_reason = str(message)
+        self._log(message, level)
+        return False
 
     def _checkForExistingFile(self, existing_file):
         """
@@ -764,8 +773,16 @@ class PostProcessor(object):
                 if not curEp:
                     raise EpisodeNotFoundException()
             except EpisodeNotFoundException as error:
-                self._log(_("Unable to create episode: {error}").format(error=error), logger.DEBUG)
-                raise EpisodePostProcessingFailedException()
+                parsed = ", ".join(episode_num(season, ep) or str(ep) for ep in episodes)
+                missing = episode_num(season, cur_episode) or f"S{season:02d}E{cur_episode:02d}"
+                detail = _("Unable to create episode: {error}").format(error=error)
+                self._log(detail, logger.DEBUG)
+                kind = _("multi-ep file") if len(episodes) > 1 else _("file")
+                raise EpisodePostProcessingFailedException(
+                    _("Unable to post-process {kind}: missing {missing} (parsed episodes: {parsed}). {detail}").format(
+                        kind=kind, missing=missing, parsed=parsed, detail=detail
+                    )
+                ) from error
 
             # associate all the episodes together under a single root episode
             if root_ep is None:
@@ -915,20 +932,18 @@ class PostProcessor(object):
         :return: True on success, False on failure
         """
 
+        self.failure_reason = ""
         self._log(_("Processing {directory} ({release_name})").format(directory=self.directory, release_name=self.release_name))
 
         if os.path.isdir(self.directory):
-            self._log(_("File {directory} seems to be a directory").format(directory=self.directory))
-            return False
+            return self._fail(_("File {directory} seems to be a directory").format(directory=self.directory))
 
         if not os.path.exists(self.directory):
-            self._log(_("File {directory} doesn't exist, did unrar fail?").format(directory=self.directory))
-            return False
+            return self._fail(_("File {directory} doesn't exist, did unrar fail?").format(directory=self.directory))
 
         for ignore_file in self.IGNORED_FILESTRINGS:
             if ignore_file in self.directory:
-                self._log(_("File {directory} is ignored type, skipping").format(directory=self.directory))
-                return False
+                return self._fail(_("File {directory} is ignored type, skipping").format(directory=self.directory))
 
         # reset per-file stuff
         self.in_history = False
@@ -939,11 +954,11 @@ class PostProcessor(object):
         # try to find the file info
         (show, season, episodes, quality, version) = self._find_info()
         if not show:
-            self._log(_("This show isn't in your list, you need to add it to SC before post-processing an episode"))
-            raise EpisodePostProcessingFailedException()
+            message = _("This show isn't in your list, you need to add it to SC before post-processing an episode")
+            self._log(message)
+            raise EpisodePostProcessingFailedException(message)
         elif season is None or not episodes:
-            self._log(_("Not enough information to determine what episode this is. Quitting post-processing"))
-            return False
+            return self._fail(_("Not enough information to determine what episode this is. Quitting post-processing"))
 
         # retrieve/create the corresponding TVEpisode objects
         episode_object = self._get_ep_obj(show, season, episodes)
@@ -985,8 +1000,7 @@ class PostProcessor(object):
                 else:
                     allowed_qualities_, preferred_qualities = common.Quality.splitQuality(int(show.quality))
                     if new_ep_quality not in preferred_qualities:
-                        self._log(_("File exists and new file quality is not in a preferred quality list, marking it unsafe to replace"))
-                        return False
+                        return self._fail(_("File exists and new file quality is not in a preferred quality list, marking it unsafe to replace"))
 
             # Check if the processed file season is already in our indexer. If not, the file is most probably mislabled/fake and will be skipped
             # Only proceed if the file season is > 0
@@ -997,25 +1011,23 @@ class PostProcessor(object):
                 )
 
                 if not isinstance(max_season[0]["last_season"], int) or max_season[0]["last_season"] < 0:
-                    self._log(
+                    return self._fail(
                         f"File has season {episode_object.season}, while the database does not have any known seasons yet. "
                         "Try forcing a full update on the show and process this file again. "
                         "The file may be incorrectly labeled or fake, aborting."
                     )
-                    return False
 
                 # If the file season (episode_object.season) is bigger than the indexer season (max_season[0][0]), skip the file
                 newest_season = max_season[0]["last_season"]
                 episode_season = episode_object.season
                 if int(episode_season) > newest_season:
-                    self._log(
+                    return self._fail(
                         _(
                             "File has season {episode_season}, while the indexer is on season {newest_season}. "
                             "Try forcing a full update on the show and process this file again. "
                             "The file may be incorrectly labeled or fake, aborting."
                         ).format(episode_season=episode_season, newest_season=newest_season)
                     )
-                    return False
 
         # if the file is priority then we're going to replace it even if it exists
         else:
@@ -1027,8 +1039,7 @@ class PostProcessor(object):
                 if not verify_freespace(
                     self.directory, episode_object.show.get_location, [episode_object] + episode_object.related_episodes, method=self.process_method
                 ):
-                    self._log(_("Not enough disk space to continue processing, exiting"), logger.WARNING)
-                    return False
+                    return self._fail(_("Not enough disk space to continue processing, exiting"), logger.WARNING)
             else:
                 self._log(_("Unable to determine needed file space as the source file is locked for access"))
 

--- a/sickchill/oldbeard/processTV.py
+++ b/sickchill/oldbeard/processTV.py
@@ -498,13 +498,15 @@ def process_media(process_path, video_files, release_name, process_method, force
         try:
             processor = postProcessor.PostProcessor(cur_video_file_path, release_name, process_method, is_priority)
             result.result = processor.process()
-            process_fail_message = ""
+            process_fail_message = getattr(processor, "failure_reason", "") or ""
         except EpisodePostProcessingFailedException as error:
             result.result = False
-            process_fail_message = error
+            process_fail_message = str(error) if str(error) else _("Episode post-processing failed")
 
         if processor:
             result.output += processor.log
+            if not result.result and not process_fail_message:
+                process_fail_message = getattr(processor, "failure_reason", "") or _("Episode post-processing failed")
 
         if result.result:
             result.output += log_helper(f"Processing succeeded for {cur_video_file_path}")

--- a/sickchill/show/History.py
+++ b/sickchill/show/History.py
@@ -183,13 +183,24 @@ class History(object, metaclass=Singleton):
         """
         Log history of download
 
-        :param episode: episode of show
+        :param episode: episode of show (root; related_episodes are logged too for multi-ep files)
         :param filename: file on disk where the download is
         :param quality: Quality of download
         :param group: Release group
         :param version: Version of file (defaults to -1)
         """
-        self._log_history_item(episode.status, episode.show.indexerid, episode.season, episode.episode, quality, filename, group or -1, version)
+        # Parity with log_snatch: one history row per episode sharing the file.
+        for cur_episode in [episode] + list(getattr(episode, "related_episodes", None) or []):
+            self._log_history_item(
+                cur_episode.status,
+                cur_episode.show.indexerid,
+                cur_episode.season,
+                cur_episode.episode,
+                quality,
+                filename,
+                group or -1,
+                version,
+            )
 
     def log_subtitle(self, show: int, season: int, episode: int, status: int, subtitle: subliminal.subtitle.Subtitle, scores: "Scores"):
         """

--- a/tests/sickchill_tests/show/test_history.py
+++ b/tests/sickchill_tests/show/test_history.py
@@ -3,12 +3,45 @@ Test history
 """
 
 import unittest
+from unittest.mock import MagicMock, patch
+
+from sickchill.oldbeard.common import DOWNLOADED, Quality
+from sickchill.show.History import History
 
 
 class HistoryTests(unittest.TestCase):
     """
     Test history
     """
+
+    def test_log_download_writes_related_episodes_for_multi_ep(self):
+        """Multi-ep PP must history-log E04, E05, and E06 — not only the root."""
+        history = History()
+        show = MagicMock()
+        show.indexerid = 299994
+
+        def make_ep(episode_number):
+            ep = MagicMock()
+            ep.show = show
+            ep.season = 1
+            ep.episode = episode_number
+            ep.status = Quality.compositeStatus(DOWNLOADED, Quality.HDTV)
+            ep.related_episodes = []
+            return ep
+
+        root = make_ep(4)
+        root.related_episodes = [make_ep(5), make_ep(6)]
+
+        with patch.object(history, "_log_history_item") as log_item:
+            history.log_download(root, "/videos/Puffin.Rock.S01E04E05E06.mkv", Quality.HDTV, group="MEMENTO", version=-1)
+
+        self.assertEqual(log_item.call_count, 3)
+        # positional: action, showid, season, episode, quality, resource, ...
+        logged_episodes = [c.args[3] for c in log_item.call_args_list]
+        self.assertEqual(logged_episodes, [4, 5, 6])
+        for c in log_item.call_args_list:
+            self.assertEqual(c.args[2], 1)  # season
+            self.assertEqual(c.args[5], "/videos/Puffin.Rock.S01E04E05E06.mkv")
 
 
 if __name__ == "__main__":

--- a/tests/sickchill_tests/show/test_history.py
+++ b/tests/sickchill_tests/show/test_history.py
@@ -20,28 +20,36 @@ class HistoryTests(unittest.TestCase):
         show = MagicMock()
         show.indexerid = 299994
 
-        def make_ep(episode_number):
+        def make_ep(episode_number, quality):
             ep = MagicMock()
             ep.show = show
             ep.season = 1
             ep.episode = episode_number
-            ep.status = Quality.compositeStatus(DOWNLOADED, Quality.HDTV)
+            # Distinct statuses so we catch accidentally logging root.status for every ep.
+            ep.status = Quality.compositeStatus(DOWNLOADED, quality)
             ep.related_episodes = []
             return ep
 
-        root = make_ep(4)
-        root.related_episodes = [make_ep(5), make_ep(6)]
+        root = make_ep(4, Quality.SDTV)
+        related_a = make_ep(5, Quality.HDTV)
+        related_b = make_ep(6, Quality.FULLHDTV)
+        root.related_episodes = [related_a, related_b]
+        expected = [
+            (root.status, 4),
+            (related_a.status, 5),
+            (related_b.status, 6),
+        ]
 
         with patch.object(history, "_log_history_item") as log_item:
             history.log_download(root, "/videos/Puffin.Rock.S01E04E05E06.mkv", Quality.HDTV, group="MEMENTO", version=-1)
 
         self.assertEqual(log_item.call_count, 3)
         # positional: action, showid, season, episode, quality, resource, ...
-        logged_episodes = [c.args[3] for c in log_item.call_args_list]
-        self.assertEqual(logged_episodes, [4, 5, 6])
-        for c in log_item.call_args_list:
-            self.assertEqual(c.args[2], 1)  # season
-            self.assertEqual(c.args[5], "/videos/Puffin.Rock.S01E04E05E06.mkv")
+        for call_args, (expected_status, expected_episode) in zip(log_item.call_args_list, expected, strict=True):
+            self.assertEqual(call_args.args[0], expected_status)
+            self.assertEqual(call_args.args[2], 1)  # season
+            self.assertEqual(call_args.args[3], expected_episode)
+            self.assertEqual(call_args.args[5], "/videos/Puffin.Rock.S01E04E05E06.mkv")
 
 
 if __name__ == "__main__":

--- a/tests/test_name_parser.py
+++ b/tests/test_name_parser.py
@@ -20,6 +20,9 @@ SIMPLE_TEST_CASES = {
         "Show.Name.S01E02E03.Source.Quality.Etc-Group": parser.ParseResult(None, "Show Name", 1, [2, 3], "Source.Quality.Etc", "Group"),
         "Mr. Show Name - S01E02-03 - My Ep Name": parser.ParseResult(None, "Mr. Show Name", 1, [2, 3], "My Ep Name"),
         "Show.Name.S01.E02.E03": parser.ParseResult(None, "Show Name", 1, [2, 3]),
+        # Three shorts in one file (Puffin Rock style Official numbering)
+        "Show.Name.S01E01-E03.Ep.One.&.Ep.Two.&.Ep.Three": parser.ParseResult(None, "Show Name", 1, [1, 2, 3], "Ep.One.&.Ep.Two.&.Ep.Three"),
+        "Show.Name.S01E01E02E03.Source.Quality": parser.ParseResult(None, "Show Name", 1, [1, 2, 3], "Source.Quality"),
         "Show.Name-0.2010.S01E02.Source.Quality.Etc-Group": parser.ParseResult(None, "Show Name-0 2010", 1, [2], "Source.Quality.Etc", "Group"),
         "S01E02 Ep Name": parser.ParseResult(None, None, 1, [2], "Ep Name"),
         "Show Name - S06E01 - 2009-12-20 - Ep Name": parser.ParseResult(None, "Show Name", 6, [1], "2009-12-20 - Ep Name"),
@@ -630,6 +633,38 @@ class BasicFailedTests(conftest.SickChillTestDBCase):
         self._test_names(name_parser, "scene_date_format", lambda x: x + ".avi")
 
 
+class SceneMultiEpContiguousTests(unittest.TestCase):
+    """Scene maps must not turn contiguous multi-ep releases into gapped indexer lists."""
+
+    def test_is_contiguous_helper(self):
+        self.assertTrue(parser.NameParser._is_contiguous([1, 2, 3]))
+        self.assertTrue(parser.NameParser._is_contiguous([16, 17, 18]))
+        self.assertFalse(parser.NameParser._is_contiguous([1, 4, 7]))
+        self.assertFalse(parser.NameParser._is_contiguous([]))
+
+    def test_scene_gap_keeps_release_numbering_for_three_ep_file(self):
+        from unittest.mock import MagicMock, patch
+
+        show = MagicMock()
+        show.is_scene = True
+        show.is_anime = False
+        show.indexerid = 299994
+        show.indexer = 1
+        show.name = "Puffin Rock"
+
+        # DVD/scene pack N → Official short 1 + 3*(N-1): 1→1, 2→4, 3→7
+        def scene_to_indexer(_indexerid, _indexer, season, episode):
+            return season, 1 + 3 * (episode - 1)
+
+        name = "Puffin.Rock.S01E01-E03.Puffin.Practice.&.The.Shiny.Shell.&.Beach.Rescue.1080p.WEB.DL.h265"
+        with patch("sickchill.oldbeard.scene_numbering.get_indexer_numbering", side_effect=scene_to_indexer):
+            with patch("sickchill.oldbeard.helpers.get_show", return_value=show):
+                result = parser.NameParser(show_object=show, naming_pattern=False).parse(name, cache_result=False)
+
+        self.assertEqual(result.season_number, 1)
+        self.assertEqual(result.episode_numbers, [1, 2, 3])
+
+
 if __name__ == "__main__":
     if len(sys.argv) > 1:
         SUITE = unittest.TestLoader().loadTestsFromName("name_parser_tests.BasicTests.test_" + sys.argv[1])
@@ -648,4 +683,7 @@ if __name__ == "__main__":
     unittest.TextTestRunner(verbosity=2).run(SUITE)
 
     SUITE = unittest.TestLoader().loadTestsFromTestCase(AnimeTests)
+    unittest.TextTestRunner(verbosity=2).run(SUITE)
+
+    SUITE = unittest.TestLoader().loadTestsFromTestCase(SceneMultiEpContiguousTests)
     unittest.TextTestRunner(verbosity=2).run(SUITE)

--- a/tests/test_pp.py
+++ b/tests/test_pp.py
@@ -5,8 +5,11 @@ Test post processing
 import os.path
 import shutil
 import unittest
+from unittest.mock import MagicMock, patch
 
 from sickchill import settings
+from sickchill.helper.exceptions import EpisodeNotFoundException, EpisodePostProcessingFailedException
+from sickchill.oldbeard import processTV
 from sickchill.oldbeard.helpers import make_dirs
 from sickchill.oldbeard.name_cache import add_name
 from sickchill.oldbeard.postProcessor import PostProcessor
@@ -62,6 +65,54 @@ class PPBasicTests(conftest.SickChillTestDBCase):
 
         post_processor = PostProcessor(conftest.FILE_PATH)
         assert post_processor.process()
+
+
+class PPMultiEpFailureMessageTests(unittest.TestCase):
+    """Multi-ep (3 shorts in one file) must not fail with an empty reason."""
+
+    def test_get_ep_obj_missing_third_episode_message(self):
+        show = MagicMock()
+
+        def get_episode(season, episode):
+            if episode == 18:
+                raise EpisodeNotFoundException("Couldn't find episode S{0:02d}E{1:02d}".format(season, episode))
+            ep = MagicMock()
+            ep.season = season
+            ep.episode = episode
+            return ep
+
+        show.get_episode.side_effect = get_episode
+        post_processor = PostProcessor("/tmp/Puffin.Rock.S02E16e17e18.mkv")
+
+        with self.assertRaises(EpisodePostProcessingFailedException) as ctx:
+            post_processor._get_ep_obj(show, 2, [16, 17, 18])
+
+        message = str(ctx.exception)
+        self.assertTrue(message.strip(), "failure exception must include a reason")
+        self.assertIn("S02E18", message)
+        self.assertIn("S02E16", message)
+        self.assertIn("multi-ep", message.lower())
+
+    def test_process_media_surfaces_failure_reason_on_false(self):
+        result = processTV.ProcessResult()
+        processor = MagicMock()
+        processor.process.return_value = False
+        processor.failure_reason = "File exists and new file quality is not in a preferred quality list"
+        processor.log = "processor log line\n"
+
+        with patch("sickchill.oldbeard.processTV.postProcessor.PostProcessor", return_value=processor):
+            with patch("sickchill.oldbeard.processTV.already_processed", return_value=False):
+                processTV.process_media("/tmp", ["Show.S02E16e17e18.mkv"], None, "move", False, False, result)
+
+        self.assertFalse(result.result)
+        self.assertIn(processor.failure_reason, result.output)
+        self.assertNotIn("Processing failed for /tmp/Show.S02E16e17e18.mkv:\n", result.output)
+        self.assertIn("Processing failed for /tmp/Show.S02E16e17e18.mkv: " + processor.failure_reason, result.output)
+
+    def test_fail_helper_sets_failure_reason(self):
+        post_processor = PostProcessor("/tmp/missing.mkv")
+        self.assertFalse(post_processor._fail("did unrar fail?"))
+        self.assertEqual(post_processor.failure_reason, "did unrar fail?")
 
 
 class ListAssociatedFiles(unittest.TestCase):

--- a/tests/test_pp.py
+++ b/tests/test_pp.py
@@ -99,15 +99,19 @@ class PPMultiEpFailureMessageTests(unittest.TestCase):
         processor.process.return_value = False
         processor.failure_reason = "File exists and new file quality is not in a preferred quality list"
         processor.log = "processor log line\n"
+        video_name = "Show.S02E16e17e18.mkv"
+        process_path = os.path.join(os.path.sep, "tmp")
+        video_path = os.path.join(process_path, video_name)
 
         with patch("sickchill.oldbeard.processTV.postProcessor.PostProcessor", return_value=processor):
             with patch("sickchill.oldbeard.processTV.already_processed", return_value=False):
-                processTV.process_media("/tmp", ["Show.S02E16e17e18.mkv"], None, "move", False, False, result)
+                processTV.process_media(process_path, [video_name], None, "move", False, False, result)
 
         self.assertFalse(result.result)
         self.assertIn(processor.failure_reason, result.output)
-        self.assertNotIn("Processing failed for /tmp/Show.S02E16e17e18.mkv:\n", result.output)
-        self.assertIn("Processing failed for /tmp/Show.S02E16e17e18.mkv: " + processor.failure_reason, result.output)
+        # Empty reason after colon must not appear; path join is OS-specific (\ vs /).
+        self.assertNotIn(f"Processing failed for {video_path}:\n", result.output)
+        self.assertIn(f"Processing failed for {video_path}: {processor.failure_reason}", result.output)
 
     def test_fail_helper_sets_failure_reason(self):
         post_processor = PostProcessor("/tmp/missing.mkv")


### PR DESCRIPTION
Fixes multi ep post processing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved recognition of multi-episode releases, including contiguous episodes and scene-numbered filenames.
  - Multi-episode downloads now create history entries for every included episode.

- **Bug Fixes**
  - Improved handling of multi-episode files when one or more episodes cannot be found.
  - Processing failures now display clearer, actionable reasons instead of generic or empty messages.
  - Episode-specific details are now preserved in multi-episode download history.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->